### PR TITLE
feat: self-learning chatbot with live product_features DB and question analytics

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import Anthropic from '@anthropic-ai/sdk';
 import { createClient } from '@/lib/supabase/server';
 import { createClient as createAdmin } from '@supabase/supabase-js';
+// product-context.ts is the seed/fallback; runtime source of truth is product_features table
 import { PRODUCT_CONTEXT } from '@/lib/product-context';
 import { getToolDefinitions, executeTool } from './tools/registry';
 
@@ -18,9 +19,149 @@ function getAdmin() {
   );
 }
 
-const SYSTEM_PROMPT = `You are the Paybacker support assistant. You help users understand how Paybacker works and answer questions about UK consumer rights.
+// --- Product features cache (5-minute TTL per warm instance) ---
 
-${PRODUCT_CONTEXT}
+interface FeatureRow {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  tier_access: string[];
+  route_path: string | null;
+  is_active: boolean;
+  usage_count: number;
+}
+
+interface FeaturesCache {
+  features: FeatureRow[];
+  context: string;
+  ts: number;
+}
+
+let featureCache: FeaturesCache | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const CATEGORY_LABELS: Record<string, string> = {
+  money_recovery: 'Money Recovery and Disputes',
+  financial_tracking: 'Financial Tracking and Budgeting',
+  ai_tools: 'AI-Powered Tools',
+  savings: 'Savings and Challenges',
+  deals: 'Deals and Comparison',
+  social: 'Community and Rewards',
+};
+
+function buildFeaturesContext(features: FeatureRow[]): string {
+  const grouped = new Map<string, FeatureRow[]>();
+  for (const f of features) {
+    if (!grouped.has(f.category)) grouped.set(f.category, []);
+    grouped.get(f.category)!.push(f);
+  }
+
+  const lines: string[] = [
+    'About Paybacker (paybacker.co.uk):',
+    'An AI-powered savings platform for UK consumers. We help people dispute unfair bills, track subscriptions, scan bank accounts and email inboxes, and take control of their finances.',
+    '',
+    'FEATURE CATALOGUE:',
+    '',
+  ];
+
+  let num = 1;
+  for (const [cat, feats] of grouped) {
+    const label = CATEGORY_LABELS[cat] || cat;
+    lines.push(`[${label}]`);
+    for (const f of feats) {
+      const tiers = f.tier_access.join(', ');
+      lines.push(`${num}. ${f.name} (${tiers}): ${f.description}`);
+      if (f.route_path) lines.push(`   Dashboard: ${f.route_path}`);
+      num++;
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+async function getFeatures(): Promise<FeaturesCache> {
+  if (featureCache && Date.now() - featureCache.ts < CACHE_TTL_MS) {
+    return featureCache;
+  }
+  try {
+    const admin = getAdmin();
+    const { data, error } = await admin
+      .from('product_features')
+      .select('id, name, description, category, tier_access, route_path, is_active, usage_count')
+      .eq('is_active', true)
+      .order('category')
+      .order('name');
+
+    if (error || !data || data.length === 0) {
+      console.warn('[chat] product_features fetch failed or empty, using static fallback:', error?.message);
+      featureCache = { features: [], context: PRODUCT_CONTEXT, ts: Date.now() };
+    } else {
+      featureCache = {
+        features: data,
+        context: buildFeaturesContext(data),
+        ts: Date.now(),
+      };
+    }
+  } catch (err) {
+    console.error('[chat] getFeatures threw, using static fallback:', err);
+    featureCache = { features: [], context: PRODUCT_CONTEXT, ts: Date.now() };
+  }
+  return featureCache!;
+}
+
+// Fire-and-forget: log a chatbot question with matched features and confidence
+async function logChatQuestion(
+  userId: string | null,
+  question: string,
+  response: string,
+  features: FeatureRow[]
+): Promise<void> {
+  try {
+    const admin = getAdmin();
+    const responseLower = response.toLowerCase();
+
+    // Which feature names appear in the bot's response?
+    const matchedFeatures = features
+      .filter(f => responseLower.includes(f.name.toLowerCase()))
+      .map(f => f.name);
+
+    // Detect low-confidence signals in the response
+    const LOW_CONF_SIGNALS = [
+      "i'm not sure", "i don't have", "i don't know", "not available",
+      "i cannot find", "i can't find", "unable to find", "i'm unable",
+      "not something i", "sorry, i", "i'm sorry, i", "i don't have information",
+      "i can't answer", "i cannot answer", "not in my knowledge",
+    ];
+    const hasLowConfidence = LOW_CONF_SIGNALS.some(s => responseLower.includes(s));
+
+    const confidence = hasLowConfidence ? 0.25 : (matchedFeatures.length > 0 ? 0.85 : 0.6);
+    const unanswered = hasLowConfidence && matchedFeatures.length === 0;
+
+    await admin.from('chatbot_question_log').insert({
+      user_id: userId,
+      question: question.slice(0, 1000), // cap length
+      matched_features: matchedFeatures,
+      confidence,
+      unanswered,
+    });
+
+    // Increment usage_count for each matched feature (atomic via SQL function)
+    for (const featureName of matchedFeatures) {
+      admin.rpc('increment_feature_usage', { p_feature_name: featureName })
+        .then(({ error }) => {
+          if (error) console.error('[chat] Feature usage increment failed:', error.message);
+        });
+    }
+  } catch (err) {
+    console.error('[chat] logChatQuestion failed:', err);
+  }
+}
+
+function buildSystemPrompt(featuresCtx: string): string {
+  return `You are the Paybacker support assistant. You help users understand how Paybacker works and answer questions about UK consumer rights.
+
+${featuresCtx}
 
 ## Dashboard Customisation
 Users can customise their dashboard layout through you. When they ask to show, hide, or rearrange widgets, include a dashboard command in your response:
