### PR TITLE
GDPR: Add data export API for right to data portability

### DIFF
--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+
+async function safeSelect(
+  admin: ReturnType<typeof createAdminClient>,
+  table: string,
+  column: string,
+  value: string,
+): Promise<any[]> {
+  try {
+    const { data, error } = await admin.from(table).select('*').eq(column, value);
+    if (error) {
+      console.error(`GDPR export: failed on ${table}:`, error.message);
+      return [];
+    }
+    return data || [];
+  } catch {
+    return [];
+  }
+}
+
+export async function POST() {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const admin = createAdminClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    const userId = user.id;
+
+    // Fetch all user data in parallel, mirroring the tables from account/delete
+    const [
+      profile,
+      bankTransactions,
+      bankConnections,
+      subscriptions,
+      disputes,
+      correspondence,
+      contractExtractions,
+      budgets,
+      assets,
+      liabilities,
+      savingsGoals,
+      categoryOverrides,
+      alerts,
+      challenges,
+      points,
+      referrals,
+      supportTickets,
+      ticketMessages,
+      chatbotLog,
+      npsResponses,
+      tasks,
+      detectedIssues,
+      priceAlerts,
+      subscriptionComparisons,
+      verifiedSavings,
+    ] = await Promise.all([
+      safeSelect(admin, 'profiles', 'id', userId),
+      safeSelect(admin, 'bank_transactions', 'user_id', userId),
+      safeSelect(admin, 'bank_connections', 'user_id', userId),
+      safeSelect(admin, 'subscriptions', 'user_id', userId),
+      safeSelect(admin, 'disputes', 'user_id', userId),
+      safeSelect(admin, 'correspondence', 'user_id', userId),
+      safeSelect(admin, 'contract_extractions', 'user_id', userId),
+      safeSelect(admin, 'money_hub_budgets', 'user_id', userId),
+      safeSelect(admin, 'money_hub_assets', 'user_id', userId),
+      safeSelect(admin, 'money_hub_liabilities', 'user_id', userId),
+      safeSelect(admin, 'money_hub_savings_goals', 'user_id', userId),
+      safeSelect(admin, 'money_hub_category_overrides', 'user_id', userId),
+      safeSelect(admin, 'money_hub_alerts', 'user_id', userId),
+      safeSelect(admin, 'user_challenges', 'user_id', userId),
+      safeSelect(admin, 'user_points', 'user_id', userId),
+      safeSelect(admin, 'referrals', 'user_id', userId),
+      safeSelect(admin, 'support_tickets', 'user_id', userId),
+      safeSelect(admin, 'ticket_messages', 'user_id', userId),
+      safeSelect(admin, 'chatbot_question_log', 'user_id', userId),
+      safeSelect(admin, 'nps_responses', 'user_id', userId),
+      safeSelect(admin, 'tasks', 'user_id', userId),
+      safeSelect(admin, 'detected_issues', 'user_id', userId),
+      safeSelect(admin, 'price_increase_alerts', 'user_id', userId),
+      safeSelect(admin, 'subscription_comparisons', 'user_id', userId),
+      safeSelect(admin, 'verified_savings', 'user_id', userId),
+    ]);
+
+    // Strip sensitive fields from bank connections (tokens, secrets)
+    const sanitisedConnections = bankConnections.map(({ access_token, refresh_token, token_expires_at, ...rest }) => rest);
+
+    const exportData = {
+      exported_at: new Date().toISOString(),
+      user_id: userId,
+      email: user.email,
+      profile: profile[0] || null,
+      bank_transactions: bankTransactions,
+      bank_connections: sanitisedConnections,
+      subscriptions,
+      disputes,
+      correspondence,
+      contract_extractions: contractExtractions,
+      money_hub: {
+        budgets,
+        assets,
+        liabilities,
+        savings_goals: savingsGoals,
+        category_overrides: categoryOverrides,
+        alerts,
+      },
+      engagement: {
+        challenges,
+        points,
+        referrals,
+      },
+      support: {
+        tickets: supportTickets,
+        messages: ticketMessages,
+      },
+      chatbot_history: chatbotLog,
+      nps_responses: npsResponses,
+      tasks,
+      detected_issues: detectedIssues,
+      price_increase_alerts: priceAlerts,
+      subscription_comparisons: subscriptionComparisons,
+      verified_savings: verifiedSavings,
+    };
+
+    return new NextResponse(JSON.stringify(exportData, null, 2), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="paybacker-data-export-${new Date().toISOString().split('T')[0]}.json"`,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error('GDPR data export failed:', message);
+    return NextResponse.json(
+      { error: 'Data export failed', detail: message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -3,7 +3,7 @@ import { createClient } from '@/lib/supabase/server';
 import { createClient as createAdminClient } from '@supabase/supabase-js';
 
 async function safeSelect(
-  admin: ReturnType<typeof createAdminClient>,
+  admin: any,
   table: string,
   column: string,
   value: string,

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
-import { User, Mail, CreditCard, TrendingUp, Clock, CheckCircle2, AlertCircle, Trash2, Pencil, Save, MapPin, FileText, Loader2, Sparkles } from 'lucide-react';
+import { User, Mail, CreditCard, TrendingUp, Clock, CheckCircle2, AlertCircle, Trash2, Pencil, Save, MapPin, FileText, Loader2, Sparkles, Download } from 'lucide-react';
 import Link from 'next/link';
 import { formatGBP } from '@/lib/format';
 import FinancialReport from '@/components/reports/FinancialReport';
@@ -189,6 +189,7 @@ export default function ProfilePage() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
   const [portalError, setPortalError] = useState<string | null>(null);
@@ -349,6 +350,27 @@ export default function ProfilePage() {
     } catch {
       setPortalError('Failed to open billing portal. Please try again or contact support at support@paybacker.co.uk');
       setPortalLoading(false);
+    }
+  };
+
+  const handleExportData = async () => {
+    setExporting(true);
+    try {
+      const res = await fetch('/api/account/export', { method: 'POST' });
+      if (!res.ok) throw new Error('Export failed');
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `paybacker-data-export-${new Date().toISOString().split('T')[0]}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      alert('Failed to export data. Please contact support@paybacker.co.uk');
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -935,6 +957,25 @@ export default function ProfilePage() {
           </Link>
         )}
       </div>
+      {/* Data Export — GDPR Right to Portability */}
+      <div className="bg-navy-900 backdrop-blur-sm border border-navy-700 rounded-2xl p-8 mt-6">
+        <h2 className="text-xl font-bold text-white mb-2 flex items-center gap-2">
+          <Download className="h-5 w-5 text-mint-400" />
+          Download My Data
+        </h2>
+        <p className="text-slate-400 text-sm mb-6">
+          Download a copy of all your Paybacker data in JSON format — profile, transactions,
+          subscriptions, disputes, and more. This is your right under GDPR Article 20.
+        </p>
+        <button
+          onClick={handleExportData}
+          disabled={exporting}
+          className="bg-mint-400/10 hover:bg-mint-400/20 border border-mint-400/30 text-mint-400 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm disabled:opacity-50 inline-flex items-center gap-2"
+        >
+          {exporting ? <><Loader2 className="h-4 w-4 animate-spin" /> Preparing export...</> : <><Download className="h-4 w-4" /> Download my data</>}
+        </button>
+      </div>
+
       {/* Danger Zone — Delete Account */}
       <div className="bg-navy-900 backdrop-blur-sm border border-red-900/50 rounded-2xl p-8 mt-6">
         <h2 className="text-xl font-bold text-white mb-2 flex items-center gap-2">

--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -330,7 +330,7 @@ export default function SubscriptionsPage() {
     const supabase = createClient();
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!user) return;
-      supabase.from('profiles').select('subscription_tier').eq('id', user.id).single()
+      supabase.from('profiles').select('subscription_tier, bank_prompt_dismissed_at').eq('id', user.id).single()
         .then(({ data }) => {
           if (data?.subscription_tier) setUserTier(data.subscription_tier);
           setTierLoaded(true);


### PR DESCRIPTION
## Summary
- New `POST /api/account/export` endpoint returns all user data as downloadable JSON
- Profile page gets a "Download My Data" section above the Delete Account section
- Covers 25 tables mirroring the account deletion scope (GDPR Article 20 compliance)

## What's exported
Profile, bank transactions, bank connections (tokens stripped), subscriptions, disputes, correspondence, contracts, budgets, assets, liabilities, savings goals, category overrides, alerts, challenges, points, referrals, support tickets, chatbot history, NPS responses, tasks, detected issues, price alerts, comparisons, verified savings.

## Test plan
- [ ] Click "Download my data" on profile page — JSON file downloads
- [ ] Verify JSON contains all expected sections
- [ ] Verify bank connection tokens are NOT included in export
- [ ] Verify unauthenticated POST to /api/account/export returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)