### PR TITLE
feat(cron): pause background AI jobs with MANAGED_AGENTS_ENABLED guard

### DIFF
--- a/src/app/api/cron/aggregate-provider-intelligence/route.ts
+++ b/src/app/api/cron/aggregate-provider-intelligence/route.ts
@@ -95,6 +95,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[aggregate-provider-intelligence] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const supabase = getAdmin();
 
   // Fetch all contract extractions with enough data to aggregate

--- a/src/app/api/cron/analyze-chatbot-gaps/route.ts
+++ b/src/app/api/cron/analyze-chatbot-gaps/route.ts
@@ -53,6 +53,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[analyze-chatbot-gaps] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const supabase = getAdmin();
   const weekAgo = new Date();
   weekAgo.setDate(weekAgo.getDate() - 7);

--- a/src/app/api/cron/dm-responder/route.ts
+++ b/src/app/api/cron/dm-responder/route.ts
@@ -19,6 +19,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[dm-responder] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const systemToken = process.env.META_ACCESS_TOKEN;
   if (!systemToken) return NextResponse.json({ ok: true, skipped: 'no token' });
 

--- a/src/app/api/cron/generate-social-posts/route.ts
+++ b/src/app/api/cron/generate-social-posts/route.ts
@@ -29,6 +29,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[generate-social-posts] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!

--- a/src/app/api/cron/legal-updates/route.ts
+++ b/src/app/api/cron/legal-updates/route.ts
@@ -95,6 +95,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[legal-updates] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const supabase = getAdmin();
 
   const { data: allRefs } = await supabase

--- a/src/app/api/cron/managed-agents/route.ts
+++ b/src/app/api/cron/managed-agents/route.ts
@@ -28,6 +28,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[managed-agents] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const { searchParams } = new URL(req.url);
   const agentKey = searchParams.get('agent');
   const customTask = searchParams.get('task');
@@ -98,6 +103,11 @@ export async function GET(req: NextRequest) {
   const authHeader = req.headers.get('authorization');
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[managed-agents] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
   }
 
   // Determine which agent to run from the URL path or query

--- a/src/app/api/cron/marketing-automation/route.ts
+++ b/src/app/api/cron/marketing-automation/route.ts
@@ -18,6 +18,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[marketing-automation] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const admin = getAdmin();
   let abandonedCartCount = 0;
   let activationCount = 0;

--- a/src/app/api/cron/publish-blog/route.ts
+++ b/src/app/api/cron/publish-blog/route.ts
@@ -73,6 +73,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[publish-blog] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const supabase = getAdmin();
 
   // Check which topics have already been published

--- a/src/app/api/cron/self-improve/route.ts
+++ b/src/app/api/cron/self-improve/route.ts
@@ -24,6 +24,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[self-improve] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const supabase = getAdmin();
   const weekAgo = new Date();
   weekAgo.setDate(weekAgo.getDate() - 7);

--- a/src/app/api/cron/social-engagement/route.ts
+++ b/src/app/api/cron/social-engagement/route.ts
@@ -26,6 +26,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[social-engagement] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const systemToken = process.env.META_ACCESS_TOKEN;
   if (!systemToken) {
     return NextResponse.json({ error: 'META_ACCESS_TOKEN not configured' }, { status: 503 });

--- a/src/app/api/cron/social-post/route.ts
+++ b/src/app/api/cron/social-post/route.ts
@@ -74,6 +74,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[social-post] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const systemToken = process.env.META_ACCESS_TOKEN;
   if (!systemToken) {
     return NextResponse.json({ error: 'META_ACCESS_TOKEN not configured' }, { status: 503 });

--- a/src/app/api/cron/verify-legal-refs/route.ts
+++ b/src/app/api/cron/verify-legal-refs/route.ts
@@ -34,6 +34,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  if (process.env.MANAGED_AGENTS_ENABLED !== 'true') {
+    console.log('[verify-legal-refs] Managed agents disabled (MANAGED_AGENTS_ENABLED != true)');
+    return NextResponse.json({ ok: true, message: 'Managed agents disabled' });
+  }
+
   const supabase = getAdmin();
 
   const { data: refs, error } = await supabase


### PR DESCRIPTION
## Summary

- Adds `MANAGED_AGENTS_ENABLED` env var guard to 12 cron routes that call Claude/Anthropic API or external AI services
- When the env var is not set to `"true"`, these routes return `200 { ok: true, message: 'Managed agents disabled' }` immediately with no API calls
- vercel.json is unchanged (cron schedules stay, just no-op silently)

## Routes guarded (all burn Anthropic API tokens on schedule)

| Route | Model/Service | Frequency |
|-------|--------------|-----------|
| `managed-agents` | Claude Agent SDK | 5x daily |
| `social-post` | Claude Haiku + Perplexity + fal.ai | Daily 10am |
| `legal-updates` | Claude Sonnet | Daily 6am |
| `dm-responder` | Claude Haiku | Hourly |
| `social-engagement` | Claude Haiku | Every 4h |
| `publish-blog` | Claude Sonnet + Perplexity | 3x/week |
| `marketing-automation` | Claude Haiku | Daily 10am |
| `analyze-chatbot-gaps` | Claude Haiku | Weekly Mon |
| `self-improve` | Claude Haiku | Weekly Sun |
| `verify-legal-refs` | Claude Haiku | Weekly Sun |
| `aggregate-provider-intelligence` | Claude Haiku | Weekly Sun |
| `generate-social-posts` | fal.ai image gen | Weekly Mon |

## Routes NOT touched (user-facing, no Claude)

bank-sync, telegram-scheduler, renewal-reminders, churn-prevention, price-increases, deal-alerts, targeted-deals, compare-subscriptions, verify-challenges, apply-learned-rules, contract-expiry, contract-expiry-alerts, detect-subscriptions, check-deal-prices, overcharge-assessment, energy-tariff-monitor, weekly-money-digest, all telegram-* routes, waitlist-emails, onboarding-emails, email-monitor, founding-member-expiry, dispute-reminders, consent-renewal, discover-features

## How to re-enable

In Vercel: **Settings > Environment Variables > Add `MANAGED_AGENTS_ENABLED` = `true`** then redeploy.

## Railway note

The `agent-server/` (package: `paybacker-agent-server`) is deployed separately on Railway and runs the executive agent team (Alex, Morgan, Jamie, Taylor, Jordan, Charlie, Sam, Riley). This PR does NOT affect Railway. To pause those agents, go to the Railway dashboard and suspend/delete the service manually.

## Test plan

- [ ] Merge and deploy
- [ ] Set `MANAGED_AGENTS_ENABLED` to empty/unset in Vercel env
- [ ] Verify cron logs show "Managed agents disabled" messages (no 500s)
- [ ] Confirm Anthropic usage drops to near-zero on background jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)