### PR TITLE
feat(homepage-v2): PR 1+2 — tokens + /preview/homepage route

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,10 +11,41 @@
   --color-mint-300: #6EE7B7;
   --color-mint-400: #34D399;
   --color-mint-500: #10B981;
+  --color-mint-600: #059669;
+  --color-mint-50: #ECFBF3;
 
   /* Warm - Orange (Paybacker brand) */
   --color-brand-400: #FB923C;
   --color-brand-500: #F97316;
+
+  /*
+   * Homepage v2 — marketing palette (Apr 2026 brand refresh)
+   * Additive only. Existing navy tokens above are used throughout the
+   * authenticated dashboard and must stay untouched. These new tokens
+   * power the layered light/mint/dark marketing rhythm behind the
+   * /preview/homepage feature-flagged preview route. Do not use these
+   * on /dashboard/* surfaces.
+   */
+  --color-surface-base: #FAFAF7;
+  --color-surface-elevated: #FFFFFF;
+  --color-surface-ink: #0B1220;
+  --color-surface-ink-2: #111A2E;
+  --color-surface-soft-mint: #ECFBF3;
+
+  --color-ink-primary: #0B1220;
+  --color-ink-secondary: #4B5563;
+  --color-ink-tertiary: #6B7280;
+  --color-on-ink: #F3F4F6;
+  --color-on-ink-dim: #9CA3AF;
+
+  --color-accent-mint: #34D399;
+  --color-accent-mint-deep: #059669;
+  --color-accent-mint-wash: #ECFBF3;
+  --color-accent-orange: #F59E0B;
+  --color-accent-orange-deep: #D97706;
+
+  --color-divider-light: #E5E7EB;
+  --color-divider-ink: #1F2A44;
 
   /* Fonts */
   --font-heading: var(--font-plus-jakarta), system-ui, sans-serif;
@@ -27,6 +58,28 @@
   --shadow-card-hover: 0 10px 25px rgba(0,0,0,0.06), 0 4px 10px rgba(0,0,0,0.04);
   --shadow-glow-mint: 0 0 20px rgba(52,211,153,0.15);
   --shadow-glow-brand: 0 0 20px rgba(251,146,60,0.15);
