### PR TITLE
fix(home): tier 1 formatting quick-wins (dupe chat, widow, badge boxes)

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -120,7 +120,6 @@ const TESTIMONIALS: Testimonial[] = [
 
 export default function HomepageV2Preview() {
   const [navScrolled, setNavScrolled] = useState(false);
-  const [chatShown, setChatShown] = useState(false);
   const [letterBusy, setLetterBusy] = useState(false);
   const [letterLabel, setLetterLabel] = useState('Generate letter →');
   const [letterPreview, setLetterPreview] = useState<string | null>(null);
@@ -165,12 +164,6 @@ export default function HomepageV2Preview() {
     );
     container.querySelectorAll('.reveal').forEach((el) => io.observe(el));
     return () => io.disconnect();
-  }, []);
-
-  // Chat widget appears after 2s — matches the export's behaviour.
-  useEffect(() => {
-    const t = window.setTimeout(() => setChatShown(true), 2000);
-    return () => window.clearTimeout(t);
   }, []);
 
   // Fetch live stats from /api/preview/homepage-stats on mount.
@@ -443,9 +436,8 @@ export default function HomepageV2Preview() {
             <div className="why-copy reveal">
               <span className="eyebrow">Why we exist</span>
               <h2>
-                The average UK household is
-                <br />
-                overcharged <span className="accent">£1,000+</span> a year.
+                The average UK household is overcharged{' '}
+                <span className="accent">£1,000+</span> a year.
               </h2>
               <p className="lead">
                 Broadband price hikes. Energy tariffs that quietly roll over. Gym memberships you
@@ -1737,25 +1729,12 @@ export default function HomepageV2Preview() {
         </div>
       </footer>
 
-      {/* Live chat widget — appears 2s after load ------------------ */}
-      <button
-        className={`live-chat${chatShown ? ' shown' : ''}`}
-        aria-label="Open chat"
-        type="button"
-      >
-        <svg
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
-        </svg>
-      </button>
+      {/*
+        Live chat button removed — the site-wide <ChatWidget /> in
+        src/app/layout.tsx already renders a fixed bottom-right chat
+        launcher on every route, so the homepage's own button was a
+        visual duplicate. (Paul, 19 Apr 2026.)
+      */}
     </div>
   );
 }

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -385,15 +385,19 @@
   display: flex; flex-direction: column; align-items: center; gap: 6px;
 }
 .m-v2-root .trust-item .ring {
-  width: 28px; height: 28px; border-radius: 8px;
+  /* Export shipped a fixed 28×28 box which clipped 'GDPR'. Expand to
+     hug the label and keep a min square shape for single-char rings. */
+  min-width: 44px; height: 28px; padding: 0 10px; border-radius: 8px;
   border: 1.5px solid #D1D5DB;
-  display: grid; place-items: center;
+  display: inline-flex; align-items: center; justify-content: center;
   font-size: 12px; color: #9CA3AF; font-weight: 700;
+  letter-spacing: 0.04em;
 }
 
 /* Stats ----------------------------------------------------------- */
 .m-v2-root .stats-section { padding: 120px 0; }
 .m-v2-root .section-head { text-align: left; max-width: 720px; margin-bottom: 56px; }
+.m-v2-root .why-copy h2 { text-wrap: balance; }
 .m-v2-root .section-head h2 {
   font-size: var(--fs-h2);
   letter-spacing: var(--track-tight);


### PR DESCRIPTION
## Three visible bugs Paul flagged

1. **Duplicate chat bubble.** The site-wide `<ChatWidget />` in `src/app/layout.tsx` already renders a fixed bottom-right chat launcher on every route. The v2 homepage shipped with its own `.live-chat` button too, so users saw two bubbles. Dropped the homepage's copy (plus its `chatShown` state + 2s-delay effect) and kept the global one.

2. **"The average UK household is / overcharged £1,000+" widow.** The hardcoded `<br/>` after "is" orphaned the word on a line by itself on mobile. Removed the break and added `text-wrap: balance` to the heading so copy stays pleasant whatever the width.

3. **ICO / FCA / GDPR / UK / £ badge boxes.** The static export shipped a fixed 28×28px `.ring` which was narrower than "GDPR" at 12px (the text overflowed the box). Relaxed to `min-width: 44px; height: 28px; padding: 0 10px` with flex alignment so each badge hugs its label cleanly.

## Not in this PR

The bigger items Paul flagged still to come:

- Mobile nav hamburger (tabs hidden below 980px with no replacement)
- Hero typography scaling on mobile
- Telegram/Pocket Agent section formatting
- Deals section polish
- Pricing — surface Pro exports + Pocket Agent on Free
- `avgSavingsPerUser` calculation (currently skewed by property-portfolio users)
- Founding-member counter floor (trust calibration)
- AI Disputes Centre weight increase + inline letter → signup gate
- Email thread analysis / Google Sheets export messaging
- `/careers` form page