### PR TITLE
feat(telegram): quiet hours guard — suppress proactive messages 23:00–05:00

### DIFF
--- a/src/app/api/cron/telegram-alerts/route.ts
+++ b/src/app/api/cron/telegram-alerts/route.ts
@@ -23,6 +23,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { sendProactiveAlert } from '@/lib/telegram/user-bot';
 import { queueTelegramAlert } from '@/lib/telegram/queue';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -69,7 +70,7 @@ export async function GET(request: NextRequest) {
   const userIds = sessions.map((s) => s.user_id);
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', userIds);
 
   const proUserIds = new Set(
@@ -87,9 +88,14 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
-
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   for (const session of proSessions) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
+
+    if (isQuietHours(tzMap.get(userId))) {
+      console.log(`[telegram-alerts] quiet hours: suppressed alerts for user ${userId}`);
+      continue;
+    }
 
     // Check for existing active detected_issues to avoid duplicates
     const { data: existingIssues } = await supabase

--- a/src/app/api/cron/telegram-budget-alerts/route.ts
+++ b/src/app/api/cron/telegram-budget-alerts/route.ts
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -90,6 +90,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences
@@ -109,7 +110,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-budget-alerts] quiet hours: suppressed message to chat ${chatId}`);
         continue;
       }

--- a/src/app/api/cron/telegram-budget-alerts/route.ts
+++ b/src/app/api/cron/telegram-budget-alerts/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -108,6 +109,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-budget-alerts] quiet hours: suppressed message to chat ${chatId}`);
+        continue;
+      }
       // Get user's budget limits
       const { data: budgets } = await supabase
         .from('money_hub_budgets')

--- a/src/app/api/cron/telegram-contract-expiry/route.ts
+++ b/src/app/api/cron/telegram-contract-expiry/route.ts
@@ -102,7 +102,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -120,6 +120,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences
@@ -146,7 +147,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-contract-expiry] quiet hours: suppressed message to chat ${chatId}`);
         continue;
       }

--- a/src/app/api/cron/telegram-contract-expiry/route.ts
+++ b/src/app/api/cron/telegram-contract-expiry/route.ts
@@ -10,6 +10,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -145,6 +146,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-contract-expiry] quiet hours: suppressed message to chat ${chatId}`);
+        continue;
+      }
       // Contracts expiring in next 30 days
       const { data: expiring } = await supabase
         .from('subscriptions')

--- a/src/app/api/cron/telegram-dispute-tracker/route.ts
+++ b/src/app/api/cron/telegram-dispute-tracker/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -118,6 +119,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-dispute-tracker] quiet hours: suppressed message to chat ${chatId}`);
+        continue;
+      }
       // Get open/awaiting disputes
       const { data: disputes } = await supabase
         .from('disputes')

--- a/src/app/api/cron/telegram-dispute-tracker/route.ts
+++ b/src/app/api/cron/telegram-dispute-tracker/route.ts
@@ -82,7 +82,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -100,6 +100,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences
@@ -119,7 +120,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-dispute-tracker] quiet hours: suppressed message to chat ${chatId}`);
         continue;
       }

--- a/src/app/api/cron/telegram-evening-summary/route.ts
+++ b/src/app/api/cron/telegram-evening-summary/route.ts
@@ -16,6 +16,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { sendBatchedDigest } from '@/lib/telegram/queue';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -173,6 +174,11 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-evening-summary] quiet hours: suppressed message to chat ${chatId}`);
+        skipped++;
+        continue;
+      }
       // ── 0. Flush any pending alert queue first (separate message) ──────────
       // Batches all queued findings from email scans / detections into one
       // concise "daily money update" message with inline action buttons.

--- a/src/app/api/cron/telegram-evening-summary/route.ts
+++ b/src/app/api/cron/telegram-evening-summary/route.ts
@@ -118,7 +118,7 @@ export async function GET(request: NextRequest) {
   const userIds = sessions.map((s) => s.user_id);
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', userIds);
 
   const proUserIds = new Set(
@@ -136,7 +136,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
-
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   // Check alert preferences — skip users who disabled evening summary
   const { data: allPrefs } = await supabase
     .from('telegram_alert_preferences')
@@ -174,7 +174,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-evening-summary] quiet hours: suppressed message to chat ${chatId}`);
         skipped++;
         continue;

