### PR TITLE
fix(disputes): won/partial/lost statuses counted as resolved — BUG-M1 + BUG-M3

### DIFF
--- a/src/app/api/cron/telegram-alerts/route.ts
+++ b/src/app/api/cron/telegram-alerts/route.ts
@@ -38,6 +38,11 @@ function fmt(amount: number): string {
   return `£${Math.abs(amount).toFixed(2)}`;
 }
 
+/** Escape special characters for Telegram Markdown (legacy mode). */
+function escapeMd(text: string): string {
+  return text.replace(/[_*`[]/g, '\\$&');
+}
+
 function fmtDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString('en-GB', {
     day: '2-digit',
@@ -426,7 +431,7 @@ export async function GET(request: NextRequest) {
 
       const cycle = sub.billing_cycle ?? 'monthly';
       const title = `${sub.provider_name} renews in ${daysLeft} day${daysLeft !== 1 ? 's' : ''}`;
-      const detail = `${fmt(Number(sub.amount))}/${cycle} will be charged on ${fmtDate(sub.next_billing_date)}.`;
+      const detail = `${fmt(Number(sub.amount))}/${escapeMd(cycle)} will be charged on ${fmtDate(sub.next_billing_date)}.`;
       const recommendation = null; // Cancellation email button handles this
 
       const { data: issue } = await supabase

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { isResolved } from '@/lib/disputes/statuses';
 import Link from 'next/link';
 import {
   FileText, Sparkles, Download, Copy, CheckCircle, Clock, History,
@@ -150,10 +151,7 @@ const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
 // Active statuses that can be changed via the status dropdown
 const ACTIVE_STATUSES = ['open', 'in_progress', 'awaiting_response', 'escalated', 'ombudsman'];
 
-// Check if a dispute is resolved/closed
-function isResolved(status: string): boolean {
-  return ['resolved_won', 'resolved_partial', 'resolved_lost', 'closed', 'won', 'partial', 'lost', 'withdrawn'].includes(status);
-}
+// isResolved imported from @/lib/disputes/statuses — single source of truth
 
 // Dispute summary type
 interface DisputeSummary {

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
+import { isResolved as isDisputeResolved } from '@/lib/disputes/statuses';
 import { User, Mail, CreditCard, TrendingUp, Clock, CheckCircle2, AlertCircle, Trash2, Pencil, Save, MapPin, FileText, Loader2, Sparkles, Download, Lock, X, Eye, EyeOff } from 'lucide-react';
 import Link from 'next/link';
 import { formatGBP } from '@/lib/format';
@@ -39,17 +40,18 @@ function ProfileStatsSection({ supabase, fallbackRecovered }: { supabase: Return
     const load = async () => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) { setLoaded(true); return; }
-      const [disputes, resolved] = await Promise.all([
-        supabase.from('disputes').select('id, status').eq('user_id', user.id),
+      // Use count-only head queries to avoid the 1000-row Supabase API cap.
+      // For money_recovered we still need the values — tasks are typically few.
+      const [lettersCount, activeCount, resolved] = await Promise.all([
+        supabase.from('disputes').select('id', { count: 'exact', head: true }).eq('user_id', user.id),
+        supabase.from('disputes').select('id', { count: 'exact', head: true }).eq('user_id', user.id)
+          .not('status', 'in', '(resolved_won,resolved_partial,resolved_lost,won,partial,lost,closed,withdrawn,dismissed)'),
         supabase.from('tasks').select('money_recovered').eq('user_id', user.id).eq('status', 'resolved'),
       ]);
-      const allDisputes = disputes.data || [];
-      setLettersWritten(allDisputes.length);
+      setLettersWritten(lettersCount.count || 0);
       const totalRecovered = (resolved.data || []).reduce((sum, t) => sum + (parseFloat(String(t.money_recovered)) || 0), 0);
       setMoneyRecovered(Math.max(totalRecovered, fallbackRecovered));
-      const RESOLVED_STATUSES = ['resolved_won', 'resolved_partial', 'resolved_lost', 'won', 'partial', 'lost', 'closed', 'withdrawn', 'dismissed'];
-      const activeCount = allDisputes.filter(d => !RESOLVED_STATUSES.includes(d.status)).length;
-      setActiveDisputes(activeCount);
+      setActiveDisputes(activeCount.count || 0);
       setLoaded(true);
     };
     load();

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -39,15 +39,17 @@ function ProfileStatsSection({ supabase, fallbackRecovered }: { supabase: Return
     const load = async () => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) { setLoaded(true); return; }
-      const [letters, resolved, disputes] = await Promise.all([
-        supabase.from('disputes').select('id', { count: 'exact', head: true }).eq('user_id', user.id),
+      const [disputes, resolved] = await Promise.all([
+        supabase.from('disputes').select('id, status').eq('user_id', user.id),
         supabase.from('tasks').select('money_recovered').eq('user_id', user.id).eq('status', 'resolved'),
-        supabase.from('disputes').select('id', { count: 'exact', head: true }).eq('user_id', user.id).eq('status', 'open'),
       ]);
-      setLettersWritten(letters.count || 0);
+      const allDisputes = disputes.data || [];
+      setLettersWritten(allDisputes.length);
       const totalRecovered = (resolved.data || []).reduce((sum, t) => sum + (parseFloat(String(t.money_recovered)) || 0), 0);
       setMoneyRecovered(Math.max(totalRecovered, fallbackRecovered));
-      setActiveDisputes(disputes.count || 0);
+      const RESOLVED_STATUSES = ['resolved_won', 'resolved_partial', 'resolved_lost', 'won', 'partial', 'lost', 'closed', 'withdrawn', 'dismissed'];
+      const activeCount = allDisputes.filter(d => !RESOLVED_STATUSES.includes(d.status)).length;
+      setActiveDisputes(activeCount);
       setLoaded(true);
     };
     load();

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -4,7 +4,10 @@
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
-import { isResolved as isDisputeResolved } from '@/lib/disputes/statuses';
+import { isResolved as isDisputeResolved, RESOLVED_STATUSES } from '@/lib/disputes/statuses';
+
+// Derived from the canonical RESOLVED_STATUSES constant — never edit this inline.
+const RESOLVED_IN = `(${RESOLVED_STATUSES.join(',')})` as const;
 import { User, Mail, CreditCard, TrendingUp, Clock, CheckCircle2, AlertCircle, Trash2, Pencil, Save, MapPin, FileText, Loader2, Sparkles, Download, Lock, X, Eye, EyeOff } from 'lucide-react';
 import Link from 'next/link';
 import { formatGBP } from '@/lib/format';
@@ -45,7 +48,7 @@ function ProfileStatsSection({ supabase, fallbackRecovered }: { supabase: Return
       const [lettersCount, activeCount, resolved] = await Promise.all([
         supabase.from('disputes').select('id', { count: 'exact', head: true }).eq('user_id', user.id),
         supabase.from('disputes').select('id', { count: 'exact', head: true }).eq('user_id', user.id)
-          .not('status', 'in', '(resolved_won,resolved_partial,resolved_lost,won,partial,lost,closed,withdrawn,dismissed)'),
+          .not('status', 'in', RESOLVED_IN),
         supabase.from('tasks').select('money_recovered').eq('user_id', user.id).eq('status', 'resolved'),
       ]);
       setLettersWritten(lettersCount.count || 0);

--- a/src/lib/disputes/statuses.ts
+++ b/src/lib/disputes/statuses.ts
@@ -1,0 +1,50 @@
+/**
+ * Single source of truth for dispute status groupings.
+ *
+ * These must stay in sync with:
+ *  - disputes table CHECK constraint (supabase/migrations)
+ *  - get_dispute_summary() RPC
+ *  - complaints/page.tsx (isResolved / ACTIVE_STATUSES)
+ *  - profile/page.tsx (ProfileStatsSection)
+ *
+ * Adding a new status? Update all four places.
+ */
+
+/** Statuses that represent a dispute still in flight */
+export const OPEN_STATUSES = [
+  'open',
+  'in_progress',
+  'awaiting_response',
+  'escalated',
+  'ombudsman',
+  'pending_response',
+] as const;
+
+/**
+ * Statuses that represent a dispute that has reached a terminal outcome.
+ * Both long-form ('resolved_won') and short-form ('won') aliases are included
+ * because the resolution modal writes the short form.
+ */
+export const RESOLVED_STATUSES = [
+  'resolved_won',
+  'resolved_partial',
+  'resolved_lost',
+  'won',
+  'partial',
+  'lost',
+  'closed',
+  'withdrawn',
+  'dismissed',
+] as const;
+
+export type OpenStatus = (typeof OPEN_STATUSES)[number];
+export type ResolvedStatus = (typeof RESOLVED_STATUSES)[number];
+export type DisputeStatus = OpenStatus | ResolvedStatus;
+
+export function isResolved(status: string): boolean {
+  return (RESOLVED_STATUSES as readonly string[]).includes(status);
+}
+
+export function isOpen(status: string): boolean {
+  return (OPEN_STATUSES as readonly string[]).includes(status);
+}

--- a/supabase/migrations/20260417000000_fix_dispute_summary_rpc.sql
+++ b/supabase/migrations/20260417000000_fix_dispute_summary_rpc.sql
@@ -1,0 +1,37 @@
+-- Fix get_dispute_summary RPC to correctly count all resolved statuses including 'won', 'partial', 'lost'
+-- BUG-M1 from QA report 2026-04-11: disputes with status 'won' were showing as Active instead of Resolved.
+-- The resolved_statuses array was incomplete, missing the short-form aliases used by the dispute resolution modal.
+
+CREATE OR REPLACE FUNCTION get_dispute_summary(p_user_id uuid)
+RETURNS TABLE(
+  total_open        bigint,
+  total_resolved    bigint,
+  total_disputed_amount numeric,
+  total_recovered   numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+AS $$
+  SELECT
+    COUNT(*) FILTER (
+      WHERE status NOT IN (
+        'resolved_won', 'resolved_partial', 'resolved_lost',
+        'won', 'partial', 'lost',
+        'closed', 'withdrawn', 'dismissed'
+      )
+    )::bigint                                                AS total_open,
+    COUNT(*) FILTER (
+      WHERE status IN (
+        'resolved_won', 'resolved_partial', 'resolved_lost',
+        'won', 'partial', 'lost',
+        'closed', 'withdrawn'
+      )
+    )::bigint                                                AS total_resolved,
+    COALESCE(SUM(disputed_amount), 0)                        AS total_disputed_amount,
+    COALESCE(SUM(money_recovered), 0)                        AS total_recovered
+  FROM disputes
+  WHERE user_id = p_user_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_dispute_summary(uuid) TO authenticated, service_role;

--- a/supabase/migrations/20260417000000_fix_dispute_summary_rpc.sql
+++ b/supabase/migrations/20260417000000_fix_dispute_summary_rpc.sql
@@ -1,18 +1,64 @@
 -- Fix get_dispute_summary RPC to correctly count all resolved statuses including 'won', 'partial', 'lost'
 -- BUG-M1 from QA report 2026-04-11: disputes with status 'won' were showing as Active instead of Resolved.
 -- The resolved_statuses array was incomplete, missing the short-form aliases used by the dispute resolution modal.
+--
+-- Additional fixes in this migration:
+--   P1: Added auth.uid() identity check — SECURITY DEFINER was previously readable by any authenticated user.
+--   P2: 'dismissed' added to total_resolved count (was excluded from both open and resolved).
+--   P1: Expanded disputes CHECK constraint to include all statuses used by the codebase.
+--   P2: New statuses ('in_progress', 'ombudsman', 'pending_response', 'won', 'partial', 'lost',
+--       'withdrawn', 'dismissed') were referenced in code but not allowed by the DB constraint.
 
+-- ============================================================
+-- 1. EXPAND disputes STATUS CHECK CONSTRAINT
+--    Adds all statuses referenced in src/lib/disputes/statuses.ts
+-- ============================================================
+ALTER TABLE disputes DROP CONSTRAINT IF EXISTS disputes_status_check;
+ALTER TABLE disputes ADD CONSTRAINT disputes_status_check CHECK (status IN (
+  -- Open statuses (in_progress, ombudsman, pending_response are new)
+  'open',
+  'in_progress',
+  'awaiting_response',
+  'escalated',
+  'ombudsman',
+  'pending_response',
+  -- Resolved statuses (won, partial, lost, withdrawn, dismissed are new)
+  'resolved_won',
+  'resolved_partial',
+  'resolved_lost',
+  'won',
+  'partial',
+  'lost',
+  'closed',
+  'withdrawn',
+  'dismissed'
+));
+
+-- ============================================================
+-- 2. REWRITE get_dispute_summary RPC
+--    - Switch to plpgsql so we can run procedural auth guard
+--    - Guard: caller must be the user they're querying (P1 fix)
+--    - Add 'dismissed' to resolved count (P2 fix)
+-- ============================================================
 CREATE OR REPLACE FUNCTION get_dispute_summary(p_user_id uuid)
 RETURNS TABLE(
-  total_open        bigint,
-  total_resolved    bigint,
+  total_open            bigint,
+  total_resolved        bigint,
   total_disputed_amount numeric,
-  total_recovered   numeric
+  total_recovered       numeric
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 AS $$
+BEGIN
+  -- P1 security fix: prevent any authenticated user from reading another user's data
+  IF auth.uid() IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Unauthorized: caller % cannot query disputes for user %', auth.uid(), p_user_id
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
   SELECT
     COUNT(*) FILTER (
       WHERE status NOT IN (
@@ -25,13 +71,14 @@ AS $$
       WHERE status IN (
         'resolved_won', 'resolved_partial', 'resolved_lost',
         'won', 'partial', 'lost',
-        'closed', 'withdrawn'
+        'closed', 'withdrawn', 'dismissed'
       )
     )::bigint                                                AS total_resolved,
     COALESCE(SUM(disputed_amount), 0)                        AS total_disputed_amount,
     COALESCE(SUM(money_recovered), 0)                        AS total_recovered
   FROM disputes
   WHERE user_id = p_user_id;
+END;
 $$;
 
 GRANT EXECUTE ON FUNCTION get_dispute_summary(uuid) TO authenticated, service_role;


### PR DESCRIPTION
## Summary

Comprehensive fix for dispute status consistency and the get_dispute_summary RPC. Addresses 5 issues flagged during code review of commit be2fe88.

## Changes

### Migration: \`20260417000000_fix_dispute_summary_rpc.sql\`

**P1 — Security (SECURITY DEFINER auth guard)**
The function was declared \`SECURITY DEFINER\` but had no \`auth.uid()\` check, meaning any authenticated user could query another user's dispute counts by passing a different UUID. The rewritten function raises \`insufficient_privilege\` if \`auth.uid() IS DISTINCT FROM p_user_id\`.

**P1 — CHECK constraint expanded**
New statuses used by the resolution modal (\`won\`, \`partial\`, \`lost\`, \`withdrawn\`, \`dismissed\`) and by the status lib (\`in_progress\`, \`ombudsman\`, \`pending_response\`) were referenced in code but not allowed by the DB constraint. Any insert with these values would fail silently. The migration drops and recreates the constraint to include all 15 valid statuses.

**P2 — \`dismissed\` counted as resolved**
\`dismissed\` was excluded from both the \`total_open\` NOT IN list and the \`total_resolved\` IN list, making dismissed disputes disappear from all counts. Fixed by adding \`dismissed\` to the resolved IN list.

**P2 — Switched to \`LANGUAGE plpgsql\`**
Needed to support the procedural \`RAISE EXCEPTION\` auth guard (plain SQL functions cannot use procedural statements).

### \`src/lib/disputes/statuses.ts\` (NEW)
Single source of truth for dispute status groupings — \`OPEN_STATUSES\`, \`RESOLVED_STATUSES\`, \`isResolved()\`, \`isOpen()\`. Comments note all 4 places that must stay in sync (migration, RPC, complaints page, profile page).

### \`src/app/dashboard/complaints/page.tsx\`
Removed local \`isResolved\` function; now imports from \`@/lib/disputes/statuses\`.

### \`src/app/dashboard/profile/page.tsx\`

**P2 — Scalable count queries**
Replaced \`select('id, status').eq('user_id', user.id)\` (which Supabase silently truncates at 1,000 rows) with two count-only queries using \`select('id', { count: 'exact', head: true })\`. Users with 1,000+ disputes will now see accurate counts on their profile.

Removed inline \`RESOLVED_STATUSES\` array; now imports shared constant from \`@/lib/disputes/statuses\`.

### \`src/app/auth/login/page.tsx\`
Fixed pre-existing TypeScript error (missing closing \`}\`) that caused \`tsc --noEmit\` to fail on this branch.

## Test plan

- [ ] Open a dispute and mark it as "Won" via the Resolve modal — Resolved counter increments, Active decrements
- [ ] Mark a dispute as "dismissed" — it counts as Resolved, not Active, not invisible
- [ ] Profile page Active disputes count matches Disputes page count
- [ ] Attempt to insert a dispute with status \`in_progress\`, \`ombudsman\`, \`pending_response\`, \`won\`, \`partial\`, \`lost\`, \`withdrawn\`, \`dismissed\` — all succeed without constraint violation
- [ ] Calling \`get_dispute_summary\` with another user's UUID returns permission denied
- [ ] User with 1,000+ disputes sees accurate Active and Resolved counts on Profile page

🤖 Generated with [Claude Code](https://claude.com/claude-code)