### PR TITLE
feat: morning briefing transaction detail & dispute status fix

### DIFF
--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -44,6 +44,11 @@ function fmtMerchant(raw: string): string {
   return capped.length > 25 ? capped.slice(0, 25) + '\u2026' : capped;
 }
 
+function escapeMd(text: string): string {
+  // Escape Telegram MarkdownV1 special chars: _ * ` [
+  return text.replace(/([_*`\[])/g, '\\$1');
+}
+
 function fmtDisputeStatus(status: string): string {
   const normalised = status.toLowerCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
   const map: Record<string, string> = {
@@ -255,7 +260,7 @@ export async function GET(request: NextRequest) {
 
         let spendingSection = `\n\n*Yesterday's Spending (${fmtGbp(total)})*`;
         for (const t of displayed) {
-          const name = fmtMerchant(t.merchant_name || t.description || 'Unknown');
+          const name = escapeMd(fmtMerchant(t.merchant_name || t.description || 'Unknown'));
           spendingSection += `\n  \u2022 ${name} \u2014 ${fmtGbp(Number(t.amount))}`;
         }
         if (remainder.length > 0) {
@@ -279,7 +284,7 @@ export async function GET(request: NextRequest) {
         let renewalSection = '\n\n*Upcoming Renewals*';
         for (const sub of renewals) {
           const when = sub.next_billing_date === todayStr ? 'Today' : 'Tomorrow';
-          renewalSection += `\n  - ${sub.provider_name}: ${fmt(Number(sub.amount))}/${sub.billing_cycle ?? 'month'} (${when})`;
+          renewalSection += `\n  - ${escapeMd(sub.provider_name)}: ${fmt(Number(sub.amount))}/${sub.billing_cycle ?? 'month'} (${when})`;
         }
         sections.push(renewalSection);
       }
@@ -297,7 +302,7 @@ export async function GET(request: NextRequest) {
       if (expiringContracts && expiringContracts.length > 0) {
         let contractSection = '\n\n*Contracts Expiring This Week*';
         for (const c of expiringContracts) {
-          contractSection += `\n  - ${c.provider_name}: ends ${fmtDate(c.contract_end_date)}`;
+          contractSection += `\n  - ${escapeMd(c.provider_name)}: ends ${fmtDate(c.contract_end_date)}`;
         }
         sections.push(contractSection);
       }
@@ -336,7 +341,7 @@ export async function GET(request: NextRequest) {
         let budgetSection = '\n\n*Budget Warnings*';
         for (const w of budgetWarnings) {
           const emoji = w.pct >= 100 ? '\u26a0\ufe0f' : '\u23f3';
-          budgetSection += `\n  ${emoji} ${w.category}: ${fmt(w.spent)} / ${fmt(w.limit)} (${Math.round(w.pct)}%)`;
+          budgetSection += `\n  ${emoji} ${escapeMd(w.category)}: ${fmt(w.spent)} / ${fmt(w.limit)} (${Math.round(w.pct)}%)`;
         }
         sections.push(budgetSection);
       }
@@ -351,7 +356,7 @@ export async function GET(request: NextRequest) {
       if (openDisputes && openDisputes.length > 0) {
         let disputeSection = `\n\n*Open Disputes (${openDisputes.length})*`;
         for (const d of openDisputes.slice(0, 3)) {
-          disputeSection += `\n  - ${d.provider_name}: ${d.issue_type} (${fmtDisputeStatus(d.status)})`;
+          disputeSection += `\n  - ${escapeMd(d.provider_name)}: ${escapeMd(d.issue_type)} (${fmtDisputeStatus(d.status)})`;
         }
         if (openDisputes.length > 3) {
           disputeSection += `\n  _...and ${openDisputes.length - 3} more_`;

--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -260,7 +260,7 @@ export async function GET(request: NextRequest) {
 
         let spendingSection = `\n\n*Yesterday's Spending (${fmtGbp(total)})*`;
         for (const t of displayed) {
-          const name = escapeMd(fmtMerchant(t.merchant_name || t.description || 'Unknown'));
+          const name = escapeMd(fmtMerchant(t.merchant_name?.trim() || t.description?.trim() || 'Unknown'));
           spendingSection += `\n  \u2022 ${name} \u2014 ${fmtGbp(Number(t.amount))}`;
         }
         if (remainder.length > 0) {
@@ -356,7 +356,7 @@ export async function GET(request: NextRequest) {
       if (openDisputes && openDisputes.length > 0) {
         let disputeSection = `\n\n*Open Disputes (${openDisputes.length})*`;
         for (const d of openDisputes.slice(0, 3)) {
-          disputeSection += `\n  - ${escapeMd(d.provider_name)}: ${escapeMd(d.issue_type)} (${fmtDisputeStatus(d.status)})`;
+          disputeSection += `\n  - ${escapeMd(d.provider_name)}: ${escapeMd(d.issue_type)} (${escapeMd(fmtDisputeStatus(d.status))})`;
         }
         if (openDisputes.length > 3) {
           disputeSection += `\n  _...and ${openDisputes.length - 3} more_`;

--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -34,6 +34,31 @@ function fmtDate(dateStr: string): string {
   });
 }
 
+function fmtGbp(amount: number): string {
+  return `£${Math.abs(amount).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function fmtMerchant(raw: string): string {
+  const trimmed = raw.trim();
+  const capped = trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+  return capped.length > 25 ? capped.slice(0, 25) + '\u2026' : capped;
+}
+
+function fmtDisputeStatus(status: string): string {
+  const normalised = status.toLowerCase().replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
+  const map: Record<string, string> = {
+    'resolved won': 'resolved (won)',
+    'resolvedwon': 'resolved (won)',
+    'resolved lost': 'resolved (lost)',
+    'resolvedlost': 'resolved (lost)',
+    'awaiting response': 'awaiting response',
+    'awaitingresponse': 'awaiting response',
+    'in progress': 'in progress',
+    'inprogress': 'in progress',
+  };
+  return map[normalised] ?? normalised;
+}
+
 function splitMessage(text: string, limit = 4000): string[] {
   if (text.length <= limit) return [text];
   const chunks: string[] = [];
@@ -205,10 +230,10 @@ export async function GET(request: NextRequest) {
       sections.push('*Good morning! Here\'s your daily money briefing:*');
 
       // ------ 1. Yesterday's spending ------
-      const EXCLUDE_CATS = new Set(['transfers', 'income']);
+      const EXCLUDE_CATS = new Set(['transfers', 'income', 'internal_transfer']);
       const { data: yesterdayTxRaw } = await supabase
         .from('bank_transactions')
-        .select('user_category, amount')
+        .select('merchant_name, description, user_category, amount')
         .eq('user_id', userId)
         .lt('amount', 0)
         .gte('timestamp', yesterdayStart.toISOString())
@@ -220,22 +245,21 @@ export async function GET(request: NextRequest) {
 
       if (yesterdayTx.length > 0) {
         const total = yesterdayTx.reduce((sum, t) => sum + Math.abs(Number(t.amount)), 0);
-        const byCategory: Record<string, number> = {};
-        for (const t of yesterdayTx) {
-          const cat = t.user_category ?? 'Other';
-          byCategory[cat] = (byCategory[cat] ?? 0) + Math.abs(Number(t.amount));
+
+        const sorted = [...yesterdayTx].sort(
+          (a, b) => Math.abs(Number(b.amount)) - Math.abs(Number(a.amount)),
+        );
+        const displayed = sorted.slice(0, 8);
+        const remainder = sorted.slice(8);
+        const remainderTotal = remainder.reduce((sum, t) => sum + Math.abs(Number(t.amount)), 0);
+
+        let spendingSection = `\n\n*Yesterday's Spending (${fmtGbp(total)})*`;
+        for (const t of displayed) {
+          const name = fmtMerchant(t.merchant_name || t.description || 'Unknown');
+          spendingSection += `\n  \u2022 ${name} \u2014 ${fmtGbp(Number(t.amount))}`;
         }
-
-        const topCategories = Object.entries(byCategory)
-          .sort(([, a], [, b]) => b - a)
-          .slice(0, 3);
-
-        let spendingSection = `\n\n*Yesterday's Spending*\nTotal: *${fmt(total)}*`;
-        if (topCategories.length > 0) {
-          spendingSection += '\nTop categories:';
-          for (const [cat, amount] of topCategories) {
-            spendingSection += `\n  - ${cat}: ${fmt(amount)}`;
-          }
+        if (remainder.length > 0) {
+          spendingSection += `\n  _\u2026and ${remainder.length} more (${fmtGbp(remainderTotal)})_`;
         }
         sections.push(spendingSection);
       } else {
@@ -327,7 +351,7 @@ export async function GET(request: NextRequest) {
       if (openDisputes && openDisputes.length > 0) {
         let disputeSection = `\n\n*Open Disputes (${openDisputes.length})*`;
         for (const d of openDisputes.slice(0, 3)) {
-          disputeSection += `\n  - ${d.provider_name}: ${d.issue_type} (${d.status})`;
+          disputeSection += `\n  - ${d.provider_name}: ${d.issue_type} (${fmtDisputeStatus(d.status)})`;
         }
         if (openDisputes.length > 3) {
           disputeSection += `\n  _...and ${openDisputes.length - 3} more_`;


### PR DESCRIPTION
## Summary

- **Yesterday's Spending** now lists individual transactions instead of category totals
  - Header shows total inline: `Yesterday's Spending (£99.54)`
  - Transactions sorted by amount descending, top 8 shown
  - Each line: `• Merchant Name — £12.34`
  - Overflow: `…and X more (£Y)` if more than 8 transactions
  - Fetches `merchant_name` / `description` from `bank_transactions`; excludes `transfers`, `income`, and `internal_transfer` categories
- **Dispute status** now renders as human-readable text:
  - `resolvedwon` / `resolved_won` → `resolved (won)`
  - `awaitingresponse` / `awaiting_response` → `awaiting response`
  - `in_progress` / `inprogress` → `in progress`
  - Any other status: underscores replaced with spaces, lowercased

## Files changed

- `src/app/api/cron/telegram-morning-summary/route.ts`
  - Added `fmtGbp`, `fmtMerchant`, `fmtDisputeStatus` helpers
  - Replaced category aggregation logic with individual transaction listing
  - Applied `fmtDisputeStatus` to dispute status output

## Test plan

- [ ] Trigger the cron locally with a user who has yesterday's bank transactions — verify bullet list appears with merchant names and amounts
- [ ] Verify overflow line appears correctly when user has >8 transactions
- [ ] Verify a dispute with status `resolvedwon` renders as `resolved (won)` in the message
- [ ] Verify a dispute with status `awaiting_response` renders as `awaiting response`
- [ ] Confirm no spending section shows "No spending recorded yesterday" when there are no transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)