### PR TITLE
fix(migration): P1 fixes — dedup before unique index + auth ownership guard

### DIFF
--- a/supabase/migrations/20260417000000_subscription_category_unity.sql
+++ b/supabase/migrations/20260417000000_subscription_category_unity.sql
@@ -40,6 +40,26 @@
 --   (a) a single merchant-wide override per user per pattern
 --   (b) many transaction-specific overrides for the same pattern
 -- by scoping uniqueness to transaction_id IS NULL rows only.
+
+-- Deduplicate existing merchant-pattern overrides before creating the unique
+-- index. Prior code paths could insert duplicate (user_id, merchant_pattern)
+-- rows with transaction_id IS NULL without any uniqueness guard, so we must
+-- remove them first or the CREATE UNIQUE INDEX will abort. We keep the most
+-- recently created row per pair and delete all others.
+DELETE FROM money_hub_category_overrides
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+           ROW_NUMBER() OVER (
+             PARTITION BY user_id, merchant_pattern
+             ORDER BY created_at DESC NULLS LAST, id DESC
+           ) AS rn
+    FROM money_hub_category_overrides
+    WHERE transaction_id IS NULL
+  ) ranked
+  WHERE rn > 1
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_mhco_user_merchant_pattern_uniq
   ON money_hub_category_overrides (user_id, merchant_pattern)
   WHERE transaction_id IS NULL;
@@ -85,6 +105,15 @@ DECLARE
 BEGIN
   IF p_user_id IS NULL OR p_subscription_id IS NULL OR p_new_category IS NULL THEN
     RAISE EXCEPTION 'apply_subscription_category_correction: user_id, subscription_id, new_category required';
+  END IF;
+
+  -- Ownership guard: SECURITY DEFINER functions run as the function owner, so
+  -- we must explicitly verify the caller owns the data they are modifying.
+  -- service_role bypasses RLS and can legitimately pass any user_id (cron /
+  -- backfill), so we only enforce this check for normal authenticated sessions.
+  IF auth.uid() IS DISTINCT FROM p_user_id
+     AND current_setting('role', true) IS DISTINCT FROM 'service_role' THEN
+    RAISE EXCEPTION 'insufficient_privilege';
   END IF;
 
   -- 2a. Keep subscriptions.category authoritative (idempotent; caller usually


### PR DESCRIPTION
## Summary

Applies the two P1 fixes flagged by the Vercel bot on the Subscriptions ↔ Money Hub category unity migration:

- **P1a — Dedup before UNIQUE INDEX**: Adds a DELETE CTE before CREATE UNIQUE INDEX on money_hub_category_overrides (user_id, merchant_pattern) WHERE transaction_id IS NULL. Without this, the index creation aborts if any duplicate rows exist in production.

- **P1b — Ownership guard in apply_subscription_category_correction RPC**: The function is SECURITY DEFINER so it runs as the function owner and bypasses RLS. Added an auth.uid() IS DISTINCT FROM p_user_id check so authenticated callers cannot write to another user's data by passing a foreign p_user_id. service_role is exempted for cron/backfill paths.

## Files changed

supabase/migrations/20260417000000_subscription_category_unity.sql — both fixes are additive within the migration

## ⚠️ If migration already ran

If the migration was applied before this PR merges, the dedup fix is moot (index already created or failed), but the ownership guard is not — a follow-up migration will be needed to CREATE OR REPLACE FUNCTION with the guard.

## Test plan

- [ ] Migration applies cleanly on a branch database with existing overrides data
- [ ] service_role can still call the RPC (cron/backfill path)
- [ ] Authenticated user cannot pass another user's ID to write their data

🤖 Generated with [Claude Code](https://claude.com/claude-code)