### PR TITLE
fix: distinguish loans/mortgages from subscriptions in renewal reminder emails

### DIFF
--- a/src/app/api/cron/renewal-reminders/route.ts
+++ b/src/app/api/cron/renewal-reminders/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
 
     const { data: renewingSubs } = await supabase
       .from('subscriptions')
-      .select('user_id, provider_name, amount, category, next_billing_date, billing_cycle')
+      .select('user_id, provider_name, amount, category, next_billing_date, billing_cycle, contract_type, provider_type')
       .is('dismissed_at', null)
       .eq('status', 'active')
       .not('next_billing_date', 'is', null)
@@ -94,6 +94,8 @@ export async function GET(request: NextRequest) {
           category: s.category,
           next_billing_date: s.next_billing_date,
           billing_cycle: s.billing_cycle,
+          contract_type: s.contract_type,
+          provider_type: s.provider_type,
         })),
         days
       );

--- a/src/lib/email/renewal-reminders.ts
+++ b/src/lib/email/renewal-reminders.ts
@@ -18,9 +18,9 @@ const PAYMENT_PROVIDER_TYPES = new Set(['loan', 'mortgage', 'credit_card']);
 const PAYMENT_CATEGORIES = new Set(['loan', 'mortgage', 'credit_card', 'finance', 'debt']);
 
 function isScheduledPayment(sub: RenewalSubscription): boolean {
-  if (sub.contract_type && PAYMENT_CONTRACT_TYPES.has(sub.contract_type)) return true;
-  if (sub.provider_type && PAYMENT_PROVIDER_TYPES.has(sub.provider_type)) return true;
-  if (sub.category && PAYMENT_CATEGORIES.has(sub.category)) return true;
+  if (sub.contract_type && PAYMENT_CONTRACT_TYPES.has(sub.contract_type.toLowerCase())) return true;
+  if (sub.provider_type && PAYMENT_PROVIDER_TYPES.has(sub.provider_type.toLowerCase())) return true;
+  if (sub.category && PAYMENT_CATEGORIES.has(sub.category.toLowerCase())) return true;
   return false;
 }
 

