### PR TITLE
fix: create price_increase_alerts table and on-demand detection

### DIFF
--- a/src/app/api/price-alerts/detect/route.ts
+++ b/src/app/api/price-alerts/detect/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { detectPriceIncreases } from '@/lib/price-increase-detector';
+
+function getAdmin() {
+  return createAdminClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}
+
+/**
+ * POST /api/price-alerts/detect
+ * Run price increase detection on demand for the authenticated user.
+ * Called by the dashboard when bank data exists but no alerts are stored yet.
+ * Deduplicates against existing active alerts before inserting.
+ * Returns all active alerts after detection.
+ */
+export async function POST() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+
+  // Run detection — reads last 6 months of bank_transactions for this user
+  const increases = await detectPriceIncreases(user.id);
+
+  if (increases.length > 0) {
+    // Fetch existing active alerts to prevent duplicate inserts
+    const { data: existing } = await admin
+      .from('price_increase_alerts')
+      .select('merchant_normalized')
+      .eq('user_id', user.id)
+      .eq('status', 'active');
+
+    const existingMerchants = new Set((existing || []).map((a: { merchant_normalized: string }) => a.merchant_normalized));
+    const newAlerts = increases.filter(i => !existingMerchants.has(i.merchantNormalized));
+
+    if (newAlerts.length > 0) {
+      await admin.from('price_increase_alerts').insert(
+        newAlerts.map(i => ({
+          user_id: user.id,
+          merchant_name: i.merchantName,
+          merchant_normalized: i.merchantNormalized,
+          old_amount: i.oldAmount,
+          new_amount: i.newAmount,
+          increase_pct: i.increasePct,
+          annual_impact: i.annualImpact,
+          old_date: i.oldDate,
+          new_date: i.newDate,
+          status: 'active',
+        }))
+      );
+    }
+  }
+
+  // Return all active alerts sorted by annual impact
+  const { data: alerts } = await admin
+    .from('price_increase_alerts')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('status', 'active')
+    .order('annual_impact', { ascending: false });
+
+  return NextResponse.json({ alerts: alerts || [] });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -147,6 +147,9 @@ export default function DashboardPage() {
 
   useEffect(() => {
     const fetchData = async () => {
+      let hasBankConnection = false;
+      let hasStoredAlerts = false;
+
       try {
         const { data: { user } } = await supabase.auth.getUser();
         if (!user) return;
@@ -169,7 +172,8 @@ export default function DashboardPage() {
         ]);
 
         setUserTier(profile.data?.subscription_tier || 'free');
-        setBankConnected((banks.count || 0) > 0);
+        hasBankConnection = (banks.count || 0) > 0;
+        setBankConnected(hasBankConnection);
 
         // Check trial status
         if (profile.data?.founding_member && profile.data?.founding_member_expires && !profile.data?.stripe_subscription_id) {
@@ -227,6 +231,7 @@ export default function DashboardPage() {
           .eq('status', 'active')
           .order('annual_impact', { ascending: false });
         setPriceAlerts(priceAlertData || []);
+        hasStoredAlerts = (priceAlertData || []).length > 0;
 
       } catch (error) {
         console.error('Error fetching dashboard data:', error);
@@ -259,6 +264,21 @@ export default function DashboardPage() {
           setComparisonDeals(dealsList);
         }
       } catch {} // Non-critical
+
+      // On-demand price increase detection: if the user has bank data but no
+      // stored alerts yet, run detection immediately rather than waiting for
+      // the 8 AM daily cron. Deduplication in the endpoint prevents double inserts.
+      if (hasBankConnection && !hasStoredAlerts) {
+        try {
+          const detectRes = await fetch('/api/price-alerts/detect', { method: 'POST' });
+          if (detectRes.ok) {
+            const detectData = await detectRes.json();
+            if (detectData.alerts?.length > 0) {
+              setPriceAlerts(detectData.alerts);
+            }
+          }
+        } catch {} // Non-critical
+      }
     };
     fetchData();
   }, [supabase]);

--- a/supabase/migrations/20260401000000_price_increase_alerts.sql
+++ b/supabase/migrations/20260401000000_price_increase_alerts.sql
@@ -1,0 +1,36 @@
+-- Price increase alerts table
+-- Stores recurring payment increases detected from bank transaction history.
+-- Populated by the daily cron at /api/cron/price-increases and on-demand via
+-- /api/price-alerts/detect when a user first loads the dashboard with bank data.
+CREATE TABLE IF NOT EXISTS price_increase_alerts (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES profiles(id) ON DELETE CASCADE NOT NULL,
+  merchant_name TEXT,
+  merchant_normalized TEXT NOT NULL,
+  old_amount DECIMAL(10,2) NOT NULL,
+  new_amount DECIMAL(10,2) NOT NULL,
+  increase_pct DECIMAL(5,2) NOT NULL,
+  annual_impact DECIMAL(10,2) NOT NULL,
+  old_date DATE,
+  new_date DATE,
+  status TEXT DEFAULT 'active' CHECK (status IN ('active', 'dismissed', 'actioned')),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE price_increase_alerts ENABLE ROW LEVEL SECURITY;
+
+-- Users can read their own alerts
+CREATE POLICY "Users can view own price alerts"
+  ON price_increase_alerts FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Users can update status of their own alerts (dismiss / action)
+CREATE POLICY "Users can update own price alert status"
+  ON price_increase_alerts FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Indexes for dashboard and cron queries
+CREATE INDEX idx_pia_user_status ON price_increase_alerts(user_id, status) WHERE status = 'active';
+CREATE INDEX idx_pia_user_created ON price_increase_alerts(user_id, created_at DESC);
+CREATE INDEX idx_pia_user_impact  ON price_increase_alerts(user_id, annual_impact DESC);


### PR DESCRIPTION
## Summary

- **Root cause**: `price_increase_alerts` table had no migration, so it didn't exist in the database. Every query silently returned empty, the daily cron failed to insert, and the dashboard showed £0.00/yr with the alerts section hidden.
- Added migration `20260401000000_price_increase_alerts.sql` with the table schema, RLS policies (users read/update own rows), and indexes for dashboard and cron queries
- Added `POST /api/price-alerts/detect` endpoint — runs `detectPriceIncreases` for the authenticated user and stores results with deduplication, so users don't wait for the 8 AM cron after connecting their bank
- Updated dashboard `fetchData` to call `/detect` non-blockingly when bank is connected but no stored alerts exist

## Test plan

- [ ] Apply migration in Supabase: `supabase/migrations/20260401000000_price_increase_alerts.sql`
- [ ] Connect a bank account and load the dashboard — Price Increase Alerts section should populate within seconds (on-demand detect)
- [ ] Dismiss an alert — verify it disappears (PATCH /api/price-alerts updates status to dismissed)
- [ ] Verify the "Price hikes detected £X/yr" overview card reflects the detected total
- [ ] Check cron `/api/cron/price-increases` no longer errors on the missing table

🤖 Generated with [Claude Code](https://claude.com/claude-code)