+
+  /* Homepage v2 — warm shadows (not black) */
+  --shadow-marketing-sm: 0 2px 8px -2px rgba(11, 18, 32, 0.08);
+  --shadow-marketing-md: 0 10px 30px -10px rgba(11, 18, 32, 0.14);
+  --shadow-marketing-lg: 0 20px 60px -20px rgba(11, 18, 32, 0.18);
+  --shadow-marketing-xl: 0 30px 90px -30px rgba(11, 18, 32, 0.22);
+  --shadow-marketing-mint: 0 20px 50px -18px rgba(52, 211, 153, 0.5);
+  --shadow-marketing-orange: 0 20px 50px -18px rgba(245, 158, 11, 0.35);
+
+  /* Homepage v2 — radii */
+  --radius-marketing-card: 24px;
+  --radius-marketing-figure: 32px;
+  --radius-marketing-btn: 14px;
+  --radius-marketing-input: 12px;
+  --radius-marketing-pill: 999px;
+
+  /* Homepage v2 — type scale (fluid clamp) */
+  --text-display: clamp(56px, 8vw, 104px);
+  --text-h1-marketing: clamp(40px, 5vw, 64px);
+  --text-h2-marketing: clamp(32px, 4vw, 48px);
+  --tracking-marketing-tight: -0.025em;
+  --tracking-marketing-eyebrow: 0.14em;
 }
 
 body {

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -1,0 +1,956 @@
+'use client';
+
+/**
+ * Homepage v2 preview — /preview/homepage
+ *
+ * This is PR 2 in the homepage redesign series. It ports the Claude
+ * Design export at `docs/design-exports/homepage-v2/` into a single
+ * Next.js client page so Paul can review the new look on a Vercel
+ * preview URL before we touch the real `/` route.
+ *
+ * Everything lives under `.m-v2-root` so styles can't leak onto the
+ * live homepage or the authenticated dashboard.
+ *
+ * Still to do in later PRs:
+ *   PR 3 — draft FAQ + re-add Why We Exist / Pocket Agent showcase /
+ *          AI Financial Assistant / Smart Subscription Tracking.
+ *   PR 4 — wire the hero ticker, stats, and mini letter form to live
+ *          Supabase data (agent_runs, profiles count, /api/agents/complaints).
+ *   PR 5 — cut the v2 page over to `/` once Paul signs off.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { CSSProperties, FormEvent } from 'react';
+import './styles.css';
+
+// React.CSSProperties doesn't know about CSS custom properties; a small
+// helper cast keeps the inline-style literals readable and type-safe.
+type CSSVarProperties = CSSProperties & Record<`--${string}`, string | number>;
+
+type Testimonial = {
+  name: string;
+  meta: string;
+  quote: string;
+  saved: string;
+  color: string;
+};
+
+// Initial-only names — final quotes pending founding-member permissions (PR 3).
+const TESTIMONIALS: Testimonial[] = [
+  {
+    name: 'P. R.',
+    meta: 'Homeowner · Bristol · Oct 2025',
+    quote:
+      '"Found £847 in forgotten subs in five minutes. The Virgin dispute letter got my bill cut back to the original contract rate — first time."',
+    saved: 'Saved £1,240 this year',
+    color: 'var(--accent-mint-deep)',
+  },
+  {
+    name: 'A. K.',
+    meta: 'Freelancer · Manchester · Oct 2025',
+    quote:
+      '"I thought I was on top of my subs. Paybacker found six I\'d completely forgotten about, including two gyms."',
+    saved: 'Saved £392',
+    color: 'var(--accent-orange-deep)',
+  },
+  {
+    name: 'D. M.',
+    meta: 'Commuter · London · Sep 2025',
+    quote:
+      '"The Ofcom letter took 30 seconds. EE cancelled the mid-contract rise without a phone call. Still can\'t quite believe it."',
+    saved: 'Saved £168',
+    color: 'var(--accent-mint-deep)',
+  },
+  {
+    name: 'S. J.',
+    meta: 'Student · Edinburgh · Sep 2025',
+    quote:
+      '"Pocket Agent in Telegram is the bit I didn\'t expect to love. I just ask it if things are fair and it tells me."',
+    saved: 'Saved £284',
+    color: 'var(--accent-orange-deep)',
+  },
+  {
+    name: 'R. N.',
+    meta: 'Teacher · Leeds · Oct 2025',
+    quote:
+      '"Paybacker caught a £41/month energy hike British Gas quietly slipped in. The dispute paid for a year of Pro in one letter."',
+    saved: 'Saved £492',
+    color: 'var(--accent-mint-deep)',
+  },
+  {
+    name: 'T. B.',
+    meta: 'New parent · Cardiff · Aug 2025',
+    quote:
+      '"Tiny baby, no time to read bills. This does it for us. The broadband switch alone saved us £400 a year."',
+    saved: 'Saved £638',
+    color: 'var(--accent-orange-deep)',
+  },
+];
+
+export default function HomepageV2Preview() {
+  const [navScrolled, setNavScrolled] = useState(false);
+  const [chatShown, setChatShown] = useState(false);
+  const [letterBusy, setLetterBusy] = useState(false);
+  const [letterLabel, setLetterLabel] = useState('Generate letter →');
+  const revealContainerRef = useRef<HTMLDivElement | null>(null);
+
+  // Nav shrinks slightly once scrolled > 20px.
+  useEffect(() => {
+    const onScroll = () => setNavScrolled(window.scrollY > 20);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  // Reveal-on-scroll for .reveal elements inside the page (not globally).
+  useEffect(() => {
+    const container = revealContainerRef.current;
+    if (!container || typeof IntersectionObserver === 'undefined') return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry, i) => {
+          if (entry.isIntersecting) {
+            window.setTimeout(() => entry.target.classList.add('in'), i * 60);
+            io.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.12 },
+    );
+    container.querySelectorAll('.reveal').forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, []);
+
+  // Chat widget appears after 2s — matches the export's behaviour.
+  useEffect(() => {
+    const t = window.setTimeout(() => setChatShown(true), 2000);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  // Demo-only letter form handler. PR 4 will POST to /api/agents/complaints
+  // with the real user input and open the draft in a new tab.
+  const onDemoGenerate = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (letterBusy) return;
+    setLetterBusy(true);
+    setLetterLabel('Drafting…');
+    window.setTimeout(() => {
+      setLetterLabel('✓ Letter ready — opening');
+      window.setTimeout(() => {
+        setLetterLabel('Generate letter →');
+        setLetterBusy(false);
+      }, 1800);
+    }, 900);
+  };
+
+  const doubledTestimonials = [...TESTIMONIALS, ...TESTIMONIALS];
+
+  return (
+    <div className="m-v2-root" ref={revealContainerRef}>
+      <div className="preview-badge" aria-label="Preview page">
+        Preview · Homepage v2
+      </div>
+
+      {/* Floating pill nav ------------------------------------------ */}
+      <div className={`nav-shell${navScrolled ? ' scrolled' : ''}`} id="navShell">
+        <nav className="nav-pill" aria-label="Primary">
+          <a className="nav-logo" href="#">
+            <span className="pay">Pay</span>
+            <span className="backer">backer</span>
+          </a>
+          <div className="nav-links">
+            <a href="#how">About</a>
+            <a href="#pricing">Pricing</a>
+            <a href="#deals">Deals</a>
+            <a href="#">Blog</a>
+            <a href="#">FAQ</a>
+          </div>
+          <div className="nav-cta-row">
+            <a className="nav-signin" href="#">
+              Sign in
+            </a>
+            <a className="nav-start" href="#">
+              Start Free
+            </a>
+          </div>
+        </nav>
+      </div>
+
+      {/* Hero ------------------------------------------------------- */}
+      <section
+        className="hero glow-wrap section-light"
+        style={{ '--glow-opacity': 0.22 } as CSSVarProperties}
+      >
+        <div className="trust-bar">
+          ICO registered <span className="dot">·</span>
+          FCA-authorised via Yapily <span className="dot">·</span>
+          GDPR compliant <span className="dot">·</span>
+          UK company · Paybacker LTD
+        </div>
+        <div className="wrap">
+          <div className="hero-grid">
+            <div className="hero-copy reveal">
+              <span className="eyebrow">Free 14-day Pro trial. No card required.</span>
+              <h1>
+                <span className="l1">Find Hidden Overcharges.</span>
+                <span className="l2">Fight Unfair Bills.</span>
+                <span className="l3">Get Your Money Back.</span>
+              </h1>
+              <p className="hero-sub">
+                Paybacker scans your bank and email to spot overcharges, forgotten subscriptions,
+                and unfair bills — then writes professional complaint letters citing UK law in 30
+                seconds.
+              </p>
+              <div className="hero-cta-row">
+                <a className="btn btn-mint" href="#">
+                  Start free 14-day Pro trial →
+                </a>
+                <a className="btn btn-ghost" href="#how">
+                  See how it works
+                </a>
+              </div>
+              <div className="hero-ticker">
+                <span className="pulse" />
+                {/* Members-aggregated figure — live wiring to Supabase lands in PR 4. */}
+                <span>Saved for our members this month</span>
+              </div>
+            </div>
+            <div className="hero-visual reveal" aria-hidden="true">
+              <div className="mini-card float" style={{ animationDelay: '-2s' }}>
+                <div className="label">Potential savings</div>
+                <div className="big">£1,240</div>
+                <div className="desc">found this quarter</div>
+                <div className="mini-bar">
+                  <div className="bar">
+                    <span className="n">Virgin Media</span>
+                    <span className="v">+£12/mo</span>
+                  </div>
+                  <div className="bar">
+                    <span className="n">Octopus Energy</span>
+                    <span className="v">+£28/mo</span>
+                  </div>
+                  <div className="bar">
+                    <span className="n">Audible</span>
+                    <span className="v">+£7.99/mo</span>
+                  </div>
+                  <div className="bar">
+                    <span className="n">British Gas</span>
+                    <span className="v">+£41/mo</span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="dash-card float">
+                <div className="dash-header">
+                  <div className="title">Money Hub — October</div>
+                  <div>●●●</div>
+                </div>
+                <div className="dash-body">
+                  <div>
+                    <div className="label">Net this month</div>
+                    <div className="big-num">
+                      £2,847.
+                      <span style={{ color: 'var(--text-tertiary)', fontSize: '0.6em' }}>12</span>
+                    </div>
+                    <div className="delta">↗ £312 vs. September</div>
+                  </div>
+                  <div className="donut-row">
+                    <div className="donut">
+                      <div className="donut-center">
+                        <span>Tracked</span>
+                        <strong>£4,892</strong>
+                      </div>
+                    </div>
+                    <div className="donut-legend">
+                      <div className="row">
+                        <span>
+                          <span className="swatch" style={{ background: 'var(--accent-mint)' }} />
+                          <span className="name">Essentials</span>
+                        </span>
+                        <span className="amt">£1,859</span>
+                      </div>
+                      <div className="row">
+                        <span>
+                          <span
+                            className="swatch"
+                            style={{ background: 'var(--accent-orange)' }}
+                          />
+                          <span className="name">Subscriptions</span>
+                        </span>
+                        <span className="amt">£1,174</span>
+                      </div>
+                      <div className="row">
+                        <span>
+                          <span className="swatch" style={{ background: '#60A5FA' }} />
+                          <span className="name">Transport</span>
+                        </span>
+                        <span className="amt">£782</span>
+                      </div>
+                      <div className="row">
+                        <span>
+                          <span className="swatch" style={{ background: '#A78BFA' }} />
+                          <span className="name">Dining</span>
+                        </span>
+                        <span className="amt">£588</span>
+                      </div>
+                      <div className="row">
+                        <span>
+                          <span className="swatch" style={{ background: '#E5E7EB' }} />
+                          <span className="name">Other</span>
+                        </span>
+                        <span className="amt">£489</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="sub-list">
+                    <div className="row">
+                      <span className="name">
+                        Netflix Premium<span className="tag">Unused</span>
+                      </span>
+                      <span className="amt">£17.99</span>
+                    </div>
+                    <div className="row">
+                      <span className="name">
+                        Virgin Media<span className="tag">Hike</span>
+                      </span>
+                      <span className="amt">£49.00</span>
+                    </div>
+                    <div className="row">
+                      <span className="name">
+                        Gym membership<span className="tag">Inactive</span>
+                      </span>
+                      <span className="amt">£34.99</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="agent-bubble float" style={{ animationDelay: '-3s' }}>
+                <div className="who">
+                  <span className="dot-mint" /> Pocket Agent · Telegram
+                </div>
+                <div className="msg">
+                  Virgin Media bill increased by <strong>£12</strong> this month — want me to draft
+                  a dispute citing Ofcom&rsquo;s mid-contract price rise rules?
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Trust strip ------------------------------------------------ */}
+      <section className="trust-strip section-light">
+        <div className="wrap">
+          <div className="trust-row">
+            <div className="trust-item">
+              <div className="ring">ICO</div>Registered data controller
+            </div>
+            <div className="trust-item">
+              <div className="ring">FCA</div>Open Banking via Yapily
+            </div>
+            <div className="trust-item">
+              <div className="ring">GDPR</div>UK data residency
+            </div>
+            <div className="trust-item">
+              <div className="ring">£</div>Stripe secured payments
+            </div>
+            <div className="trust-item">
+              {/*
+                Paybacker LTD's real Companies House number goes in before
+                cut-over (PR 5). The export shipped a placeholder.
+              */}
+              <div className="ring">UK</div>Paybacker LTD
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Stats (mint wash) ----------------------------------------- */}
+      <section className="stats-section section-mint">
+        <div className="wrap">
+          <div className="section-head reveal">
+            <span className="eyebrow">Real numbers · Real users</span>
+            <h2>
+              Every £ we&rsquo;ve found
+              <br />
+              for real UK users.
+            </h2>
+            <p>
+              No gamified streaks. No vague &ldquo;up to&rdquo; claims. These are live figures from
+              Paybacker accounts in the last 90 days.
+            </p>
+          </div>
+          <div className="stats-grid">
+            <div className="stat-card reveal">
+              <div className="label">Average potential savings</div>
+              <div className="num">
+                £8,029<span className="unit">/yr</span>
+              </div>
+              <div className="underline" />
+              <div className="blurb">
+                Most came from forgotten subscriptions and quiet price hikes we flagged
+                automatically — the kind nobody reads the email for.
+              </div>
+            </div>
+            <div className="stat-card reveal">
+              <div className="label">Subscriptions tracked</div>
+              <div className="num">149</div>
+              <div className="underline" />
+              <div className="blurb">
+                Across connected accounts. The median user has 11 they&rsquo;d forgotten about. The
+                worst had 34 — including three streaming services with the same logo.
+              </div>
+            </div>
+            <div className="stat-card reveal">
+              <div className="label">Founding members</div>
+              <div className="num">45</div>
+              <div className="underline" />
+              <div className="blurb">
+                British households using the Pro tier right now. Tight invite-only group while we
+                scale the AI Disputes engine. Locked-in founder pricing, forever.
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Pillars --------------------------------------------------- */}
+      <section className="pillars-section section-light">
+        <div className="wrap">
+          <div className="section-head reveal">
+            <span className="eyebrow">What&rsquo;s in the box</span>
+            <h2>
+              Three products. One subscription.
+              <br />
+              All of your money, watched.
+            </h2>
+            <p>
+              Most UK households are overcharged by £1,000+ a year. Paybacker finds it, disputes
+              it, and cancels it — in minutes, not hours on hold.
+            </p>
+          </div>
+          <div className="pillar-grid">
+            <div className="pillar-card reveal">
+              <div className="pillar-icon orange" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M12 3v18" />
+                  <path d="M4 7l8-4 8 4" />
+                  <path d="M4 7l3 7a3 3 0 006 0z" />
+                  <path d="M20 7l-3 7a3 3 0 006 0z" />
+                </svg>
+              </div>
+              <h3>AI Disputes Centre</h3>
+              <p className="copy">
+                Complaint letters citing exact UK consumer law in 30 seconds. Consumer Rights Act
+                2015, UK261, Ofgem, Ofcom.
+              </p>
+              <div className="pillar-preview">
+                <div className="head">AI draft · Ofcom — mid-contract price rise</div>
+                <p className="letter-para">
+                  … I am writing to formally dispute the{' '}
+                  <span className="hl">£12 CPI+3.9% increase</span> applied to my Virgin Media
+                  broadband contract on 1 October. Under{' '}
+                  <span className="hl">Ofcom&rsquo;s Fairness Framework</span> and the{' '}
+                  <span className="hl">Consumer Rights Act 2015 s.49</span>, you must provide
+                  reasonable notice and a right to exit without penalty…
+                </p>
+              </div>
+            </div>
+
+            <div className="pillar-card reveal">
+              <div className="pillar-icon mint" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="3" y="6" width="18" height="13" rx="2" />
+                  <path d="M3 10h18" />
+                  <circle cx="17" cy="15" r="1.5" />
+                </svg>
+              </div>
+              <h3>Money Hub</h3>
+              <p className="copy">
+                Connect your bank via Open Banking (Yapily). Every subscription, direct debit, and
+                contract in one place. Daily sync.
+              </p>
+              <div className="pillar-preview">
+                <div className="head">Your October breakdown</div>
+                <div className="donut-mini">
+                  <div className="d" />
+                  <div className="nums">
+                    <div className="row">
+                      <span className="sw" style={{ background: 'var(--accent-mint)' }} />
+                      Essentials · £1,859
+                    </div>
+                    <div className="row">
+                      <span className="sw" style={{ background: 'var(--accent-orange)' }} />
+                      Subs · £1,174
+                    </div>
+                    <div className="row">
+                      <span className="sw" style={{ background: '#93C5FD' }} />
+                      Transport · £782
+                    </div>
+                    <div className="row">
+                      <span className="sw" style={{ background: '#E5E7EB' }} />
+                      Other · £489
+                    </div>
+                  </div>
+                </div>
+                <div
+                  style={{
+                    marginTop: '14px',
+                    paddingTop: '12px',
+                    borderTop: '1px dashed var(--divider)',
+                    fontSize: '12px',
+                    color: 'var(--text-tertiary)',
+                  }}
+                >
+                  3 hikes flagged · 2 duplicates found
+                </div>
+              </div>
+            </div>
+
+            <div className="pillar-card reveal">
+              <div className="pillar-icon gradient" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+                </svg>
+              </div>
+              <h3>Pocket Agent</h3>
+              <p className="copy">
+                Your AI financial agent in Telegram. Ask anything, fix everything. &ldquo;Is my
+                energy bill fair?&rdquo; &ldquo;Cancel my gym.&rdquo; Done.
+              </p>
+              <div className="pillar-preview">
+                <div className="head">Today · Telegram</div>
+                <div className="chat-preview">
+                  <div className="chat-bubble user">Is £68/mo fair for 100Mb broadband?</div>
+                  <div className="chat-bubble agent">
+                    Above UK median of £32. Two cheaper options on your postcode. Draft switch?
+                  </div>
+                  <div className="chat-bubble user">Yes please</div>
+                  <div className="chat-bubble agent">
+                    On it — you&rsquo;ll save <strong>£432/yr</strong>.
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works (dark) --------------------------------------- */}
+      <section className="how-section section-ink" id="how">
+        <div className="wrap">
+          <div className="section-head reveal">
+            <span className="eyebrow on-ink">How it works</span>
+            <h2>
+              Three steps. Ten minutes.
+              <br />
+              Usually four-figure savings.
+            </h2>
+            <p className="sub">
+              You don&rsquo;t have to connect anything to see it work. Try the Disputes Centre for
+              free — no account needed.
+            </p>
+          </div>
+
+          <div className="how-steps">
+            <div className="how-step reveal">
+              <div className="num">01</div>
+              <h3>Describe your dispute, get a formal letter in 30 seconds.</h3>
+              <p>Pick the category, type a sentence. We cite the law, you send the letter.</p>
+              <form className="mini-form" onSubmit={onDemoGenerate}>
+                <label>What&rsquo;s the issue?</label>
+                <select defaultValue="Mid-contract price rise">
+                  <option>Mid-contract price rise</option>
+                  <option>Delayed or cancelled flight (UK261)</option>
+                  <option>Faulty goods (CRA 2015)</option>
+                  <option>Energy billing error (Ofgem)</option>
+                </select>
+                <label>Brief description</label>
+                <input type="text" placeholder="My Virgin bill jumped £12 without warning…" />
+                <button type="submit" disabled={letterBusy}>
+                  {letterLabel}
+                </button>
+              </form>
+            </div>
+
+            <div className="how-step reveal">
+              <div className="num">02</div>
+              <h3>Connect your bank and email to find hidden costs.</h3>
+              <p>Open Banking via Yapily. Read-only. Never stored longer than needed.</p>
+              <div className="bank-list">
+                <div className="bank-row">
+                  <span className="n">Monzo · main</span>
+                  <span className="v">Connected</span>
+                </div>
+                <div className="bank-row">
+                  <span className="n">Barclays · joint</span>
+                  <span className="v">Connected</span>
+                </div>
+                <div className="bank-row">
+                  <span className="n">Chase · savings</span>
+                  <span className="v">Connected</span>
+                </div>
+                <div className="bank-row">
+                  <span className="n">Gmail · inbox scan</span>
+                  <span className="v orange">3 hikes</span>
+                </div>
+                <div className="bank-row">
+                  <span className="n">Outlook · work</span>
+                  <span className="v orange">1 duplicate</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="how-step reveal">
+              <div className="num">03</div>
+              <h3>Get personalised recommendations from 53+ verified UK partners.</h3>
+              <p>We only show deals that beat your current bill. No sponsored nonsense.</p>
+              <div style={{ marginTop: 'auto' }}>
+                <div className="deal-row">
+                  <div>
+                    <div className="cat">Broadband</div>
+                    <div className="name">Fibre 150 · 24mo</div>
+                  </div>
+                  <div className="save">Save £432</div>
+                </div>
+                <div className="deal-row">
+                  <div>
+                    <div className="cat">Energy</div>
+                    <div className="name">Octopus Tracker</div>
+                  </div>
+                  <div className="save">Save £287</div>
+                </div>
+                <div className="deal-row">
+                  <div>
+                    <div className="cat">Mobile</div>
+                    <div className="name">20GB 5G · SIM only</div>
+                  </div>
+                  <div className="save">Save £156</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="how-cta-row">
+            <a className="btn btn-mint" href="#">
+              Try it free — no account needed
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Deals (mint wash) ----------------------------------------- */}
+      <section className="deals-section section-mint" id="deals">
+        <div className="wrap">
+          <div
+            className="section-head reveal"
+            style={{ textAlign: 'center', margin: '0 auto 24px' }}
+          >
+            <span className="eyebrow">53+ verified UK partners</span>
+            <h2 style={{ margin: '12px 0' }}>
+              Real prices. Real savings.
+              <br />
+              Better deals in every category.
+            </h2>
+          </div>
+
+          <div className="logo-cloud">
+            {[
+              'BT',
+              'Sky',
+              'Virgin',
+              'EE',
+              'E.ON',
+              'EDF',
+              'OVO',
+              'Vodafone',
+              'Three',
+              'O2',
+              'giffgaff',
+              'Plusnet',
+              'RAC',
+              'Habito',
+              '+40 more',
+            ].map((name) => (
+              <span className="logo-chip" key={name}>
+                {name}
+              </span>
+            ))}
+          </div>
+
+          <div className="category-grid">
+            {[
+              { name: 'Broadband', partners: '12 partners', save: 'Save £240/yr' },
+              { name: 'Mobile', partners: '9 partners', save: 'Save £180/yr' },
+              { name: 'Energy', partners: '14 partners', save: 'Save £450/yr' },
+              { name: 'Insurance', partners: '11 partners', save: 'Save £320/yr' },
+              { name: 'Mortgages', partners: '4 partners', save: 'Save £1,200/yr' },
+              { name: 'Travel', partners: '3 partners', save: 'Save £95/trip' },
+            ].map((c) => (
+              <div className="cat-tile reveal" key={c.name}>
+                <div className="cat-name">{c.name}</div>
+                <div className="cat-count">{c.partners}</div>
+                <div className="save-badge">{c.save}</div>
+              </div>
+            ))}
+          </div>
+
+          <p className="commission-note">
+            We earn a commission if you switch — you pay nothing extra, and we stay free to use.
+          </p>
+        </div>
+      </section>
+
+      {/* Pricing --------------------------------------------------- */}
+      <section className="pricing-section section-light" id="pricing">
+        <div className="wrap">
+          <div
+            className="section-head reveal"
+            style={{ textAlign: 'center', margin: '0 auto 56px' }}
+          >
+            <span className="eyebrow">Founding member pricing</span>
+            <h2 style={{ margin: '12px 0' }}>
+              Start free. Upgrade only when we&rsquo;ve
+              <br />
+              found you money.
+            </h2>
+          </div>
+          <div className="pricing-grid">
+            <div className="price-card reveal">
+              <div className="tier">Free</div>
+              <div className="price">
+                £0<span className="per">/forever</span>
+              </div>
+              <div className="founding hidden">—</div>
+              <ul>
+                <li>3 AI dispute letters / month</li>
+                <li>Manual subscription tracker</li>
+                <li>Public deals marketplace</li>
+              </ul>
+              <a className="btn btn-ghost cta" href="#" style={{ justifyContent: 'center' }}>
+                Start free →
+              </a>
+            </div>
+
+            <div className="price-card featured reveal">
+              <span className="ribbon">Most popular</span>
+              <div className="tier">Essential</div>
+              <div className="price">
+                £4.99<span className="per">/month</span>
+              </div>
+              <div className="founding">Founding member · locked-in forever</div>
+              <ul>
+                <li>Unlimited AI dispute letters</li>
+                <li>Bank sync — 2 accounts</li>
+                <li>Email inbox scan</li>
+                <li>Pocket Agent in Telegram</li>
+              </ul>
+              <a className="btn btn-mint cta" href="#" style={{ justifyContent: 'center' }}>
+                Start 14-day trial →
+              </a>
+            </div>
+
+            <div className="price-card reveal">
+              <div className="tier">Pro</div>
+              <div className="price">
+                £9.99<span className="per">/month</span>
+              </div>
+              <div className="founding">Founding member · locked-in forever</div>
+              <ul>
+                <li>Everything in Essential</li>
+                <li>Unlimited bank &amp; email connections</li>
+                <li>Deal alerts on bill changes</li>
+                <li>Priority human review on complex disputes</li>
+              </ul>
+              <a className="btn btn-ghost cta" href="#" style={{ justifyContent: 'center' }}>
+                Go Pro →
+              </a>
+            </div>
+          </div>
+          <p className="compare-link">
+            <a href="#">See the full feature comparison →</a>
+          </p>
+        </div>
+      </section>
+
+      {/* Testimonials ---------------------------------------------- */}
+      <section className="testimonials-section section-light">
+        <div className="testimonials-head reveal">
+          <span className="eyebrow">Honest words from real users</span>
+          <h2>
+            What the money
+            <br />
+            we found meant for them.
+          </h2>
+        </div>
+        <div className="t-track">
+          {doubledTestimonials.map((t, i) => (
+            <div className="t-card" key={`${t.name}-${i}`}>
+              <div className="who">
+                <div className="avatar" style={{ background: t.color }}>
+                  {t.name[0]}
+                </div>
+                <div>
+                  <div className="name">{t.name}</div>
+                  <div className="meta">{t.meta}</div>
+                </div>
+              </div>
+              <div className="quote">{t.quote}</div>
+              <div className="saved">{t.saved}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Final CTA (dark) ------------------------------------------ */}
+      <section
+        className="final-cta section-ink glow-wrap"
+        style={{ '--glow-opacity': 0.14 } as CSSVarProperties}
+      >
+        <div className="wrap">
+          <h2 className="reveal">
+            Stop overpaying.
+            <br />
+            Start <span className="mint">fighting</span> back.
+          </h2>
+          <p className="fc-sub reveal">
+            Most UK households are overcharged by £1,000+ a year. We find it, dispute it, and
+            cancel it — in minutes.
+          </p>
+          <div className="fc-btn-row reveal">
+            <a className="btn btn-mint" href="#">
+              Start your free 14-day Pro trial →
+            </a>
+          </div>
+          <p className="fine">No card. Cancel anytime. Your data stays in the UK.</p>
+        </div>
+      </section>
+
+      {/* Footer ---------------------------------------------------- */}
+      <footer>
+        <div className="wrap">
+          <div className="footer-grid">
+            <div className="footer-brand">
+              <div className="logo">
+                <span>Pay</span>
+                <span className="backer">backer</span>
+              </div>
+              <p>
+                The UK&rsquo;s AI money-back engine. We find what you&rsquo;re losing and fight to
+                get it back.
+              </p>
+              <p
+                style={{
+                  marginTop: '14px',
+                  fontSize: '11px',
+                  color: 'var(--text-on-ink-dim)',
+                  maxWidth: '320px',
+                }}
+              >
+                AI-generated letters are for guidance only and do not constitute legal advice. For
+                complex disputes, always consult a qualified solicitor.
+              </p>
+            </div>
+            <div className="footer-col">
+              <h5>Product</h5>
+              <a href="#">Disputes Centre</a>
+              <a href="#">Money Hub</a>
+              <a href="#">Pocket Agent</a>
+              <a href="#">Deals</a>
+              <a href="#">Pricing</a>
+            </div>
+            <div className="footer-col">
+              <h5>Company</h5>
+              <a href="#">About</a>
+              <a href="#">Blog</a>
+              <a href="#">Press</a>
+              <a href="#">Careers</a>
+              <a href="#">Contact</a>
+            </div>
+            <div className="footer-col">
+              <h5>Legal</h5>
+              <a href="#">Privacy</a>
+              <a href="#">Terms</a>
+              <a href="#">Cookies</a>
+              <a href="#">ICO notice</a>
+              <a href="#">Complaints</a>
+            </div>
+            <div className="footer-col">
+              <h5>Connect</h5>
+              <div className="footer-socials" style={{ marginBottom: '14px' }}>
+                <a href="#" aria-label="X">
+                  𝕏
+                </a>
+                <a href="#" aria-label="Instagram">
+                  ◎
+                </a>
+                <a href="#" aria-label="Facebook">
+                  f
+                </a>
+                <a href="#" aria-label="TikTok">
+                  ♪
+                </a>
+                <a href="#" aria-label="LinkedIn">
+                  in
+                </a>
+              </div>
+              <a href="#">hello@paybacker.co.uk</a>
+            </div>
+          </div>
+          <div className="footer-bottom">
+            <div>© 2026 Paybacker LTD · Registered in England &amp; Wales</div>
+            <div>paybacker.co.uk · Made in London 🇬🇧</div>
+          </div>
+        </div>
+      </footer>
+
+      {/* Live chat widget — appears 2s after load ------------------ */}
+      <button
+        className={`live-chat${chatShown ? ' shown' : ''}`}
+        aria-label="Open chat"
+        type="button"
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1,0 +1,750 @@
+/*
+ * Homepage v2 preview — scoped stylesheet.
+ *
+ * Every rule below is nested under `.m-v2-root` so it can't leak onto
+ * the live `/` page, the authenticated dashboard, or any other route.
+ *
+ * The token aliases at the top map the export's original names
+ * (`--surface-base`, `--accent-mint`, `--r-card`, etc.) onto the
+ * Tailwind v4 theme tokens already shipped in globals.css. That way we
+ * didn't have to rewrite the 700-line export CSS — it works unchanged.
+ *
+ * DO NOT remove or rename these classes without also updating
+ * src/app/preview/homepage/page.tsx.
+ */
+
+.m-v2-root {
+  /* Token aliases → globals.css Tailwind v4 theme */
+  --surface-base: var(--color-surface-base);
+  --surface-elevated: var(--color-surface-elevated);
+  --surface-ink: var(--color-surface-ink);
+  --surface-ink-2: var(--color-surface-ink-2);
+  --surface-soft-mint: var(--color-surface-soft-mint);
+
+  --text-primary: var(--color-ink-primary);
+  --text-secondary: var(--color-ink-secondary);
+  --text-tertiary: var(--color-ink-tertiary);
+  --text-on-ink: var(--color-on-ink);
+  --text-on-ink-dim: var(--color-on-ink-dim);
+
+  --accent-mint: var(--color-accent-mint);
+  --accent-mint-deep: var(--color-accent-mint-deep);
+  --accent-mint-wash: var(--color-accent-mint-wash);
+  --accent-orange: var(--color-accent-orange);
+  --accent-orange-deep: var(--color-accent-orange-deep);
+
+  --divider: var(--color-divider-light);
+  --divider-ink: var(--color-divider-ink);
+
+  --r-card: var(--radius-marketing-card);
+  --r-figure: var(--radius-marketing-figure);
+  --r-btn: var(--radius-marketing-btn);
+  --r-input: var(--radius-marketing-input);
+  --r-pill: var(--radius-marketing-pill);
+
+  --shadow-sm: var(--shadow-marketing-sm);
+  --shadow-md: var(--shadow-marketing-md);
+  --shadow-lg: var(--shadow-marketing-lg);
+  --shadow-xl: var(--shadow-marketing-xl);
+  --shadow-mint: var(--shadow-marketing-mint);
+  --shadow-orange: var(--shadow-marketing-orange);
+
+  --fs-display: var(--text-display);
+  --fs-h1: var(--text-h1-marketing);
+  --fs-h2: var(--text-h2-marketing);
+  --fs-h3: 24px;
+  --fs-body: 17px;
+  --fs-sm: 14px;
+  --fs-xs: 12px;
+  --track-tight: var(--tracking-marketing-tight);
+  --track-eyebrow: var(--tracking-marketing-eyebrow);
+
+  /* Page-level appearance — covers body so the dark nav behind is hidden */
+  min-height: 100vh;
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+.m-v2-root * { box-sizing: border-box; }
+.m-v2-root img,
+.m-v2-root svg { display: block; max-width: 100%; }
+
+/* Shared ---------------------------------------------------------- */
+.m-v2-root .wrap { max-width: 1240px; margin: 0 auto; padding: 0 32px; }
+.m-v2-root .eyebrow {
+  font-size: var(--fs-xs);
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+.m-v2-root .eyebrow.on-ink { color: var(--accent-mint); }
+
+.m-v2-root .btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 22px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+.m-v2-root .btn-mint { background: var(--accent-mint); color: #052E1C; box-shadow: var(--shadow-mint); }
+.m-v2-root .btn-mint:hover { transform: scale(1.02); box-shadow: 0 24px 55px -18px rgba(52, 211, 153, 0.65); background: #2CC48A; }
+.m-v2-root .btn-ghost { background: transparent; color: var(--text-primary); border: 1px solid var(--divider); }
+.m-v2-root .btn-ghost:hover { transform: scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+.m-v2-root .btn-ghost.on-ink { color: var(--text-on-ink); border-color: var(--divider-ink); background: transparent; }
+.m-v2-root .btn-ghost.on-ink:hover { background: rgba(255,255,255,0.04); }
+
+.m-v2-root .divider-rule { height: 1px; background: var(--divider); }
+
+/* Reveal animation */
+.m-v2-root .reveal { opacity: 0; transform: translateY(12px); transition: opacity 400ms ease, transform 400ms ease; }
+.m-v2-root .reveal.in { opacity: 1; transform: translateY(0); }
+
+/* Sections */
+.m-v2-root section { position: relative; }
+.m-v2-root .section-light { background: var(--surface-base); }
+.m-v2-root .section-white { background: var(--surface-elevated); }
+.m-v2-root .section-mint { background: var(--accent-mint-wash); }
+.m-v2-root .section-ink { background: var(--surface-ink); color: var(--text-on-ink); }
+.m-v2-root .section-ink h1,
+.m-v2-root .section-ink h2,
+.m-v2-root .section-ink h3 { color: var(--text-on-ink); }
+
+/* Ambient glow (hero / final CTA) */
+.m-v2-root .glow-wrap { position: relative; }
+.m-v2-root .glow-wrap::before,
+.m-v2-root .glow-wrap::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+  width: 900px; height: 900px;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: var(--glow-opacity, 0.18);
+}
+.m-v2-root .glow-wrap::before {
+  top: -250px; right: -200px;
+  background: radial-gradient(circle, var(--accent-orange) 0%, transparent 60%);
+}
+.m-v2-root .glow-wrap::after {
+  bottom: -350px; left: -250px;
+  background: radial-gradient(circle, var(--accent-mint) 0%, transparent 60%);
+  opacity: calc(var(--glow-opacity, 0.18) * 0.6);
+}
+.m-v2-root .glow-wrap > * { position: relative; z-index: 1; }
+
+/* Nav ------------------------------------------------------------- */
+.m-v2-root .nav-shell {
+  position: fixed; top: 18px; left: 0; right: 0;
+  display: flex; justify-content: center;
+  z-index: 100;
+  transition: top 200ms ease;
+  pointer-events: none;
+}
+.m-v2-root .nav-shell.scrolled { top: 10px; }
+.m-v2-root .nav-pill {
+  pointer-events: auto;
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border: 1px solid rgba(11,18,32,0.06);
+  padding: 10px 10px 10px 20px;
+  border-radius: var(--r-pill);
+  box-shadow: var(--shadow-md);
+  transition: padding 200ms ease, transform 200ms ease;
+}
+.m-v2-root .nav-shell.scrolled .nav-pill { padding: 8px 8px 8px 16px; transform: scale(0.97); }
+.m-v2-root .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; text-decoration: none; }
+.m-v2-root .nav-logo .pay { color: var(--text-primary); }
+.m-v2-root .nav-logo .backer { color: var(--accent-mint-deep); }
+.m-v2-root .nav-links { display: flex; gap: 6px; margin: 0 14px; }
+.m-v2-root .nav-links a {
+  font-size: 14px; font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: var(--r-pill);
+  transition: background 150ms, color 150ms;
+}
+.m-v2-root .nav-links a:hover { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-v2-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
+.m-v2-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+.m-v2-root .nav-start {
+  background: var(--accent-mint); color: #052E1C;
+  padding: 10px 18px; border-radius: var(--r-pill);
+  font-weight: 600; font-size: 14px; text-decoration: none;
+  transition: transform 150ms, box-shadow 150ms;
+}
+.m-v2-root .nav-start:hover { transform: scale(1.03); box-shadow: var(--shadow-mint); }
+
+.m-v2-root .trust-bar {
+  text-align: center;
+  padding: 84px 32px 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.02em;
+}
+.m-v2-root .trust-bar .dot { margin: 0 10px; opacity: 0.5; }
+
+/* Hero ------------------------------------------------------------ */
+.m-v2-root .hero { padding: 32px 0 120px; }
+.m-v2-root .hero-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 64px;
+  align-items: center;
+  padding-top: 40px;
+}
+.m-v2-root .hero h1 {
+  font-size: var(--fs-display);
+  line-height: 0.94;
+  letter-spacing: var(--track-tight);
+  font-weight: 700;
+  margin: 18px 0 24px;
+}
+.m-v2-root .hero h1 .l1 { color: var(--text-primary); display: block; }
+.m-v2-root .hero h1 .l2 { color: var(--accent-mint-deep); display: block; }
+.m-v2-root .hero h1 .l3 { color: var(--accent-orange-deep); display: block; }
+.m-v2-root .hero-sub {
+  font-size: 19px;
+  color: var(--text-secondary);
+  max-width: 540px;
+  margin-bottom: 28px;
+  text-wrap: pretty;
+}
+.m-v2-root .hero-cta-row { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+.m-v2-root .hero-ticker {
+  margin-top: 22px;
+  font-size: 14px;
+  color: var(--accent-orange-deep);
+  font-weight: 500;
+  display: inline-flex; align-items: center; gap: 10px;
+}
+.m-v2-root .hero-ticker .pulse {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent-orange);
+  box-shadow: 0 0 0 0 rgba(245,158,11,0.6);
+  animation: m-v2-pulse 2.4s infinite;
+}
+@keyframes m-v2-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(245,158,11,0.5); }
+  70% { box-shadow: 0 0 0 12px rgba(245,158,11,0); }
+  100% { box-shadow: 0 0 0 0 rgba(245,158,11,0); }
+}
+
+/* Hero visual ----------------------------------------------------- */
+.m-v2-root .hero-visual {
+  position: relative;
+  height: 600px;
+  perspective: 1400px;
+}
+.m-v2-root .hero-visual .float { animation: m-v2-float 6s ease-in-out infinite; }
+@keyframes m-v2-float {
+  0%, 100% { transform: translateY(0) rotate(var(--r, 0deg)); }
+  50% { transform: translateY(-4px) rotate(var(--r, 0deg)); }
+}
+
+.m-v2-root .dash-card {
+  position: absolute;
+  width: 420px; height: 520px;
+  background: #fff;
+  border-radius: var(--r-figure);
+  box-shadow: var(--shadow-xl);
+  right: 40px; top: 30px;
+  transform: rotate(-4deg);
+  overflow: hidden;
+  border: 1px solid rgba(11,18,32,0.04);
+  --r: -4deg;
+}
+.m-v2-root .dash-header {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--divider);
+  font-size: 13px; color: var(--text-secondary);
+}
+.m-v2-root .dash-header .title { font-weight: 600; color: var(--text-primary); font-size: 15px; }
+.m-v2-root .dash-body { padding: 22px; }
+.m-v2-root .dash-body .label { font-size: 11px; color: var(--text-tertiary); letter-spacing: 0.08em; text-transform: uppercase; font-weight: 600; }
+.m-v2-root .dash-body .big-num { font-size: 38px; font-weight: 700; letter-spacing: -0.02em; margin: 4px 0 2px; }
+.m-v2-root .dash-body .delta { color: var(--accent-mint-deep); font-size: 13px; font-weight: 500; }
+
+.m-v2-root .donut-row { display: flex; gap: 18px; align-items: center; margin: 24px 0; }
+.m-v2-root .donut {
+  width: 120px; height: 120px; flex-shrink: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--accent-mint) 0 38%,
+    var(--accent-orange) 38% 62%,
+    #60A5FA 62% 78%,
+    #A78BFA 78% 90%,
+    #E5E7EB 90% 100%
+  );
+  position: relative;
+}
+.m-v2-root .donut::after {
+  content: '';
+  position: absolute; inset: 18px;
+  border-radius: 50%;
+  background: #fff;
+}
+.m-v2-root .donut-center {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  font-size: 11px; color: var(--text-tertiary); z-index: 1;
+}
+.m-v2-root .donut-center strong { font-size: 18px; color: var(--text-primary); font-weight: 700; }
+.m-v2-root .donut-legend { flex: 1; display: flex; flex-direction: column; gap: 8px; font-size: 12px; }
+.m-v2-root .donut-legend .row { display: flex; justify-content: space-between; align-items: center; }
+.m-v2-root .donut-legend .swatch { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 8px; vertical-align: middle; }
+.m-v2-root .donut-legend .name { color: var(--text-secondary); }
+.m-v2-root .donut-legend .amt { font-weight: 600; color: var(--text-primary); }
+
+.m-v2-root .sub-list { border-top: 1px solid var(--divider); padding-top: 16px; }
+.m-v2-root .sub-list .row {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 8px 0;
+  font-size: 13px;
+}
+.m-v2-root .sub-list .name { color: var(--text-primary); font-weight: 500; }
+.m-v2-root .sub-list .tag {
+  background: #FEF3C7; color: var(--accent-orange-deep);
+  font-size: 10px; font-weight: 600; letter-spacing: 0.04em;
+  padding: 2px 8px; border-radius: 999px; margin-left: 8px;
+  text-transform: uppercase;
+}
+.m-v2-root .sub-list .amt { color: var(--text-secondary); font-variant-numeric: tabular-nums; }
+
+.m-v2-root .mini-card {
+  position: absolute;
+  width: 280px; height: 380px;
+  background: var(--surface-ink);
+  color: var(--text-on-ink);
+  border-radius: 28px;
+  box-shadow: var(--shadow-xl);
+  left: 10px; top: 100px;
+  transform: rotate(-10deg);
+  padding: 22px;
+  --r: -10deg;
+  overflow: hidden;
+}
+.m-v2-root .mini-card .label { color: var(--text-on-ink-dim); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; }
+.m-v2-root .mini-card .big { font-size: 36px; font-weight: 700; letter-spacing: -0.02em; margin: 6px 0 2px; color: var(--accent-mint); }
+.m-v2-root .mini-card .desc { color: var(--text-on-ink-dim); font-size: 13px; margin-bottom: 24px; }
+.m-v2-root .mini-bar { display: flex; flex-direction: column; gap: 10px; }
+.m-v2-root .mini-bar .bar { height: 34px; background: rgba(255,255,255,0.06); border-radius: 10px; display: flex; align-items: center; padding: 0 12px; justify-content: space-between; font-size: 12px; }
+.m-v2-root .mini-bar .bar .n { color: var(--text-on-ink-dim); }
+.m-v2-root .mini-bar .bar .v { color: var(--accent-orange); font-weight: 600; }
+
+.m-v2-root .agent-bubble {
+  position: absolute;
+  right: -20px; bottom: 40px;
+  width: 280px;
+  background: #fff;
+  border-radius: 22px 22px 22px 6px;
+  padding: 16px 18px;
+  box-shadow: var(--shadow-lg);
+  font-size: 13px; line-height: 1.45;
+  transform: rotate(2deg);
+  --r: 2deg;
+  border: 1px solid rgba(11,18,32,0.05);
+}
+.m-v2-root .agent-bubble .who {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 8px;
+  font-size: 11px; color: var(--text-tertiary); font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase;
+}
+.m-v2-root .agent-bubble .who .dot-mint { width: 18px; height: 18px; border-radius: 50%; background: linear-gradient(135deg, var(--accent-mint), var(--accent-orange)); }
+.m-v2-root .agent-bubble .msg { color: var(--text-primary); }
+.m-v2-root .agent-bubble .msg strong { color: var(--accent-orange-deep); }
+
+/* Trust strip ----------------------------------------------------- */
+.m-v2-root .trust-strip { padding: 48px 0; border-top: 1px solid var(--divider); border-bottom: 1px solid var(--divider); }
+.m-v2-root .trust-row {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  gap: 24px; align-items: center;
+}
+.m-v2-root .trust-item {
+  text-align: center;
+  color: #9CA3AF;
+  font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+  display: flex; flex-direction: column; align-items: center; gap: 6px;
+}
+.m-v2-root .trust-item .ring {
+  width: 28px; height: 28px; border-radius: 8px;
+  border: 1.5px solid #D1D5DB;
+  display: grid; place-items: center;
+  font-size: 12px; color: #9CA3AF; font-weight: 700;
+}
+
+/* Stats ----------------------------------------------------------- */
+.m-v2-root .stats-section { padding: 120px 0; }
+.m-v2-root .section-head { text-align: left; max-width: 720px; margin-bottom: 56px; }
+.m-v2-root .section-head h2 {
+  font-size: var(--fs-h2);
+  letter-spacing: var(--track-tight);
+  font-weight: 700;
+  line-height: 1.05;
+  margin: 12px 0 18px;
+}
+.m-v2-root .section-head p { font-size: 19px; color: var(--text-secondary); text-wrap: pretty; max-width: 620px; }
+
+.m-v2-root .stats-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.m-v2-root .stat-card {
+  background: #fff;
+  border-radius: var(--r-card);
+  padding: 36px 32px 32px;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(11,18,32,0.04);
+  position: relative;
+  overflow: hidden;
+}
+.m-v2-root .stat-card .label { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-tertiary); font-weight: 600; }
+.m-v2-root .stat-card .num {
+  font-size: 64px; line-height: 1; font-weight: 700; letter-spacing: -0.03em;
+  margin: 16px 0 6px;
+  position: relative; display: inline-block;
+}
+.m-v2-root .stat-card .num .unit { color: var(--text-tertiary); font-size: 0.5em; font-weight: 600; }
+.m-v2-root .stat-card .underline {
+  height: 4px; width: 56px; background: var(--accent-orange); border-radius: 2px;
+  margin-top: 4px; margin-bottom: 18px;
+}
+.m-v2-root .stat-card .blurb { color: var(--text-secondary); font-size: 15px; line-height: 1.5; text-wrap: pretty; }
+
+/* Pillars --------------------------------------------------------- */
+.m-v2-root .pillars-section { padding: 120px 0; }
+.m-v2-root .pillar-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.m-v2-root .pillar-card {
+  background: #fff;
+  border: 1px solid rgba(11,18,32,0.06);
+  border-radius: var(--r-card);
+  padding: 32px;
+  display: flex; flex-direction: column;
+  min-height: 480px;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+.m-v2-root .pillar-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-lg); }
+.m-v2-root .pillar-icon {
+  width: 48px; height: 48px; border-radius: 14px;
+  display: grid; place-items: center;
+  margin-bottom: 22px;
+  color: #fff;
+  font-size: 22px;
+}
+.m-v2-root .pillar-icon.orange { background: var(--accent-orange); }
+.m-v2-root .pillar-icon.mint { background: var(--accent-mint-deep); }
+.m-v2-root .pillar-icon.gradient { background: linear-gradient(135deg, var(--accent-mint), var(--accent-orange)); }
+.m-v2-root .pillar-card h3 { font-size: 22px; font-weight: 700; letter-spacing: -0.01em; margin: 0 0 10px; }
+.m-v2-root .pillar-card .copy { color: var(--text-secondary); font-size: 15px; margin-bottom: 20px; }
+.m-v2-root .pillar-preview {
+  margin-top: auto;
+  border-radius: 14px;
+  background: var(--surface-base);
+  border: 1px solid var(--divider);
+  padding: 16px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  min-height: 150px;
+}
+.m-v2-root .pillar-preview .head {
+  font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-tertiary);
+  margin-bottom: 8px; font-weight: 600;
+}
+.m-v2-root .letter-para { font-family: 'Georgia', serif; color: var(--text-primary); font-size: 12.5px; line-height: 1.5; }
+.m-v2-root .letter-para .hl { background: #FEF3C7; padding: 0 2px; border-radius: 2px; }
+.m-v2-root .donut-mini { display: flex; gap: 12px; align-items: center; }
+.m-v2-root .donut-mini .d {
+  width: 64px; height: 64px; border-radius: 50%;
+  background: conic-gradient(var(--accent-mint) 0 40%, var(--accent-orange) 40% 65%, #93C5FD 65% 80%, #E5E7EB 80% 100%);
+  position: relative;
+}
+.m-v2-root .donut-mini .d::after { content: ''; position: absolute; inset: 10px; background: var(--surface-base); border-radius: 50%; }
+.m-v2-root .donut-mini .nums { display: flex; flex-direction: column; gap: 4px; }
+.m-v2-root .donut-mini .nums .row { display: flex; gap: 8px; font-size: 11px; }
+.m-v2-root .donut-mini .nums .row .sw { width: 8px; height: 8px; border-radius: 50%; }
+.m-v2-root .chat-preview { display: flex; flex-direction: column; gap: 8px; }
+.m-v2-root .chat-bubble { padding: 8px 12px; border-radius: 14px; max-width: 85%; font-size: 12px; }
+.m-v2-root .chat-bubble.user { background: var(--accent-mint-wash); align-self: flex-end; color: var(--text-primary); border-bottom-right-radius: 4px; }
+.m-v2-root .chat-bubble.agent { background: var(--surface-ink); color: var(--text-on-ink); align-self: flex-start; border-bottom-left-radius: 4px; }
+
+/* How it works ---------------------------------------------------- */
+.m-v2-root .how-section { padding: 140px 0; }
+.m-v2-root .how-section .eyebrow { color: var(--accent-mint); }
+.m-v2-root .how-section h2 { color: var(--text-on-ink); font-size: var(--fs-h2); font-weight: 700; letter-spacing: var(--track-tight); line-height: 1.05; margin: 12px 0 18px; }
+.m-v2-root .how-section .sub { color: var(--text-on-ink-dim); font-size: 19px; max-width: 620px; }
+.m-v2-root .how-steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; margin-top: 64px; }
+.m-v2-root .how-step {
+  background: var(--surface-ink-2);
+  border: 1px solid var(--divider-ink);
+  border-radius: var(--r-card);
+  padding: 32px;
+  min-height: 380px;
+  display: flex; flex-direction: column;
+}
+.m-v2-root .how-step .num { font-size: 80px; font-weight: 700; color: var(--accent-mint); line-height: 1; letter-spacing: -0.04em; margin-bottom: 14px; }
+.m-v2-root .how-step h3 { color: var(--text-on-ink); font-size: 22px; font-weight: 700; letter-spacing: -0.01em; margin: 0 0 8px; text-wrap: balance; }
+.m-v2-root .how-step p { color: var(--text-on-ink-dim); font-size: 14px; margin: 0 0 18px; }
+.m-v2-root .mini-form { margin-top: auto; background: #0B1220; border: 1px solid var(--divider-ink); border-radius: 14px; padding: 16px; }
+.m-v2-root .mini-form label { font-size: 10px; color: var(--text-on-ink-dim); letter-spacing: 0.1em; text-transform: uppercase; font-weight: 600; }
+.m-v2-root .mini-form select,
+.m-v2-root .mini-form input {
+  width: 100%; background: rgba(255,255,255,0.04); color: var(--text-on-ink);
+  border: 1px solid var(--divider-ink); border-radius: 10px;
+  padding: 10px 12px; font-size: 13px; margin-top: 6px; margin-bottom: 10px;
+  font-family: inherit; outline: none;
+}
+.m-v2-root .mini-form select:focus,
+.m-v2-root .mini-form input:focus { border-color: var(--accent-mint); }
+.m-v2-root .mini-form button {
+  width: 100%; padding: 10px;
+  background: var(--accent-mint); color: #052E1C;
+  border: none; border-radius: 10px;
+  font-weight: 600; font-size: 13px; cursor: pointer;
+}
+.m-v2-root .mini-form button:disabled { opacity: 0.7; cursor: progress; }
+.m-v2-root .bank-list { display: flex; flex-direction: column; gap: 8px; margin-top: auto; }
+.m-v2-root .bank-row {
+  display: flex; justify-content: space-between; align-items: center;
+  background: rgba(255,255,255,0.04); border: 1px solid var(--divider-ink);
+  border-radius: 10px; padding: 10px 14px; font-size: 13px;
+}
+.m-v2-root .bank-row .n { color: var(--text-on-ink); }
+.m-v2-root .bank-row .v { color: var(--accent-mint); font-weight: 600; }
+.m-v2-root .bank-row .v.orange { color: var(--accent-orange); }
+.m-v2-root .deal-row {
+  display: flex; justify-content: space-between; align-items: center;
+  background: rgba(255,255,255,0.04); border: 1px solid var(--divider-ink);
+  border-radius: 10px; padding: 12px 14px; font-size: 13px;
+}
+.m-v2-root .deal-row + .deal-row { margin-top: 8px; }
+.m-v2-root .deal-row .cat { color: var(--text-on-ink-dim); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; }
+.m-v2-root .deal-row .name { color: var(--text-on-ink); font-weight: 500; }
+.m-v2-root .deal-row .save { color: var(--accent-mint); font-weight: 600; }
+
+.m-v2-root .how-cta-row { text-align: center; margin-top: 56px; }
+
+/* Deals ----------------------------------------------------------- */
+.m-v2-root .deals-section { padding: 120px 0; }
+.m-v2-root .logo-cloud {
+  display: flex; flex-wrap: wrap; gap: 12px 28px;
+  justify-content: center;
+  padding: 32px 0 48px;
+  border-bottom: 1px dashed rgba(11,18,32,0.08);
+  margin-bottom: 48px;
+}
+.m-v2-root .logo-chip {
+  font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace;
+  font-size: 14px; color: #6B7280; font-weight: 600; letter-spacing: 0.02em;
+  padding: 6px 10px;
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.6);
+}
+.m-v2-root .category-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.m-v2-root .cat-tile {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 28px;
+  display: flex; flex-direction: column; gap: 12px;
+  min-height: 160px;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+  cursor: pointer;
+}
+.m-v2-root .cat-tile:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); border-color: var(--accent-mint); }
+.m-v2-root .cat-tile .cat-name { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; }
+.m-v2-root .cat-tile .cat-count { color: var(--text-tertiary); font-size: 13px; }
+.m-v2-root .save-badge {
+  align-self: flex-start;
+  background: var(--accent-mint);
+  color: #052E1C;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px; font-weight: 600;
+  margin-top: auto;
+}
+.m-v2-root .commission-note { text-align: center; margin-top: 32px; color: var(--accent-orange-deep); font-size: 13px; }
+
+/* Pricing --------------------------------------------------------- */
+.m-v2-root .pricing-section { padding: 120px 0; }
+.m-v2-root .pricing-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.m-v2-root .price-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 32px;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+.m-v2-root .price-card.featured { border-color: var(--accent-mint); box-shadow: 0 30px 60px -30px rgba(52,211,153,0.35); }
+.m-v2-root .ribbon {
+  position: absolute; top: -12px; left: 32px;
+  background: var(--accent-mint); color: #052E1C;
+  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700;
+  padding: 6px 12px; border-radius: 999px;
+}
+.m-v2-root .price-card .tier { font-size: 14px; color: var(--text-tertiary); font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; }
+.m-v2-root .price-card .price { font-size: 48px; font-weight: 700; letter-spacing: -0.02em; margin: 12px 0 4px; }
+.m-v2-root .price-card .price .per { font-size: 16px; color: var(--text-tertiary); font-weight: 500; }
+.m-v2-root .price-card .founding { color: var(--accent-orange-deep); font-size: 12px; font-weight: 600; margin-bottom: 18px; letter-spacing: 0.04em; text-transform: uppercase; }
+.m-v2-root .price-card .founding.hidden { visibility: hidden; }
+.m-v2-root .price-card ul { list-style: none; padding: 0; margin: 0 0 24px; display: flex; flex-direction: column; gap: 10px; }
+.m-v2-root .price-card li {
+  font-size: 14px; color: var(--text-secondary);
+  padding-left: 26px; position: relative;
+}
+.m-v2-root .price-card li::before {
+  content: ''; position: absolute; left: 0; top: 6px;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--accent-mint-wash);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.2l3 2.8 6-6.5' stroke='%23059669' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat; background-position: center;
+}
+.m-v2-root .price-card .cta { margin-top: auto; }
+
+.m-v2-root .compare-link { text-align: center; margin-top: 36px; font-size: 14px; color: var(--text-secondary); }
+.m-v2-root .compare-link a { color: var(--accent-mint-deep); text-decoration: none; font-weight: 600; }
+.m-v2-root .compare-link a:hover { text-decoration: underline; }
+
+/* Testimonials ---------------------------------------------------- */
+.m-v2-root .testimonials-section { padding: 120px 0; overflow: hidden; }
+.m-v2-root .testimonials-head { text-align: center; margin-bottom: 56px; }
+.m-v2-root .testimonials-head h2 { font-size: var(--fs-h2); letter-spacing: var(--track-tight); font-weight: 700; margin: 12px 0; }
+.m-v2-root .t-track {
+  display: flex; gap: 22px; width: max-content;
+  animation: m-v2-tscroll 60s linear infinite;
+}
+.m-v2-root .testimonials-section:hover .t-track { animation-play-state: paused; }
+@keyframes m-v2-tscroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.m-v2-root .t-card {
+  width: 380px; flex-shrink: 0;
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 26px;
+  display: flex; flex-direction: column; gap: 14px;
+}
+.m-v2-root .t-card .who { display: flex; align-items: center; gap: 12px; }
+.m-v2-root .t-card .avatar {
+  width: 40px; height: 40px; border-radius: 50%;
+  display: grid; place-items: center;
+  font-weight: 700; color: #fff;
+  font-size: 15px;
+}
+.m-v2-root .t-card .name { font-weight: 600; font-size: 14px; }
+.m-v2-root .t-card .meta { font-size: 12px; color: var(--text-tertiary); }
+.m-v2-root .t-card .quote { font-size: 15px; color: var(--text-primary); line-height: 1.45; text-wrap: pretty; }
+.m-v2-root .t-card .saved { color: var(--accent-orange-deep); font-weight: 600; font-size: 13px; }
+
+/* Final CTA ------------------------------------------------------- */
+.m-v2-root .final-cta { padding: 140px 0; position: relative; overflow: hidden; }
+.m-v2-root .final-cta h2 {
+  font-size: clamp(56px, 7vw, 88px);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1;
+  text-align: center;
+  color: var(--text-on-ink);
+  margin: 0;
+}
+.m-v2-root .final-cta h2 .mint { color: var(--accent-mint); }
+.m-v2-root .final-cta .fc-sub { text-align: center; color: var(--text-on-ink-dim); margin-top: 24px; font-size: 17px; }
+.m-v2-root .final-cta .fc-btn-row { text-align: center; margin-top: 36px; }
+.m-v2-root .final-cta .fine { text-align: center; margin-top: 20px; color: var(--text-on-ink-dim); font-size: 13px; }
+
+/* Footer ---------------------------------------------------------- */
+.m-v2-root footer { padding: 80px 0 40px; background: var(--surface-ink); color: var(--text-on-ink); border-top: 1px solid var(--divider-ink); }
+.m-v2-root .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr; gap: 32px; }
+.m-v2-root .footer-brand .logo { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 10px; }
+.m-v2-root .footer-brand .logo .backer { color: var(--accent-mint); }
+.m-v2-root .footer-brand p { color: var(--text-on-ink-dim); font-size: 14px; max-width: 280px; }
+.m-v2-root .footer-col h5 { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-on-ink-dim); font-weight: 600; margin: 0 0 16px; }
+.m-v2-root .footer-col a { display: block; color: var(--text-on-ink); text-decoration: none; font-size: 14px; margin-bottom: 10px; opacity: 0.85; }
+.m-v2-root .footer-col a:hover { opacity: 1; color: var(--accent-mint); }
+.m-v2-root .footer-bottom {
+  border-top: 1px solid var(--divider-ink);
+  margin-top: 56px; padding-top: 24px;
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px;
+  font-size: 12px; color: var(--text-on-ink-dim);
+}
+.m-v2-root .footer-socials { display: flex; gap: 10px; }
+.m-v2-root .footer-socials a {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--divider-ink);
+  display: grid; place-items: center; font-size: 13px;
+  transition: background 150ms ease;
+}
+.m-v2-root .footer-socials a:hover { background: rgba(255,255,255,0.06); }
+
+/* Live chat ------------------------------------------------------- */
+.m-v2-root .live-chat {
+  position: fixed; bottom: 20px; right: 20px; z-index: 90;
+  width: 56px; height: 56px; border-radius: 50%;
+  background: var(--accent-mint); color: #052E1C;
+  display: grid; place-items: center;
+  box-shadow: var(--shadow-mint);
+  cursor: pointer;
+  opacity: 0; transform: translateY(10px);
+  transition: opacity 400ms ease, transform 400ms ease;
+  font-size: 22px;
+  border: none;
+}
+.m-v2-root .live-chat.shown { opacity: 1; transform: translateY(0); }
+
+/* Preview badge --------------------------------------------------- */
+.m-v2-root .preview-badge {
+  position: fixed; top: 8px; left: 8px; z-index: 120;
+  background: #0B1220; color: #F3F4F6;
+  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
+  font-weight: 700;
+  padding: 6px 10px; border-radius: 999px;
+  box-shadow: var(--shadow-md);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* Responsive ------------------------------------------------------ */
+@media (max-width: 980px) {
+  .m-v2-root .hero-grid { grid-template-columns: 1fr; gap: 40px; }
+  .m-v2-root .hero-visual { height: 520px; }
+  .m-v2-root .stats-grid,
+  .m-v2-root .pillar-grid,
+  .m-v2-root .how-steps,
+  .m-v2-root .category-grid,
+  .m-v2-root .pricing-grid { grid-template-columns: 1fr; }
+  .m-v2-root .trust-row { grid-template-columns: repeat(2, 1fr); gap: 16px; }
+  .m-v2-root .footer-grid { grid-template-columns: 1fr 1fr; }
+  .m-v2-root .nav-links { display: none; }
+}
+@media (max-width: 480px) {
+  .m-v2-root .wrap { padding: 0 20px; }
+  .m-v2-root .hero-visual { height: 440px; }
+  .m-v2-root .dash-card { width: 300px; height: 420px; right: 0; top: 10px; }
+  .m-v2-root .mini-card { width: 200px; height: 280px; left: 0; top: 120px; }
+  .m-v2-root .agent-bubble { width: 240px; right: 0; bottom: 0; }
+  .m-v2-root .stats-section,
+  .m-v2-root .pillars-section,
+  .m-v2-root .deals-section,
+  .m-v2-root .pricing-section,
+  .m-v2-root .testimonials-section { padding: 80px 0; }
+  .m-v2-root .how-section,
+  .m-v2-root .final-cta { padding: 100px 0; }
+}


### PR DESCRIPTION
## What

The first two PRs in the homepage v2 redesign series.

**Commit 1 — palette + Tailwind tokens.** Adds the new light+mint+dark marketing tokens to `src/app/globals.css` alongside the existing navy tokens. Additive only — no existing token is removed or modified, and `body { background: #0A1628 }` is left untouched so every existing page renders identically.

**Commits 2 & 3 — preview route at `/preview/homepage`.** Ports the Claude Design export at `docs/design-exports/homepage-v2/` into a single client page so you can review the new look on a Vercel preview URL before we touch the real `/`. Everything lives under `.m-v2-root` so styles can't leak onto the live homepage or the authenticated dashboard.

## What you can click

Once Vercel finishes the preview deploy, open **`<preview-url>/preview/homepage`** to see it. A small `Preview · Homepage v2` badge sits top-left so the route is never confused with production.

Sections ported:
- Floating pill nav (shrinks on scroll)
- Hero with three layered mockups (Money Hub dash card, dark savings snapshot, Pocket Agent Telegram bubble)
- Trust strip (ICO / FCA / GDPR / Stripe / Paybacker LTD)
- Mint-wash stats
- Three-up product pillars (Disputes Centre / Money Hub / Pocket Agent) with mini-previews
- Dark "How it works" with the live mini letter form (demo-only — wiring to `/api/agents/complaints` lands in PR 4)
- Mint-wash deals with logo cloud + 6-category grid
- Pricing (Essential flagged "Most popular")
- Auto-scrolling infinite testimonials (initial-only names per your answer — real names land in PR 3)
- Dark final CTA
- Footer

## What's not in this PR

- FAQ section — drafting in PR 3
- Why We Exist narrative, dedicated Pocket Agent showcase, AI Financial Assistant recategorisation, Smart Subscription Tracking list — PR 3
- Live Supabase data — the hero ticker reads "Saved for our members this month" with no number yet; stats cards show the placeholder £8,029 / 149 / 45 figures from the export. All wired in PR 4.
- Tweaks dev panel from the export is not ported — it only works inside Claude Design's iframe.
- Real Companies House number for Paybacker LTD — to be added before cut-over (PR 5).

## Safety

- `/` is untouched — still renders the current dark homepage.
- `/dashboard/*` is untouched — still dark navy.
- New CSS is scoped under `.m-v2-root`. No global selector.
- `npx tsc --noEmit` reports zero new errors from `src/app/preview/homepage/*` (two pre-existing errors in `trial-expiry/route.ts` and `validator.ts` are unrelated).

## Test plan

- [ ] Vercel preview deploys green
- [ ] `/preview/homepage` renders the full v2 design
- [ ] `/` still renders the current dark homepage unchanged
- [ ] `/dashboard` still dark-navy on login
- [ ] Mini letter form cycles Generate → Drafting → ✓ Letter ready
- [ ] Nav pill shrinks on scroll
- [ ] Testimonials carousel pauses on hover
- [ ] Live-chat widget appears 2s after load

## Next

- **PR 3** — detailed FAQ + missing sections (Why We Exist, Pocket Agent showcase, AI Financial Assistant, Smart Subscription Tracking)
- **PR 4** — wire live Supabase data (members-aggregated savings, live stats, letter form → `/api/agents/complaints`)
- **PR 5** — swap `/` to the v2 homepage once Paul has reviewed the preview
