### PR TITLE
feat: re-enable TrueLayer as open banking provider via env toggle

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -26,6 +26,10 @@ CRON_SECRET=your-cron-secret
 # Token encryption — generate with: openssl rand -hex 32
 ENCRYPTION_KEY=your-64-char-hex-string
 
+# Open Banking Provider toggle: 'truelayer' or 'yapily' (default: truelayer)
+OPEN_BANKING_PROVIDER=truelayer
+NEXT_PUBLIC_OPEN_BANKING_PROVIDER=truelayer
+
 # TrueLayer Open Banking
 TRUELAYER_CLIENT_ID=
 TRUELAYER_CLIENT_SECRET=

--- a/src/app/api/bank/sync-now/route.ts
+++ b/src/app/api/bank/sync-now/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createClient as createAdmin } from '@supabase/supabase-js';
 import { getTransactions } from '@/lib/yapily';
+import {
+  getAccessToken as getTrueLayerAccessToken,
+  fetchTransactions as fetchTrueLayerTransactions,
+} from '@/lib/truelayer';
 import { decrypt } from '@/lib/encrypt';
 import { detectRecurring } from '@/lib/detect-recurring';
 import { getUserPlan } from '@/lib/get-user-plan';
@@ -19,8 +23,14 @@ interface BankConnection {
   id: string;
   user_id: string;
   provider: string;
+  // Yapily fields
   consent_token: string | null;
   consent_expires_at: string | null;
+  // TrueLayer fields
+  access_token: string | null;
+  refresh_token: string | null;
+  token_expires_at: string | null;
+  // Common
   account_ids: string[] | null;
   bank_name: string | null;
   status: string;
@@ -112,13 +122,13 @@ export async function POST(request: NextRequest) {
     // No body — sync all connections
   }
 
-  // Fetch active Yapily connection(s)
+  // Fetch active bank connection(s) — TrueLayer and Yapily
   let connectionsQuery = supabase
     .from('bank_connections')
     .select('*')
     .eq('user_id', user.id)
     .eq('status', 'active')
-    .eq('provider', 'yapily');
+    .in('provider', ['truelayer', 'yapily']);
 
   if (connectionId) {
     connectionsQuery = connectionsQuery.eq('id', connectionId);
@@ -161,28 +171,9 @@ export async function POST(request: NextRequest) {
   const now = new Date().toISOString();
 
   for (const conn of connections as BankConnection[]) {
-    // Check consent token exists
-    if (!conn.consent_token) {
-      await supabase
-        .from('bank_connections')
-        .update({ status: 'expired', updated_at: now })
-        .eq('id', conn.id);
-
-      await supabase.from('bank_sync_log').insert({
-        user_id: user.id,
-        connection_id: conn.id,
-        trigger_type: 'manual',
-        status: 'failed',
-        api_calls_made: apiCallsMade,
-        error_message: 'No consent token — reconnect required',
-      });
-      continue;
-    }
-
-    // Check consent expiry (Yapily consents are valid for 90 days)
-    if (conn.consent_expires_at) {
-      const expiresAt = new Date(conn.consent_expires_at).getTime();
-      if (Date.now() >= expiresAt) {
+    if (conn.provider === 'truelayer') {
+      // === TrueLayer path ===
+      if (!conn.access_token) {
         await supabase
           .from('bank_connections')
           .update({ status: 'expired', updated_at: now })
@@ -194,45 +185,118 @@ export async function POST(request: NextRequest) {
           trigger_type: 'manual',
           status: 'failed',
           api_calls_made: apiCallsMade,
-          error_message: 'Consent expired — reconnect required',
+          error_message: 'No access token — reconnect required',
         });
         continue;
       }
-    }
 
-    // Decrypt consent token
-    const consentToken = decrypt(conn.consent_token);
+      // Get access token, refreshing if expired (uses user session via createClient internally)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const accessToken = await getTrueLayerAccessToken(conn as any);
 
-    const accountIds = conn.account_ids || [];
-    for (const accountId of accountIds) {
-      try {
-        const fromDate = ninetyDaysAgo.toISOString().split('T')[0];
-        const toDate = new Date().toISOString().split('T')[0];
-        const transactions = await getTransactions(accountId, consentToken, fromDate, toDate);
-        apiCallsMade++;
+      const accountIds = conn.account_ids || [];
+      for (const accountId of accountIds) {
+        try {
+          const transactions = await fetchTrueLayerTransactions(accessToken, accountId, ninetyDaysAgo);
+          apiCallsMade++;
 
-        if (transactions.length === 0) continue;
+          if (transactions.length === 0) continue;
 
-        const rows = transactions.map((tx) => ({
+          const rows = transactions.map((tx) => ({
+            user_id: user.id,
+            connection_id: conn.id,
+            transaction_id: tx.transaction_id,
+            account_id: accountId,
+            amount: tx.amount,
+            currency: tx.currency || 'GBP',
+            description: tx.description || null,
+            merchant_name: tx.merchant_name || null,
+            category: null,
+            timestamp: tx.timestamp,
+          }));
+
+          const { error } = await supabase
+            .from('bank_transactions')
+            .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });
+
+          if (!error) totalSynced += rows.length;
+        } catch {
+          // Non-fatal per-account error — continue with next account
+        }
+      }
+    } else {
+      // === Yapily path ===
+      if (!conn.consent_token) {
+        await supabase
+          .from('bank_connections')
+          .update({ status: 'expired', updated_at: now })
+          .eq('id', conn.id);
+
+        await supabase.from('bank_sync_log').insert({
           user_id: user.id,
           connection_id: conn.id,
-          transaction_id: tx.id,
-          account_id: accountId,
-          amount: tx.transactionAmount.amount,
-          currency: tx.transactionAmount.currency || 'GBP',
-          description: tx.description || null,
-          merchant_name: tx.merchantName || null,
-          category: null,
-          timestamp: tx.bookingDateTime,
-        }));
+          trigger_type: 'manual',
+          status: 'failed',
+          api_calls_made: apiCallsMade,
+          error_message: 'No consent token — reconnect required',
+        });
+        continue;
+      }
 
-        const { error } = await supabase
-          .from('bank_transactions')
-          .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });
+      // Check consent expiry (Yapily consents are valid for 90 days)
+      if (conn.consent_expires_at) {
+        const expiresAt = new Date(conn.consent_expires_at).getTime();
+        if (Date.now() >= expiresAt) {
+          await supabase
+            .from('bank_connections')
+            .update({ status: 'expired', updated_at: now })
+            .eq('id', conn.id);
 
-        if (!error) totalSynced += rows.length;
-      } catch {
-        // Non-fatal per-account error — continue with next account
+          await supabase.from('bank_sync_log').insert({
+            user_id: user.id,
+            connection_id: conn.id,
+            trigger_type: 'manual',
+            status: 'failed',
+            api_calls_made: apiCallsMade,
+            error_message: 'Consent expired — reconnect required',
+          });
+          continue;
+        }
+      }
+
+      const consentToken = decrypt(conn.consent_token);
+
+      const accountIds = conn.account_ids || [];
+      for (const accountId of accountIds) {
+        try {
+          const fromDate = ninetyDaysAgo.toISOString().split('T')[0];
+          const toDate = new Date().toISOString().split('T')[0];
+          const transactions = await getTransactions(accountId, consentToken, fromDate, toDate);
+          apiCallsMade++;
+
+          if (transactions.length === 0) continue;
+
+          const rows = transactions.map((tx) => ({
+            user_id: user.id,
+            connection_id: conn.id,
+            transaction_id: tx.id,
+            account_id: accountId,
+            amount: tx.transactionAmount.amount,
+            currency: tx.transactionAmount.currency || 'GBP',
+            description: tx.description || null,
+            merchant_name: tx.merchantName || null,
+            category: null,
+            timestamp: tx.bookingDateTime,
+          }));
+
+          const { error } = await supabase
+            .from('bank_transactions')
+            .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });
+
+          if (!error) totalSynced += rows.length;
+        } catch {
+          // Non-fatal per-account error — continue with next account
+        }
       }
     }
 

