### PR TITLE
fix: email readability, transaction search, recategorisation state sync

### DIFF
--- a/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
+++ b/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
@@ -10,7 +10,7 @@ interface CategoryDrillDownModalProps {
   incomeType?: string | null;
   searchQuery?: string | null;
   selectedMonth: string;
-  onRecategorised: () => void;
+  onRecategorised: (fromCategory: string, toCategory: string, amount: number) => void;
 }
 
 const ALL_CATEGORIES = [
@@ -55,7 +55,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
     setLoading(false);
   };
 
-  const handleRecategorise = async (merchantPattern: string, newCategory: string) => {
+  const handleRecategorise = async (merchantPattern: string, newCategory: string, movedAmount?: number) => {
     setRecatLoading(true);
     try {
       await fetch('/api/money-hub/recategorise', {
@@ -69,7 +69,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
         body: JSON.stringify({ rawName: merchantPattern, category: newCategory }),
       });
       await loadData();
-      onRecategorised();
+      onRecategorised(category || incomeType || 'other', newCategory, movedAmount ?? 0);
     } catch {
       // silent
     }
@@ -143,7 +143,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                             {ALL_CATEGORIES.map(c => (
                               <button
                                 key={c}
-                                onClick={() => handleRecategorise(m.merchant, c)}
+                                onClick={() => handleRecategorise(m.merchant, c, m.total)}
                                 disabled={recatLoading}
                                 className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
                               >
@@ -187,7 +187,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                               {ALL_CATEGORIES.map(c => (
                                 <button
                                   key={c}
-                                  onClick={() => handleRecategorise(cleanMerchantName(txn.description || ''), c)}
+                                  onClick={() => handleRecategorise(cleanMerchantName(txn.description || ''), c, Math.abs(txn.amount))}
                                   disabled={recatLoading}
                                   className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
                                 >

--- a/src/app/dashboard/money-hub/OverviewPanel.tsx
+++ b/src/app/dashboard/money-hub/OverviewPanel.tsx
@@ -2,7 +2,7 @@
 
 import { fmtNum } from '@/lib/format';
 import { TrendingUp, TrendingDown, Target, Wallet, BarChart3 } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import CategoryDrillDownModal from './CategoryDrillDownModal';
 
 const INCOME_LABELS: Record<string, { label: string; icon: string; color: string }> = {
@@ -46,16 +46,31 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
   const [drillSpendingCategory, setDrillSpendingCategory] = useState<string | null>(null);
   const [showAllIncome, setShowAllIncome] = useState(false);
   const [showAllSpending, setShowAllSpending] = useState(false);
+  // Optimistic adjustments applied immediately after recategorisation
+  const [spendAdj, setSpendAdj] = useState<Record<string, number>>({});
+  const [incomeAdj, setIncomeAdj] = useState<Record<string, number>>({});
+  const prevDataRef = useRef(data);
+
+  // Clear adjustments once the server data has been refreshed
+  useEffect(() => {
+    if (prevDataRef.current !== data) {
+      prevDataRef.current = data;
+      setSpendAdj({});
+      setIncomeAdj({});
+    }
+  }, [data]);
 
   const { overview, healthScore, spending } = data;
   const { monthlyIncome, monthlyOutgoings, savingsRate, incomeBreakdown } = overview;
   const monthlyTrends = spending?.monthlyTrends || [];
 
-  // Income breakdown entries
-  const incomeEntries = Object.entries(incomeBreakdown || {})
-    .map(([type, amount]) => ({
+  // Income breakdown entries — with optimistic adjustments applied
+  const rawIncomeBreakdown: Record<string, number> = incomeBreakdown || {};
+  const allIncomeKeys = new Set([...Object.keys(rawIncomeBreakdown), ...Object.keys(incomeAdj)]);
+  const incomeEntries = Array.from(allIncomeKeys)
+    .map((type) => ({
       type,
-      amount: amount as number,
+      amount: Math.max(0, (rawIncomeBreakdown[type] ?? 0) + (incomeAdj[type] ?? 0)),
       ...(INCOME_LABELS[type] || INCOME_LABELS.other),
     }))
     .filter(e => e.amount > 0)
@@ -63,7 +78,20 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
 
   const totalIncomeFromBreakdown = incomeEntries.reduce((s, e) => s + e.amount, 0);
 
-  const spendingCategories = spending?.categories || [];
+  // Spending categories — with optimistic adjustments applied
+  const rawSpendingCategories: Array<{ category: string; total: number }> = spending?.categories || [];
+  const allSpendKeys = new Set([
+    ...rawSpendingCategories.map((c) => c.category),
+    ...Object.keys(spendAdj),
+  ]);
+  const spendingCategories = Array.from(allSpendKeys)
+    .map((cat) => ({
+      category: cat,
+      total: Math.max(0, (rawSpendingCategories.find((c) => c.category === cat)?.total ?? 0) + (spendAdj[cat] ?? 0)),
+    }))
+    .filter((c) => c.total > 0)
+    .sort((a, b) => b.total - a.total);
+
   const totalSpentFromBreakdown = spendingCategories.reduce((s: number, c: any) => s + c.total, 0);
 
   const VISIBLE_ROWS = 6;
@@ -282,7 +310,17 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
           category={null}
           incomeType={drillIncomeType}
           selectedMonth={selectedMonth || ''}
-          onRecategorised={() => { setDrillIncomeType(null); refreshData?.(); }}
+          onRecategorised={(fromCat, toCat, amount) => {
+            if (amount > 0) {
+              setIncomeAdj((prev) => ({
+                ...prev,
+                [fromCat]: (prev[fromCat] ?? 0) - amount,
+                [toCat]: (prev[toCat] ?? 0) + amount,
+              }));
+            }
+            setDrillIncomeType(null);
+            refreshData?.();
+          }}
         />
       )}
 
@@ -292,7 +330,17 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
           onClose={() => setDrillSpendingCategory(null)}
           category={drillSpendingCategory}
           selectedMonth={selectedMonth || ''}
-          onRecategorised={() => { setDrillSpendingCategory(null); refreshData?.(); }}
+          onRecategorised={(fromCat, toCat, amount) => {
+            if (amount > 0) {
+              setSpendAdj((prev) => ({
+                ...prev,
+                [fromCat]: (prev[fromCat] ?? 0) - amount,
+                [toCat]: (prev[toCat] ?? 0) + amount,
+              }));
+            }
+            setDrillSpendingCategory(null);
+            refreshData?.();
+          }}
         />
       )}
     </div>

--- a/src/app/dashboard/money-hub/TransactionSearchPanel.tsx
+++ b/src/app/dashboard/money-hub/TransactionSearchPanel.tsx
@@ -35,6 +35,7 @@ export default function TransactionSearchPanel({
   const [recatDropdown, setRecatDropdown] = useState<string | null>(null);
   const [recatLoading, setRecatLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -44,17 +45,23 @@ export default function TransactionSearchPanel({
       return;
     }
     debounceRef.current = setTimeout(async () => {
+      // Abort any in-flight request from a previous query
+      if (abortRef.current) abortRef.current.abort();
+      abortRef.current = new AbortController();
+      const { signal } = abortRef.current;
+
       setLoading(true);
       try {
         const monthParam = selectedMonth ? `&month=${selectedMonth}` : '';
         const res = await fetch(
           `/api/money-hub/transactions?search=${encodeURIComponent(query.trim())}${monthParam}`,
-          { cache: 'no-store' }
+          { cache: 'no-store', signal }
         );
         const d = await res.json();
         setResults(d.transactions || []);
-      } catch {
-        setResults([]);
+      } catch (err: any) {
+        // Ignore AbortError — a newer request superseded this one
+        if (err?.name !== 'AbortError') setResults([]);
       }
       setLoading(false);
     }, 300);

--- a/src/app/dashboard/money-hub/TransactionSearchPanel.tsx
+++ b/src/app/dashboard/money-hub/TransactionSearchPanel.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { Search, X, Loader2 } from 'lucide-react';
+import { fmtNum } from '@/lib/format';
+import { cleanMerchantName } from '@/lib/merchant-utils';
+
+const ALL_CATEGORIES = [
+  'bills', 'cash', 'charity', 'credit', 'eating_out', 'education', 'energy',
+  'fees', 'fuel', 'gambling', 'groceries', 'healthcare', 'income', 'insurance',
+  'motoring', 'other', 'parking', 'pets', 'shopping', 'software', 'streaming',
+  'transport', 'transfers', 'travel', 'water',
+];
+
+interface SearchTransaction {
+  id: string;
+  description: string;
+  merchant_name?: string;
+  amount: number;
+  category?: string;
+  timestamp: string;
+  kind?: string;
+}
+
+export default function TransactionSearchPanel({
+  selectedMonth,
+  refreshData,
+}: {
+  selectedMonth: string;
+  refreshData: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchTransaction[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [recatDropdown, setRecatDropdown] = useState<string | null>(null);
+  const [recatLoading, setRecatLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (query.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const monthParam = selectedMonth ? `&month=${selectedMonth}` : '';
+        const res = await fetch(
+          `/api/money-hub/transactions?search=${encodeURIComponent(query.trim())}${monthParam}`,
+          { cache: 'no-store' }
+        );
+        const d = await res.json();
+        setResults(d.transactions || []);
+      } catch {
+        setResults([]);
+      }
+      setLoading(false);
+    }, 300);
+  }, [query, selectedMonth]);
+
+  const handleRecategorise = async (txn: SearchTransaction, newCategory: string) => {
+    setRecatLoading(true);
+    try {
+      const merchantPattern = cleanMerchantName(txn.merchant_name || txn.description || '');
+      await fetch('/api/money-hub/recategorise', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ merchantPattern, newCategory, applyToAll: true }),
+      });
+      setResults((prev) =>
+        prev.map((r) => (r.id === txn.id ? { ...r, category: newCategory } : r))
+      );
+      refreshData();
+    } catch {
+      // silent
+    }
+    setRecatDropdown(null);
+    setRecatLoading(false);
+  };
+
+  const clearSearch = () => {
+    setQuery('');
+    setResults([]);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <Search className="h-5 w-5 text-mint-400" />
+        <h3 className="text-white font-semibold text-lg">Search Transactions</h3>
+      </div>
+
+      <div className="relative mb-4">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500 pointer-events-none" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search by merchant or description..."
+          className="w-full bg-navy-800 border border-navy-700/50 rounded-xl pl-9 pr-9 py-3 text-white text-sm placeholder-slate-500 focus:outline-none focus:border-mint-400/50 transition-colors"
+        />
+        {query && (
+          <button
+            onClick={clearSearch}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-white transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {loading && (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="h-6 w-6 text-mint-400 animate-spin" />
+        </div>
+      )}
+
+      {!loading && query.trim().length >= 2 && results.length === 0 && (
+        <p className="text-slate-500 text-sm text-center py-8">
+          No transactions found for &ldquo;{query}&rdquo;
+        </p>
+      )}
+
+      {!loading && results.length > 0 && (
+        <div>
+          <p className="text-xs text-slate-500 mb-2">
+            {results.length} result{results.length !== 1 ? 's' : ''}
+          </p>
+          <div className="bg-navy-950/20 rounded-xl border border-navy-800 divide-y divide-navy-800">
+            {results.map((txn) => {
+              const dt = new Date(txn.timestamp);
+              const isRecatOpen = recatDropdown === txn.id;
+              const displayName = txn.merchant_name || txn.description || 'Unknown';
+              return (
+                <div key={txn.id} className="p-4 flex items-center justify-between relative">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-white text-sm font-medium truncate">{displayName}</p>
+                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                      <span className="text-slate-500 text-xs">
+                        {dt.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
+                      </span>
+                      {txn.category && (
+                        <span className="text-[10px] bg-navy-800 text-slate-300 px-2 py-0.5 rounded-md capitalize">
+                          {txn.category.replace(/_/g, ' ')}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="text-right ml-4 shrink-0">
+                    <p
+                      className={`text-sm font-medium ${
+                        txn.amount >= 0 ? 'text-green-400' : 'text-white'
+                      }`}
+                    >
+                      {txn.amount >= 0 ? '+' : ''}£{fmtNum(Math.abs(txn.amount))}
+                    </p>
+                    <button
+                      onClick={() => setRecatDropdown(isRecatOpen ? null : txn.id)}
+                      className="text-[10px] text-slate-500 hover:text-purple-400 transition-colors"
+                    >
+                      Change category
+                    </button>
+                  </div>
+
+                  {isRecatOpen && (
+                    <div className="absolute top-12 right-4 w-48 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
+                      <div className="p-2 border-b border-navy-700 bg-navy-900/50">
+                        <p className="text-xs text-slate-400 font-medium">Move to category...</p>
+                      </div>
+                      <div className="max-h-60 overflow-y-auto custom-scrollbar p-1">
+                        {ALL_CATEGORIES.map((c) => (
+                          <button
+                            key={c}
+                            onClick={() => handleRecategorise(txn, c)}
+                            disabled={recatLoading}
+                            className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
+                          >
+                            {c.replace(/_/g, ' ')}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -20,6 +20,7 @@ import SpendingPanel from './SpendingPanel';
 import GoalsAndBudgetsPanel from './GoalsAndBudgetsPanel';
 import NetWorthPanel from './NetWorthPanel';
 import ContractsPanel from './ContractsPanel';
+import TransactionSearchPanel from './TransactionSearchPanel';
 
 // ─── Utilities ──────────────────────────────────────────────────────────────
 
@@ -117,7 +118,7 @@ export default function MoneyHubPage() {
     try {
       const targetMonth = month ?? selectedMonth;
       const url = targetMonth ? `/api/money-hub?month=${targetMonth}` : '/api/money-hub';
-      const res = await fetch(url);
+      const res = await fetch(url, { cache: 'no-store' });
       const d = await res.json();
       if (!d.error) { setData(d); setError(null); }
       else setError(d.error);
@@ -718,6 +719,12 @@ export default function MoneyHubPage() {
 
       {/* Spending Intelligence */}
       <SpendingPanel data={data} isPro={isPro} refreshData={refreshData} selectedMonth={selectedMonth || data.selectedMonth} />
+
+      {/* Transaction Search */}
+      <TransactionSearchPanel
+        selectedMonth={selectedMonth || data.selectedMonth || ''}
+        refreshData={refreshData}
+      />
 
       {/* Expected Bills (for the selected month) */}
       {expectedBills.length > 0 && (


### PR DESCRIPTION
## Summary

- **Email formatting (Issue 1):** Converted `renewal-reminders.ts` and `onboarding-sequence.ts` email templates from dark-background design to a light-background layout. Body now uses `#f8fafc` (light grey outer), `#ffffff` white card, `#0a1628` dark navy header, `#1e293b` body text, and `#34d399` mint CTAs. Prevents washed-out grey text in email clients (Gmail, Outlook) that strip dark `background-color` from divs.

- **Transaction search (Issue 2):** Added `TransactionSearchPanel` component to the Money Hub page — a debounced search bar that finds transactions by merchant name or description across all categories. Results show the current category badge and an inline "Change category" dropdown for recategorisation. The `/api/money-hub/transactions` route now accepts a `?search=` param that filters resolved transactions in JS.

- **Recategorisation state sync (Issue 3):** `SpendingPanel` now maintains a `catAdjustments` local state map that applies optimistic updates immediately when a recategorise action completes — the category totals shift instantly without waiting for the server re-fetch. The adjustments are cleared once the authoritative `refreshData` response arrives. `CategoryDrillDownModal` passes `(fromCategory, toCategory, amount)` back via the `onRecategorised` callback. `refreshData` also now uses `cache: 'no-store'` to ensure no stale cached response is used.

## Test plan

- [ ] Receive a renewal reminder email — body text should be dark and clearly legible on light background; header remains dark navy; CTA buttons are mint green
- [ ] Open Money Hub with a connected bank — "Search Transactions" panel appears below the spending/budgets grid; typing 2+ characters returns matching transactions with category badges
- [ ] Recategorise a transaction from the spending drill-down — the category total in the Spending Breakdown panel updates immediately (e.g. Mortgage total decreases, Credit total increases) without requiring a page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)