### PR TITLE
fix: sync all bank tiers 4x/day, remove free-tier weekly gate

### DIFF
--- a/src/app/api/cron/bank-sync/route.ts
+++ b/src/app/api/cron/bank-sync/route.ts
@@ -70,9 +70,7 @@ export async function GET(request: NextRequest) {
   }
 
   const supabase = getAdmin();
-  const today = new Date();
-  const isMonday = today.getUTCDay() === 1; // 0=Sunday, 1=Monday
-  const now = today.toISOString();
+  const now = new Date().toISOString();
 
   // Check global API ceiling before doing anything
   const callCountAtStart = await getTodayApiCallCount(supabase);
@@ -89,11 +87,9 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  // Determine which tiers to sync today
-  // Pro + Essential: every day. Free: Mondays only.
-  const tiersToSync = isMonday
-    ? ['pro', 'essential', 'free']
-    : ['pro', 'essential'];
+  // Sync all tiers every run — transaction fetches are free under TrueLayer's pricing.
+  // Connection limits (Free: 1, Essential: 2, Pro: unlimited) are enforced at OAuth time.
+  const tiersToSync = ['pro', 'essential', 'free'];
 
   // Fetch all users by tier, maintaining processing order (Pro first)
   const { data: allProfiles } = await supabase
@@ -580,12 +576,11 @@ export async function GET(request: NextRequest) {
   console.log(
     `Bank sync complete: connections=${results.length} txs=${totalTxs} ` +
     `recurring=${totalRecurring} errors=${errors} api_calls=${totalApiCalls} ` +
-    `monday=${isMonday} tiers_synced=${tiersToSync.join(',')}`
+    `tiers_synced=${tiersToSync.join(',')}`
   );
 
   return NextResponse.json({
     ok: true,
-    is_monday: isMonday,
     tiers_synced: tiersToSync,
     connections_processed: results.length,
     total_transactions: totalTxs,

--- a/src/lib/bank-tier-config.ts
+++ b/src/lib/bank-tier-config.ts
@@ -10,8 +10,8 @@ export type BankTier = 'free' | 'essential' | 'pro';
 export const TIER_CONFIG = {
   free: {
     maxConnections: 1,
-    dailyCron: false,     // Only syncs on Mondays via cron
-    weeklyCron: true,
+    dailyCron: true,
+    weeklyCron: false,
     manualSyncAllowed: false,
     manualSyncCooldownHours: 0,
     manualSyncDailyLimit: 0,

--- a/vercel.json
+++ b/vercel.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "/api/cron/bank-sync",
-      "schedule": "0 3,14,19 * * *"
+      "schedule": "0 0,6,12,18 * * *"
     },
     {
       "path": "/api/cron/renewal-reminders",


### PR DESCRIPTION
## Summary

- **`vercel.json`**: Bank-sync cron changed from `0 3,14,19 * * *` (3x/day, uneven spread) to `0 0,6,12,18 * * *` (4x/day, every 6 hours)
- **`src/lib/bank-tier-config.ts`**: Free tier `dailyCron` set to `true`, `weeklyCron` set to `false`
- **`src/app/api/cron/bank-sync/route.ts`**: Removed `isMonday` gate — all tiers (`['pro', 'essential', 'free']`) sync on every cron run

## Why

Transaction fetches against an already-connected bank account are free under TrueLayer's pricing model — only the OAuth connection itself costs money. The previous code synced free-tier users only on Mondays with no cost justification. All connected users now get the same sync frequency.

4x/day (every 6h) is the practical safe maximum under UK Open Banking / PSD2: banks typically allow up to 4 polling calls per day per account before rate-limiting, and FCA guidance requires fetching no more often than necessary for the service.

Connection limits (Free: 1 bank, Essential: 2, Pro: unlimited) are unaffected — those are still enforced at TrueLayer OAuth time.

## Test plan

- [ ] Verify cron fires at 00:00, 06:00, 12:00, 18:00 UTC in Vercel dashboard after deploy
- [ ] Confirm a free-tier user with a connected bank gets transactions on a non-Monday run
- [ ] Check `bank_sync_log` — `tiers_synced` should always include `free`
- [ ] Confirm `is_monday` field is gone from cron response JSON (callers should not depend on it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)