@@ -128,6 +269,7 @@ When a user says "find me a better broadband deal", "complain about my energy bi
 - Use British English and £ symbols
 - NEVER use em dashes. Use commas, full stops, or colons instead.
 - End with a helpful follow-up question or suggestion where appropriate`;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -149,6 +291,9 @@ export async function POST(request: NextRequest) {
     } catch (authErr: any) {
       console.error('[chat] Auth threw exception:', authErr.message);
     }
+
+    // Load product features from DB (cached 5 min)
+    const { features: featureList, context: featuresCtx } = await getFeatures();
 
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
       return NextResponse.json({ error: 'Messages required' }, { status: 400 });
@@ -231,7 +376,7 @@ ${userTier === 'pro' ? `
       }
     }
 
-    const systemPrompt = SYSTEM_PROMPT + anonymousRules + tierContext + subscriptionContext;
+    const systemPrompt = buildSystemPrompt(featuresCtx) + anonymousRules + tierContext + subscriptionContext;
 
     // Only provide tools to logged-in users
     const tools: Anthropic.Messages.Tool[] = isLoggedIn
@@ -316,6 +461,12 @@ ${userTier === 'pro' ? `
       if (round === MAX_TOOL_ROUNDS - 1) {
         finalText = textBlocks.map((b) => b.text).join('\n') || 'I have completed the requested changes to your subscriptions.';
       }
+    }
+
+    // Log question to chatbot_question_log (fire-and-forget, non-blocking)
+    const lastUserMessage = [...messages].reverse().find((m: { role: string; content: string }) => m.role === 'user');
+    if (lastUserMessage && finalText) {
+      logChatQuestion(userId, lastUserMessage.content, finalText, featureList);
     }
 
     // Cost tracking -- Sonnet 4: input $3/1M, output $15/1M

--- a/src/app/api/cron/analyze-chatbot-gaps/route.ts
+++ b/src/app/api/cron/analyze-chatbot-gaps/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import Anthropic from '@anthropic-ai/sdk';
+
+export const maxDuration = 120;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+async function sendTelegram(message: string) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_FOUNDER_CHAT_ID;
+  if (!token || !chatId) return;
+  // Split long messages to stay under Telegram's 4096 char limit
+  const chunks: string[] = [];
+  for (let i = 0; i < message.length; i += 4000) {
+    chunks.push(message.slice(i, i + 4000));
+  }
+  for (const chunk of chunks) {
+    try {
+      await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chat_id: Number(chatId),
+          text: chunk,
+          parse_mode: 'Markdown',
+        }),
+      });
+    } catch (err) {
+      console.error('[analyze-chatbot-gaps] Telegram send failed:', err);
+    }
+  }
+}
+
+/**
+ * Weekly chatbot gap analysis cron.
+ * Finds questions the chatbot could not answer confidently in the past week,
+ * groups them by theme using Claude Haiku, and reports to Paul via Telegram.
+ * This is product intelligence: what are users asking for that we do not have yet?
+ *
+ * Schedule: Monday 6am
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = getAdmin();
+  const weekAgo = new Date();
+  weekAgo.setDate(weekAgo.getDate() - 7);
+
+  // Fetch unanswered or low-confidence questions from the past week
+  const { data: gaps, error: gapsErr } = await supabase
+    .from('chatbot_question_log')
+    .select('question, confidence, unanswered, created_at')
+    .gte('created_at', weekAgo.toISOString())
+    .or('unanswered.eq.true,confidence.lt.0.5')
+    .order('created_at', { ascending: false })
+    .limit(200);
+
+  if (gapsErr) {
+    console.error('[analyze-chatbot-gaps] DB fetch failed:', gapsErr.message);
+    return NextResponse.json({ error: gapsErr.message }, { status: 500 });
+  }
+
+  // Also grab overall stats for context
+  const [
+    { count: totalQuestions },
+    { count: unansweredCount },
+    { count: lowConfidenceCount },
+  ] = await Promise.all([
+    supabase.from('chatbot_question_log')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', weekAgo.toISOString()),
+    supabase.from('chatbot_question_log')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', weekAgo.toISOString())
+      .eq('unanswered', true),
+    supabase.from('chatbot_question_log')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', weekAgo.toISOString())
+      .lt('confidence', 0.5),
+  ]);
+
+  if (!gaps || gaps.length === 0) {
+    const msg = `*Paybacker Chatbot Weekly Gap Report*\n\nNo unanswered or low-confidence questions this week. The chatbot handled all ${totalQuestions || 0} questions confidently.`;
+    await sendTelegram(msg);
+    await supabase.from('business_log').insert({
+      category: 'analytics',
+      title: 'Weekly chatbot gap analysis: no gaps found',
+      content: `Total questions: ${totalQuestions || 0}. No unanswered questions.`,
+      created_by: 'analyze_chatbot_gaps_cron',
+    });
+    return NextResponse.json({ ok: true, gaps: 0, total: totalQuestions || 0 });
+  }
+
+  // Use Claude Haiku to group by theme and extract product insights
+  const questionList = gaps.map(g => g.question).join('\n');
+
+  const aiResponse = await anthropic.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 1024,
+    messages: [{
+      role: 'user',
+      content: `You are analysing chatbot questions that users asked but the bot could not answer confidently. These are questions from users of Paybacker, a UK consumer rights and savings platform.
+
+Group these questions into themes. For each theme, identify:
+1. The topic users are asking about
+2. Whether this is a MISSING FEATURE (something Paybacker does not offer yet) or MISSING DOCUMENTATION (feature exists but bot needs better info about it)
+3. How many questions fall into this theme
+
+Return ONLY a JSON array:
+[{"theme": "short theme name", "count": N, "type": "missing_feature|missing_docs", "example_questions": ["q1", "q2"], "recommendation": "one sentence on what to do"}]
+
+Questions to analyse:
+${questionList}`,
+    }],
+  });
+
+  let themes: any[] = [];
+  const content = aiResponse.content[0];
+  if (content.type === 'text') {
+    const raw = content.text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+    const match = raw.match(/\[[\s\S]*\]/);
+    if (match) {
+      try {
+        themes = JSON.parse(match[0]);
+      } catch {
+        themes = [];
+      }
+    }
+  }
+
+  // Build Telegram report
+  const lines: string[] = [
+    `*Paybacker Chatbot Weekly Gap Report*`,
+    `Week ending: ${new Date().toLocaleDateString('en-GB')}`,
+    ``,
+    `*Overview:*`,
+    `  Total questions: ${totalQuestions || 0}`,
+    `  Unanswered: ${unansweredCount || 0}`,
+    `  Low confidence: ${lowConfidenceCount || 0}`,
+    `  Gap rate: ${totalQuestions ? Math.round(((gaps.length) / totalQuestions) * 100) : 0}%`,
+    ``,
+    `*Top themes where chatbot struggled:*`,
+    ``,
+  ];
+
+  for (const t of themes.slice(0, 8)) {
+    const icon = t.type === 'missing_feature' ? '🔴' : '🟡';
+    lines.push(`${icon} *${t.theme}* (${t.count} questions)`);
+    lines.push(`  Type: ${t.type === 'missing_feature' ? 'Missing feature' : 'Needs better docs'}`);
+    lines.push(`  ${t.recommendation}`);
+    if (t.example_questions?.length > 0) {
+      lines.push(`  Example: "${t.example_questions[0]}"`);
+    }
+    lines.push('');
+  }
+
+  const missingFeatureCount = themes.filter(t => t.type === 'missing_feature').length;
+  if (missingFeatureCount > 0) {
+    lines.push(`*Action needed:* ${missingFeatureCount} theme(s) suggest missing features. Consider adding to the product roadmap.`);
+  }
+
+  await sendTelegram(lines.join('\n'));
+
+  // Save to business_log
+  await supabase.from('business_log').insert({
+    category: 'analytics',
+    title: 'Weekly chatbot gap analysis completed',
+    content: `Total: ${totalQuestions || 0} questions. Gaps: ${gaps.length}. Themes identified: ${themes.length}. Missing features: ${missingFeatureCount}.`,
+    created_by: 'analyze_chatbot_gaps_cron',
+  });
+
+  console.log(`[analyze-chatbot-gaps] Done. Gaps: ${gaps.length}, Themes: ${themes.length}`);
+  return NextResponse.json({
+    ok: true,
+    total_questions: totalQuestions || 0,
+    gaps_found: gaps.length,
+    themes: themes.length,
+    missing_features: missingFeatureCount,
+  });
+}

--- a/src/app/api/cron/discover-features/route.ts
+++ b/src/app/api/cron/discover-features/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'fs';
+import path from 'path';
+
+export const maxDuration = 60;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+async function sendTelegram(message: string) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_FOUNDER_CHAT_ID;
+  if (!token || !chatId) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: Number(chatId),
+        text: message,
+        parse_mode: 'Markdown',
+      }),
+    });
+  } catch (err) {
+    console.error('[discover-features] Telegram send failed:', err);
+  }
+}
+
+/**
+ * Scan the dashboard directory for page.tsx files and map them to route paths.
+ * Returns an array of discovered route paths like /dashboard/complaints.
+ */
+function discoverDashboardRoutes(): string[] {
+  const routes: string[] = [];
+  const baseDir = path.join(process.cwd(), 'src', 'app', 'dashboard');
+
+  try {
+    if (!fs.existsSync(baseDir)) {
+      console.warn('[discover-features] Dashboard dir not found at:', baseDir);
+      return routes;
+    }
+
+    function scan(dir: string, routePrefix: string) {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          // Skip admin routes — not user-facing features
+          if (entry.name === 'admin') continue;
+          scan(path.join(dir, entry.name), `${routePrefix}/${entry.name}`);
+        } else if (entry.name === 'page.tsx') {
+          routes.push(routePrefix);
+        }
+      }
+    }
+
+    // Add the dashboard root itself if page.tsx exists
+    if (fs.existsSync(path.join(baseDir, 'page.tsx'))) {
+      routes.push('/dashboard');
+    }
+    scan(baseDir, '/dashboard');
+  } catch (err) {
+    console.error('[discover-features] Filesystem scan failed:', err);
+  }
+
+  return [...new Set(routes)]; // deduplicate
+}
+
+/**
+ * Nightly feature discovery cron.
+ * Scans dashboard routes and compares against product_features table.
+ * Alerts Paul via Telegram for any new or removed routes.
+ *
+ * Schedule: Daily at 2am
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = getAdmin();
+
+  // Fetch all known routes from product_features
+  const { data: knownFeatures, error: fetchErr } = await supabase
+    .from('product_features')
+    .select('id, name, route_path, is_active');
+
+  if (fetchErr) {
+    console.error('[discover-features] DB fetch failed:', fetchErr.message);
+    return NextResponse.json({ error: fetchErr.message }, { status: 500 });
+  }
+
+  const knownRoutes = new Map<string, { id: string; name: string; is_active: boolean }>();
+  for (const f of knownFeatures || []) {
+    if (f.route_path) {
+      knownRoutes.set(f.route_path, { id: f.id, name: f.name, is_active: f.is_active });
+    }
+  }
+
+  // Discover routes from filesystem
+  const discoveredRoutes = discoverDashboardRoutes();
+  console.log('[discover-features] Discovered routes:', discoveredRoutes);
+
+  const newRoutes: string[] = [];
+  const removedRoutes: string[] = [];
+  const reactivated: string[] = [];
+
+  // Find routes in filesystem but not in DB (or marked inactive)
+  for (const route of discoveredRoutes) {
+    const known = knownRoutes.get(route);
+    if (!known) {
+      newRoutes.push(route);
+      // Create a draft entry — is_active=false until Paul reviews
+      await supabase.from('product_features').insert({
+        name: `[Draft] ${route}`,
+        description: `Auto-discovered route at ${route}. Please update name and description then set is_active=true.`,
+        category: 'uncategorised',
+        tier_access: ['free', 'essential', 'pro'],
+        route_path: route,
+        is_active: false,
+      });
+    } else if (!known.is_active) {
+      reactivated.push(route);
+    }
+  }
+
+  // Find routes in DB but no longer in filesystem (mark inactive)
+  for (const [route, feature] of knownRoutes.entries()) {
+    if (!discoveredRoutes.includes(route) && feature.is_active) {
+      removedRoutes.push(route);
+      await supabase
+        .from('product_features')
+        .update({ is_active: false })
+        .eq('id', feature.id);
+    }
+  }
+
+  // Send Telegram alerts if anything changed
+  const alerts: string[] = [];
+
+  if (newRoutes.length > 0) {
+    alerts.push(
+      `*New dashboard routes detected* (${newRoutes.length}):\n` +
+      newRoutes.map(r => `  • \`${r}\` — draft entry created, set is_active=true to activate`).join('\n')
+    );
+  }
+
+  if (removedRoutes.length > 0) {
+    alerts.push(
+      `*Routes no longer found in codebase* (${removedRoutes.length}):\n` +
+      removedRoutes.map(r => {
+        const f = knownRoutes.get(r);
+        return `  • \`${r}\` (${f?.name || 'unknown'}) — marked inactive`;
+      }).join('\n')
+    );
+  }
+
+  if (alerts.length > 0) {
+    const msg = `*Paybacker Feature Discovery*\n\n${alerts.join('\n\n')}\n\nReview at: paybacker.co.uk/dashboard/admin`;
+    await sendTelegram(msg);
+  }
+
+  // Log the discovery run to business_log
+  await supabase.from('business_log').insert({
+    category: 'system',
+    title: 'Feature discovery cron completed',
+    content: `Discovered ${discoveredRoutes.length} routes. New: ${newRoutes.length}, Removed: ${removedRoutes.length}, Reactivated candidates: ${reactivated.length}.`,
+    created_by: 'discover_features_cron',
+  });
+
+  console.log(`[discover-features] Done. New: ${newRoutes.length}, Removed: ${removedRoutes.length}`);
+  return NextResponse.json({
+    ok: true,
+    discovered: discoveredRoutes.length,
+    new_routes: newRoutes,
+    removed_routes: removedRoutes,
+  });
+}