--- a/src/app/api/bank/sync-now/route.ts
+++ b/src/app/api/bank/sync-now/route.ts
@@ -190,9 +190,34 @@ export async function POST(request: NextRequest) {
         continue;
       }
 
-      // Get access token, refreshing if expired (uses user session via createClient internally)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const accessToken = await getTrueLayerAccessToken(conn as any);
+      // Get access token, refreshing if expired — mark connection expired if refresh fails
+      let accessToken: string;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        accessToken = await getTrueLayerAccessToken(conn as any);
+      } catch {
+        await supabase
+          .from('bank_connections')
+          .update({ status: 'expired', updated_at: now })
+          .eq('id', conn.id);
+
+        await supabase.from('bank_sync_log').insert({
+          user_id: user.id,
+          connection_id: conn.id,
+          trigger_type: 'manual',
+          status: 'failed',
+          api_calls_made: apiCallsMade,
+          error_message: 'Token refresh failed — reconnect required',
+        });
+
+        return NextResponse.json(
+          {
+            error: 'Your bank connection has expired. Please reconnect your bank account.',
+            reconnectRequired: true,
+          },
+          { status: 401 }
+        );
+      }
 
       const accountIds = conn.account_ids || [];
       for (const accountId of accountIds) {

--- a/src/app/api/cron/bank-sync/route.ts
+++ b/src/app/api/cron/bank-sync/route.ts
@@ -196,9 +196,39 @@ export async function GET(request: NextRequest) {
           continue;
         }
 
-        // Get access token, refreshing if expired
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const accessToken = await getAccessTokenWithClient(connection as any, supabase);
+        // Get access token, refreshing if expired — mark connection expired if refresh fails
+        let accessToken: string;
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          accessToken = await getAccessTokenWithClient(connection as any, supabase);
+        } catch (refreshErr: any) {
+          console.error(`Bank sync: token refresh failed for ${connection.id}:`, refreshErr.message);
+          await supabase
+            .from('bank_connections')
+            .update({ status: 'expired', updated_at: now })
+            .eq('id', connection.id);
+
+          await supabase.from('bank_sync_log').insert({
+            user_id: connection.user_id,
+            connection_id: connection.id,
+            trigger_type: 'cron',
+            status: 'failed',
+            api_calls_made: connectionApiCalls,
+            error_message: 'Token refresh failed — reconnect required',
+          });
+
+          results.push({
+            user_id: connection.user_id,
+            connection_id: connection.id,
+            tier,
+            transactions: 0,
+            recurring: 0,
+            api_calls: connectionApiCalls,
+            error: 'Token refresh failed',
+          });
+          totalApiCalls += connectionApiCalls;
+          continue;
+        }
 
         // Backfill bank name if missing
         if (!connection.bank_name) {

--- a/src/app/api/cron/bank-sync/route.ts
+++ b/src/app/api/cron/bank-sync/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getAccounts, getTransactions } from '@/lib/yapily';
+import {
+  getAccessTokenWithClient,
+  fetchAccounts as fetchTrueLayerAccounts,
+  fetchTransactions as fetchTrueLayerTransactions,
+} from '@/lib/truelayer';
 import { decrypt } from '@/lib/encrypt';
 import { detectRecurring } from '@/lib/detect-recurring';
 import {
@@ -17,8 +22,14 @@ interface BankConnection {
   id: string;
   user_id: string;
   provider: string;
+  // Yapily fields
   consent_token: string | null;
   consent_expires_at: string | null;
+  // TrueLayer fields
+  access_token: string | null;
+  refresh_token: string | null;
+  token_expires_at: string | null;
+  // Common
   account_ids: string[] | null;
   bank_name: string | null;
   status: string;
@@ -99,12 +110,12 @@ export async function GET(request: NextRequest) {
 
   const orderedUserIds = sortedProfiles.map((p) => p.id);
 
-  // Fetch active bank connections for these users (Yapily only)
+  // Fetch active bank connections for these users (TrueLayer + Yapily)
   const { data: connections, error: connError } = await supabase
     .from('bank_connections')
     .select('*')
     .eq('status', 'active')
-    .eq('provider', 'yapily')
+    .in('provider', ['truelayer', 'yapily'])
     .in('user_id', orderedUserIds.length > 0 ? orderedUserIds : ['00000000-0000-0000-0000-000000000000']);
 
   if (connError || !connections || connections.length === 0) {
@@ -152,41 +163,12 @@ export async function GET(request: NextRequest) {
     let connectionApiCalls = 0;
 
     try {
-      // Check consent token exists
-      if (!connection.consent_token) {
-        console.error(`Bank sync: no consent token for ${connection.id}`);
-        await supabase
-          .from('bank_connections')
-          .update({ status: 'expired', updated_at: now })
-          .eq('id', connection.id);
+      let totalSynced = 0;
 
-        await supabase.from('bank_sync_log').insert({
-          user_id: connection.user_id,
-          connection_id: connection.id,
-          trigger_type: 'cron',
-          status: 'failed',
-          api_calls_made: connectionApiCalls,
-          error_message: 'No consent token — reconnect required',
-        });
-
-        results.push({
-          user_id: connection.user_id,
-          connection_id: connection.id,
-          tier,
-          transactions: 0,
-          recurring: 0,
-          api_calls: connectionApiCalls,
-          error: 'No consent token',
-        });
-        totalApiCalls += connectionApiCalls;
-        continue;
-      }
-
-      // Check consent expiry (Yapily consents are valid for 90 days)
-      if (connection.consent_expires_at) {
-        const expiresAt = new Date(connection.consent_expires_at).getTime();
-        if (Date.now() >= expiresAt) {
-          console.error(`Bank sync: consent expired for ${connection.id}`);
+      if (connection.provider === 'truelayer') {
+        // === TrueLayer path ===
+        if (!connection.access_token) {
+          console.error(`Bank sync: no access token for TrueLayer connection ${connection.id}`);
           await supabase
             .from('bank_connections')
             .update({ status: 'expired', updated_at: now })
@@ -198,7 +180,7 @@ export async function GET(request: NextRequest) {
             trigger_type: 'cron',
             status: 'failed',
             api_calls_made: connectionApiCalls,
-            error_message: 'Consent expired — reconnect required',
+            error_message: 'No access token — reconnect required',
           });
 
           results.push({
@@ -208,69 +190,184 @@ export async function GET(request: NextRequest) {
             transactions: 0,
             recurring: 0,
             api_calls: connectionApiCalls,
-            error: 'Consent expired',
+            error: 'No access token',
           });
           totalApiCalls += connectionApiCalls;
           continue;
         }
-      }
 
-      // Decrypt consent token
-      const consentToken = decrypt(connection.consent_token);
+        // Get access token, refreshing if expired
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const accessToken = await getAccessTokenWithClient(connection as any, supabase);
 
-      // Backfill bank name if missing
-      if (!connection.bank_name) {
-        try {
-          const accounts = await getAccounts(consentToken);
-          connectionApiCalls++;
-          const bankName = accounts[0]?.institution?.name || null;
-          const displayNames = accounts.map((a) =>
-            a.accountNames?.[0]?.name || a.type || 'Account'
-          );
-          await supabase.from('bank_connections').update({
-            bank_name: bankName,
-            account_display_names: displayNames,
-            account_ids: accounts.map((a) => a.id),
-          }).eq('id', connection.id);
-        } catch {
-          // Non-fatal
+        // Backfill bank name if missing
+        if (!connection.bank_name) {
+          try {
+            const accounts = await fetchTrueLayerAccounts(accessToken);
+            connectionApiCalls++;
+            const bankName = accounts[0]?.provider?.display_name || accounts[0]?.display_name || null;
+            const displayNames = accounts.map((a) => a.display_name || 'Account');
+            await supabase.from('bank_connections').update({
+              bank_name: bankName,
+              account_display_names: displayNames,
+              account_ids: accounts.map((a) => a.account_id),
+            }).eq('id', connection.id);
+          } catch {
+            // Non-fatal
+          }
         }
-      }
 
-      // Sync transactions
-      const accountIds = connection.account_ids || [];
-      let totalSynced = 0;
+        // Sync transactions for each account
+        const accountIds = connection.account_ids || [];
+        for (const accountId of accountIds) {
+          try {
+            const transactions = await fetchTrueLayerTransactions(accessToken, accountId, ninetyDaysAgo);
+            connectionApiCalls++;
 
-      for (const accountId of accountIds) {
-        try {
-          const fromDate = ninetyDaysAgo.toISOString().split('T')[0];
-          const toDate = new Date().toISOString().split('T')[0];
-          const transactions = await getTransactions(accountId, consentToken, fromDate, toDate);
-          connectionApiCalls++;
+            if (transactions.length === 0) continue;
 
-          if (transactions.length === 0) continue;
+            const rows = transactions.map((tx) => ({
+              user_id: connection.user_id,
+              connection_id: connection.id,
+              transaction_id: tx.transaction_id,
+              account_id: accountId,
+              amount: tx.amount,
+              currency: tx.currency || 'GBP',
+              description: tx.description || null,
+              merchant_name: tx.merchant_name || null,
+              category: null,
+              timestamp: tx.timestamp,
+            }));
 
-          const rows = transactions.map((tx) => ({
+            const { error: upsertError } = await supabase
+              .from('bank_transactions')
+              .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });
+
+            if (!upsertError) totalSynced += rows.length;
+            else console.error(`Bank sync: upsert error for ${accountId}:`, upsertError);
+          } catch (err: any) {
+            console.error(`Bank sync: error on account ${accountId}:`, err.message);
+          }
+        }
+      } else {
+        // === Yapily path ===
+        if (!connection.consent_token) {
+          console.error(`Bank sync: no consent token for ${connection.id}`);
+          await supabase
+            .from('bank_connections')
+            .update({ status: 'expired', updated_at: now })
+            .eq('id', connection.id);
+
+          await supabase.from('bank_sync_log').insert({
             user_id: connection.user_id,
             connection_id: connection.id,
-            transaction_id: tx.id,
-            account_id: accountId,
-            amount: tx.transactionAmount.amount,
-            currency: tx.transactionAmount.currency || 'GBP',
-            description: tx.description || null,
-            merchant_name: tx.merchantName || null,
-            category: null,
-            timestamp: tx.bookingDateTime,
-          }));
+            trigger_type: 'cron',
+            status: 'failed',
+            api_calls_made: connectionApiCalls,
+            error_message: 'No consent token — reconnect required',
+          });
 
-          const { error: upsertError } = await supabase
-            .from('bank_transactions')
-            .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });
+          results.push({
+            user_id: connection.user_id,
+            connection_id: connection.id,
+            tier,
+            transactions: 0,
+            recurring: 0,
+            api_calls: connectionApiCalls,
+            error: 'No consent token',
+          });
+          totalApiCalls += connectionApiCalls;
+          continue;
+        }
 
-          if (!upsertError) totalSynced += rows.length;
-          else console.error(`Bank sync: upsert error for ${accountId}:`, upsertError);
-        } catch (err: any) {
-          console.error(`Bank sync: error on account ${accountId}:`, err.message);
+        // Check consent expiry (Yapily consents are valid for 90 days)
+        if (connection.consent_expires_at) {
+          const expiresAt = new Date(connection.consent_expires_at).getTime();
+          if (Date.now() >= expiresAt) {
+            console.error(`Bank sync: consent expired for ${connection.id}`);
+            await supabase
+              .from('bank_connections')
+              .update({ status: 'expired', updated_at: now })
+              .eq('id', connection.id);
+
+            await supabase.from('bank_sync_log').insert({
+              user_id: connection.user_id,
+              connection_id: connection.id,
+              trigger_type: 'cron',
+              status: 'failed',
+              api_calls_made: connectionApiCalls,
+              error_message: 'Consent expired — reconnect required',
+            });
+
+            results.push({
+              user_id: connection.user_id,
+              connection_id: connection.id,
+              tier,
+              transactions: 0,
+              recurring: 0,
+              api_calls: connectionApiCalls,
+              error: 'Consent expired',
+            });
+            totalApiCalls += connectionApiCalls;
+            continue;
+          }
+        }
+
+        // Decrypt consent token
+        const consentToken = decrypt(connection.consent_token);
+
+        // Backfill bank name if missing
+        if (!connection.bank_name) {
+          try {
+            const accounts = await getAccounts(consentToken);
+            connectionApiCalls++;
+            const bankName = accounts[0]?.institution?.name || null;
+            const displayNames = accounts.map((a) =>
+              a.accountNames?.[0]?.name || a.type || 'Account'
+            );
+            await supabase.from('bank_connections').update({
+              bank_name: bankName,
+              account_display_names: displayNames,
+              account_ids: accounts.map((a) => a.id),
+            }).eq('id', connection.id);
+          } catch {
+            // Non-fatal
+          }
+        }
+
+        // Sync transactions
+        const accountIds = connection.account_ids || [];
+        for (const accountId of accountIds) {
+          try {
+            const fromDate = ninetyDaysAgo.toISOString().split('T')[0];
+            const toDate = new Date().toISOString().split('T')[0];
+            const transactions = await getTransactions(accountId, consentToken, fromDate, toDate);
+            connectionApiCalls++;
+
+            if (transactions.length === 0) continue;
+
+            const rows = transactions.map((tx) => ({
+              user_id: connection.user_id,
+              connection_id: connection.id,
+              transaction_id: tx.id,
+              account_id: accountId,
+              amount: tx.transactionAmount.amount,
+              currency: tx.transactionAmount.currency || 'GBP',
+              description: tx.description || null,
+              merchant_name: tx.merchantName || null,
+              category: null,
+              timestamp: tx.bookingDateTime,
+            }));
+
+            const { error: upsertError } = await supabase
+              .from('bank_transactions')
+              .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });
+
+            if (!upsertError) totalSynced += rows.length;
+            else console.error(`Bank sync: upsert error for ${accountId}:`, upsertError);
+          } catch (err: any) {
+            console.error(`Bank sync: error on account ${accountId}:`, err.message);
+          }
         }
       }
 
@@ -302,8 +399,8 @@ export async function GET(request: NextRequest) {
       });
 
       console.log(
-        `Bank sync: conn=${connection.id} tier=${tier} txs=${totalSynced} ` +
-        `recurring=${recurringDetected} api_calls=${connectionApiCalls}`
+        `Bank sync: conn=${connection.id} provider=${connection.provider} tier=${tier} ` +
+        `txs=${totalSynced} recurring=${recurringDetected} api_calls=${connectionApiCalls}`
       );
     } catch (err: any) {
       console.error(`Bank sync: fatal error for ${connection.id}:`, err.message);

--- a/src/components/BankPickerModal.tsx
+++ b/src/components/BankPickerModal.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import { X, Search, Loader2, Building2 } from 'lucide-react';
 
+const OPEN_BANKING_PROVIDER = process.env.NEXT_PUBLIC_OPEN_BANKING_PROVIDER || 'truelayer';
+
 interface Institution {
   id: string;
   name: string;
@@ -23,6 +25,14 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
 
   useEffect(() => {
     if (!isOpen) return;
+
+    // TrueLayer has its own bank picker — redirect directly
+    if (OPEN_BANKING_PROVIDER === 'truelayer') {
+      window.location.href = '/api/auth/truelayer';
+      return;
+    }
+
+    // Yapily: load institution list
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -47,6 +57,23 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
 
   if (!isOpen) return null;
 
+  // TrueLayer: show a loading state while the redirect happens
+  if (OPEN_BANKING_PROVIDER === 'truelayer') {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+        <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-lg p-10 text-center shadow-2xl">
+          <Loader2 className="h-8 w-8 text-amber-500 animate-spin mx-auto mb-4" />
+          <p className="text-white font-semibold">Connecting to your bank...</p>
+          <p className="text-slate-400 text-sm mt-1">
+            You&apos;ll be redirected to TrueLayer to select your bank securely.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Yapily: institution picker
   const filtered = search
     ? institutions.filter(i => i.name.toLowerCase().includes(search.toLowerCase()))
     : institutions;
@@ -69,6 +96,8 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
       setConnecting(null);
     }
   };
+
+  const providerLabel = OPEN_BANKING_PROVIDER === 'truelayer' ? 'TrueLayer' : 'Yapily';
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -146,7 +175,7 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
         {/* Footer */}
         <div className="p-4 border-t border-navy-700/50 flex-shrink-0">
           <p className="text-xs text-slate-500 text-center">
-            FCA regulated via Yapily. Read-only access. We never store your bank credentials.
+            FCA regulated via {providerLabel}. Read-only access. We never store your bank credentials.
           </p>
         </div>
       </div>

--- a/src/lib/open-banking-config.ts
+++ b/src/lib/open-banking-config.ts
@@ -1,0 +1,3 @@
+export const OPEN_BANKING_PROVIDER = process.env.OPEN_BANKING_PROVIDER || 'truelayer';
+export const isTrueLayer = OPEN_BANKING_PROVIDER === 'truelayer';
+export const isYapily = OPEN_BANKING_PROVIDER === 'yapily';

--- a/src/lib/truelayer.ts
+++ b/src/lib/truelayer.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/server';
 import { encrypt, decrypt } from '@/lib/encrypt';
 
@@ -245,4 +246,72 @@ export async function fetchPendingTransactions(
     console.log(`Pending transactions fetch failed (non-fatal):`, err);
     return [];
   }
+}
+
+/**
+ * Refreshes a TrueLayer access token using a provided Supabase client.
+ * Use this in cron contexts where createClient() from next/headers is unavailable.
+ */
+export async function refreshTokenWithClient(
+  connection: BankConnection,
+  supabase: SupabaseClient
+): Promise<string> {
+  if (!connection.refresh_token) {
+    throw new Error('No refresh token available');
+  }
+
+  const res = await fetch(`${TRUELAYER_AUTH_URL}/connect/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: process.env.TRUELAYER_CLIENT_ID!,
+      client_secret: process.env.TRUELAYER_CLIENT_SECRET!,
+      refresh_token: decrypt(connection.refresh_token),
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Token refresh failed: ${res.status}`);
+  }
+
+  const data = await res.json();
+  const expiresAt = new Date(Date.now() + data.expires_in * 1000).toISOString();
+
+  await supabase
+    .from('bank_connections')
+    .update({
+      access_token: encrypt(data.access_token),
+      refresh_token: data.refresh_token
+        ? encrypt(data.refresh_token)
+        : encrypt(decrypt(connection.refresh_token)),
+      token_expires_at: expiresAt,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', connection.id);
+
+  return data.access_token;
+}
+
+/**
+ * Returns a valid TrueLayer access token, refreshing if expired.
+ * Use this in cron contexts where createClient() from next/headers is unavailable.
+ */
+export async function getAccessTokenWithClient(
+  connection: BankConnection,
+  supabase: SupabaseClient
+): Promise<string> {
+  if (!connection.access_token) {
+    throw new Error('No access token for connection');
+  }
+
+  if (connection.token_expires_at) {
+    const expiresAt = new Date(connection.token_expires_at).getTime();
+    const now = Date.now() + 60_000; // 60s buffer
+    if (now >= expiresAt) {
+      return refreshTokenWithClient(connection, supabase);
+    }
+  }
+
+  return decrypt(connection.access_token);
 }


### PR DESCRIPTION
## Summary

- Adds `OPEN_BANKING_PROVIDER` env var (`truelayer` | `yapily`, defaults to `truelayer`)
- `BankPickerModal` now redirects directly to `/api/auth/truelayer` when TrueLayer is active (no institution picker — TrueLayer has its own)
- Bank-sync cron and manual sync-now route handle both providers, branching on `connection.provider`
- Added `getAccessTokenWithClient` + `refreshTokenWithClient` to `truelayer.ts` for cron context (no user session available)
- Yapily code fully preserved — flip `OPEN_BANKING_PROVIDER=yapily` to switch back when live account is ready
- Trust signal in BankPickerModal footer now shows correct provider name

## Env vars to set in Vercel

```
OPEN_BANKING_PROVIDER=truelayer
NEXT_PUBLIC_OPEN_BANKING_PROVIDER=truelayer
```

(TrueLayer credentials already in Vercel from original integration)

## Test plan

- [ ] Connect a bank — should redirect to TrueLayer auth flow, not show institution picker
- [ ] Complete TrueLayer OAuth — callback stores tokens, syncs accounts/transactions
- [ ] Check bank-sync cron picks up TrueLayer connections alongside any Yapily ones
- [ ] Manual sync-now works for TrueLayer connections (Pro users)
- [ ] Set `OPEN_BANKING_PROVIDER=yapily` — BankPickerModal shows institution list as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)