### PR TITLE
fix(telegram): callback_data collision + webhook fail-open security fix

### DIFF
--- a/src/app/api/telegram/user-webhook/route.ts
+++ b/src/app/api/telegram/user-webhook/route.ts
@@ -40,10 +40,14 @@ function getBotInstance() {
 }
 
 export async function POST(request: Request) {
-  // Validate webhook secret — only enforced when the env var is configured.
+  // Validate webhook secret — fail closed if env var is missing or token mismatches.
   const expectedSecret = process.env.TELEGRAM_USER_WEBHOOK_SECRET;
+  if (!expectedSecret) {
+    console.error('[UserBotWebhook] TELEGRAM_USER_WEBHOOK_SECRET is not configured — rejecting request');
+    return new Response('Internal Server Error', { status: 500 });
+  }
   const secret = request.headers.get('x-telegram-bot-api-secret-token');
-  if (expectedSecret && secret !== expectedSecret) {
+  if (secret !== expectedSecret) {
     console.error('[UserBotWebhook] Secret mismatch — update TELEGRAM_USER_WEBHOOK_SECRET or re-register webhook');
     return new Response('Unauthorized', { status: 403 });
   }

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -847,7 +847,7 @@ Rules:
   // -------------------------------------------------------
   // Callback: Generate cancellation email for expiring contract / renewal
   // -------------------------------------------------------
-  bot.callbackQuery(/^cancel_contract_(.+)$/, async (ctx) => {
+  bot.callbackQuery(/^cxlmail_(.+)$/, async (ctx) => {
     await ctx.answerCallbackQuery({ text: 'Generating cancellation email...' });
     const issueId = ctx.match[1];
     const chatId = ctx.chat?.id;
@@ -945,7 +945,7 @@ Return JSON: { "subject": "...", "body": "..." }`;
         { parse_mode: 'Markdown' },
       );
     } catch (err) {
-      console.error('[UserBot] cancel_contract callback error:', err);
+      console.error('[UserBot] cxlmail callback error:', err);
       await ctx.api.sendMessage(chatId!, `Sorry, I couldn't generate the email. Try asking me: "Write a cancellation email for [provider]"`);
     }
   });
@@ -1202,7 +1202,7 @@ export async function sendProactiveAlert(params: {
   } else if (issue.issue_type === 'contract_expiring' || issue.issue_type === 'renewal_imminent') {
     replyMarkup = {
       inline_keyboard: [
-        [{ text: '📧 Cancellation email', callback_data: `cancel_contract_${issue.id}` }],
+        [{ text: '📧 Cancellation email', callback_data: `cxlmail_${issue.id}` }],
         [
           { text: 'Snooze 7 days', callback_data: `snooze_${issue.id}` },
           { text: 'Dismiss', callback_data: `dismiss_${issue.id}` },


### PR DESCRIPTION
## Summary
- **P1**: Renamed `cancel_contract_` callback prefix to `cxlmail_` — the existing `/^cancel_(.+)$/` handler (cancel draft letter flow) was matching first, so the "📧 Cancellation email" button was silently routing to the wrong handler
- **P2**: Webhook secret guard now fails **closed** — returns 500 when `TELEGRAM_USER_WEBHOOK_SECRET` env var is unset, instead of allowing all unauthenticated requests through

## Test plan
- [ ] Press "📧 Cancellation email" on a contract_expiring or renewal_imminent alert — should generate cancellation email, not trigger the cancel-draft flow
- [ ] Confirm `TELEGRAM_USER_WEBHOOK_SECRET` is set in Vercel env (it is) — webhook continues to work normally
- [ ] If env var were removed, endpoint returns 500 not 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)