### PR TITLE
GDPR/PECR: Add cookie consent banner and gate all tracking

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import CookieSettingsButton from '@/components/CookieSettingsButton';
 
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -37,7 +38,9 @@ export default function MarketingLayout({ children }: { children: React.ReactNod
               <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
               <Link href="/about" className="hover:text-white transition-all">About</Link>
               <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy</Link>
+              <Link href="/cookie-policy" className="hover:text-white transition-all">Cookies</Link>
               <Link href="/legal/terms" className="hover:text-white transition-all">Terms</Link>
+              <CookieSettingsButton />
             </div>
           </div>
         </footer>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import CookieSettingsButton from '@/components/CookieSettingsButton';
+
+export const metadata: Metadata = {
+  title: 'Cookie Policy',
+  description: 'How Paybacker uses cookies and similar technologies.',
+};
+
+export default function CookiePolicyPage() {
+  return (
+    <div className="min-h-screen bg-navy-950 text-slate-300">
+      <div className="container mx-auto px-6 py-16 max-w-3xl">
+        <Link href="/" className="text-mint-400 text-sm hover:underline">&larr; Back to home</Link>
+        <h1 className="text-3xl font-bold text-white mt-6 mb-8">Cookie Policy</h1>
+        <p className="text-sm text-slate-400 mb-8">Last updated: 4 April 2026</p>
+
+        <div className="space-y-8 text-sm leading-relaxed">
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">What are cookies?</h2>
+            <p>
+              Cookies are small text files stored on your device when you visit a website.
+              They help the site remember your preferences and understand how you use it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">How we use cookies</h2>
+            <p className="mb-4">Paybacker uses cookies and similar technologies in the following categories:</p>
+
+            <h3 className="text-lg font-medium text-white mt-4 mb-2">Essential cookies</h3>
+            <p className="mb-2">Required for the site to function. Cannot be disabled.</p>
+            <ul className="list-disc list-inside space-y-1 text-slate-400">
+              <li><strong className="text-slate-300">Supabase auth cookies</strong> — maintain your login session</li>
+              <li><strong className="text-slate-300">pb_consent</strong> — stores your cookie consent preferences</li>
+            </ul>
+
+            <h3 className="text-lg font-medium text-white mt-4 mb-2">Analytics cookies</h3>
+            <p className="mb-2">Help us understand how visitors use Paybacker. Only set with your consent.</p>
+            <ul className="list-disc list-inside space-y-1 text-slate-400">
+              <li><strong className="text-slate-300">Google Analytics (GA4)</strong> — page views, user journeys, performance metrics. ID: G-GRL9XKYTN1</li>
+              <li><strong className="text-slate-300">PostHog</strong> — product analytics sent via our server (no client-side cookies set)</li>
+            </ul>
+
+            <h3 className="text-lg font-medium text-white mt-4 mb-2">Marketing cookies</h3>
+            <p className="mb-2">Used for advertising and affiliate tracking. Only set with your consent.</p>
+            <ul className="list-disc list-inside space-y-1 text-slate-400">
+              <li><strong className="text-slate-300">Meta Pixel</strong> — measures ad effectiveness and enables retargeting. Pixel ID: 722806327584909</li>
+              <li><strong className="text-slate-300">Meta Conversions API</strong> — server-side event tracking for ad optimisation</li>
+              <li><strong className="text-slate-300">Awin</strong> — affiliate tracking for partner deals</li>
+            </ul>
+
+            <h3 className="text-lg font-medium text-white mt-4 mb-2">Functional cookies</h3>
+            <p className="mb-2">Enable enhanced features. Only set with your consent.</p>
+            <ul className="list-disc list-inside space-y-1 text-slate-400">
+              <li><strong className="text-slate-300">Chat preferences</strong> — remembers your chatbot interaction state</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">Managing your preferences</h2>
+            <p className="mb-3">
+              You can change your cookie preferences at any time using the Cookie Settings button
+              in the website footer, or by clicking below:
+            </p>
+            <CookieSettingsButton />
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">Third-party cookies</h2>
+            <p>
+              Some cookies are set by third-party services that appear on our pages (Google, Meta, Awin).
+              We do not control these cookies. Please refer to the respective privacy policies of
+              these providers for more information.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">Your rights</h2>
+            <p>
+              Under UK GDPR and PECR, you have the right to refuse non-essential cookies.
+              Essential cookies that are strictly necessary for the site to function cannot be
+              disabled as they are required to provide the service you have requested.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-white mb-3">Contact</h2>
+            <p>
+              If you have questions about our use of cookies, contact us at{' '}
+              <a href="mailto:hello@paybacker.co.uk" className="text-mint-400 hover:underline">hello@paybacker.co.uk</a>.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono, Plus_Jakarta_Sans, Inter } from "next/font/google";
 import "./globals.css";
 import PostHogProvider from "@/components/PostHogProvider";
 import ChatWidget from "@/components/ChatWidget";
+import CookieConsentBanner from "@/components/CookieConsentBanner";
+import TrackingScripts from "@/components/TrackingScripts";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -99,35 +101,6 @@ export default function RootLayout({
         {/* Preconnect to critical external domains for faster loading */}
         <link rel="preconnect" href="https://kcxxlesishltdmfctlmo.supabase.co" />
         <link rel="dns-prefetch" href="https://kcxxlesishltdmfctlmo.supabase.co" />
-        <link rel="preconnect" href="https://www.googletagmanager.com" />
-        <link rel="dns-prefetch" href="https://connect.facebook.net" />
-
-        {/* Awin Advertiser Mastertag. Set NEXT_PUBLIC_AWIN_ADVERTISER_ID in Vercel to activate. */}
-        {process.env.NEXT_PUBLIC_AWIN_ADVERTISER_ID && (
-          <script async src={`https://www.dwin1.com/${process.env.NEXT_PUBLIC_AWIN_ADVERTISER_ID}.js`} type="text/javascript" />
-        )}
-        {/* Meta Pixel */}
-        <script dangerouslySetInnerHTML={{ __html: `
-          !function(f,b,e,v,n,t,s)
-          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-          n.queue=[];t=b.createElement(e);t.async=!0;
-          t.src=v;s=b.getElementsByTagName(e)[0];
-          s.parentNode.insertBefore(t,s)}(window, document,'script',
-          'https://connect.facebook.net/en_US/fbevents.js');
-          fbq('init', '722806327584909');
-          fbq('track', 'PageView');
-        `}} />
-        <noscript><img height="1" width="1" style={{display:'none'}} src="https://www.facebook.com/tr?id=722806327584909&ev=PageView&noscript=1" /></noscript>
-        {/* Google Analytics GA4 */}
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-GRL9XKYTN1" />
-        <script dangerouslySetInnerHTML={{ __html: `
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', 'G-GRL9XKYTN1');
-        `}} />
       </head>
       <body className="min-h-full flex flex-col">
         <script
@@ -154,6 +127,8 @@ export default function RootLayout({
           {children}
           <ChatWidget />
         </PostHogProvider>
+        <TrackingScripts />
+        <CookieConsentBanner />
       </body>
     </html>
   );

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import {
+  getConsent,
+  setConsent,
+  hasConsentBeenGiven,
+  acceptAll,
+  rejectAll,
+  type ConsentPreferences,
+} from '@/lib/consent';
+
+export default function CookieConsentBanner() {
+  const [visible, setVisible] = useState(false);
+  const [showPreferences, setShowPreferences] = useState(false);
+  const [prefs, setPrefs] = useState({ analytics: false, marketing: false, functional: false });
+
+  useEffect(() => {
+    if (!hasConsentBeenGiven()) {
+      setVisible(true);
+    }
+  }, []);
+
+  // Listen for "open cookie settings" events from footer link
+  useEffect(() => {
+    function handleOpen() {
+      const existing = getConsent();
+      if (existing) setPrefs({ analytics: existing.analytics, marketing: existing.marketing, functional: existing.functional });
+      setShowPreferences(true);
+      setVisible(true);
+    }
+    window.addEventListener('open-cookie-settings', handleOpen);
+    return () => window.removeEventListener('open-cookie-settings', handleOpen);
+  }, []);
+
+  function handleAcceptAll() {
+    acceptAll();
+    setVisible(false);
+    window.dispatchEvent(new Event('consent-updated'));
+  }
+
+  function handleRejectAll() {
+    rejectAll();
+    setVisible(false);
+    window.dispatchEvent(new Event('consent-updated'));
+  }
+
+  function handleSavePreferences() {
+    setConsent(prefs);
+    setVisible(false);
+    setShowPreferences(false);
+    window.dispatchEvent(new Event('consent-updated'));
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-0 inset-x-0 z-[9999] p-4">
+      <div className="max-w-2xl mx-auto bg-navy-900 border border-navy-700 rounded-2xl shadow-2xl p-6">
+        {!showPreferences ? (
+          <>
+            <p className="text-sm text-slate-300 mb-4">
+              We use cookies to improve your experience and analyse how our site is used.
+              You can accept all cookies, reject non-essential ones, or manage your preferences.
+              See our <Link href="/cookie-policy" className="text-mint-400 underline hover:text-mint-300">Cookie Policy</Link> for details.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <button
+                onClick={handleAcceptAll}
+                className="bg-mint-400 hover:bg-mint-500 text-navy-950 text-sm font-semibold px-5 py-2.5 rounded-xl transition-all"
+              >
+                Accept All
+              </button>
+              <button
+                onClick={handleRejectAll}
+                className="bg-navy-800 hover:bg-navy-700 text-slate-300 text-sm font-medium px-5 py-2.5 rounded-xl border border-navy-600 transition-all"
+              >
+                Reject All
+              </button>
+              <button
+                onClick={() => setShowPreferences(true)}
+                className="text-slate-400 hover:text-white text-sm font-medium px-5 py-2.5 transition-all"
+              >
+                Manage Preferences
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h3 className="text-white font-semibold mb-4">Cookie Preferences</h3>
+            <div className="space-y-3 mb-5">
+              <label className="flex items-center justify-between p-3 bg-navy-800 rounded-xl">
+                <div>
+                  <span className="text-sm text-white font-medium">Essential</span>
+                  <p className="text-xs text-slate-400 mt-0.5">Required for login and basic functionality. Cannot be disabled.</p>
+                </div>
+                <input type="checkbox" checked disabled className="accent-mint-400 w-4 h-4" />
+              </label>
+              <label className="flex items-center justify-between p-3 bg-navy-800 rounded-xl cursor-pointer">
+                <div>
+                  <span className="text-sm text-white font-medium">Analytics</span>
+                  <p className="text-xs text-slate-400 mt-0.5">Help us understand how you use Paybacker (PostHog, Google Analytics).</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={prefs.analytics}
+                  onChange={(e) => setPrefs(p => ({ ...p, analytics: e.target.checked }))}
+                  className="accent-mint-400 w-4 h-4"
+                />
+              </label>
+              <label className="flex items-center justify-between p-3 bg-navy-800 rounded-xl cursor-pointer">
+                <div>
+                  <span className="text-sm text-white font-medium">Marketing</span>
+                  <p className="text-xs text-slate-400 mt-0.5">Used for ads and referral tracking (Meta Pixel, Awin).</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={prefs.marketing}
+                  onChange={(e) => setPrefs(p => ({ ...p, marketing: e.target.checked }))}
+                  className="accent-mint-400 w-4 h-4"
+                />
+              </label>
+              <label className="flex items-center justify-between p-3 bg-navy-800 rounded-xl cursor-pointer">
+                <div>
+                  <span className="text-sm text-white font-medium">Functional</span>
+                  <p className="text-xs text-slate-400 mt-0.5">Enhanced features like chat and personalisation.</p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={prefs.functional}
+                  onChange={(e) => setPrefs(p => ({ ...p, functional: e.target.checked }))}
+                  className="accent-mint-400 w-4 h-4"
+                />
+              </label>
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={handleSavePreferences}
+                className="bg-mint-400 hover:bg-mint-500 text-navy-950 text-sm font-semibold px-5 py-2.5 rounded-xl transition-all"
+              >
+                Save Preferences
+              </button>
+              <button
+                onClick={handleAcceptAll}
+                className="bg-navy-800 hover:bg-navy-700 text-slate-300 text-sm font-medium px-5 py-2.5 rounded-xl border border-navy-600 transition-all"
+              >
+                Accept All
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CookieSettingsButton.tsx
+++ b/src/components/CookieSettingsButton.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export default function CookieSettingsButton() {
+  return (
+    <button
+      onClick={() => window.dispatchEvent(new Event('open-cookie-settings'))}
+      className="hover:text-white transition-all"
+    >
+      Cookie Settings
+    </button>
+  );
+}

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -3,9 +3,12 @@
 import { useEffect, Suspense, useCallback } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
+import { hasConsent } from '@/lib/consent';
 
-// Server-side tracking — guaranteed to work, no ad blockers
+// Server-side tracking — gated behind analytics consent
 function trackEvent(event: string, properties?: Record<string, unknown>) {
+  if (typeof window !== 'undefined' && !hasConsent('analytics')) return;
+
   const distinctId = typeof window !== 'undefined'
     ? localStorage.getItem('pb_distinct_id') || crypto.randomUUID()
     : 'server';

--- a/src/components/TrackingScripts.tsx
+++ b/src/components/TrackingScripts.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Script from 'next/script';
+import { hasConsent } from '@/lib/consent';
+
+export default function TrackingScripts() {
+  const [analyticsAllowed, setAnalyticsAllowed] = useState(false);
+  const [marketingAllowed, setMarketingAllowed] = useState(false);
+
+  function checkConsent() {
+    setAnalyticsAllowed(hasConsent('analytics'));
+    setMarketingAllowed(hasConsent('marketing'));
+  }
+
+  useEffect(() => {
+    checkConsent();
+    window.addEventListener('consent-updated', checkConsent);
+    return () => window.removeEventListener('consent-updated', checkConsent);
+  }, []);
+
+  return (
+    <>
+      {/* Google Analytics GA4 — analytics category */}
+      {analyticsAllowed && (
+        <>
+          <Script
+            src="https://www.googletagmanager.com/gtag/js?id=G-GRL9XKYTN1"
+            strategy="afterInteractive"
+          />
+          <Script id="ga4-init" strategy="afterInteractive">
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-GRL9XKYTN1');
+            `}
+          </Script>
+        </>
+      )}
+
+      {/* Meta Pixel — marketing category */}
+      {marketingAllowed && (
+        <>
+          <Script id="meta-pixel" strategy="afterInteractive">
+            {`
+              !function(f,b,e,v,n,t,s)
+              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+              'https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '722806327584909');
+              fbq('track', 'PageView');
+            `}
+          </Script>
+        </>
+      )}
+
+      {/* Awin — marketing category */}
+      {marketingAllowed && process.env.NEXT_PUBLIC_AWIN_ADVERTISER_ID && (
+        <Script
+          src={`https://www.dwin1.com/${process.env.NEXT_PUBLIC_AWIN_ADVERTISER_ID}.js`}
+          strategy="afterInteractive"
+        />
+      )}
+    </>
+  );
+}

--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -1,0 +1,44 @@
+export type ConsentCategory = 'analytics' | 'marketing' | 'functional';
+
+export interface ConsentPreferences {
+  analytics: boolean;
+  marketing: boolean;
+  functional: boolean;
+  timestamp: string;
+}
+
+const COOKIE_NAME = 'pb_consent';
+const COOKIE_MAX_AGE = 365 * 24 * 60 * 60; // 1 year
+
+export function getConsent(): ConsentPreferences | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(new RegExp(`(?:^|; )${COOKIE_NAME}=([^;]*)`));
+  if (!match) return null;
+  try {
+    return JSON.parse(decodeURIComponent(match[1]));
+  } catch {
+    return null;
+  }
+}
+
+export function setConsent(prefs: Omit<ConsentPreferences, 'timestamp'>): void {
+  const value: ConsentPreferences = { ...prefs, timestamp: new Date().toISOString() };
+  document.cookie = `${COOKIE_NAME}=${encodeURIComponent(JSON.stringify(value))};path=/;max-age=${COOKIE_MAX_AGE};SameSite=Lax`;
+}
+
+export function hasConsentBeenGiven(): boolean {
+  return getConsent() !== null;
+}
+
+export function hasConsent(category: ConsentCategory): boolean {
+  const prefs = getConsent();
+  return prefs?.[category] === true;
+}
+
+export function acceptAll(): void {
+  setConsent({ analytics: true, marketing: true, functional: true });
+}
+
+export function rejectAll(): void {
+  setConsent({ analytics: false, marketing: false, functional: false });
+}

--- a/src/lib/meta-conversions.ts
+++ b/src/lib/meta-conversions.ts
@@ -7,8 +7,22 @@
  * the same event_id so Meta counts it once.
  */
 
+import { cookies } from 'next/headers';
+
 const PIXEL_ID = '722806327584909';
 const API_VERSION = 'v25.0';
+
+function hasMarketingConsent(): boolean {
+  try {
+    const cookieStore = cookies();
+    const consentCookie = (cookieStore as any).get?.('pb_consent');
+    if (!consentCookie?.value) return false;
+    const prefs = JSON.parse(decodeURIComponent(consentCookie.value));
+    return prefs.marketing === true;
+  } catch {
+    return false;
+  }
+}
 
 interface MetaEvent {
   event_name: string;
@@ -55,6 +69,8 @@ export async function sendMetaEvent(params: {
   url?: string;
   customData?: Record<string, any>;
 }): Promise<{ ok: boolean; error?: string }> {
+  if (!hasMarketingConsent()) return { ok: false, error: 'No marketing consent' };
+
   const accessToken = process.env.META_ACCESS_TOKEN;
   if (!accessToken) return { ok: false, error: 'META_ACCESS_TOKEN not set' };
 

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -1,8 +1,11 @@
 // Server-side PostHog tracking via /api/analytics
 // This bypasses all ad blockers since events go through our own API
 
+import { hasConsent } from '@/lib/consent';
+
 export function capture(event: string, properties?: Record<string, unknown>) {
   if (typeof window === 'undefined') return;
+  if (!hasConsent('analytics')) return;
 
   const distinctId = localStorage.getItem('pb_distinct_id') || 'anonymous';
 


### PR DESCRIPTION
## Summary
- Adds a cookie consent banner compliant with UK PECR and GDPR
- All non-essential tracking scripts (GA4, Meta Pixel, Awin, PostHog, Meta CAPI) now require explicit user consent before loading
- Granular consent categories: Essential (always), Analytics, Marketing, Functional

## What changed
- **New**: `src/lib/consent.ts` — consent cookie read/write utility
- **New**: `src/components/CookieConsentBanner.tsx` — Accept All / Reject All / Manage Preferences UI
- **New**: `src/components/TrackingScripts.tsx` — consent-gated script loader (replaces inline scripts)
- **New**: `src/components/CookieSettingsButton.tsx` — footer button to reopen preferences
- **New**: `src/app/cookie-policy/page.tsx` — full cookie disclosure page
- **Modified**: `src/app/layout.tsx` — removed unconditional inline tracking scripts
- **Modified**: `src/components/PostHogProvider.tsx` — analytics consent check
- **Modified**: `src/lib/posthog.ts` — analytics consent check
- **Modified**: `src/lib/meta-conversions.ts` — marketing consent check (server-side)
- **Modified**: `src/app/(marketing)/layout.tsx` — Cookie Settings link + Cookies link in footer

## Test plan
- [ ] Visit site for first time — banner appears at bottom
- [ ] Click Reject All — no GA4/Meta/Awin scripts load (check Network tab)
- [ ] Click Accept All — all scripts load
- [ ] Manage Preferences — toggle individual categories
- [ ] Refresh page — banner does not reappear (consent stored in `pb_consent` cookie)
- [ ] Click Cookie Settings in footer — banner reopens with current preferences
- [ ] Visit /cookie-policy — page renders correctly
- [ ] PostHog events do not fire without analytics consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)