--- a/src/lib/product-context.ts
+++ b/src/lib/product-context.ts
@@ -1,11 +1,17 @@
 /**
- * Single source of truth for product information used by:
- * - Website chatbot (/api/chat)
- * - Social media engagement (comments, DMs)
- * - Telegram bot (Charlie)
+ * FALLBACK AND SEED — not the runtime source of truth for the chatbot.
  *
- * Update this file when features change — the chatbot automatically picks up new descriptions.
- * Import this instead of hardcoding product info in each prompt.
+ * The chatbot (/api/chat) now reads product features at runtime from the
+ * `product_features` Supabase table (cached 5 minutes). That table is seeded
+ * from the migration 20260331000000_chatbot_self_learning.sql.
+ *
+ * This file is still used by:
+ * - Social media engagement agent (comments, DMs) — no DB connection
+ * - Telegram bot (Charlie) — uses simple prompt, not DB-aware
+ * - Fallback if the product_features table query fails
+ *
+ * To update chatbot knowledge: edit the product_features table directly via Supabase,
+ * or add a new migration. Do NOT rely on editing this file to update the chatbot.
  */
 
 export const PRODUCT_CONTEXT = `

--- a/supabase/migrations/20260331000000_chatbot_self_learning.sql
+++ b/supabase/migrations/20260331000000_chatbot_self_learning.sql
@@ -1,0 +1,234 @@
+-- Chatbot Self-Learning: Product Features Catalogue and Question Log
+-- 2026-03-31
+
+-- Product features table: single source of truth for chatbot feature awareness
+CREATE TABLE IF NOT EXISTS product_features (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  category TEXT NOT NULL,
+  tier_access TEXT[] NOT NULL DEFAULT ARRAY['free','essential','pro'],
+  route_path TEXT,
+  api_routes TEXT[] DEFAULT ARRAY[]::TEXT[],
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  added_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  usage_count INTEGER NOT NULL DEFAULT 0,
+  last_used_at TIMESTAMPTZ
+);
+
+ALTER TABLE product_features ENABLE ROW LEVEL SECURITY;
+
+-- Name must be unique so seed inserts are idempotent
+CREATE UNIQUE INDEX IF NOT EXISTS idx_product_features_name ON product_features(name);
+
+-- Anyone can read active features (chatbot uses anon/service role)
+CREATE POLICY "Anyone can read active product_features"
+  ON product_features FOR SELECT
+  USING (is_active = true);
+
+-- Service role manages everything
+CREATE POLICY "Service role can manage product_features"
+  ON product_features FOR ALL
+  USING (true)
+  WITH CHECK (true);
+
+CREATE INDEX IF NOT EXISTS idx_product_features_category ON product_features(category);
+CREATE INDEX IF NOT EXISTS idx_product_features_active ON product_features(is_active);
+
+-- Auto-update updated_at on change
+CREATE OR REPLACE FUNCTION touch_product_features_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER product_features_updated_at
+  BEFORE UPDATE ON product_features
+  FOR EACH ROW EXECUTE FUNCTION touch_product_features_updated_at();
+
+-- Atomic usage increment called by the chatbot after each answered question
+CREATE OR REPLACE FUNCTION increment_feature_usage(p_feature_name TEXT)
+RETURNS void AS $$
+  UPDATE product_features
+  SET usage_count = usage_count + 1,
+      last_used_at = NOW()
+  WHERE name = p_feature_name AND is_active = true;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- Chatbot question log: every question the bot is asked, with metadata for analysis
+CREATE TABLE IF NOT EXISTS chatbot_question_log (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  question TEXT NOT NULL,
+  matched_features TEXT[] DEFAULT ARRAY[]::TEXT[],
+  confidence FLOAT NOT NULL DEFAULT 0.5,
+  was_helpful BOOLEAN,
+  unanswered BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE chatbot_question_log ENABLE ROW LEVEL SECURITY;
+
+-- Users see only their own logs
+CREATE POLICY "Users can read own question log"
+  ON chatbot_question_log FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Service role reads all (analytics)
+CREATE POLICY "Service role can manage chatbot_question_log"
+  ON chatbot_question_log FOR ALL
+  USING (true)
+  WITH CHECK (true);
+
+CREATE INDEX IF NOT EXISTS idx_chatbot_ql_user ON chatbot_question_log(user_id);
+CREATE INDEX IF NOT EXISTS idx_chatbot_ql_unanswered ON chatbot_question_log(unanswered);
+CREATE INDEX IF NOT EXISTS idx_chatbot_ql_created ON chatbot_question_log(created_at);
+CREATE INDEX IF NOT EXISTS idx_chatbot_ql_confidence ON chatbot_question_log(confidence);
+
+-- Seed all current Paybacker features
+INSERT INTO product_features (name, description, category, tier_access, route_path, api_routes) VALUES
+
+('AI Complaint and Dispute Letters',
+ 'Generates professional complaint letters in 30 seconds. Cites 86+ verified UK law references with confidence badges. Covers energy bills, broadband, flight delay compensation (up to £520), parking charges, council tax challenges, debt collection responses, insurance, NHS, and refunds. Text-to-speech available on Essential and Pro. Dispute thread tracking shows full correspondence history.',
+ 'money_recovery',
+ ARRAY['free','essential','pro'],
+ '/dashboard/complaints',
+ ARRAY['/api/complaints/generate', '/api/complaints/usage', '/api/complaints/[id]/letter', '/api/complaints/[id]/approve']),
+
+('Government Forms and Official Letters',
+ 'Generates official letters for HMRC tax rebates, council tax band challenges, DVLA issues, NHS formal complaints, parking fine appeals, and debt dispute responses (Section 77/78 requests). Available to all plans; counts toward the Free plan letter limit.',
+ 'money_recovery',
+ ARRAY['free','essential','pro'],
+ '/dashboard/forms',
+ ARRAY['/api/forms/generate']),
+
+('AI Cancellation Emails',
+ 'Writes cancellation emails citing relevant UK consumer law: Consumer Contracts Regulations 2013 (14-day cooling off), Ofcom mid-contract price rise exit rights, Ofgem tariff rules, and the Consumer Rights Act for gym memberships. Provides provider-specific advice for 80+ UK companies. Available on Essential and Pro plans only.',
+ 'ai_tools',
+ ARRAY['essential','pro'],
+ '/dashboard/subscriptions',
+ ARRAY['/api/subscriptions/cancellation-email']),
+
+('Bank Connection and Open Banking',
+ 'Connects bank accounts securely (read-only, FCA regulated) using Open Banking. Scans 12 months of transactions to automatically detect all subscriptions, recurring payments, and hidden charges. Free users get a one-time scan. Essential users get 1 bank account with daily auto-sync. Pro users get unlimited bank accounts with daily auto-sync and on-demand manual sync.',
+ 'financial_tracking',
+ ARRAY['free','essential','pro'],
+ '/dashboard/money-hub',
+ ARRAY['/api/bank/connection', '/api/bank/sync', '/api/bank/disconnect']),
+
+('Money Hub Financial Dashboard',
+ 'Complete financial intelligence centre. Full spending breakdown across 20+ categories, income tracking, net worth snapshot, budget planner with 80%/100% breach email alerts, monthly spending trends with interactive charts, and transaction-level drill-down. Savings goals with progress tracking available on Pro. Free users see top 5 spending categories only.',
+ 'financial_tracking',
+ ARRAY['free','essential','pro'],
+ '/dashboard/money-hub',
+ ARRAY['/api/money-hub', '/api/money-hub/budgets', '/api/money-hub/goals', '/api/money-hub/net-worth', '/api/money-hub/transactions', '/api/money-hub/recategorise']),
+
+('Subscription and Contract Tracking',
+ 'Track every subscription, direct debit, mortgage, loan, insurance policy, and contract in one dashboard. Shows monthly and annual spend totals. Contract end date tracking with countdown badges. Contract upload: upload a PDF or photo of any contract and AI analyses key terms, end dates, and exit conditions. Renewal email alerts at 30, 14, and 7 days before any contract renews. Add manually or auto-detect via bank scan.',
+ 'financial_tracking',
+ ARRAY['free','essential','pro'],
+ '/dashboard/subscriptions',
+ ARRAY['/api/subscriptions', '/api/subscriptions/[id]', '/api/contracts', '/api/contracts/analyse', '/api/contracts/upload']),
+
+('Price Increase Alerts',
+ 'Automatically detects when any recurring payment increases in price. Shows old vs new amount, percentage increase, and annual cost impact. Checked daily after each bank sync. Lets you write a complaint letter or find a better deal directly from the alert. Available on Essential and Pro plans (requires bank connection).',
+ 'financial_tracking',
+ ARRAY['essential','pro'],
+ '/dashboard/subscriptions',
+ ARRAY['/api/price-alerts']),
+
+('Receipt and Bill Scanning',
+ 'Upload receipts or bills as photos or PDFs. AI extracts amounts, dates, and merchant names. Automatically flags potential overcharges and creates action items. Available on Essential and Pro plans.',
+ 'ai_tools',
+ ARRAY['essential','pro'],
+ '/dashboard/scanner',
+ ARRAY['/api/receipts', '/api/receipts/scan']),
+
+('Email Inbox Scanning',
+ 'Connect Gmail or Outlook (read-only, Google OAuth). Scans up to 2 years of email history. Finds overcharges, forgotten subscriptions, flight delay opportunities, debt disputes, and price increase notices. Smart action buttons: Add to Subscriptions, Write Complaint, Claim Compensation, Create Task, Dismiss. Free gets a one-time scan. Essential gets monthly re-scans. Pro gets unlimited scans.',
+ 'ai_tools',
+ ARRAY['free','essential','pro'],
+ '/dashboard/scanner',
+ ARRAY['/api/gmail/scan', '/api/outlook/scan', '/api/email/scan', '/api/gmail/detect-subscriptions']),
+
+('Deal Comparison',
+ '59+ deals across 9 categories from verified UK providers: Energy, Broadband, Mobile, Insurance, Mortgages, Loans, Credit Cards, Car Finance, and Travel. Compares against your current subscription data to highlight potential savings. Awin affiliate integration for trusted switching. Free to browse for all users.',
+ 'deals',
+ ARRAY['free','essential','pro'],
+ '/dashboard/deals',
+ ARRAY['/api/deals', '/api/deals/click', '/api/affiliate-deals']),
+
+('Savings Challenges',
+ '12 gamified savings challenges including no-spend week, switch and save, and cancel one subscription. Bank-verified completion: the system checks your bank data to confirm you actually saved. Earn loyalty points on completion. Available on Essential and Pro plans.',
+ 'savings',
+ ARRAY['essential','pro'],
+ '/dashboard/rewards',
+ ARRAY['/api/challenges']),
+
+('Annual Financial Report PDF',
+ 'Full yearly summary of income, spending, savings achieved, and contracts reviewed. PDF export with charts and category breakdown. Available on Pro plan only.',
+ 'financial_tracking',
+ ARRAY['pro'],
+ '/dashboard/profile/report',
+ ARRAY['/api/reports/generate', '/api/reports']),
+
+('AI Support Chatbot',
+ 'Available on every page to all users. Answers UK consumer rights questions and helps navigate the platform. Can manage subscriptions, query your spending, find deals, and detect price increases directly in the chat. Escalates to a human support agent when needed. Available on all plans.',
+ 'ai_tools',
+ ARRAY['free','essential','pro'],
+ NULL,
+ ARRAY['/api/chat']),
+
+('Loyalty Rewards',
+ 'Earn points for every action: generating letters, adding subscriptions, completing challenges, and referring friends. Reward tiers: Bronze, Silver, Gold, Platinum. Redeem points for subscription discounts. Available on all plans.',
+ 'social',
+ ARRAY['free','essential','pro'],
+ '/dashboard/rewards',
+ ARRAY['/api/loyalty', '/api/loyalty/award', '/api/loyalty/redeem']),
+
+('Referral Programme',
+ 'Share your unique referral link. Both you and your friend get 1 free month of Essential when they sign up and become a paying subscriber. Track referrals and earnings from your profile. Available on all plans.',
+ 'social',
+ ARRAY['free','essential','pro'],
+ '/dashboard/profile',
+ ARRAY['/api/referrals', '/api/referrals/track', '/api/referrals/process']),
+
+('Share Your Win',
+ 'Share a savings achievement to social media with a pre-formatted post that includes your referral link so you earn additional rewards when people sign up. Available on all plans.',
+ 'social',
+ ARRAY['free','essential','pro'],
+ '/dashboard',
+ ARRAY[]),
+
+('Contract Vault',
+ 'Upload and store your contracts securely in one place. AI analyses key terms, end dates, and exit conditions for any contract you upload. View all contracts with expiry countdowns and auto-renewal warnings. Available on Essential and Pro plans.',
+ 'financial_tracking',
+ ARRAY['essential','pro'],
+ '/dashboard/contracts',
+ ARRAY['/api/contracts', '/api/contracts/upload', '/api/contracts/analyse']),
+
+('Spending Intelligence',
+ 'Full transaction-level analysis of your spending across 20+ categories. See exactly where your money goes each month with interactive charts. Recategorise any transaction to keep your data accurate. Full access on Essential and Pro; Free tier gets top 5 categories only.',
+ 'financial_tracking',
+ ARRAY['free','essential','pro'],
+ '/dashboard/spending',
+ ARRAY['/api/spending', '/api/money-hub/transactions', '/api/money-hub/recategorise']),
+
+('Budget Planner',
+ 'Set monthly budget limits for each spending category. Visual progress bars show how much you have spent vs your limit. Get email alerts when you reach 80% and 100% of any budget. Available on Essential and Pro plans.',
+ 'savings',
+ ARRAY['essential','pro'],
+ '/dashboard/money-hub',
+ ARRAY['/api/money-hub/budgets']),
+
+('Savings Goals',
+ 'Set financial targets such as building an emergency fund or saving for a holiday. Track progress with visual charts linked to your actual bank data. Available on Pro plan only.',
+ 'savings',
+ ARRAY['pro'],
+ '/dashboard/money-hub',
+ ARRAY['/api/money-hub/goals'])
+
+ON CONFLICT (name) DO NOTHING;

--- a/vercel.json
+++ b/vercel.json
@@ -123,6 +123,14 @@
     {
       "path": "/api/cron/check-deal-prices",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/discover-features",
+      "schedule": "0 2 * * *"
+    },
+    {
+      "path": "/api/cron/analyze-chatbot-gaps",
+      "schedule": "0 6 * * 1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **`product_features` table** seeded with all 20 current features across 6 categories, plus `chatbot_question_log` table. RLS: users read their own logs; service role reads all for analytics. `increment_feature_usage()` Postgres function for atomic usage tracking.
- **`/api/chat` updated** to query `product_features` at runtime (5-min module-level cache). Falls back to `product-context.ts` if DB unavailable. Every question is logged with matched features, confidence score, and `unanswered` flag.
- **`/api/cron/discover-features`** (daily 2am): scans `src/app/dashboard` for `page.tsx` files, diffs against DB, creates draft entries for new routes, marks removed ones inactive, Telegrams Paul on any change.
- **`/api/cron/analyze-chatbot-gaps`** (Monday 6am): clusters last week's unanswered/low-confidence questions with Claude Haiku, classifies `missing_feature` vs `missing_docs`, sends gap report to Paul via Telegram.
- **`product-context.ts`** retained as fallback seed for social/Telegram agents; header updated to clarify its role.

## Test plan

- [ ] Run migration `20260331000000_chatbot_self_learning.sql` on production Supabase
- [ ] Verify `product_features` has 20 rows with `is_active=true`
- [ ] Send a chat message and confirm `chatbot_question_log` gets a new row
- [ ] Send an unanswerable question and confirm `unanswered=true`, `confidence=0.25`
- [ ] Call `GET /api/cron/discover-features` with `Authorization: Bearer $CRON_SECRET`
- [ ] Call `GET /api/cron/analyze-chatbot-gaps` with bearer token and confirm Telegram message

🤖 Generated with [Claude Code](https://claude.com/claude-code)