### PR TITLE
fix(money-hub): budget category mapping and bill reconciliation

### DIFF
--- a/src/app/api/cron/bank-sync/route.ts
+++ b/src/app/api/cron/bank-sync/route.ts
@@ -170,6 +170,7 @@ export async function GET(request: NextRequest) {
     try {
       let totalSynced = 0;
       let transactionSyncSucceeded = false;
+      const accountErrors: string[] = [];
 
       if (connection.provider === 'truelayer') {
         // === TrueLayer path ===
@@ -271,7 +272,6 @@ export async function GET(request: NextRequest) {
         const fromDate = connectedAtDate > ninetyDaysAgo ? connectedAtDate : ninetyDaysAgo;
 
         // Sync transactions for each account
-        const accountErrors: string[] = [];
         for (const accountId of accountIds) {
           try {
             const transactions = await fetchTrueLayerTransactions(accessToken, accountId, fromDate);

--- a/src/app/api/money-hub/budgets/route.ts
+++ b/src/app/api/money-hub/budgets/route.ts
@@ -21,15 +21,34 @@ export async function GET() {
 
   if (budgets.length === 0) return NextResponse.json([]);
 
-  // Import the learning engine for runtime categorisation
+  // Import the learning engine + merchant fallback for runtime categorisation
   const { loadLearnedRules, categoriseWithLearningSync: categorise } = await import('@/lib/learning-engine');
+  const { detectFallbackSpendingCategory, normalizeSpendingCategoryKey } = await import('@/lib/money-hub-classification');
   await loadLearnedRules();
+
+  // Soft categories — auto-assigned by the SQL fallback, not user-set.
+  // For these we attempt merchant-level detection before accepting 'other'.
+  const SOFT_CATS = new Set(['other', 'bills', 'shopping']);
 
   // Build spending by category using the same logic as the main money-hub API
   const categorySpend: Record<string, number> = {};
   for (const t of txns) {
-    const rawCat = t.user_category || '';
-    const cat = rawCat || categorise(t.description || '', t.category || '') || 'other';
+    const storedCat = normalizeSpendingCategoryKey(t.user_category || '');
+    let cat: string;
+
+    if (storedCat && !SOFT_CATS.has(storedCat)) {
+      // User-assigned or confidently categorised — use as-is
+      cat = storedCat;
+    } else {
+      // Soft / uncategorised — try merchant detection then learning engine
+      const desc = [t.merchant_name, t.description].filter(Boolean).join(' ');
+      const merchantCat = detectFallbackSpendingCategory(desc);
+      cat = merchantCat
+        || normalizeSpendingCategoryKey(categorise(t.description || '', t.category || ''))
+        || storedCat
+        || 'other';
+    }
+
     const amt = Math.abs(parseFloat(String(t.amount)));
     categorySpend[cat] = (categorySpend[cat] || 0) + amt;
   }

--- a/src/app/api/money-hub/expected-bills/mark-paid/route.ts
+++ b/src/app/api/money-hub/expected-bills/mark-paid/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createAdmin } from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+
+function getAdmin() {
+  return createAdmin(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+}
+
+/** POST — toggle a bill as manually paid/unpaid for a given month.
+ *  Body: { bill_key: string, bill_month: string (YYYY-MM), paid: boolean }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await request.json();
+    const { bill_key, bill_month, paid } = body;
+
+    if (!bill_key || !bill_month) {
+      return NextResponse.json({ error: 'bill_key and bill_month required' }, { status: 400 });
+    }
+
+    // Validate bill_month format
+    if (!/^\d{4}-\d{2}$/.test(bill_month)) {
+      return NextResponse.json({ error: 'bill_month must be YYYY-MM' }, { status: 400 });
+    }
+
+    const admin = getAdmin();
+
+    if (paid) {
+      // Mark as paid: upsert into bill_paid_overrides
+      const { error } = await admin
+        .from('bill_paid_overrides')
+        .upsert(
+          { user_id: user.id, bill_key, bill_month },
+          { onConflict: 'user_id,bill_key,bill_month' }
+        );
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    } else {
+      // Unmark: delete the override
+      const { error } = await admin
+        .from('bill_paid_overrides')
+        .delete()
+        .eq('user_id', user.id)
+        .eq('bill_key', bill_key)
+        .eq('bill_month', bill_month);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, bill_key, bill_month, paid });
+  } catch (err: any) {
+    console.error('mark-paid error:', err.message);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/api/money-hub/expected-bills/route.ts
+++ b/src/app/api/money-hub/expected-bills/route.ts
@@ -20,6 +20,45 @@ function normaliseBillName(name: string): string {
     .trim();
 }
 
+/**
+ * Fuzzy name match between a transaction and an expected bill.
+ * Returns true if any of these hold:
+ *   1. Normalised prefix overlap (original logic, 10-char cap)
+ *   2. Any word ≥ 4 chars in billName appears in pmName (word-level check)
+ *   3. pmName contains billName as a full substring (after normalisation)
+ */
+function fuzzyNameMatch(pmName: string, billName: string): boolean {
+  if (!pmName || !billName) return false;
+
+  const pmNorm  = normaliseBillName(pmName);
+  const billNorm = normaliseBillName(billName);
+  if (!pmNorm || !billNorm) return false;
+
+  // Strategy 1: prefix overlap (capped at 10 chars)
+  const minLen = Math.min(pmNorm.length, billNorm.length, 10);
+  if (minLen >= 3) {
+    if (
+      pmNorm.includes(billNorm.substring(0, minLen)) ||
+      billNorm.includes(pmNorm.substring(0, minLen))
+    ) return true;
+  }
+
+  // Strategy 2: full substring either direction
+  if (pmNorm.includes(billNorm) || billNorm.includes(pmNorm)) return true;
+
+  // Strategy 3: word-level — all significant words (≥4 chars) from the bill
+  // name must appear in the transaction name (handles "DD PARATUS AMC REF..." cases)
+  const billWords = billNorm.split(/\s+/).filter(w => w.length >= 4);
+  if (billWords.length > 0 && billWords.every(w => pmNorm.includes(w))) return true;
+
+  // Strategy 4: first significant word of transaction matches first significant
+  // word of bill (catches "STARLINK" matching "Starlink Services")
+  const pmWords   = pmNorm.split(/\s+/).filter(w => w.length >= 4);
+  if (pmWords.length > 0 && billWords.length > 0 && pmWords[0] === billWords[0]) return true;
+
+  return false;
+}
+
 export async function GET(request: Request) {
   try {
     const supabase = await createClient();
@@ -29,7 +68,7 @@ export async function GET(request: Request) {
     const admin = getAdmin();
     const url = new URL(request.url);
     const monthParam = url.searchParams.get('month');
-    
+
     let year = new Date().getFullYear();
     let month = new Date().getMonth() + 1;
     let baseDate = new Date();
@@ -74,7 +113,6 @@ export async function GET(request: Request) {
     // M7: Clean garbled provider names (strip bank reference suffixes)
     for (const bill of bills) {
       if (bill.provider_name) {
-        // Strip patterns like "LLAIR0012/0001/BIS26VIA" or long alphanumeric suffixes
         bill.provider_name = bill.provider_name
           .replace(/\s+[A-Z]{2,}[\d\/]+[A-Z]*\d*$/i, '')
           .replace(/\s+\d{8,}.*$/, '')
@@ -82,14 +120,13 @@ export async function GET(request: Request) {
       }
     }
 
-    // Merge similar providers by normalised name (e.g. "COMMUNITYFIBRE LTD" + "Community Fibre")
+    // Merge similar providers by normalised name
     const mergedMap = new Map<string, any>();
     for (const bill of bills) {
       const normKey = normaliseBillName(bill.provider_name);
       if (!normKey) continue;
       const existing = mergedMap.get(normKey);
       if (existing) {
-        // Prefer subscription over non-subscription, then higher occurrence_count
         if (bill.is_subscription && !existing.is_subscription) {
           mergedMap.set(normKey, bill);
         } else if (existing.is_subscription && !bill.is_subscription) {
@@ -119,54 +156,51 @@ export async function GET(request: Request) {
       }
     }
 
-    // Check which bills have been paid this month
+    // Fetch all debits this month — include timestamp for date-window checks
     const startOfMonth = new Date(year, month - 1, 1).toISOString();
-    const endOfMonth = new Date(year, month, 0, 23, 59, 59, 999).toISOString();
-    
+    // Extend end window by 5 days for late-posting bills
+    const endOfWindow = new Date(year, month, 5, 23, 59, 59, 999).toISOString();
+
     const { data: currentMonthTxns } = await admin
       .from('bank_transactions')
-      .select('merchant_name, description, amount')
+      .select('merchant_name, description, amount, timestamp')
       .eq('user_id', user.id)
       .lt('amount', 0)
       .gte('timestamp', startOfMonth)
-      .lte('timestamp', endOfMonth);
+      .lte('timestamp', endOfWindow);
 
-    const paidMerchants = (currentMonthTxns || []).map(t => ({
-      name: (t.merchant_name || t.description || '').substring(0, 40).trim().toLowerCase(),
+    const paidTransactions = (currentMonthTxns || []).map(t => ({
+      name: (t.merchant_name || t.description || '').substring(0, 60).trim().toLowerCase(),
       amount: Math.abs(parseFloat(String(t.amount)) || 0),
+      day: new Date(t.timestamp).getDate(),
     }));
+
+    // Fetch manual "mark as paid" overrides for this month
+    const billMonth = `${year}-${String(month).padStart(2, '0')}`;
+    const { data: manualOverrides } = await admin
+      .from('bill_paid_overrides')
+      .select('bill_key')
+      .eq('user_id', user.id)
+      .eq('bill_month', billMonth);
+
+    const manuallyPaidKeys = new Set((manualOverrides || []).map((o: any) => o.bill_key));
 
     // Smart category detection for known provider names
     const PROVIDER_CATEGORIES: Array<{ pattern: RegExp; category: string }> = [
-      // Mortgages / property
-      { pattern: /\b(paratus|lendinvest|nationwide|halifax|santander.*mortgage|barclays.*mortgage|natwest.*mortgage|hsbc.*mortgage|virgin.*money|coventry|skipton|leeds|yorkshire|accord|kent reliance|godiva)\b/i, category: 'mortgage' },
-      // Loans
-      { pattern: /\b(santander.*loan|amigo|zopa|ratesetter|lending works|funding circle|hitachi.*capital|creation.*finance|motonovo)\b/i, category: 'loans' },
-      // Council tax
+      { pattern: /\b(paratus|lendinvest|nationwide|halifax|santander.*mortgage|barclays.*mortgage|natwest.*mortgage|hsbc.*mortgage|virgin.*money|coventry|skipton|leeds|yorkshire|accord|kent reliance|godiva|platform.*home)\b/i, category: 'mortgage' },
+      { pattern: /\b(santander.*loan|amigo|zopa|ratesetter|lending works|funding circle|hitachi.*capital|creation.*finance|motonovo|loqbox|drafty)\b/i, category: 'loans' },
       { pattern: /\b(council|borough|district|city.*of)\b/i, category: 'council_tax' },
-      // Energy
       { pattern: /\b(british gas|edf|eon|octopus.*energy|bulb|sse|scottish.*power|ovo|shell.*energy|utilita|so.*energy|affect.*energy)\b/i, category: 'energy' },
-      // Water
       { pattern: /\b(thames.*water|severn.*trent|anglian|united.*utilities|wessex|southw|welsh.*water|dwr.*cymru|yorkshire.*water|northumbrian)\b/i, category: 'water' },
-      // Broadband / TV
       { pattern: /\b(bt|virgin.*media|sky|talktalk|plusnet|hyperoptic|community.*fibre|zen.*internet|vodafone.*broadband|now.*broadband|starlink)\b/i, category: 'broadband' },
-      // Mobile
       { pattern: /\b(three|o2|ee|vodafone|giffgaff|tesco.*mobile|id.*mobile|smarty|lebara)\b/i, category: 'mobile' },
-      // Insurance
       { pattern: /\b(aviva|direct.*line|admiral|lv=?|axa|zurich|legal.*general|royal.*london|prudential|vitality|bupa|simply.*health)\b/i, category: 'insurance' },
-      // Streaming
       { pattern: /\b(netflix|spotify|disney|apple.*tv|amazon.*prime|now.*tv|dazn|crunchyroll|paramount|youtube.*premium)\b/i, category: 'streaming' },
-      // Fitness
       { pattern: /\b(puregym|the.*gym|david.*lloyd|nuffield|fitness.*first|anytime.*fitness|jd.*gym|better.*gym)\b/i, category: 'fitness' },
-      // Software / subscriptions
       { pattern: /\b(adobe|microsoft|google|dropbox|icloud|1password|notion|slack|zoom|canva|chatgpt|openai|patreon)\b/i, category: 'software' },
-      // DVLA / vehicle
       { pattern: /\b(dvla|vehicle.*tax|road.*tax)\b/i, category: 'motoring' },
-      // Childcare
       { pattern: /\b(nursery|childcare|childminder|after.*school)\b/i, category: 'childcare' },
-      // Credit monitoring
       { pattern: /\b(experian|equifax|clearscore|credit.*karma|checkmyfile)\b/i, category: 'credit_monitoring' },
-      // Charity
       { pattern: /\b(charity|oxfam|red.*cross|cancer.*research|nspcc|rspca|unicef|wwf|amnesty)\b/i, category: 'charity' },
     ];
 
@@ -180,88 +214,59 @@ export async function GET(request: Request) {
 
     // Transform to frontend format
     const enrichedBills = bills.map((bill: any) => {
-      // Use subscription category if linked, otherwise auto-detect from provider name
       const category = bill.subscription_id
         ? (subCategories[bill.subscription_id] || detectCategory(bill.provider_name))
         : detectCategory(bill.provider_name);
 
-      const billNameNorm = normaliseBillName(bill.provider_name);
-
-      // Check if this bill has been paid this month by matching transactions
       const billAmount = parseFloat(bill.expected_amount) || 0;
-      const expectedDate = bill.billing_day || 15;
-      
-      const paid = paidMerchants.some(pm => {
-        const pmNorm = normaliseBillName(pm.name);
-        if (!pmNorm && !billNameNorm) return false;
-        
-        let nameMatch = false;
-        if (pmNorm && billNameNorm) {
-            const minLen = Math.min(pmNorm.length, billNameNorm.length, 10);
-            nameMatch = pmNorm.includes(billNameNorm.substring(0, minLen)) ||
-                        billNameNorm.includes(pmNorm.substring(0, minLen));
-        }
+      const billingDay = bill.billing_day || 0;
 
-        // Amount match: within 5% tolerance (bills can vary slightly month-to-month, or exactly match loans)
+      // Check manual override first
+      if (manuallyPaidKeys.has(bill.bill_key)) {
+        return buildBill(bill, category, billAmount, true, false);
+      }
+
+      // Match against transactions: name fuzzy-match + amount tolerance
+      const paid = paidTransactions.some(pm => {
+        const nameMatch = fuzzyNameMatch(pm.name, bill.provider_name);
+
+        // Amount: within £1 absolute OR within 20% if name matches / within 5% otherwise
         let amountMatch = false;
         if (billAmount > 0 && pm.amount > 0) {
+          const diff  = Math.abs(pm.amount - billAmount);
           const ratio = pm.amount / billAmount;
-          amountMatch = ratio >= 0.95 && ratio <= 1.05;
+          amountMatch = diff <= 1.00 || (nameMatch ? ratio >= 0.80 && ratio <= 1.20 : ratio >= 0.95 && ratio <= 1.05);
         }
 
-        // If the name strictly matches, and amount is broadly okay (~20%) -> Paid
-        if (nameMatch) {
-            if (billAmount > 0 && pm.amount > 0) {
-                const ratio = pm.amount / billAmount;
-                if (ratio >= 0.8 && ratio <= 1.2) return true;
-            } else {
-                return true;
-            }
+        // Date window: within 5 days after billing day (or anywhere in month if no billing day)
+        let inWindow = true;
+        if (billingDay > 0 && pm.day > 0) {
+          inWindow = pm.day >= billingDay - 1 && pm.day <= billingDay + 5;
         }
-        
-        // If the name completely obfuscated (doesn't match), BUT the amount is a near-exact match (<5% variance) 
-        // AND it occurred roughly around the expected billing day (timestamp handling would be ideal here 
-        // but we assume if a 5% strict absolute value hit in the same calendar month bounds it is the bill).
-        if (!nameMatch && amountMatch && billAmount > 0) {
-            return true;
-        }
+
+        if (nameMatch && amountMatch) return true;
+        // Amount-only match (obfuscated merchant) must be strict + in date window
+        if (!nameMatch && amountMatch && billAmount > 5 && inWindow) return true;
 
         return false;
       });
 
-      // Check if billing day has passed (in relation to baseDate vs today)
+      // Past due check
       let isPastDue = false;
-      const billingDay = bill.billing_day || 0;
-      
       if (billingDay > 0 && !paid) {
         const now = new Date();
         const currentYearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-        const targetYearMonth = `${year}-${String(month).padStart(2, '0')}`;
-        
+        const targetYearMonth  = `${year}-${String(month).padStart(2, '0')}`;
         if (targetYearMonth < currentYearMonth) {
-          isPastDue = true; // In the past, it definitely passed.
+          isPastDue = true;
         } else if (targetYearMonth === currentYearMonth) {
           isPastDue = billingDay < now.getDate();
         }
       }
 
-      return {
-        name: bill.provider_name,
-        expected_amount: billAmount,
-        category,
-        source: bill.is_subscription ? 'subscription' as const : 'recurring' as const,
-        paid,
-        past_due: isPastDue,
-        expected_date: bill.expected_date,
-        billing_day: bill.billing_day,
-        occurrence_count: bill.occurrence_count,
-        is_subscription: bill.is_subscription,
-        subscription_id: bill.subscription_id,
-        bill_key: bill.bill_key,
-      };
+      return buildBill(bill, category, billAmount, paid, isPastDue);
     });
 
-    // Sort by billing day (when in the month the bill is expected)
     enrichedBills.sort((a: any, b: any) => a.billing_day - b.billing_day);
 
     const totalExpected = enrichedBills.reduce((s: number, b: any) => s + b.expected_amount, 0);
@@ -274,4 +279,21 @@ export async function GET(request: Request) {
     console.error('Expected bills error:', err.message);
     return NextResponse.json({ error: err.message }, { status: 500 });
   }
+}
+
+function buildBill(bill: any, category: string, billAmount: number, paid: boolean, isPastDue: boolean) {
+  return {
+    name: bill.provider_name,
+    expected_amount: billAmount,
+    category,
+    source: bill.is_subscription ? 'subscription' as const : 'recurring' as const,
+    paid,
+    past_due: isPastDue,
+    expected_date: bill.expected_date,
+    billing_day: bill.billing_day,
+    occurrence_count: bill.occurrence_count,
+    is_subscription: bill.is_subscription,
+    subscription_id: bill.subscription_id,
+    bill_key: bill.bill_key,
+  };
 }

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -35,7 +35,7 @@ function formatTimeAgo(dateStr: string) {
 type ExpectedBill = {
   name: string; expected_amount: number; category: string;
   paid: boolean; past_due: boolean; source: string; expected_date?: string;
-  billing_day?: number; bill_key?: string;
+  billing_day?: number; bill_key?: string; occurrence_count?: number;
 };
 
 // ─── Main Page ──────────────────────────────────────────────────────────────
@@ -113,6 +113,27 @@ export default function MoneyHubPage() {
         setExpectedBillsTotal(d.totalExpected || 0);
       }
     } catch { /* silent */ }
+  };
+
+  const markBillPaid = async (bill: ExpectedBill, paid: boolean) => {
+    const billKey = bill.bill_key;
+    if (!billKey) return;
+    const billMonth = (selectedMonth || `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}`);
+    // Optimistic update
+    setExpectedBills(prev => prev.map(b => b.bill_key === billKey ? { ...b, paid, past_due: paid ? false : b.past_due } : b));
+    try {
+      const res = await fetch('/api/money-hub/expected-bills/mark-paid', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bill_key: billKey, bill_month: billMonth, paid }),
+      });
+      if (!res.ok) throw new Error('Failed');
+      showToast(paid ? `${bill.name} marked as paid` : `${bill.name} unmarked`, 'success');
+    } catch {
+      // Revert optimistic update on failure
+      setExpectedBills(prev => prev.map(b => b.bill_key === billKey ? { ...b, paid: !paid } : b));
+      showToast('Could not update bill status', 'error');
+    }
   };
 
   // ─── Initial load ──────────────────────────────────────────────────────
@@ -594,17 +615,35 @@ export default function MoneyHubPage() {
               const amountColor = bill.paid ? 'text-green-400' : bill.past_due ? 'text-red-400' : 'text-amber-400';
               const catLabel = bill.category !== 'other' ? bill.category.replace(/_/g, ' ') : '';
               return (
-                <div key={bill.bill_key || bill.name} className={`rounded-xl p-3 border flex items-center justify-between ${statusColor}`}>
-                  <div className="min-w-0">
-                    <p className={`text-sm font-medium truncate ${bill.paid ? 'text-slate-400 line-through' : 'text-white'}`}>{bill.name}</p>
-                    <div className="flex items-center gap-2 mt-0.5">
-                      {bill.billing_day > 0 && <span className="text-[10px] text-slate-500">Due ~{bill.billing_day}th</span>}
-                      {catLabel && <span className="text-[10px] text-slate-500 capitalize">{catLabel}</span>}
-                      {bill.paid && <span className="text-[10px] text-green-400 font-medium">✓ Paid</span>}
-                      {bill.past_due && !bill.paid && <span className="text-[10px] text-red-400 font-medium">⚠ Not seen</span>}
+                <div key={bill.bill_key || bill.name} className={`rounded-xl p-3 border ${statusColor}`}>
+                  <div className="flex items-center justify-between">
+                    <div className="min-w-0 flex-1">
+                      <p className={`text-sm font-medium truncate ${bill.paid ? 'text-slate-400 line-through' : 'text-white'}`}>{bill.name}</p>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        {bill.billing_day > 0 && <span className="text-[10px] text-slate-500">Due ~{bill.billing_day}th</span>}
+                        {catLabel && <span className="text-[10px] text-slate-500 capitalize">{catLabel}</span>}
+                        {bill.paid && <span className="text-[10px] text-green-400 font-medium">✓ Paid</span>}
+                        {bill.past_due && !bill.paid && <span className="text-[10px] text-red-400 font-medium">⚠ Not seen</span>}
+                      </div>
                     </div>
+                    <span className={`text-sm font-semibold whitespace-nowrap ml-2 ${amountColor}`}>£{fmtNum(bill.expected_amount)}</span>
                   </div>
-                  <span className={`text-sm font-semibold whitespace-nowrap ml-2 ${amountColor}`}>£{fmtNum(bill.expected_amount)}</span>
+                  {bill.bill_key && !bill.paid && (
+                    <button
+                      onClick={() => markBillPaid(bill, true)}
+                      className="mt-2 text-[10px] text-slate-500 hover:text-green-400 transition-colors underline underline-offset-2"
+                    >
+                      Mark as paid
+                    </button>
+                  )}
+                  {bill.bill_key && bill.paid && (
+                    <button
+                      onClick={() => markBillPaid(bill, false)}
+                      className="mt-2 text-[10px] text-slate-600 hover:text-slate-400 transition-colors underline underline-offset-2"
+                    >
+                      Unmark paid
+                    </button>
+                  )}
                 </div>
               );
             })}

--- a/src/lib/money-hub-classification.ts
+++ b/src/lib/money-hub-classification.ts
@@ -20,6 +20,7 @@ const SPENDING_CATEGORY_ALIASES: Record<string, string> = {
   fee: 'fees',
   loan: 'loans',
   utility: 'energy',
+  transport: 'travel',
 };
 
 type OverrideMap = Map<string, string>;
@@ -438,25 +439,40 @@ export function isCountableIncomeType(value: string | null | undefined) {
   return REAL_INCOME_TYPES.has(key);
 }
 
-function detectFallbackSpendingCategory(description: string): string | null {
+export function detectFallbackSpendingCategory(description: string): string | null {
   const d = ` ${description.toLowerCase()} `;
-  
-  if (/\b(skipton|nationwide|halifax|santander.*mortgage|barclays.*mortgage|natwest.*mortgage|hsbc.*mortgage|virgin.*money|coventry|leeds|yorkshire|accord|godiva)\b/.test(d)) return 'mortgage';
-  if (/\b(santander.*loan|amigo|zopa|ratesetter|lending works|funding circle|hitachi.*capital|creation.*finance|motonovo|loan)\b/.test(d)) return 'loans';
-  if (/\b(council|borough|district|city.*of)\b/.test(d) && d.includes('tax')) return 'council_tax';
-  if (/\b(british gas|edf|eon|octopus.*energy|bulb|sse|scottish.*power|ovo|shell.*energy|utilita|so.*energy)\b/.test(d)) return 'energy';
-  if (/\b(thames.*water|severn.*trent|anglian|united.*utilities|wessex|southw|welsh.*water|dwr.*cymru|yorkshire.*water)\b/.test(d)) return 'water';
-  if (/\b(bt|virgin.*media|sky|talktalk|plusnet|hyperoptic|community.*fibre)\b/.test(d)) return 'broadband';
-  if (/\b(three|o2|ee|vodafone|giffgaff|tesco.*mobile|id.*mobile|smarty|lebara)\b/.test(d)) return 'mobile';
-  if (/\b(aviva|direct.*line|admiral|lv=?|axa|zurich|legal.*general|bupa)\b/.test(d) && !d.includes('refund')) return 'insurance';
-  if (/\b(netflix|spotify|disney|apple.*tv|amazon.*prime|now.*tv|youtube.*premium|crunchyroll)\b/.test(d)) return 'streaming';
-  if (/\b(puregym|the.*gym|david.*lloyd|nuffield|fitness.*first)\b/.test(d)) return 'fitness';
-  if (/\b(tesco|sainsburys|asda|morrisons|aldi|lidl|waitrose|co-op|iceland|ocado|farmfoods|marks and spencer)\b/.test(d)) return 'groceries';
-  if (/\b(amazon|ebay|argos|john lewis|next|asoss|boohoo|primark|tk maxx|boots|superdrug|currys)\b/.test(d)) return 'shopping';
-  if (/\b(mcdonalds|kfc|burger king|nandos|dominos|greggs|costa|starbucks|pret|deliveroo|uber.*eats|just.*eat|wetherspoon)\b/.test(d)) return 'eating_out';
-  if (/\b(tfl|uber|trainline|lner|gwr|tpe|southern|northern|tfl|stagecoach|arriva|first.*bus|national.*express)\b/.test(d)) return 'transport';
-  if (/\b(dvla|vehicle.*tax)\b/.test(d)) return 'motoring';
-  if (/\b(charity|oxfam|red.*cross|cancer.*research|nspcc|rspca|unicef|wwf)\b/.test(d)) return 'charity';
+
+  if (/\b(skipton|nationwide|halifax|santander.*mortgage|barclays.*mortgage|natwest.*mortgage|hsbc.*mortgage|virgin.*money|coventry|leeds building|yorkshire building|accord|godiva|paratus|lendinvest|platform.*home|kent reliance)\b/.test(d)) return 'mortgage';
+  if (/\b(santander.*loan|amigo|zopa|ratesetter|lending works|funding circle|hitachi.*capital|creation.*finance|motonovo|loqbox|drafty)\b/.test(d)) return 'loans';
+  if (/\b(council|borough|district|city.*of)\b/.test(d) && /\btax\b/.test(d)) return 'council_tax';
+  if (/\b(british gas|edf|e\.on|eon|octopus.*energy|bulb|sse|scottish.*power|ovo|shell.*energy|utilita|so.*energy|affect.*energy|pure planet|green energy)\b/.test(d)) return 'energy';
+  if (/\b(thames.*water|severn.*trent|anglian|united.*utilities|wessex|south west water|welsh.*water|dwr.*cymru|yorkshire.*water|northumbrian)\b/.test(d)) return 'water';
+  if (/\b(bt |virgin.*media|sky|talktalk|plusnet|hyperoptic|community.*fibre|zen internet|now.*broadband|starlink)\b/.test(d)) return 'broadband';
+  if (/\b(three mobile|o2|ee mobile|vodafone|giffgaff|tesco.*mobile|id.*mobile|smarty|lebara)\b/.test(d)) return 'mobile';
+  if (/\b(aviva|direct.*line|admiral|lv=?|axa|zurich|legal.*general|royal.*london|bupa|vitality|simply.*health|pet plan)\b/.test(d) && !d.includes('refund')) return 'insurance';
+  if (/\b(netflix|spotify|disney\+?|apple.*tv|amazon.*prime|now.*tv|youtube.*premium|crunchyroll|paramount\+?|dazn)\b/.test(d)) return 'streaming';
+  if (/\b(puregym|the.*gym|david.*lloyd|nuffield|fitness.*first|anytime fitness|jd.*gym|better.*gym)\b/.test(d)) return 'fitness';
+  if (/\b(adobe|microsoft 365|google one|dropbox|icloud|1password|notion|slack|zoom|canva|chatgpt|openai|patreon)\b/.test(d)) return 'software';
+  // Groceries — must come before eating_out (e.g. tesco can be food or petrol, but we treat all tesco as groceries)
+  if (/\b(tesco|sainsbury|asda|morrisons|aldi|lidl|waitrose|co.?op|one stop|spar|nisa|budgens|farmfood|marks.*spencer food|m&s food|iceland food|iceland grocery|costco|amazon.*fresh|amazon grocery|ocado|deliveroo|uber.*eat|just.*eat|juste\s*at)\b/.test(d)) return 'groceries';
+  // Eating out — after groceries check
+  if (/\b(mcdonalds?|mcdonald|kfc|burger king|nandos|dominos?|greggs|costa coffee|starbucks|pret|wetherspoon|wagamama|itsu|pizza hut|yo.*sushi|yo sushi|frankie|harvester)\b/.test(d)) return 'eating_out';
+  // Travel — petrol stations, rail, flights, parking, car hire, ride-hail
+  if (/\b(shell|texaco|gulf petro|jet petro|moto service|welcome break|extra msa|mfg|forecourt|petrol|fuel station)\b/.test(d)) return 'travel';
+  if (/\besso\b/.test(d) && !/shell.*energy/.test(d)) return 'travel';
+  if (/\b(bp |bp petrol|bpme)\b/.test(d)) return 'travel';
+  if (/\b(trainline|national rail|avanti|lner|gwr|crosscountry|tpe|northern rail|southern rail|southeastern|c2c|greater anglia|thameslink|eurostar|first.*capital connect)\b/.test(d)) return 'travel';
+  if (/\b(ryanair|easyjet|british airways|ba\.com|jet2|wizz air|tui|flybe)\b/.test(d)) return 'travel';
+  if (/\b(tfl|oyster|tube fare|bus fare)\b/.test(d)) return 'travel';
+  if (/\b(ncp park|q.?park|parking.*charge|car park|justpark|ringgo|paybyphone|parkopedia)\b/.test(d)) return 'travel';
+  if (/\b(enterprise rent|hertz|europcar|zipcar|sixt rent|avis rent)\b/.test(d)) return 'travel';
+  if (/\b(santander cycle|cycle hire)\b/.test(d)) return 'travel';
+  if (/\b(uber|bolt |lyft|free now|cabify)\b/.test(d) && !/uber.*eat/.test(d)) return 'travel';
+  // Generic transport (older category — alias handles mapping to 'travel')
+  if (/\b(stagecoach|arriva|first.*bus|national.*express)\b/.test(d)) return 'travel';
+  if (/\b(dvla|vehicle.*tax|road.*tax)\b/.test(d)) return 'motoring';
+  if (/\b(amazon|ebay|argos|john lewis|next|asos|boohoo|primark|tk maxx|boots|superdrug|currys|very\.co|studio retail)\b/.test(d)) return 'shopping';
+  if (/\b(charity|oxfam|red.*cross|cancer.*research|nspcc|rspca|unicef|wwf|amnesty|british heart)\b/.test(d)) return 'charity';
 
   return null;
 }

--- a/supabase/migrations/20260412000006_budget_categories_and_bill_reconciliation.sql
+++ b/supabase/migrations/20260412000006_budget_categories_and_bill_reconciliation.sql
@@ -1,0 +1,325 @@
+-- ============================================================
+-- Budget merchant categories + bill reconciliation — 2026-04-12
+--
+-- 1. Update auto_categorise_transactions to detect groceries, travel,
+--    eating_out, and software categories from merchant names BEFORE
+--    the 'other' fallback in Phase 6.
+-- 2. Re-categorise existing transactions where user_category = 'other'
+--    but the merchant matches a known pattern.
+-- 3. Add bill_paid_overrides table for manual "Mark as paid" per bill per month.
+-- ============================================================
+
+
+-- ─── 1. bill_paid_overrides table ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS bill_paid_overrides (
+  id            UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id       UUID REFERENCES profiles(id) ON DELETE CASCADE NOT NULL,
+  bill_key      TEXT NOT NULL,
+  bill_month    TEXT NOT NULL,  -- format: 'YYYY-MM'
+  marked_paid_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, bill_key, bill_month)
+);
+
+ALTER TABLE bill_paid_overrides ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users manage own bill paid overrides"
+  ON bill_paid_overrides FOR ALL USING (auth.uid() = user_id);
+CREATE INDEX IF NOT EXISTS idx_bill_paid_overrides_user_month
+  ON bill_paid_overrides(user_id, bill_month);
+
+
+-- ─── 2. Updated auto_categorise_transactions ──────────────────────────────────
+-- Adds Phase 5.5: detect specific spending categories from merchant/description
+-- keywords before the catch-all 'other' assignment in Phase 6.
+-- All other phases and safety guards unchanged.
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION auto_categorise_transactions(p_user_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_transfers integer := 0;
+  v_income    integer := 0;
+  v_spending  integer := 0;
+  v_groceries integer := 0;
+  v_travel    integer := 0;
+  v_eating    integer := 0;
+  v_software  integer := 0;
+BEGIN
+
+  -- Phase 1: user-defined merchant-pattern overrides
+  UPDATE bank_transactions bt
+  SET user_category = o.user_category
+  FROM money_hub_category_overrides o
+  WHERE o.user_id            = p_user_id
+    AND bt.user_id           = p_user_id
+    AND bt.user_category     IS NULL
+    AND o.transaction_id     IS NULL
+    AND o.merchant_pattern  != 'txn_specific'
+    AND (
+      LOWER(COALESCE(bt.merchant_name, '')) LIKE '%' || LOWER(o.merchant_pattern) || '%'
+      OR LOWER(COALESCE(bt.description, '')) LIKE '%' || LOWER(o.merchant_pattern) || '%'
+    );
+
+  -- Phase 2: description-based transfer detection (debits + credits)
+  UPDATE bank_transactions
+  SET user_category = 'transfers',
+      income_type   = CASE WHEN amount > 0 THEN 'transfer' ELSE income_type END
+  WHERE user_id        = p_user_id
+    AND user_category  IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = p_user_id AND o.transaction_id = bank_transactions.id::text
+    )
+    AND (
+         LOWER(COALESCE(description,'')) LIKE '%to a/c%'
+      OR LOWER(COALESCE(description,'')) LIKE '%from a/c%'
+      OR LOWER(COALESCE(description,'')) LIKE '%personal transfer%'
+      OR LOWER(COALESCE(description,'')) LIKE '%via mobile xfer%'
+      OR LOWER(COALESCE(description,'')) LIKE '%via mobile-pymt%'
+      OR LOWER(COALESCE(description,'')) LIKE '%via online-pymt%'
+      OR LOWER(COALESCE(description,'')) LIKE '%transfer to%'
+      OR LOWER(COALESCE(description,'')) LIKE '%transfer from%'
+      OR LOWER(COALESCE(description,'')) LIKE '%from savings%'
+      OR LOWER(COALESCE(description,'')) LIKE '%from current account%'
+      OR LOWER(COALESCE(description,'')) LIKE '%isa transfer%'
+      OR LOWER(COALESCE(description,'')) LIKE '%savings transfer%'
+      OR LOWER(COALESCE(description,'')) LIKE '%account transfer%'
+      OR LOWER(COALESCE(description,'')) LIKE '%barclaycard%'
+      OR LOWER(COALESCE(description,'')) LIKE '%securepay.bos%'
+      OR LOWER(COALESCE(description,'')) LIKE '% tfr %'
+      OR LOWER(COALESCE(description,'')) LIKE '% trf %'
+      OR LOWER(COALESCE(description,'')) ~ '^\s*(tfr|trf)\s+'
+    );
+  GET DIAGNOSTICS v_transfers = ROW_COUNT;
+
+  -- Phase 3: credit/loan disbursements
+  UPDATE bank_transactions
+  SET user_category = 'transfers',
+      income_type   = 'credit_loan'
+  WHERE user_id      = p_user_id
+    AND amount       > 0
+    AND user_category IS NULL
+    AND (
+         LOWER(COALESCE(description,'')) LIKE '%flexipay%'
+      OR LOWER(COALESCE(description,'')) LIKE '%credit facility%'
+      OR LOWER(COALESCE(description,'')) LIKE '%loan advance%'
+      OR LOWER(COALESCE(description,'')) LIKE '%loan drawdown%'
+      OR LOWER(COALESCE(description,'')) LIKE '%overdraft advance%'
+    );
+
+  -- Phase 4: income-type detection for remaining credits
+  UPDATE bank_transactions
+  SET income_type = CASE
+    WHEN LOWER(COALESCE(description,'')) LIKE '%salary%'
+      OR LOWER(COALESCE(description,'')) LIKE '%payroll%'
+      OR LOWER(COALESCE(description,'')) LIKE '%wages%'
+      OR LOWER(COALESCE(description,'')) LIKE '%monthly pay%'
+      OR LOWER(COALESCE(description,'')) LIKE '%net pay%'
+      OR LOWER(COALESCE(description,'')) LIKE '%director%'
+      OR LOWER(COALESCE(description,'')) LIKE '%pay ref%'         THEN 'salary'
+    WHEN LOWER(COALESCE(description,'')) LIKE '%hmrc%'
+      OR LOWER(COALESCE(description,'')) LIKE '%dwp%'
+      OR LOWER(COALESCE(description,'')) LIKE '%universal credit%'
+      OR LOWER(COALESCE(description,'')) LIKE '%child benefit%'
+      OR LOWER(COALESCE(description,'')) LIKE '%tax credit%'
+      OR LOWER(COALESCE(description,'')) LIKE '%working tax%'     THEN 'benefits'
+    WHEN LOWER(COALESCE(description,'')) LIKE '%dividend%'
+      OR LOWER(COALESCE(description,'')) LIKE '%interest earned%'
+      OR LOWER(COALESCE(description,'')) LIKE '%interest payment%'
+      OR LOWER(COALESCE(description,'')) LIKE '%capital gain%'    THEN 'investment'
+    WHEN LOWER(COALESCE(description,'')) LIKE '%invoice%'
+      OR LOWER(COALESCE(description,'')) LIKE '%consulting%'
+      OR LOWER(COALESCE(description,'')) LIKE '%freelance%'       THEN 'freelance'
+    WHEN (
+           LOWER(COALESCE(description,'')) LIKE '% rent %'
+        OR LOWER(COALESCE(description,'')) LIKE 'rent %'
+        OR LOWER(COALESCE(description,'')) LIKE '%rental income%'
+        OR LOWER(COALESCE(description,'')) LIKE '%letting income%'
+        OR LOWER(COALESCE(description,'')) LIKE '%airbnb%'
+        OR LOWER(COALESCE(description,'')) LIKE '%booking.com%'
+      )
+      AND LOWER(COALESCE(description,'')) NOT LIKE '%transfer%'
+      AND LOWER(COALESCE(description,'')) NOT LIKE '%current account%' THEN 'rental'
+    WHEN LOWER(COALESCE(description,'')) LIKE '%refund from%'
+      OR LOWER(COALESCE(description,'')) LIKE '%your refund%'
+      OR LOWER(COALESCE(description,'')) LIKE '%cashback%'        THEN 'refund'
+    WHEN amount > 1000                                             THEN 'salary'
+    ELSE                                                                'other'
+  END
+  WHERE user_id      = p_user_id
+    AND amount       > 0
+    AND user_category IS NULL
+    AND income_type  IS NULL;
+
+  -- Phase 5: mark remaining uncategorised credits as 'income'
+  UPDATE bank_transactions
+  SET user_category = 'income'
+  WHERE user_id      = p_user_id
+    AND amount       > 0
+    AND user_category IS NULL;
+  GET DIAGNOSTICS v_income = ROW_COUNT;
+
+  -- Phase 5.5: detect known spending categories from merchant/description
+  -- Groceries
+  UPDATE bank_transactions
+  SET user_category = 'groceries'
+  WHERE user_id     = p_user_id
+    AND amount      < 0
+    AND user_category IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = p_user_id AND o.transaction_id = bank_transactions.id::text
+    )
+    AND LOWER(COALESCE(merchant_name,'') || ' ' || COALESCE(description,''))
+        ~* '(tesco|sainsbury|asda|morrisons|lidl|aldi|waitrose|co.?op|one stop|spar \
+|nisa local|budgens|farmfood|marks.{0,8}spencer food|m&s food|iceland food|iceland grocery|costco|ocado|amazon.{0,6}fresh|amazon grocery)';
+  GET DIAGNOSTICS v_groceries = ROW_COUNT;
+
+  -- Travel (petrol, rail, flights, parking, ride-hail, car hire)
+  UPDATE bank_transactions
+  SET user_category = 'travel'
+  WHERE user_id     = p_user_id
+    AND amount      < 0
+    AND user_category IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = p_user_id AND o.transaction_id = bank_transactions.id::text
+    )
+    AND LOWER(COALESCE(merchant_name,'') || ' ' || COALESCE(description,''))
+        ~* '(shell[^a-z]|shell$| bp | bp$|bpme|esso[^n]|texaco|gulf petro|jet petro|moto service|welcome break|extra msa|forecourt|petrol station\
+|trainline|national rail|avanti west|lner|gwr|crosscountry|tpe |northern rail|southeastern rail|thameslink|c2c train|greater anglia|eurostar\
+|ryanair|easyjet|british airways|jet2|wizz air\
+|tfl |oyster card|tube fare|bus fare\
+|ncp park|q.?park|ringgo|justpark|paybyphone\
+|enterprise rent|hertz|europcar|zipcar|sixt rent\
+|santander cycle|cycle hire\
+|bolt ride|lyft|free now)';
+  GET DIAGNOSTICS v_travel = ROW_COUNT;
+
+  -- Eating out
+  UPDATE bank_transactions
+  SET user_category = 'eating_out'
+  WHERE user_id     = p_user_id
+    AND amount      < 0
+    AND user_category IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = p_user_id AND o.transaction_id = bank_transactions.id::text
+    )
+    AND LOWER(COALESCE(merchant_name,'') || ' ' || COALESCE(description,''))
+        ~* '(mcdonald|burger king|kfc |nandos|dominos|greggs|costa coffee|starbucks|pret a|wetherspoon|wagamama|itsu|pizza hut|yo sushi)';
+  GET DIAGNOSTICS v_eating = ROW_COUNT;
+
+  -- Software / subscriptions
+  UPDATE bank_transactions
+  SET user_category = 'software'
+  WHERE user_id     = p_user_id
+    AND amount      < 0
+    AND user_category IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = p_user_id AND o.transaction_id = bank_transactions.id::text
+    )
+    AND LOWER(COALESCE(merchant_name,'') || ' ' || COALESCE(description,''))
+        ~* '(adobe systems|microsoft 365|google one|dropbox|icloud storage|1password|notion|slack|zoom video|canva|chatgpt|openai|patreon)';
+  GET DIAGNOSTICS v_software = ROW_COUNT;
+
+  -- Phase 6: mark remaining uncategorised debits as 'other'
+  UPDATE bank_transactions
+  SET user_category = 'other'
+  WHERE user_id      = p_user_id
+    AND amount       < 0
+    AND user_category IS NULL;
+  GET DIAGNOSTICS v_spending = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'transfers', v_transfers,
+    'income',    v_income,
+    'groceries', v_groceries,
+    'travel',    v_travel,
+    'eating_out',v_eating,
+    'software',  v_software,
+    'other',     v_spending,
+    'status',    'complete'
+  );
+END;
+$$;
+GRANT EXECUTE ON FUNCTION auto_categorise_transactions(uuid) TO authenticated, service_role;
+
+
+-- ─── 3. Re-categorise existing 'other' transactions for known merchants ────────
+-- Safe to run: only touches user_category = 'other' rows where no
+-- transaction-specific user override exists in money_hub_category_overrides.
+-- ──────────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  total_groceries integer := 0;
+  total_travel    integer := 0;
+  total_eating    integer := 0;
+  total_software  integer := 0;
+  n               integer := 0;
+BEGIN
+
+  -- Groceries
+  UPDATE bank_transactions
+  SET user_category = 'groceries'
+  WHERE amount < 0
+    AND user_category = 'other'
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = bank_transactions.user_id
+        AND o.transaction_id = bank_transactions.id::text
+    )
+    AND LOWER(COALESCE(merchant_name,'') || ' ' || COALESCE(description,''))
+        ~* '(tesco|sainsbury|asda|morrisons|lidl|aldi|waitrose|co.?op|one stop|spar |nisa local|budgens|farmfood|marks.{0,8}spencer food|m&s food|iceland food|iceland grocery|costco|ocado|amazon.{0,6}fresh|amazon grocery)';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  total_groceries := n;
+
+  -- Travel
+  UPDATE bank_transactions
+  SET user_category = 'travel'
+  WHERE amount < 0
+    AND user_category = 'other'
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = bank_transactions.user_id
+        AND o.transaction_id = bank_transactions.id::text
+    )
+    AND LOWER(COALESCE(merchant_name,'') || ' ' || COALESCE(description,''))
+        ~* '(shell[^a-z]|shell$| bp | bp$|bpme|esso[^n]|texaco|gulf petro|jet petro|moto service|welcome break|extra msa|forecourt|petrol station|trainline|national rail|avanti west|lner|gwr|crosscountry|tpe |ryanair|easyjet|british airways|jet2|wizz air|tfl |oyster card|ncp park|q.?park|ringgo|justpark|paybyphone|enterprise rent|hertz|europcar|zipcar|santander cycle|bolt ride|lyft|free now)';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  total_travel := n;
+
+  -- Eating out
+  UPDATE bank_transactions
+  SET user_category = 'eating_out'
+  WHERE amount < 0
+    AND user_category = 'other'
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = bank_transactions.user_id
+        AND o.transaction_id = bank_transactions.id::text
+    )
+    AND LOWER(COALESCE(merchant_name,'') || ' ' || COALESCE(description,''))
+        ~* '(mcdonald|burger king|kfc |nandos|dominos|greggs|costa coffee|starbucks|pret a|wetherspoon|wagamama|itsu|pizza hut|yo sushi)';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  total_eating := n;
+
+  -- Software
+  UPDATE bank_transactions
+  SET user_category = 'software'
+  WHERE amount < 0
+    AND user_category = 'other'
+    AND NOT EXISTS (
+      SELECT 1 FROM money_hub_category_overrides o
+      WHERE o.user_id = bank_transactions.user_id
+        AND o.transaction_id = bank_transactions.id::text
+    )
+    AND LOWER(COALESCE(merchant_name,'') || ' ' || COALESCE(description,''))
+        ~* '(adobe systems|microsoft 365|google one|dropbox|icloud storage|1password|notion|slack|zoom video|canva|chatgpt|openai|patreon)';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  total_software := n;
+
+  RAISE NOTICE 'Re-categorised: groceries=%, travel=%, eating_out=%, software=%',
+    total_groceries, total_travel, total_eating, total_software;
+END $$;


### PR DESCRIPTION
## Summary

- **Budget categories showing £0**: Fixed root cause — Tesco, Shell, BP etc. transactions were falling through to `user_category='other'` (SQL Phase 6 catch-all), then the budgets API was treating 'other' as definitive. Now: (1) budgets API treats `other`/`bills`/`shopping` as soft and runs merchant detection, (2) `auto_categorise_transactions` has a new Phase 5.5 that detects groceries/travel/eating_out/software before the 'other' fallback, (3) migration re-categorises all existing April transactions.
- **Expected Bills showing "Not seen"**: Rewrote reconciliation with 4-strategy fuzzy matching (prefix overlap, full substring, word-level, first-word), ±£1 absolute tolerance, and a 5-day date window for late-posting. Added `bill_paid_overrides` table + `POST /api/money-hub/expected-bills/mark-paid` + "Mark as paid / Unmark paid" UI buttons per bill.
- Also fixed pre-existing TypeScript error in bank-sync route (variable scope).

## New merchant coverage
- **Groceries**: Tesco Express/Metro/Extra, M&S Food, Iceland, Spar, Co-op, Nisa, One Stop, Budgens, Costco, Amazon Fresh, Ocado, Deliveroo, Uber Eats, Just Eat, and more
- **Travel**: Shell, BP, Esso, Texaco, Gulf, Moto, Welcome Break, Trainline, LNER, GWR, Avanti, CrossCountry, Ryanair, EasyJet, BA, TfL, NCP, Q-Park, RingGo, Uber, Bolt, Enterprise, Hertz, Europcar, Zipcar, Santander Cycles, and more

## Test plan
- [ ] Check Groceries budget shows spending (Tesco Express transactions should count)
- [ ] Check Travel budget shows spending (fuel transactions should count)
- [ ] Check Paratus AMC, LendInvest, Loqbox show as Paid on Expected Bills
- [ ] Test "Mark as paid" button on a "Not seen" bill — should turn green and persist on reload
- [ ] Test "Unmark paid" reverting the manual override
- [ ] Verify migration ran: check a April Tesco transaction has `user_category='groceries'`
- [ ] Verify no regressions on Energy budget (already worked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)