### PR TITLE
feat(careers): /careers interest form + API + table

### DIFF
--- a/src/app/api/careers/route.ts
+++ b/src/app/api/careers/route.ts
@@ -1,0 +1,175 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { resend, FROM_EMAIL, REPLY_TO } from '@/lib/resend';
+
+/**
+ * POST /api/careers
+ *
+ * Careers interest form (see /careers). Two behaviours — they both run,
+ * in parallel, so neither one blocks the other:
+ *
+ *   1. Insert into `careers_interest` via the service-role client so RLS
+ *      doesn't get in the way. Graceful on duplicate — returns 200 with
+ *      a "already on file" note rather than an angry error (the candidate
+ *      shouldn't feel punished for clicking twice).
+ *
+ *   2. Forward a plaintext summary to hello@paybacker.co.uk so Paul sees
+ *      the new interest in his inbox even if the migration hasn't run in
+ *      the target environment yet.
+ *
+ * Env deps: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
+ *           RESEND_API_KEY. If any are missing, the route silently
+ *           falls back to whatever it can still do (we don't want a
+ *           missing optional key to block submissions).
+ */
+
+type CareersBody = {
+  fullName?: string;
+  email?: string;
+  roleOfInterest?: string;
+  linkedinUrl?: string;
+  portfolioUrl?: string;
+  why?: string;
+  availability?: string;
+  ukBased?: boolean;
+};
+
+function clean(v: unknown, max = 2000): string | null {
+  if (typeof v !== 'string') return null;
+  const t = v.trim();
+  if (!t) return null;
+  return t.slice(0, max);
+}
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function isSafeHttpUrl(u: string): boolean {
+  try {
+    const parsed = new URL(u);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function getAdmin() {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.SUPABASE_SERVICE_ROLE_KEY
+  ) {
+    return null;
+  }
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+}
+
+export async function POST(req: NextRequest) {
+  let body: CareersBody;
+  try {
+    body = (await req.json()) as CareersBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const fullName = clean(body.fullName, 120);
+  const email = clean(body.email, 180)?.toLowerCase() ?? null;
+  const roleOfInterest = clean(body.roleOfInterest, 80);
+  const linkedinUrl = clean(body.linkedinUrl, 300);
+  const portfolioUrl = clean(body.portfolioUrl, 300);
+  const why = clean(body.why, 2000);
+  const availability = clean(body.availability, 40);
+  const ukBased = typeof body.ukBased === 'boolean' ? body.ukBased : null;
+
+  if (!fullName || !email) {
+    return NextResponse.json(
+      { error: 'Name and email are required.' },
+      { status: 400 },
+    );
+  }
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ error: 'Invalid email address.' }, { status: 400 });
+  }
+  // Optional URLs — if present, must be http(s). Silently drop otherwise
+  // rather than fail the whole form.
+  const safeLinkedin = linkedinUrl && isSafeHttpUrl(linkedinUrl) ? linkedinUrl : null;
+  const safePortfolio = portfolioUrl && isSafeHttpUrl(portfolioUrl) ? portfolioUrl : null;
+
+  const userAgent = req.headers.get('user-agent') ?? null;
+  const referer = req.headers.get('referer') ?? null;
+
+  // 1) Supabase insert — gracefully absorb missing table / dup email.
+  let duplicated = false;
+  const supabase = getAdmin();
+  if (supabase) {
+    try {
+      const { error } = await supabase.from('careers_interest').insert({
+        full_name: fullName,
+        email,
+        role_of_interest: roleOfInterest,
+        linkedin_url: safeLinkedin,
+        portfolio_url: safePortfolio,
+        why,
+        availability,
+        uk_based: ukBased,
+        referrer: referer,
+        user_agent: userAgent,
+      });
+      if (error) {
+        // Postgres unique-violation = they're already on file. Don't 500.
+        if (error.code === '23505') {
+          duplicated = true;
+        } else {
+          // Table missing (42P01) or schema mismatch — log and continue
+          // so the Resend notification still goes out.
+          console.error('[careers] supabase insert failed', error);
+        }
+      }
+    } catch (err) {
+      console.error('[careers] supabase insert threw', err);
+    }
+  }
+
+  // 2) Resend notification — don't block the response on the send.
+  if (process.env.RESEND_API_KEY) {
+    const subject = duplicated
+      ? `Careers interest update · ${fullName}`
+      : `New careers interest · ${fullName}`;
+    const lines = [
+      `Name: ${fullName}`,
+      `Email: ${email}`,
+      roleOfInterest ? `Role: ${roleOfInterest}` : null,
+      availability ? `Availability: ${availability}` : null,
+      ukBased === null ? null : `UK-based: ${ukBased ? 'yes' : 'no'}`,
+      safeLinkedin ? `LinkedIn: ${safeLinkedin}` : null,
+      safePortfolio ? `Portfolio: ${safePortfolio}` : null,
+      why ? `\nWhy:\n${why}` : null,
+      referer ? `\nReferrer: ${referer}` : null,
+    ]
+      .filter(Boolean)
+      .join('\n');
+    resend.emails
+      .send({
+        from: FROM_EMAIL,
+        replyTo: email,
+        to: 'hello@paybacker.co.uk',
+        subject,
+        text: lines,
+      })
+      .catch((err) => console.error('[careers] resend notify failed', err));
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      duplicated,
+      message: duplicated
+        ? 'Thanks — you are already on our list. We have refreshed the details we have on file.'
+        : 'Thanks — your interest has been recorded. We will be in touch as soon as we start hiring for this role.',
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/careers/CareersInterestForm.tsx
+++ b/src/app/careers/CareersInterestForm.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useState } from 'react';
+
+type Status = 'idle' | 'submitting' | 'success' | 'error';
+
+type SubmitResponse = {
+  ok?: boolean;
+  duplicated?: boolean;
+  message?: string;
+  error?: string;
+};
+
+export default function CareersInterestForm() {
+  const [status, setStatus] = useState<Status>('idle');
+  const [serverMessage, setServerMessage] = useState<string>('');
+  const [duplicated, setDuplicated] = useState<boolean>(false);
+
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [roleOfInterest, setRoleOfInterest] = useState('');
+  const [linkedinUrl, setLinkedinUrl] = useState('');
+  const [portfolioUrl, setPortfolioUrl] = useState('');
+  const [why, setWhy] = useState('');
+  const [availability, setAvailability] = useState('');
+  const [ukBased, setUkBased] = useState<boolean>(true);
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (status === 'submitting') return;
+
+    setStatus('submitting');
+    setServerMessage('');
+    setDuplicated(false);
+
+    try {
+      const res = await fetch('/api/careers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fullName: fullName.trim(),
+          email: email.trim(),
+          roleOfInterest: roleOfInterest || null,
+          linkedinUrl: linkedinUrl.trim() || null,
+          portfolioUrl: portfolioUrl.trim() || null,
+          why: why.trim() || null,
+          availability: availability || null,
+          ukBased,
+        }),
+      });
+
+      let data: SubmitResponse = {};
+      try {
+        data = (await res.json()) as SubmitResponse;
+      } catch {
+        /* non-JSON response — fall through to generic error */
+      }
+
+      if (!res.ok || !data.ok) {
+        setStatus('error');
+        setServerMessage(
+          data.error ||
+            'Something went wrong on our end. Please try again in a moment, or email hello@paybacker.co.uk directly.',
+        );
+        return;
+      }
+
+      setStatus('success');
+      setDuplicated(Boolean(data.duplicated));
+      setServerMessage(data.message || 'Thanks — your interest has been recorded.');
+    } catch {
+      setStatus('error');
+      setServerMessage(
+        'We couldn\u2019t reach the server. Please try again in a moment, or email hello@paybacker.co.uk directly.',
+      );
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="bg-navy-900 border border-mint-400/40 rounded-2xl p-6">
+        <div className="flex items-start gap-3">
+          <span
+            aria-hidden="true"
+            className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-mint-400/15 text-mint-400"
+          >
+            &#10003;
+          </span>
+          <div>
+            <h3 className="text-white font-semibold mb-1">
+              {duplicated ? 'You\u2019re already on our list' : 'Thanks — you\u2019re on our list'}
+            </h3>
+            <p className="text-slate-300 text-sm leading-relaxed mb-4">{serverMessage}</p>
+            <p className="text-slate-400 text-xs">
+              Anything else you want us to know? Email{' '}
+              <a href="mailto:hello@paybacker.co.uk" className="text-mint-400 hover:text-mint-300">
+                hello@paybacker.co.uk
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const inputBase =
+    'w-full rounded-xl bg-navy-900 border border-navy-700/60 px-4 py-3 text-white placeholder:text-slate-500 focus:outline-none focus:border-mint-400/60 focus:ring-2 focus:ring-mint-400/20 transition-colors';
+  const labelBase = 'block text-sm font-medium text-slate-300 mb-2';
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5" noValidate>
+      <div className="grid gap-5 md:grid-cols-2">
+        <div>
+          <label htmlFor="fullName" className={labelBase}>
+            Full name <span className="text-mint-400">*</span>
+          </label>
+          <input
+            id="fullName"
+            name="fullName"
+            type="text"
+            required
+            autoComplete="name"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            maxLength={120}
+            className={inputBase}
+            placeholder="Alex Morgan"
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className={labelBase}>
+            Email <span className="text-mint-400">*</span>
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            maxLength={180}
+            className={inputBase}
+            placeholder="you@example.com"
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-2">
+        <div>
+          <label htmlFor="roleOfInterest" className={labelBase}>
+            Role of interest
+          </label>
+          <select
+            id="roleOfInterest"
+            name="roleOfInterest"
+            value={roleOfInterest}
+            onChange={(e) => setRoleOfInterest(e.target.value)}
+            className={inputBase}
+          >
+            <option value="">Pick one (or &ldquo;open&rdquo;)</option>
+            <option value="founding-engineer">Founding engineer</option>
+            <option value="growth-marketer">Growth marketer</option>
+            <option value="product-designer">Product designer</option>
+            <option value="consumer-law-policy">Consumer law / policy lead</option>
+            <option value="open">Open — something else</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="availability" className={labelBase}>
+            Availability
+          </label>
+          <select
+            id="availability"
+            name="availability"
+            value={availability}
+            onChange={(e) => setAvailability(e.target.value)}
+            className={inputBase}
+          >
+            <option value="">When could you start?</option>
+            <option value="now">Available now</option>
+            <option value="1-month">Within a month</option>
+            <option value="3-months">Within three months</option>
+            <option value="exploring">Just exploring</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-2">
+        <div>
+          <label htmlFor="linkedinUrl" className={labelBase}>
+            LinkedIn URL
+          </label>
+          <input
+            id="linkedinUrl"
+            name="linkedinUrl"
+            type="url"
+            value={linkedinUrl}
+            onChange={(e) => setLinkedinUrl(e.target.value)}
+            maxLength={300}
+            className={inputBase}
+            placeholder="https://linkedin.com/in/\u2026"
+          />
+        </div>
+        <div>
+          <label htmlFor="portfolioUrl" className={labelBase}>
+            Portfolio / GitHub URL
+          </label>
+          <input
+            id="portfolioUrl"
+            name="portfolioUrl"
+            type="url"
+            value={portfolioUrl}
+            onChange={(e) => setPortfolioUrl(e.target.value)}
+            maxLength={300}
+            className={inputBase}
+            placeholder="https://github.com/\u2026"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="why" className={labelBase}>
+          Why Paybacker?
+        </label>
+        <textarea
+          id="why"
+          name="why"
+          rows={4}
+          value={why}
+          onChange={(e) => setWhy(e.target.value)}
+          maxLength={2000}
+          className={inputBase}
+          placeholder="A few sentences on what you\u2019d bring, and why this problem matters to you."
+        />
+        <p className="mt-1 text-xs text-slate-500">{why.length}/2000</p>
+      </div>
+
+      <div className="flex items-start gap-3">
+        <input
+          id="ukBased"
+          name="ukBased"
+          type="checkbox"
+          checked={ukBased}
+          onChange={(e) => setUkBased(e.target.checked)}
+          className="mt-1 h-4 w-4 rounded border-navy-600 bg-navy-900 text-mint-400 focus:ring-mint-400/40"
+        />
+        <label htmlFor="ukBased" className="text-sm text-slate-300 leading-relaxed">
+          I&apos;m based in the UK (or have the right to work here).
+          <span className="block text-xs text-slate-500">We&apos;re London-hybrid with a strong preference for UK time-zone overlap.</span>
+        </label>
+      </div>
+
+      {status === 'error' && serverMessage && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+        >
+          {serverMessage}
+        </div>
+      )}
+
+      <div className="pt-2">
+        <button
+          type="submit"
+          disabled={status === 'submitting'}
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-mint-400 px-6 py-3 text-navy-950 font-semibold hover:bg-mint-300 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          {status === 'submitting' ? 'Submitting\u2026' : 'Register interest'}
+        </button>
+        <p className="mt-3 text-xs text-slate-500">
+          By submitting you agree to Paybacker contacting you about future roles. We&apos;ll never share your details with third parties. See our{' '}
+          <a href="/privacy-policy" className="text-mint-400 hover:text-mint-300">privacy policy</a>.
+        </p>
+      </div>
+    </form>
+  );
+}

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -1,0 +1,193 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import PublicNavbar from '@/components/PublicNavbar';
+import CareersInterestForm from './CareersInterestForm';
+
+export const metadata: Metadata = {
+  title: 'Careers at Paybacker — Help build fair consumer finance in the UK',
+  description:
+    "We're not hiring publicly yet, but we're collecting expressions of interest for the roles we plan to open. Founding-team early, London-hybrid, remote-friendly.",
+  openGraph: {
+    title: 'Careers at Paybacker — Help build fair consumer finance in the UK',
+    description:
+      "We're not hiring publicly yet, but we're collecting expressions of interest for the roles we plan to open. Founding-team early, London-hybrid, remote-friendly.",
+    url: 'https://paybacker.co.uk/careers',
+    siteName: 'Paybacker',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Careers at Paybacker',
+    description:
+      "We're collecting expressions of interest for upcoming roles. Founding-team early, London-hybrid, remote-friendly.",
+    images: ['/logo.png'],
+  },
+  alternates: {
+    canonical: 'https://paybacker.co.uk/careers',
+  },
+};
+
+export default function CareersPage() {
+  return (
+    <div className="min-h-screen bg-navy-950">
+      <PublicNavbar />
+      <div className="h-16" />
+
+      <main className="container mx-auto px-4 md:px-6 py-10 md:py-16 max-w-3xl">
+        {/* Hero */}
+        <div className="mb-10">
+          <span className="inline-block px-3 py-1 rounded-full border border-mint-400/30 bg-mint-400/10 text-mint-400 text-xs font-semibold uppercase tracking-wider mb-4">
+            Expressing interest — not hiring publicly yet
+          </span>
+          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
+            Help us build the consumer finance tool the UK deserves
+          </h1>
+          <p className="text-lg text-slate-300 leading-relaxed mb-4">
+            Paybacker is a small, founder-led team on a mission: give every UK household the legal and AI muscle to stop being overcharged. We&apos;re building in the open, shipping weekly, and looking for people who want in early.
+          </p>
+          <p className="text-lg text-slate-400 leading-relaxed">
+            We&apos;re not running a public recruitment process yet — but if any of the roles below sound like you, drop your details and we&apos;ll be in touch the moment we start hiring.
+          </p>
+        </div>
+
+        {/* What we value */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
+            What we care about
+          </h2>
+          <div className="grid gap-4">
+            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+              <h3 className="text-white font-semibold mb-1">Ship something a real person uses this week</h3>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                We prefer scrappy-and-shipped to polished-and-stuck. If you&apos;ve never pushed something to production in under a week, this probably isn&apos;t the team for you.
+              </p>
+            </div>
+            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+              <h3 className="text-white font-semibold mb-1">Care about the user, not the stack</h3>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                Our users are UK households being quietly overcharged. Every decision starts from their experience — not which framework is trendy this month.
+              </p>
+            </div>
+            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+              <h3 className="text-white font-semibold mb-1">Own outcomes, not tickets</h3>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                Small team, big scope. You&apos;ll pick up work that isn&apos;t in your job title and see it through — and we&apos;ll back you when you do.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Roles we're thinking about */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
+            Roles we&apos;re thinking about
+          </h2>
+          <p className="text-slate-400 leading-relaxed mb-5 text-sm">
+            Rough descriptions — we haven&apos;t written formal JDs yet. Tell us which feels closest and we&apos;ll tailor the conversation when we&apos;re ready.
+          </p>
+          <div className="grid gap-4">
+            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+              <h3 className="text-white font-semibold mb-1">Founding engineer (full-stack)</h3>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                Next.js + Supabase + Claude. You&apos;ll own major surfaces of the product end-to-end. Bonus if you&apos;ve worked with Open Banking, email ingestion, or LLM pipelines.
+              </p>
+            </div>
+            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+              <h3 className="text-white font-semibold mb-1">Growth marketer</h3>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                Performance + content + SEO across Google, Reddit and influencer partnerships. You get excited by a conversion funnel and a spreadsheet of CAC targets.
+              </p>
+            </div>
+            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+              <h3 className="text-white font-semibold mb-1">Product designer</h3>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                Consumer-facing fintech design. You&apos;ll shape how millions of ordinary people understand their own money — no MBAs, no jargon, no dark patterns.
+              </p>
+            </div>
+            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+              <h3 className="text-white font-semibold mb-1">Consumer law / policy lead</h3>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                You know the Consumer Rights Act 2015, Ofcom / Ofgem codes and UK261 well enough to help tune the AI&apos;s legal reasoning. Paralegal, policy or regulatory background welcome.
+              </p>
+            </div>
+            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+              <h3 className="text-white font-semibold mb-1">Open — something else?</h3>
+              <p className="text-slate-300 text-sm leading-relaxed">
+                Support, ops, data, community — if you think you&apos;d add something and it isn&apos;t on this list, tell us.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* How we work */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
+            How we work
+          </h2>
+          <div className="bg-navy-900 border border-mint-400/30 rounded-2xl p-5">
+            <ul className="space-y-3 text-slate-300 text-sm">
+              <li className="flex items-start gap-2">
+                <span className="text-mint-400 mt-1">&#8226;</span>
+                <span>
+                  <strong className="text-white">London-hybrid, remote-friendly.</strong>{' '}
+                  We expect UK-based where possible for day-to-day overlap, but the default is async.
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-mint-400 mt-1">&#8226;</span>
+                <span>
+                  <strong className="text-white">Equity from day one.</strong>{' '}
+                  Early joiners get meaningful ownership. We&apos;d rather be a small team that wins than a big one that shipwrecks.
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-mint-400 mt-1">&#8226;</span>
+                <span>
+                  <strong className="text-white">We use the tools we trust.</strong>{' '}
+                  Claude, Next.js 15, Supabase, Stripe, Resend, Yapily. No legacy stack — just the sharpest tools we can point at the problem.
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-mint-400 mt-1">&#8226;</span>
+                <span>
+                  <strong className="text-white">Founder-led but not founder-bottlenecked.</strong>{' '}
+                  Paul leads from the front, but the first engineering, design and marketing hires will own their surfaces completely.
+                </span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        {/* Form */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
+            Register your interest
+          </h2>
+          <p className="text-slate-400 leading-relaxed mb-6 text-sm">
+            Takes less than a minute. We&apos;ll only get in touch once — when we&apos;re hiring for something that fits.
+          </p>
+          <CareersInterestForm />
+        </section>
+
+        {/* Footer note */}
+        <p className="text-slate-500 text-xs leading-relaxed">
+          Paybacker is an equal-opportunity employer. We welcome applicants from every background and commit to reading every expression of interest we receive. If you have specific accessibility needs for how you&apos;d like us to get in touch, mention it in the &ldquo;why you&apos;re interested&rdquo; box and we&apos;ll accommodate.
+        </p>
+      </main>
+
+      <footer className="container mx-auto px-4 md:px-6 py-8 border-t border-navy-700/50 mt-16">
+        <div className="text-center text-slate-500 text-sm space-y-3">
+          <div className="flex flex-wrap justify-center gap-4 md:gap-6">
+            <Link href="/about" className="hover:text-white transition-all">About</Link>
+            <Link href="/blog" className="hover:text-white transition-all">Blog</Link>
+            <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy Policy</Link>
+            <Link href="/terms-of-service" className="hover:text-white transition-all">Terms of Service</Link>
+            <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
+            <a href="mailto:hello@paybacker.co.uk" className="hover:text-white transition-all">Contact</a>
+          </div>
+          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/supabase/migrations/20260420000001_careers_interest.sql
+++ b/supabase/migrations/20260420000001_careers_interest.sql
@@ -1,0 +1,54 @@
+-- /careers job-interest table
+-- 20 Apr 2026 — Paul asked for a Careers landing page with a live form
+-- that captures interest ahead of us posting roles. Email-first, with
+-- enough metadata to triage quickly.
+
+CREATE TABLE IF NOT EXISTS careers_interest (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+
+  full_name TEXT NOT NULL,
+  email TEXT NOT NULL,
+
+  -- Free-text role slug, e.g. "founding-engineer" | "growth-marketer" | "open".
+  -- Kept open so we don't have to migrate every time we add a role.
+  role_of_interest TEXT,
+
+  -- Optional profile links (LinkedIn, portfolio, GitHub).
+  linkedin_url TEXT,
+  portfolio_url TEXT,
+
+  -- Why they're interested / anything they want to tell Paul up-front.
+  why TEXT,
+
+  -- "now" | "1-month" | "3-months" | "exploring"
+  availability TEXT,
+
+  -- UK-based? (We're London-hybrid for now.)
+  uk_based BOOLEAN,
+
+  -- Admin triage
+  status TEXT DEFAULT 'new' CHECK (status IN ('new', 'in_review', 'contacted', 'archived')),
+  notes TEXT,
+
+  -- Source attribution so we can measure careers-page conversion later
+  referrer TEXT,
+  user_agent TEXT,
+
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Dedup guard: one open (non-archived) interest per email. If they change
+-- their mind later we can flip status to 'archived' and a fresh insert works.
+CREATE UNIQUE INDEX IF NOT EXISTS careers_interest_email_open_uidx
+  ON careers_interest (lower(email))
+  WHERE status <> 'archived';
+
+CREATE INDEX IF NOT EXISTS careers_interest_created_at_idx
+  ON careers_interest (created_at DESC);
+
+-- RLS — public insertions happen via service-role from the API route, so
+-- regular clients should not be able to read at all. We lock this down by
+-- enabling RLS without any permissive policies; only the service role
+-- bypasses RLS.
+ALTER TABLE careers_interest ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Builds the final item on Paul's homepage-audit punch list: a public `/careers` page that captures early interest before we run a formal recruitment process.

## What's in

**`src/app/careers/page.tsx`** — marketing page following the `/about` pattern (PublicNavbar + dark navy). Hero, what-we-care-about, rough role descriptions (founding engineer / growth marketer / product designer / consumer law / open), how-we-work, and the form section. Metadata + canonical + OpenGraph included.

**`src/app/careers/CareersInterestForm.tsx`** — client component. Name + email required, optional role / availability / LinkedIn / portfolio / why / UK-based. Inline validation, disabled-while-submitting, success + error states, character counter on the free-text box.

**`src/app/api/careers/route.ts`** — POST handler. Two things happen in parallel:
1. Insert into `careers_interest` via the service-role client. Duplicate email (Postgres `23505`) returns 200 with a friendly "already on file" message rather than a 500. Missing table (`42P01`) or missing env keys are logged but don't block the Resend notification.
2. Plaintext summary to `hello@paybacker.co.uk` via Resend with `replyTo` set to the candidate's email.

**`supabase/migrations/20260420000001_careers_interest.sql`** — `CREATE TABLE IF NOT EXISTS careers_interest` with role / availability / UK-based / links / status triage + notes + referrer + user_agent. Partial unique index on `lower(email) WHERE status <> 'archived'` so archived rows don't block a fresh expression of interest. RLS enabled with no permissive policies (service role only).

## Deploy note

Paul will need to apply the migration in the Supabase dashboard — the API route is defensive about the table being missing (it still sends the Resend notification and returns 200) so the UX doesn't break while that's pending.

## Test plan
- [ ] Apply migration in Supabase
- [ ] Load /careers on desktop + mobile
- [ ] Submit a test application, confirm row lands in careers_interest
- [ ] Confirm Resend email arrives at hello@paybacker.co.uk with all fields
- [ ] Submit the same email twice, confirm "already on file" path
- [ ] Try with invalid email / empty name — confirm inline 400s