### PR TITLE
fix: per-agent business_log queries to fix low-frequency agent starvation

### DIFF
--- a/src/app/api/admin/team-status/route.ts
+++ b/src/app/api/admin/team-status/route.ts
@@ -139,27 +139,27 @@ export async function GET(request: NextRequest) {
   }
 
   const supabase = getAdmin();
-  const agentIds = PAPERCLIP_AGENTS.map(a => a.id);
 
-  // Fetch last 10 entries per agent in one query
-  const { data: logs, error } = await supabase
-    .from('business_log')
-    .select('id, category, title, content, created_by, created_at')
-    .in('created_by', agentIds)
-    .order('created_at', { ascending: false })
-    .limit(100);
+  // Fetch per-agent to avoid high-frequency agents consuming the global limit
+  const perAgentResults = await Promise.all(
+    PAPERCLIP_AGENTS.map(agent =>
+      supabase
+        .from('business_log')
+        .select('id, category, title, content, created_by, created_at')
+        .eq('created_by', agent.id)
+        .order('created_at', { ascending: false })
+        .limit(10)
+    )
+  );
 
-  if (error) {
+  const hasError = perAgentResults.some(r => r.error);
+  if (hasError) {
     return NextResponse.json({ error: 'Failed to fetch business_log' }, { status: 500 });
   }
 
-  // Group entries by created_by
-  const grouped: Record<string, typeof logs> = {};
-  for (const entry of logs || []) {
-    if (!grouped[entry.created_by]) grouped[entry.created_by] = [];
-    if (grouped[entry.created_by]!.length < 5) {
-      grouped[entry.created_by]!.push(entry);
-    }
+  const grouped: Record<string, NonNullable<(typeof perAgentResults)[number]['data']>> = {};
+  for (let i = 0; i < PAPERCLIP_AGENTS.length; i++) {
+    grouped[PAPERCLIP_AGENTS[i].id] = perAgentResults[i].data || [];
   }
 
   const agents = PAPERCLIP_AGENTS.map(agent => {


### PR DESCRIPTION
## Summary
- **Bug:** `GET /api/admin/team-status` fetched business_log with a single `.limit(100)` across all agents. Riley (every 15 min) consumed most rows, leaving low-frequency agents (CEO Briefing, Sprint Runner etc.) with zero results — showing as "never/missed" even when they had recent runs.
- **Fix:** Replaced the global query with `Promise.all` over per-agent queries, each capped at `.limit(10)`. Every agent now gets exactly its fair share regardless of run frequency.
- Zero TypeScript errors (`npx tsc --noEmit` clean).

## Test plan
- [ ] Hit `/api/admin/team-status` and confirm all 10 agents return recent entries including daily/weekly ones
- [ ] Confirm riley-support-agent entries no longer push out ceo-briefing / sprint-runner history

🤖 Generated with [Claude Code](https://claude.com/claude-code)