--- a/src/lib/email/renewal-reminders.ts
+++ b/src/lib/email/renewal-reminders.ts
@@ -6,10 +6,28 @@ interface RenewalSubscription {
   category: string | null;
   next_billing_date: string;
   billing_cycle: string;
+  contract_type?: string | null;
+  provider_type?: string | null;
+}
+
+// Contract/provider types that are scheduled payments, not cancellable subscriptions.
+// Loans, mortgages, and similar cannot be "switched" mid-term, so renewal language and
+// deals CTAs are inappropriate for them.
+const PAYMENT_CONTRACT_TYPES = new Set(['loan', 'mortgage', 'lease']);
+const PAYMENT_PROVIDER_TYPES = new Set(['loan', 'mortgage', 'credit_card']);
+const PAYMENT_CATEGORIES = new Set(['loan', 'mortgage', 'credit_card', 'finance', 'debt']);
+
+function isScheduledPayment(sub: RenewalSubscription): boolean {
+  if (sub.contract_type && PAYMENT_CONTRACT_TYPES.has(sub.contract_type)) return true;
+  if (sub.provider_type && PAYMENT_PROVIDER_TYPES.has(sub.provider_type)) return true;
+  if (sub.category && PAYMENT_CATEGORIES.has(sub.category)) return true;
+  return false;
 }
 
 /**
- * Build a renewal reminder email for upcoming subscription renewals.
+ * Build a renewal reminder email for upcoming subscription renewals and/or scheduled payments.
+ * Subscriptions (Netflix, gym, broadband) get "renewing soon" language and deals CTAs.
+ * Loans, mortgages, and direct debits get "upcoming payment" language with no deals section.
  */
 export function buildRenewalEmail(
   userName: string,
@@ -18,28 +36,111 @@ export function buildRenewalEmail(
 ): { subject: string; html: string } {
   const totalRenewing = renewals.reduce((sum, r) => sum + r.amount, 0);
 
-  const subject = daysUntilRenewal <= 7
-    ? `${userName}, ${renewals.length} ${renewals.length === 1 ? 'subscription renews' : 'subscriptions renew'} in ${daysUntilRenewal} days`
-    : `Heads up: ${renewals.length} ${renewals.length === 1 ? 'renewal' : 'renewals'} coming up`;
+  const subscriptions = renewals.filter(r => !isScheduledPayment(r));
+  const payments = renewals.filter(r => isScheduledPayment(r));
+  const hasSubscriptions = subscriptions.length > 0;
+  const hasPayments = payments.length > 0;
+  const onlyPayments = hasPayments && !hasSubscriptions;
 
-  const urgency = daysUntilRenewal <= 7
-    ? { color: '#ef4444', text: 'Renewing soon — act now' }
-    : daysUntilRenewal <= 14
-      ? { color: '#f59e0b', text: 'Renewing in 2 weeks' }
-      : { color: '#3b82f6', text: 'Upcoming renewal' };
+  // Subject line
+  let subject: string;
+  if (onlyPayments) {
+    subject = daysUntilRenewal <= 7
+      ? `${userName}, ${renewals.length} ${renewals.length === 1 ? 'payment' : 'payments'} due in ${daysUntilRenewal} days`
+      : `Heads up: ${renewals.length} upcoming ${renewals.length === 1 ? 'payment' : 'payments'}`;
+  } else if (!hasPayments) {
+    subject = daysUntilRenewal <= 7
+      ? `${userName}, ${renewals.length} ${renewals.length === 1 ? 'subscription renews' : 'subscriptions renew'} in ${daysUntilRenewal} days`
+      : `Heads up: ${renewals.length} ${renewals.length === 1 ? 'renewal' : 'renewals'} coming up`;
+  } else {
+    subject = daysUntilRenewal <= 7
+      ? `${userName}, upcoming renewals and payments in ${daysUntilRenewal} days`
+      : `Heads up: renewals and payments coming up`;
+  }
 
-  const rows = renewals.map((r) => `
-    <tr>
-      <td style="padding: 14px 16px; border-bottom: 1px solid #1e293b;">
-        <div style="font-weight: 600; color: #ffffff; font-size: 14px;">${r.provider_name}</div>
-        <div style="color: #64748b; font-size: 12px; margin-top: 2px;">${r.category || 'subscription'} · renews ${new Date(r.next_billing_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'long' })}</div>
-      </td>
-      <td style="padding: 14px 16px; border-bottom: 1px solid #1e293b; text-align: right;">
-        <div style="font-weight: 700; color: #ffffff; font-size: 16px;">£${r.amount.toFixed(2)}</div>
-        <div style="color: #64748b; font-size: 11px;">/${r.billing_cycle}</div>
-      </td>
-    </tr>
-  `).join('');
+  // Urgency banner
+  const urgencyColor = daysUntilRenewal <= 7 ? '#ef4444' : daysUntilRenewal <= 14 ? '#f59e0b' : '#3b82f6';
+  const urgencyText = onlyPayments
+    ? (daysUntilRenewal <= 7 ? 'Payments due soon' : daysUntilRenewal <= 14 ? 'Payments due in 2 weeks' : 'Upcoming payments')
+    : (daysUntilRenewal <= 7 ? 'Renewing soon — act now' : daysUntilRenewal <= 14 ? 'Renewing in 2 weeks' : 'Upcoming renewal');
+
+  const bannerSubtext = onlyPayments
+    ? `£${totalRenewing.toFixed(2)} due in the next ${daysUntilRenewal} days`
+    : `£${totalRenewing.toFixed(2)} renewing in the next ${daysUntilRenewal} days`;
+
+  // Body text
+  let bodyText: string;
+  if (onlyPayments) {
+    bodyText = daysUntilRenewal <= 7
+      ? 'These payments are due very soon. Make sure you have enough in your account.'
+      : 'These payments are coming up. Here is what is due.';
+  } else if (!hasPayments) {
+    bodyText = daysUntilRenewal <= 7
+      ? 'These subscriptions are renewing very soon. Now is the time to check if you still need them or if there is a better deal available.'
+      : 'These subscriptions are coming up for renewal. It is worth checking if you are still getting the best deal.';
+  } else {
+    bodyText = daysUntilRenewal <= 7
+      ? 'Some of your subscriptions are renewing very soon and you also have scheduled payments due. Check for better deals on your subscriptions.'
+      : 'You have subscriptions coming up for renewal and scheduled payments due. It is worth reviewing your subscriptions for better deals.';
+  }
+
+  const buildRows = (items: RenewalSubscription[], labelType: 'renews' | 'due') =>
+    items.map((r) => `
+      <tr>
+        <td style="padding: 14px 16px; border-bottom: 1px solid #1e293b;">
+          <div style="font-weight: 600; color: #ffffff; font-size: 14px;">${r.provider_name}</div>
+          <div style="color: #64748b; font-size: 12px; margin-top: 2px;">${r.category || (labelType === 'renews' ? 'subscription' : 'payment')} · ${labelType} ${new Date(r.next_billing_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'long' })}</div>
+        </td>
+        <td style="padding: 14px 16px; border-bottom: 1px solid #1e293b; text-align: right;">
+          <div style="font-weight: 700; color: #ffffff; font-size: 16px;">£${r.amount.toFixed(2)}</div>
+          <div style="color: #64748b; font-size: 11px;">/${r.billing_cycle}</div>
+        </td>
+      </tr>
+    `).join('');
+
+  // Table section(s)
+  let tableContent: string;
+  if (!hasPayments) {
+    tableContent = `
+    <table style="width: 100%; background: #0f172a; border: 1px solid #1e293b; border-radius: 16px; border-collapse: collapse; margin-bottom: 24px;">
+      ${buildRows(subscriptions, 'renews')}
+    </table>`;
+  } else if (onlyPayments) {
+    tableContent = `
+    <table style="width: 100%; background: #0f172a; border: 1px solid #1e293b; border-radius: 16px; border-collapse: collapse; margin-bottom: 24px;">
+      ${buildRows(payments, 'due')}
+    </table>`;
+  } else {
+    // Mixed — two labelled sections
+    tableContent = `
+    <div style="color: #94a3b8; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px;">Subscriptions renewing</div>
+    <table style="width: 100%; background: #0f172a; border: 1px solid #1e293b; border-radius: 16px; border-collapse: collapse; margin-bottom: 20px;">
+      ${buildRows(subscriptions, 'renews')}
+    </table>
+    <div style="color: #94a3b8; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px;">Upcoming payments</div>
+    <table style="width: 100%; background: #0f172a; border: 1px solid #1e293b; border-radius: 16px; border-collapse: collapse; margin-bottom: 24px;">
+      ${buildRows(payments, 'due')}
+    </table>`;
+  }
+
+  // Deals section — only shown when there are cancellable subscriptions
+  const dealsSection = hasSubscriptions ? `
+    <div style="background: #0f172a; border: 1px solid #f59e0b44; border-radius: 16px; padding: 20px; margin-bottom: 24px;">
+      <div style="color: #f59e0b; font-weight: 700; font-size: 14px; margin-bottom: 12px;">Better deals available</div>
+      <div style="color: #94a3b8; font-size: 13px; line-height: 1.6; margin-bottom: 16px;">
+        Before these renew, check if you can save by switching. Your personalised deals page shows alternatives based on your current providers.
+      </div>
+      <a href="https://paybacker.co.uk/dashboard/deals" style="display: inline-block; background: linear-gradient(135deg, #f59e0b, #d97706); color: #0f172a; padding: 14px 28px; border-radius: 12px; text-decoration: none; font-weight: 700; font-size: 15px;">See Your Personalised Deals &rarr;</a>
+    </div>` : '';
+
+  // "Did you know" tip — only relevant for subscriptions
+  const didYouKnow = hasSubscriptions ? `
+    <div style="background: #0f172a; border: 1px solid #1e293b44; border-radius: 12px; padding: 16px; margin-bottom: 24px;">
+      <div style="color: #f59e0b; font-weight: 600; font-size: 13px; margin-bottom: 4px;">Did you know?</div>
+      <div style="color: #94a3b8; font-size: 12px; line-height: 1.5;">
+        Paybacker can generate a cancellation email for any subscription in seconds, citing the correct UK consumer law. Just click on any subscription in your dashboard.
+      </div>
+    </div>` : '';
 
   const html = `
 <!DOCTYPE html>
@@ -52,45 +153,29 @@ export function buildRenewalEmail(
     </div>
 
     <!-- Urgency Banner -->
-    <div style="background: ${urgency.color}22; border: 1px solid ${urgency.color}44; border-radius: 12px; padding: 16px; text-align: center; margin-bottom: 24px;">
-      <div style="color: ${urgency.color}; font-weight: 700; font-size: 14px;">${urgency.text}</div>
-      <div style="color: #94a3b8; font-size: 13px; margin-top: 4px;">£${totalRenewing.toFixed(2)} renewing in the next ${daysUntilRenewal} days</div>
+    <div style="background: ${urgencyColor}22; border: 1px solid ${urgencyColor}44; border-radius: 12px; padding: 16px; text-align: center; margin-bottom: 24px;">
+      <div style="color: ${urgencyColor}; font-weight: 700; font-size: 14px;">${urgencyText}</div>
+      <div style="color: #94a3b8; font-size: 13px; margin-top: 4px;">${bannerSubtext}</div>
     </div>
 
     <div style="color: #e2e8f0; font-size: 15px; margin-bottom: 20px; line-height: 1.6;">
       Hi ${userName},<br><br>
-      ${daysUntilRenewal <= 7
-        ? 'These subscriptions are renewing very soon. Now is the time to check if you still need them or if there is a better deal available.'
-        : 'These subscriptions are coming up for renewal. It is worth checking if you are still getting the best deal.'}
+      ${bodyText}
     </div>
 
-    <table style="width: 100%; background: #0f172a; border: 1px solid #1e293b; border-radius: 16px; border-collapse: collapse; margin-bottom: 24px;">
-      ${rows}
-    </table>
+    ${tableContent}
 
-    <!-- Personalised deal suggestions -->
-    <div style="background: #0f172a; border: 1px solid #f59e0b44; border-radius: 16px; padding: 20px; margin-bottom: 24px;">
-      <div style="color: #f59e0b; font-weight: 700; font-size: 14px; margin-bottom: 12px;">Better deals available</div>
-      <div style="color: #94a3b8; font-size: 13px; line-height: 1.6; margin-bottom: 16px;">
-        Before these renew, check if you can save by switching. Your personalised deals page shows alternatives based on your current providers.
-      </div>
-      <a href="https://paybacker.co.uk/dashboard/deals" style="display: inline-block; background: linear-gradient(135deg, #f59e0b, #d97706); color: #0f172a; padding: 14px 28px; border-radius: 12px; text-decoration: none; font-weight: 700; font-size: 15px;">See Your Personalised Deals →</a>
-    </div>
+    ${dealsSection}
 
     <div style="text-align: center; margin: 24px 0;">
-      <a href="https://paybacker.co.uk/dashboard/subscriptions" style="display: inline-block; background: #1e293b; color: #ffffff; padding: 14px 28px; border-radius: 12px; text-decoration: none; font-weight: 600; font-size: 15px;">Review Subscriptions</a>
+      <a href="https://paybacker.co.uk/dashboard/subscriptions" style="display: inline-block; background: #1e293b; color: #ffffff; padding: 14px 28px; border-radius: 12px; text-decoration: none; font-weight: 600; font-size: 15px;">${onlyPayments ? 'Review Payments' : 'Review Subscriptions'}</a>
     </div>
 
-    <div style="background: #0f172a; border: 1px solid #1e293b44; border-radius: 12px; padding: 16px; margin-bottom: 24px;">
-      <div style="color: #f59e0b; font-weight: 600; font-size: 13px; margin-bottom: 4px;">Did you know?</div>
-      <div style="color: #94a3b8; font-size: 12px; line-height: 1.5;">
-        Paybacker can generate a cancellation email for any subscription in seconds, citing the correct UK consumer law. Just click on any subscription in your dashboard.
-      </div>
-    </div>
+    ${didYouKnow}
 
     <div style="text-align: center; padding: 24px 0; border-top: 1px solid #1e293b;">
       <div style="color: #64748b; font-size: 12px; line-height: 1.6;">
-        Paybacker LTD · paybacker.co.uk<br>
+        Paybacker LTD &middot; paybacker.co.uk<br>
         <a href="https://paybacker.co.uk/dashboard/profile" style="color: #f59e0b; text-decoration: none;">Manage preferences</a>
       </div>
     </div>


### PR DESCRIPTION
## Problem

Loan and mortgage repayments were appearing in the renewal reminder email under the heading **"These subscriptions are renewing very soon"** with labels like **"loan · renews 12 April"**. A loan repayment is not a subscription renewal — it's a scheduled payment that cannot be cancelled or switched mid-term, so the existing language was misleading.

## Changes

### `src/lib/email/renewal-reminders.ts`
- Added `contract_type` and `provider_type` to the `RenewalSubscription` interface
- Added `isScheduledPayment()` helper that classifies an item as a scheduled payment when any of these match:
  - `contract_type` ∈ `loan | mortgage | lease`
  - `provider_type` ∈ `loan | mortgage | credit_card`
  - `category` ∈ `loan | mortgage | credit_card | finance | debt`
- **Payments-only email:** heading "Payments due soon", "· due [date]" row label, no deals CTA, no cancellation tip
- **Subscriptions-only email:** no change to existing behaviour
- **Mixed email:** two labelled table sections with appropriate language per section; deals CTA only shown for subscriptions

### `src/app/api/cron/renewal-reminders/route.ts`
- Added `contract_type, provider_type` to the Supabase select query

## Test plan

- [ ] Loan/mortgage-only email: "Payments due soon" heading, "· due [date]" labels, no deals CTA
- [ ] Subscriptions-only email: existing "Renewing soon" behaviour unchanged
- [ ] Mixed email: two table sections with correct labels per type
- [ ] `tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)