--- a/src/app/api/cron/telegram-month-end-recap/route.ts
+++ b/src/app/api/cron/telegram-month-end-recap/route.ts
@@ -115,7 +115,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -133,6 +133,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences
@@ -151,7 +152,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-month-end-recap] quiet hours: suppressed message to chat ${chatId}`);
         continue;
       }

--- a/src/app/api/cron/telegram-month-end-recap/route.ts
+++ b/src/app/api/cron/telegram-month-end-recap/route.ts
@@ -13,6 +13,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -150,6 +151,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-month-end-recap] quiet hours: suppressed message to chat ${chatId}`);
+        continue;
+      }
       // Parallel RPC calls — same RPCs as Money Hub dashboard
       const [prevSpendRes, prevPrevSpendRes, prevIncomeRes, prevBreakdownRes] = await Promise.all([
         supabase.rpc('get_monthly_spending_total', { p_user_id: userId, p_year: prevYear, p_month: prevMonth }),

--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -121,7 +121,7 @@ export async function GET(request: NextRequest) {
   const userIds = sessions.map((s) => s.user_id);
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', userIds);
 
   const proUserIds = new Set(
@@ -139,7 +139,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
-
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   // Check alert preferences — skip users who disabled morning summary
   const { data: allPrefs } = await supabase
     .from('telegram_alert_preferences')
@@ -191,7 +191,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-morning-summary] quiet hours: suppressed message to chat ${chatId}`);
         skipped++;
         continue;

--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -190,6 +191,11 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-morning-summary] quiet hours: suppressed message to chat ${chatId}`);
+        skipped++;
+        continue;
+      }
       // Check if user has any bank transaction data at all
       const { count: txCount } = await supabase
         .from('bank_transactions')

--- a/src/app/api/cron/telegram-payday-summary/route.ts
+++ b/src/app/api/cron/telegram-payday-summary/route.ts
@@ -13,6 +13,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -112,6 +113,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-payday-summary] quiet hours: suppressed message to chat ${chatId}`);
+        continue;
+      }
       // Look for salary/income transactions in the last 2 days
       // Income: positive amounts, categorised as income, or large credits
       const { data: incomeTxns } = await supabase

--- a/src/app/api/cron/telegram-payday-summary/route.ts
+++ b/src/app/api/cron/telegram-payday-summary/route.ts
@@ -77,7 +77,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -95,6 +95,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences
@@ -113,7 +114,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-payday-summary] quiet hours: suppressed message to chat ${chatId}`);
         continue;
       }

--- a/src/app/api/cron/telegram-payment-reminders/route.ts
+++ b/src/app/api/cron/telegram-payment-reminders/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -171,6 +172,11 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-payment-reminders] quiet hours: suppressed message to chat ${chatId}`);
+        skipped++;
+        continue;
+      }
       const { data: payments } = await supabase
         .from('subscriptions')
         .select('provider_name, amount, next_billing_date, category')

--- a/src/app/api/cron/telegram-payment-reminders/route.ts
+++ b/src/app/api/cron/telegram-payment-reminders/route.ts
@@ -120,7 +120,7 @@ export async function GET(request: NextRequest) {
   const userIds = sessions.map((s) => s.user_id);
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', userIds);
 
   const proUserIds = new Set(
@@ -138,7 +138,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
-
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) {
     return NextResponse.json({ ok: true, message: 'No Pro sessions', sent: 0 });
   }
@@ -172,7 +172,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-payment-reminders] quiet hours: suppressed message to chat ${chatId}`);
         skipped++;
         continue;

--- a/src/app/api/cron/telegram-price-increase-detection/route.ts
+++ b/src/app/api/cron/telegram-price-increase-detection/route.ts
@@ -15,6 +15,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { sendProactiveAlert } from '@/lib/telegram/user-bot';
 import { queueTelegramAlert } from '@/lib/telegram/queue';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -86,7 +87,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -104,6 +105,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences
@@ -123,6 +125,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours(tzMap.get(userId))) {
+        console.log(`[telegram-price-increase-detection] quiet hours: suppressed for user ${userId}`);
+        continue;
+      }
       // Get active subscriptions
       const { data: subscriptions } = await supabase
         .from('subscriptions')

--- a/src/app/api/cron/telegram-savings-milestone/route.ts
+++ b/src/app/api/cron/telegram-savings-milestone/route.ts
@@ -10,6 +10,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -109,6 +110,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-savings-milestone] quiet hours: suppressed message to chat ${chatId}`);
+        continue;
+      }
       // Total verified savings from verified_savings table
       const { data: savings } = await supabase
         .from('verified_savings')

--- a/src/app/api/cron/telegram-savings-milestone/route.ts
+++ b/src/app/api/cron/telegram-savings-milestone/route.ts
@@ -74,7 +74,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -92,6 +92,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences — respect users who opted out of proactive alerts
@@ -110,7 +111,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-savings-milestone] quiet hours: suppressed message to chat ${chatId}`);
         continue;
       }

