### PR TITLE
feat(money-hub): move Savings Goals above Financial Action Centre

### DIFF
--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -826,7 +826,7 @@ export default function MoneyHubPage() {
       </div>
 
       {/* Budgets & Savings Goals — above FAC for visibility */}
-      <GoalsAndBudgetsPanel data={data} isPro={isPro} refreshData={refreshData} />
+      <GoalsAndBudgetsPanel data={data} isPro={isPro} refreshData={refreshData} selectedMonth={selectedMonth || data.selectedMonth} />
 
       {/* Financial Action Centre (Pro) */}
       {isPro && (

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -716,11 +716,8 @@ export default function MoneyHubPage() {
       {/* OVERVIEW (Summary cards + Income breakdown + Monthly trends) */}
       <OverviewPanel data={data} refreshData={refreshData} selectedMonth={selectedMonth || data.selectedMonth} />
 
-      {/* MAIN GRID: Spending + Budgets & Goals */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <SpendingPanel data={data} isPro={isPro} refreshData={refreshData} selectedMonth={selectedMonth || data.selectedMonth} />
-        <GoalsAndBudgetsPanel data={data} isPro={isPro} refreshData={refreshData} selectedMonth={selectedMonth || data.selectedMonth} />
-      </div>
+      {/* Spending Intelligence */}
+      <SpendingPanel data={data} isPro={isPro} refreshData={refreshData} selectedMonth={selectedMonth || data.selectedMonth} />
 
       {/* Expected Bills (for the selected month) */}
       {expectedBills.length > 0 && (
@@ -827,6 +824,9 @@ export default function MoneyHubPage() {
         <ContractsPanel data={data} isPro={isPro} />
         <NetWorthPanel data={data} isPro={isPro} refreshData={refreshData} />
       </div>
+
+      {/* Budgets & Savings Goals — above FAC for visibility */}
+      <GoalsAndBudgetsPanel data={data} isPro={isPro} refreshData={refreshData} />
 
       {/* Financial Action Centre (Pro) */}
       {isPro && (


### PR DESCRIPTION
## What
- Removed the 2-column grid that paired SpendingPanel with GoalsAndBudgetsPanel
- SpendingPanel is now full-width (more room for category breakdown and search)
- GoalsAndBudgetsPanel (Budgets + Savings Goals) is repositioned directly above the Financial Action Centre

## Why
Paul reported Savings Goals are too hard to find in the current layout. Previously they were in a 50/50 grid with SpendingPanel above the fold, but users weren't scrolling into the panel to discover them. Moving GoalsAndBudgets to its own full-width row just before the FAC makes it much more visible.

## Test plan
- [ ] Load Money Hub as a logged-in Essential/Pro user
- [ ] Verify SpendingPanel renders full-width
- [ ] Verify Budgets & Goals panel appears below Contracts/Net Worth, above Financial Action Centre
- [ ] Verify Savings Goals progress bars render correctly
- [ ] Check mobile layout (375px) — panels should stack vertically

From task queue: Frontend: Move Savings Goals above Financial Actions Centre
🤖 Paybacker Dev Sprint Runner
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>