### PR TITLE
fix: persist bank prompt dismissal for 30 days

### DIFF
--- a/src/app/api/user/dismiss-bank-prompt/route.ts
+++ b/src/app/api/user/dismiss-bank-prompt/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST() {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ bank_prompt_dismissed_at: new Date().toISOString() })
+      .eq('id', user.id);
+
+    if (error) throw error;
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('Error dismissing bank prompt:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -278,6 +278,7 @@ export default function MoneyHubPage() {
 
   // Expired bank connections
   const [expiredConnections, setExpiredConnections] = useState<Array<{ id: string; bank_name: string; status: string }>>([]);
+  const [bankPromptDismissed, setBankPromptDismissed] = useState(false);
 
   // Toast notifications
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
@@ -489,6 +490,13 @@ export default function MoneyHubPage() {
 
   const handleReconnectBank = () => {
     setShowBankPicker(true);
+  };
+
+  const handleDismissBankPrompt = async () => {
+    setBankPromptDismissed(true);
+    try {
+      await fetch('/api/user/dismiss-bank-prompt', { method: 'POST' });
+    } catch { /* non-critical */ }
   };
 
   // ─── Category drill-down ──────────────────────────────────────────────────
@@ -864,19 +872,29 @@ export default function MoneyHubPage() {
       })
       .finally(() => setLoading(false));
 
-    // Fetch user ID and expired bank connections
+    // Fetch user ID, expired bank connections, and prompt dismissal state
     (async () => {
       try {
         const sb = createClient();
         const { data: { user } } = await sb.auth.getUser();
         if (user) {
           setUserId(user.id);
-          const { data: conns } = await sb.from('bank_connections')
-            .select('id, bank_name, status')
-            .eq('user_id', user.id)
-            .in('status', ['expired', 'token_expired']);
+          const [{ data: conns }, { data: profile }] = await Promise.all([
+            sb.from('bank_connections')
+              .select('id, bank_name, status')
+              .eq('user_id', user.id)
+              .in('status', ['expired', 'token_expired']),
+            sb.from('profiles')
+              .select('bank_prompt_dismissed_at')
+              .eq('id', user.id)
+              .single(),
+          ]);
           if (conns && conns.length > 0) {
             setExpiredConnections(conns);
+          }
+          if (profile?.bank_prompt_dismissed_at) {
+            const daysSince = (Date.now() - new Date(profile.bank_prompt_dismissed_at).getTime()) / 86_400_000;
+            setBankPromptDismissed(daysSince < 30);
           }
         }
       } catch { /* silent */ }
@@ -1376,24 +1394,22 @@ export default function MoneyHubPage() {
       )}
 
       {/* ═══ Expired Bank Connection Banner ═══ */}
-      {expiredConnections.length > 0 && (
-        <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-4 flex items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <AlertTriangle className="h-5 w-5 text-amber-400 shrink-0" />
-            <div>
-              <p className="font-medium text-amber-200">
-                Bank connection expired
-              </p>
-              <p className="text-sm text-amber-300/70">
-                Your {expiredConnections.map(c => c.bank_name || 'bank').join(' and ')} connection{expiredConnections.length > 1 ? 's have' : ' has'} expired. Reconnect to resume automatic syncing.
-              </p>
-            </div>
-          </div>
+      {expiredConnections.length > 0 && !bankPromptDismissed && (
+        <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2 flex items-center gap-2 text-xs">
+          <AlertTriangle className="h-3.5 w-3.5 text-amber-400 shrink-0" />
+          <span className="text-amber-300 flex-1">
+            {expiredConnections.map(c => c.bank_name || 'Bank').join(' & ')} connection expired.{' '}
+            <button onClick={handleReconnectBank} className="underline hover:text-amber-200 transition-colors">
+              Reconnect
+            </button>{' '}
+            to resume auto-sync.
+          </span>
           <button
-            onClick={handleReconnectBank}
-            className="shrink-0 bg-amber-500/20 hover:bg-amber-500/30 border border-amber-500/30 text-amber-200 font-medium px-4 py-2 rounded-lg text-sm transition-all"
+            onClick={handleDismissBankPrompt}
+            className="text-amber-400/60 hover:text-amber-300 transition-colors ml-1"
+            title="Dismiss for 30 days"
           >
-            Reconnect Bank
+            <X className="h-3.5 w-3.5" />
           </button>
         </div>
       )}

--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -197,6 +197,7 @@ export default function SubscriptionsPage() {
     manualSyncsToday: 0,
   });
   const [subComparisons, setSubComparisons] = useState<Record<string, any[]>>({});
+  const [bankPromptDismissed, setBankPromptDismissed] = useState(false);
 
   // Fetch contract renewal alerts
   const fetchContractAlerts = useCallback(async () => {
@@ -320,8 +321,15 @@ export default function SubscriptionsPage() {
     const supabase = createClient();
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!user) return;
-      supabase.from('profiles').select('subscription_tier').eq('id', user.id).single()
-        .then(({ data }) => { if (data?.subscription_tier) setUserTier(data.subscription_tier); });
+      supabase.from('profiles').select('subscription_tier, bank_prompt_dismissed_at').eq('id', user.id).single()
+        .then(({ data }) => {
+          if (data?.subscription_tier) setUserTier(data.subscription_tier);
+          if (data?.bank_prompt_dismissed_at) {
+            const dismissedAt = new Date(data.bank_prompt_dismissed_at).getTime();
+            const daysSince = (Date.now() - dismissedAt) / 86_400_000;
+            setBankPromptDismissed(daysSince < 30);
+          }
+        });
     });
   }, [fetchSubscriptions, fetchBankConnection, fetchComparisons, fetchContractAlerts]);
 
@@ -899,6 +907,13 @@ export default function SubscriptionsPage() {
     }
   };
 
