### PR TITLE
fix: subscriptions TS build error + remove Not Me button from alert cards

### DIFF
--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -330,7 +330,7 @@ export default function SubscriptionsPage() {
     const supabase = createClient();
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!user) return;
-      supabase.from('profiles').select('subscription_tier').eq('id', user.id).single()
+      supabase.from('profiles').select('subscription_tier, bank_prompt_dismissed_at').eq('id', user.id).single()
         .then(({ data }) => {
           if (data?.subscription_tier) setUserTier(data.subscription_tier);
           setTierLoaded(true);

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -1196,7 +1196,6 @@ export async function sendProactiveAlert(params: {
         [
           { text: 'Snooze 7 days', callback_data: `snooze_${issue.id}` },
           { text: 'Dismiss', callback_data: `dismiss_${issue.id}` },
-          { text: 'Not me', callback_data: `not_me_${issue.id}` },
         ],
       ],
     };


### PR DESCRIPTION
## Fixes

### Build-breaking TypeScript error
`subscriptions/page.tsx` was calling `.select('subscription_tier')` but then reading `data.bank_prompt_dismissed_at` — Supabase types flag it as TS2339 because the column wasn't in the select list. Every Vercel build since 14b9676 has been broken by this. Fix: add `bank_prompt_dismissed_at` to the select.

### Remove 'Not me' button
Per Paul's request: the "Not me" button has been removed from price_increase and renewal_imminent alert cards. It was confusing. Dismiss/Snooze remain, and the '📝 Dispute this increase' action button is the primary CTA.

The `not_me_` callback handler is still registered in the bot (so any existing alerts with that button will still work), but new alerts won't show it.

## Test plan
- [ ] Vercel build succeeds (no TS error)
- [ ] New price increase alerts show only: 📝 Dispute this increase / Snooze 7 days / Dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)