### PR TITLE
feat(money-hub): use Supabase RPCs for spending/income totals (fixes inflated figures)

### DIFF
--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -157,15 +157,28 @@ export async function GET(request: Request) {
     // JS-based computation (used for trends, merchant analysis, and as fallback)
     const currentSummary = summariseTransactionsForMonth(allTxns, overrides, selectedMonth, internalTransfers);
 
-    // Authoritative income/spending via JS computation (to support AI rule mapping and local recategorisation)
-    const authSpending = currentSummary.monthlyOutgoings;
-    const authIncome = currentSummary.monthlyIncome;
+    // Authoritative income/spending from RPCs (exclude transfers correctly) with JS fallback
+    const authSpending = parseFloat(String(rpcSpendingTotal)) || currentSummary.monthlyOutgoings;
+    const authIncome = parseFloat(String(rpcIncomeTotal)) || currentSummary.monthlyIncome;
 
-    // Build authoritative category breakdown via JS learning rules
-    const authCategoryBreakdown = currentSummary.categoryBreakdown;
+    // Build authoritative category breakdown from RPC; fall back to JS if RPC returned nothing
+    const rpcCategoryBreakdown = (rpcSpendingCategories || []).map((c: any) => ({
+      category: c.category as string,
+      total: parseFloat(String(c.category_total)),
+      transactions: [] as any[],
+    }));
+    const authCategoryBreakdown = rpcCategoryBreakdown.length > 0
+      ? rpcCategoryBreakdown
+      : currentSummary.categoryBreakdown;
 
-    // Build authoritative income breakdown
-    const authIncomeBreakdown: Record<string, number> = { ...currentSummary.incomeRows };
+    // Build authoritative income breakdown from RPC; fall back to JS if RPC returned nothing
+    const rpcIncomeBD: Record<string, number> = {};
+    for (const row of (rpcIncomeCategories || [])) {
+      rpcIncomeBD[row.source || 'other'] = parseFloat(String(row.source_total));
+    }
+    const authIncomeBreakdown: Record<string, number> = Object.keys(rpcIncomeBD).length > 0
+      ? rpcIncomeBD
+      : { ...currentSummary.incomeRows };
 
     // Build authoritative category totals map (for budget matching)
     const authCategoryTotals: Record<string, number> = {};

--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -158,13 +158,14 @@ export async function GET(request: Request) {
     const currentSummary = summariseTransactionsForMonth(allTxns, overrides, selectedMonth, internalTransfers);
 
     // Authoritative income/spending from RPCs (exclude transfers correctly) with JS fallback
-    const authSpending = parseFloat(String(rpcSpendingTotal)) || currentSummary.monthlyOutgoings;
-    const authIncome = parseFloat(String(rpcIncomeTotal)) || currentSummary.monthlyIncome;
+    const authSpending = rpcSpendingTotal != null ? parseFloat(String(rpcSpendingTotal)) : currentSummary.monthlyOutgoings;
+    const authIncome = rpcIncomeTotal != null ? parseFloat(String(rpcIncomeTotal)) : currentSummary.monthlyIncome;
 
     // Build authoritative category breakdown from RPC; fall back to JS if RPC returned nothing
+    // Normalize category keys so they match the keys used in budget matching
     const rpcCategoryBreakdown = (rpcSpendingCategories || []).map((c: any) => ({
-      category: c.category as string,
-      total: parseFloat(String(c.category_total)),
+      category: normalizeSpendingCategoryKey(c.category as string),
+      total: parseFloat(String(c.category_total ?? 0)),
       transactions: [] as any[],
     }));
     const authCategoryBreakdown = rpcCategoryBreakdown.length > 0
@@ -174,7 +175,7 @@ export async function GET(request: Request) {
     // Build authoritative income breakdown from RPC; fall back to JS if RPC returned nothing
     const rpcIncomeBD: Record<string, number> = {};
     for (const row of (rpcIncomeCategories || [])) {
-      rpcIncomeBD[row.source || 'other'] = parseFloat(String(row.source_total));
+      rpcIncomeBD[row.source || 'other'] = parseFloat(String(row.source_total ?? 0));
     }
     const authIncomeBreakdown: Record<string, number> = Object.keys(rpcIncomeBD).length > 0
       ? rpcIncomeBD


### PR DESCRIPTION
## What
- Replaced JS-based spending aggregation with `get_monthly_spending_total` RPC for the monthly outgoings total
- Replaced JS-based income aggregation with `get_monthly_income_total` RPC for the monthly income total
- Replaced JS-based category breakdown with `get_monthly_spending` RPC for the spending category list
- Replaced JS-based income source breakdown with `get_monthly_income` RPC for income breakdown
- JS computation still used for monthly trends (6-month bar chart) and top merchants — RPCs don't provide per-merchant data
- Both paths fall back to JS if the RPC returns empty (zero-state protection)

## Why
The JS-based aggregation was including inter-account transfers in both income and spending totals, inflating figures (Feb 2026 showed £76K spending, should be ~£20K). The Supabase RPCs exclude transfers at the database level using `user_category != 'transfers'` and `income_type != 'transfer'` filters. This is a correctness fix, not a refactor.

## Test plan
- [ ] Load Money Hub as a logged-in user with bank connected
- [ ] Verify monthly income/spending totals look reasonable (not inflated by transfers)
- [ ] Verify spending category breakdown populates correctly
- [ ] Verify income breakdown populates correctly
- [ ] Switch between months and check figures update
- [ ] Check browser console for errors
- [ ] Confirm budget tracking still works (percentage bars)

From task queue: Frontend: Use get_monthly_spending RPC for spending totals
                 Frontend: Use get_monthly_income_total and get_monthly_income RPCs
🤖 Paybacker Dev Sprint Runner
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>