+  const handleDismissBankPrompt = async () => {
+    setBankPromptDismissed(true);
+    try {
+      await fetch('/api/user/dismiss-bank-prompt', { method: 'POST' });
+    } catch { /* non-critical */ }
+  };
+
   const [bulkGenerating, setBulkGenerating] = useState(false);
   const [bulkResults, setBulkResults] = useState<{ sub: Subscription; email: any; error?: string }[] | null>(null);
 
@@ -1419,8 +1434,19 @@ export default function SubscriptionsPage() {
               );
             }
 
+            if (isFirst && bankPromptDismissed) return null;
+
             return (
-              <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6">
+              <div className="relative bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6">
+                {isFirst && (
+                  <button
+                    onClick={handleDismissBankPrompt}
+                    className="absolute top-3 right-3 text-slate-500 hover:text-slate-300 transition-colors"
+                    title="Dismiss for 30 days"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
                 <div className="flex flex-col sm:flex-row sm:items-center gap-4">
                   <div className="bg-blue-500/10 w-12 h-12 rounded-xl flex items-center justify-center shrink-0">
                     <Building2 className="h-6 w-6 text-blue-400" />

--- a/supabase/migrations/20260405020000_bank_prompt_dismissed.sql
+++ b/supabase/migrations/20260405020000_bank_prompt_dismissed.sql
@@ -1,0 +1,3 @@
+-- Add bank_prompt_dismissed_at to profiles
+-- Used to persist 30-day snooze on bank connection prompts/banners
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS bank_prompt_dismissed_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary

- Adds `bank_prompt_dismissed_at` column to `profiles` table (migration `20260405020000_bank_prompt_dismissed.sql`)
- New API route `POST /api/user/dismiss-bank-prompt` saves the dismissal timestamp server-side
- **Subscriptions page**: "Connect your bank" first-time prompt now has an X button; hidden for 30 days after dismissal, shown once more after 30 days
- **Money Hub**: "Bank connection expired" banner now has an X dismiss button and is restyled as a slim single-line strip so it no longer pushes page content down
- 30-day snooze logic is consistent across both pages

## Test plan

- [ ] Visit Subscriptions with no bank connected — "Connect your bank" card shows
- [ ] Click X — card disappears immediately; reloading keeps it hidden
- [ ] Manually set `bank_prompt_dismissed_at` to 31+ days ago in DB — card reappears
- [ ] Visit Money Hub with an expired bank connection — slim amber inline strip shows (not a large banner)
- [ ] Click X on Money Hub strip — it disappears and stays hidden
- [ ] Clicking "Reconnect" in the strip still opens the bank picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)