### PR TITLE
feat(money-hub): budget category drilldown with recategorisation

### DIFF
--- a/src/app/dashboard/money-hub/GoalsAndBudgetsPanel.tsx
+++ b/src/app/dashboard/money-hub/GoalsAndBudgetsPanel.tsx
@@ -5,9 +5,11 @@ import { Target, Lock, Settings, Plus, PiggyBank } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import GoalsAndBudgetsModal from './GoalsAndBudgetsModal';
+import CategoryDrillDownModal from './CategoryDrillDownModal';
 
-export default function GoalsAndBudgetsPanel({ data, isPro, refreshData }: { data: any, isPro: boolean, refreshData: () => void }) {
+export default function GoalsAndBudgetsPanel({ data, isPro, refreshData, selectedMonth }: { data: any, isPro: boolean, refreshData: () => void, selectedMonth: string }) {
   const [modalOpen, setModalOpen] = useState(false);
+  const [drillCategory, setDrillCategory] = useState<string | null>(null);
   const budgets = data.budgets || [];
   const goals = data.goals || [];
 
@@ -53,23 +55,27 @@ export default function GoalsAndBudgetsPanel({ data, isPro, refreshData }: { dat
               <p className="text-sm text-slate-500">No budgets set. Add one to track spending limits.</p>
             ) : (
               budgets.slice(0, 4).map((b: any) => (
-                <div key={b.id} className="mb-3">
+                <button
+                  key={b.id}
+                  onClick={() => setDrillCategory(b.category)}
+                  className="mb-3 w-full text-left group hover:bg-navy-800/40 rounded-lg px-2 -mx-2 py-1 transition-colors"
+                >
                   <div className="flex justify-between text-sm mb-1">
-                    <span className="text-white capitalize">{(b.category || '').replace(/_/g, ' ')}</span>
+                    <span className="text-white capitalize group-hover:text-mint-400 transition-colors">{(b.category || '').replace(/_/g, ' ')}</span>
                     <span className={`text-xs font-medium ${b.status === 'over_budget' ? 'text-red-400' : b.status === 'warning' ? 'text-amber-400' : 'text-slate-400'}`}>
                       £{fmtNum(b.spent)} / £{fmtNum(b.monthly_limit)}
                     </span>
                   </div>
                   <div className="w-full bg-navy-800 rounded-full h-1.5">
-                    <div 
-                      className={`h-1.5 rounded-full transition-all ${b.status === 'over_budget' ? 'bg-red-400' : b.status === 'warning' ? 'bg-amber-400' : 'bg-green-400'}`} 
-                      style={{ width: `${Math.min(b.percentage, 100)}%` }} 
+                    <div
+                      className={`h-1.5 rounded-full transition-all ${b.status === 'over_budget' ? 'bg-red-400' : b.status === 'warning' ? 'bg-amber-400' : 'bg-green-400'}`}
+                      style={{ width: `${Math.min(b.percentage, 100)}%` }}
                     />
                   </div>
                   {b.status === 'over_budget' && (
                     <p className="text-[10px] text-red-400 mt-0.5">Over by £{fmtNum(Math.abs(b.remaining))}</p>
                   )}
-                </div>
+                </button>
               ))
             )}
           </div>
@@ -114,11 +120,19 @@ export default function GoalsAndBudgetsPanel({ data, isPro, refreshData }: { dat
         </div>
       )}
       
-      <GoalsAndBudgetsModal 
-        isOpen={modalOpen} 
-        onClose={() => setModalOpen(false)} 
+      <GoalsAndBudgetsModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
         data={data}
         onUpdated={() => { refreshData(); }}
+      />
+
+      <CategoryDrillDownModal
+        isOpen={!!drillCategory}
+        onClose={() => setDrillCategory(null)}
+        category={drillCategory}
+        selectedMonth={selectedMonth}
+        onRecategorised={refreshData}
       />
     </div>
   );

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -719,7 +719,7 @@ export default function MoneyHubPage() {
       {/* MAIN GRID: Spending + Budgets & Goals */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <SpendingPanel data={data} isPro={isPro} refreshData={refreshData} selectedMonth={selectedMonth || data.selectedMonth} />
-        <GoalsAndBudgetsPanel data={data} isPro={isPro} refreshData={refreshData} />
+        <GoalsAndBudgetsPanel data={data} isPro={isPro} refreshData={refreshData} selectedMonth={selectedMonth || data.selectedMonth} />
       </div>
 
       {/* Expected Bills (for the selected month) */}


### PR DESCRIPTION
## Summary

- Budget cards in the Budgets & Goals panel are now clickable — tapping one opens a modal showing all transactions for that category in the selected month
- Each transaction row has a "Change category" button and each merchant has a "Recategorise Rule" button, both backed by the existing `/api/money-hub/recategorise` endpoint
- After recategorising, `refreshData()` is called so the budget card totals update immediately
- `selectedMonth` is now passed from the main page to `GoalsAndBudgetsPanel` so the modal always shows the correct period

## Implementation notes

- Reused the existing `CategoryDrillDownModal` (already used by SpendingPanel) — no new components or API routes
- Only two files changed: `GoalsAndBudgetsPanel.tsx` (add drilldown state + modal) and `page.tsx` (pass `selectedMonth` prop)
- TypeScript: zero errors

## Test plan

- [ ] Click a budget card on Money Hub → modal opens with that category's transactions
- [ ] Running total at modal top matches the spend shown on the budget card
- [ ] Recategorise a transaction → modal refreshes, budget card total updates
- [ ] Recategorise via merchant rule → all matching transactions move category
- [ ] Month selector on Money Hub → budget drilldown shows transactions for that month
- [ ] Free/non-pro users: budget section is locked, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)