### PR TITLE
Wire subscription RPCs and bank-sync post-processing

### DIFF
--- a/src/app/api/subscriptions/[id]/route.ts
+++ b/src/app/api/subscriptions/[id]/route.ts
@@ -145,6 +145,12 @@ export async function PATCH(
       }
     }
 
+    // If status changed to cancelled, return updated totals
+    if (body.status === 'cancelled') {
+      const { data: totals } = await supabase.rpc('get_subscription_total', { p_user_id: user.id });
+      return NextResponse.json({ ...data, subscription_totals: totals });
+    }
+
     return NextResponse.json(data);
   } catch (error: any) {
     console.error('Error updating subscription:', error);
@@ -174,16 +180,15 @@ export async function DELETE(
 
     const { id } = await params;
 
-    // Soft delete — mark as dismissed so it won't be re-created by sync
-    const { error } = await supabase
-      .from('subscriptions')
-      .update({ dismissed_at: new Date().toISOString(), status: 'dismissed' })
-      .eq('id', id)
-      .eq('user_id', user.id);
+    // Use RPC for dismiss — returns updated subscription totals
+    const { data: totals, error } = await supabase.rpc('dismiss_subscription', {
+      p_user_id: user.id,
+      p_subscription_id: id,
+    });
 
     if (error) throw error;
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, ...totals });
   } catch (error: any) {
     console.error('Error deleting subscription:', error);
     return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
## Summary
- Subscription DELETE endpoint now uses `dismiss_subscription` RPC — returns updated totals
- Subscription PATCH endpoint returns `subscription_totals` when cancelling
- Bank-sync edge function v2 deployed: runs post-sync enrichment for every user

## Bank-sync post-sync enrichment
After upserting transactions, the edge function now calls:
1. `fix_ee_card_merchant_names(user_id)` — fixes EE-branded card merchants
2. `auto_categorise_transactions(user_id)` — categorises using merchant_rules
3. `detect_and_sync_recurring_transactions(user_id)` — flags recurring and auto-creates subscriptions

## Test plan
- [ ] Dismiss a subscription — verify response includes `monthly_total`, `annual_total`, `active_count`
- [ ] Cancel a subscription — verify response includes `subscription_totals`
- [ ] Trigger a bank sync — verify post-sync functions execute (check edge function logs)
- [ ] Verify existing subscription PATCH operations (rename, recategorise) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)