--- a/src/app/api/cron/telegram-unused-subscription-alert/route.ts
+++ b/src/app/api/cron/telegram-unused-subscription-alert/route.ts
@@ -10,6 +10,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -122,6 +123,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-unused-subscription-alert] quiet hours: suppressed message to chat ${chatId}`);
+        continue;
+      }
       // Get active subscriptions (exclude one-time and yearly — yearly is expected to have gaps)
       const { data: subscriptions } = await supabase
         .from('subscriptions')

--- a/src/app/api/cron/telegram-unused-subscription-alert/route.ts
+++ b/src/app/api/cron/telegram-unused-subscription-alert/route.ts
@@ -87,7 +87,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -105,6 +105,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences
@@ -123,7 +124,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-unused-subscription-alert] quiet hours: suppressed message to chat ${chatId}`);
         continue;
       }

--- a/src/app/api/cron/telegram-weekly-summary/route.ts
+++ b/src/app/api/cron/telegram-weekly-summary/route.ts
@@ -11,6 +11,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { isQuietHours } from '@/lib/telegram/quiet-hours';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -153,6 +154,10 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
+      if (isQuietHours()) {
+        console.log(`[telegram-weekly-summary] quiet hours: suppressed message to chat ${chatId}`);
+        continue;
+      }
       // Fetch bills for the current month; also fetch next month's bills when
       // the 7-day window crosses a month boundary.
       const billFetches = [

--- a/src/app/api/cron/telegram-weekly-summary/route.ts
+++ b/src/app/api/cron/telegram-weekly-summary/route.ts
@@ -91,7 +91,7 @@ export async function GET(request: NextRequest) {
   // Filter to Pro users
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
+    .select('id, subscription_tier, subscription_status, stripe_subscription_id, timezone')
     .in('id', sessions.map((s) => s.user_id));
 
   const proUserIds = new Set(
@@ -109,6 +109,7 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const tzMap = new Map((profiles ?? []).map(p => [p.id, p.timezone ?? undefined]));
   if (proSessions.length === 0) return NextResponse.json({ ok: true, sent: 0 });
 
   // Check alert preferences
@@ -154,7 +155,7 @@ export async function GET(request: NextRequest) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      if (isQuietHours()) {
+      if (isQuietHours(tzMap.get(userId))) {
         console.log(`[telegram-weekly-summary] quiet hours: suppressed message to chat ${chatId}`);
         continue;
       }

--- a/src/lib/telegram/queue.ts
+++ b/src/lib/telegram/queue.ts
@@ -13,6 +13,7 @@
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { isQuietHours } from './quiet-hours';
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
@@ -221,6 +222,11 @@ export async function sendBatchedDigest(
 ): Promise<{ sent: boolean; count: number }> {
   const token = process.env.TELEGRAM_USER_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
   if (!token) return { sent: false, count: 0 };
+
+  if (isQuietHours()) {
+    console.log(`[telegram] quiet hours: suppressed batched digest to chat ${chatId}`);
+    return { sent: false, count: 0 };
+  }
 
   const { data: alerts, error } = await supabase
     .from('telegram_pending_alerts')

--- a/src/lib/telegram/quiet-hours.ts
+++ b/src/lib/telegram/quiet-hours.ts
@@ -2,7 +2,7 @@
  * Quiet hours guard for proactive Telegram messages.
  *
  * Returns true if the current wall-clock time in the given IANA timezone
- * falls within the do-not-disturb window (23:00–05:00 inclusive).
+ * falls within the do-not-disturb window (23:00–04:59).
  * Falls back to Europe/London when no timezone is supplied or the supplied
  * value is unrecognised.
  *

--- a/src/lib/telegram/quiet-hours.ts
+++ b/src/lib/telegram/quiet-hours.ts
@@ -1,0 +1,35 @@
+/**
+ * Quiet hours guard for proactive Telegram messages.
+ *
+ * Returns true if the current wall-clock time in the given IANA timezone
+ * falls within the do-not-disturb window (23:00–05:00 inclusive).
+ * Falls back to Europe/London when no timezone is supplied or the supplied
+ * value is unrecognised.
+ *
+ * Usage:
+ *   if (isQuietHours()) { return; }          // UK time (default)
+ *   if (isQuietHours('America/New_York')) {}  // user-local time
+ */
+export function isQuietHours(timezone?: string): boolean {
+  const tz = timezone?.trim() || 'Europe/London';
+
+  let hour: number;
+  try {
+    // Extract the hour in the target timezone using Intl.
+    // 'numeric' / hour12:false gives values 0–23.
+    const fmt = new Intl.DateTimeFormat('en-GB', {
+      timeZone: tz,
+      hour: 'numeric',
+      hour12: false,
+    });
+    hour = parseInt(fmt.format(new Date()), 10);
+    if (Number.isNaN(hour)) throw new Error('parse failed');
+  } catch {
+    // Invalid / unknown timezone — retry with London so we never throw.
+    if (tz !== 'Europe/London') return isQuietHours('Europe/London');
+    return false;
+  }
+
+  // Quiet window: 23:00 (inclusive) through 04:59 (inclusive)
+  return hour >= 23 || hour < 5;
+}

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -1712,13 +1712,13 @@ export async function sendProactiveAlert(params: {
     issue_type: string;
   };
   showFollowUpButtons?: boolean;
-}): Promise<{ messageId?: number; ok: boolean }> {
+}): Promise<{ messageId?: number; ok: boolean; suppressed?: boolean }> {
   const token = (process.env.TELEGRAM_USER_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN);
   if (!token) return { ok: false };
 
   if (isQuietHours()) {
     console.log(`[telegram] quiet hours: suppressed proactive alert to chat ${params.chatId}`);
-    return { ok: false };
+    return { ok: false, suppressed: true };
   }
 
   const { chatId, issue, showFollowUpButtons } = params;

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -15,6 +15,7 @@ import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
 import { telegramTools } from './tools';
 import { executeToolCall, type PendingAction } from './tool-handlers';
+import { isQuietHours } from './quiet-hours';
 
 // ============================================================
 // Supabase admin client
@@ -1714,6 +1715,11 @@ export async function sendProactiveAlert(params: {
 }): Promise<{ messageId?: number; ok: boolean }> {
   const token = (process.env.TELEGRAM_USER_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN);
   if (!token) return { ok: false };
+
+  if (isQuietHours()) {
+    console.log(`[telegram] quiet hours: suppressed proactive alert to chat ${params.chatId}`);
+    return { ok: false };
+  }
 
   const { chatId, issue, showFollowUpButtons } = params;
   const TELEGRAM_API = `https://api.telegram.org/bot${token}`;

--- a/supabase/migrations/20260418000000_profiles_timezone.sql
+++ b/supabase/migrations/20260418000000_profiles_timezone.sql
@@ -1,0 +1,4 @@
+-- Store the user's IANA timezone (e.g. 'Europe/London', 'America/New_York').
+-- Used by Telegram notification crons to enforce per-user quiet hours.
+-- NULL means unknown — crons fall back to Europe/London.
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS timezone TEXT;


### PR DESCRIPTION
## Summary

- Adds `src/lib/telegram/quiet-hours.ts` with an `isQuietHours(timezone?: string): boolean` utility. Defaults to `Europe/London` when no timezone is supplied; handles invalid IANA strings gracefully.
- Guards every proactive send path so no message is sent between 23:00 and 05:00 in the user's local time. Reactive replies to user commands are not affected.
- Suppressed sends are logged to Vercel (e.g. `[telegram-morning-summary] quiet hours: suppressed message to chat 123456`) so they're visible in the dashboard.

## Send locations patched

| Location | Type |
|---|---|
| `src/lib/telegram/user-bot.ts` — `sendProactiveAlert()` | Immediate urgent alerts (price spikes, contract expiry < 3d) |
| `src/lib/telegram/queue.ts` — `sendBatchedDigest()` | Batched evening alert digest |
| `cron/telegram-morning-summary` | Daily 7:30am briefing |
| `cron/telegram-evening-summary` | Daily 9pm wrap-up |
| `cron/telegram-budget-alerts` | 3x daily budget threshold alerts |
| `cron/telegram-payment-reminders` | Daily 8am payment schedule |
| `cron/telegram-contract-expiry` | Daily 8am contract expiry alerts |
| `cron/telegram-dispute-tracker` | Daily 9am dispute follow-ups |
| `cron/telegram-weekly-summary` | Weekly Monday briefing |
| `cron/telegram-payday-summary` | Payday-triggered income breakdown |
| `cron/telegram-month-end-recap` | Monthly recap on 1st |
| `cron/telegram-savings-milestone` | Weekly savings milestone celebrations |
| `cron/telegram-unused-subscription-alert` | Weekly unused subscription nudges |

`telegram-price-increase-detection` and `telegram-alerts` both go through `sendProactiveAlert()` / `queueTelegramAlert()` exclusively — covered by the guard above.

## Test plan

- [ ] Verify `isQuietHours('Europe/London')` returns `true` at 23:30 and `false` at 06:00
- [ ] Verify `isQuietHours('America/New_York')` handles timezone conversion correctly
- [ ] Verify `isQuietHours('invalid/tz')` falls back gracefully without throwing
- [ ] Confirm a manual cron trigger during quiet hours logs the suppression message and returns without sending

🤖 Generated with [Claude Code](https://claude.com/claude-code)