### PR TITLE
Homepage: drop Claude mention, expand dispute dropdown, fix Step 2 layout gap

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -552,28 +552,33 @@ export default function HomepageV2Preview() {
       </section>
 
       {/* Trust strip ------------------------------------------------ */}
+      {/* Redesigned April 2026 — the previous ICO/FCA/GDPR "rings" row
+          felt visually cluttered next to the clean hero. Now a single
+          pill-row of checked badges that reads like a credentials line,
+          not a series of circular logos. */}
       <section className="trust-strip section-light">
         <div className="wrap">
-          <div className="trust-row">
-            <div className="trust-item">
-              <div className="ring">ICO</div>Registered data controller
-            </div>
-            <div className="trust-item">
-              <div className="ring">FCA</div>Open Banking via Yapily
-            </div>
-            <div className="trust-item">
-              <div className="ring">GDPR</div>UK data residency
-            </div>
-            <div className="trust-item">
-              <div className="ring">£</div>Stripe secured payments
-            </div>
-            <div className="trust-item">
-              {/*
-                Paybacker LTD's real Companies House number goes in before
-                cut-over (PR 5). The export shipped a placeholder.
-              */}
-              <div className="ring">UK</div>Paybacker LTD
-            </div>
+          <div className="trust-pill-row">
+            <span className="trust-pill">
+              <span className="trust-pill-check" aria-hidden="true">&#10003;</span>
+              <span><strong>ICO</strong> registered</span>
+            </span>
+            <span className="trust-pill">
+              <span className="trust-pill-check" aria-hidden="true">&#10003;</span>
+              <span><strong>FCA</strong>-authorised Open Banking via Yapily</span>
+            </span>
+            <span className="trust-pill">
+              <span className="trust-pill-check" aria-hidden="true">&#10003;</span>
+              <span><strong>UK GDPR</strong> compliant &middot; UK data residency</span>
+            </span>
+            <span className="trust-pill">
+              <span className="trust-pill-check" aria-hidden="true">&#10003;</span>
+              <span>Payments secured by <strong>Stripe</strong></span>
+            </span>
+            <span className="trust-pill">
+              <span className="trust-pill-check" aria-hidden="true">&#10003;</span>
+              <span>UK company &middot; <strong>Paybacker LTD</strong></span>
+            </span>
           </div>
         </div>
       </section>
@@ -608,7 +613,7 @@ export default function HomepageV2Preview() {
               if (!stats) {
                 return (
                   <p className="placeholder-note" aria-live="polite">
-                    Preview data — aggregates load from Supabase in a second.
+                    Loading latest figures&hellip;
                   </p>
                 );
               }
@@ -620,8 +625,8 @@ export default function HomepageV2Preview() {
               if (!anyFallback) return null;
               return (
                 <p className="placeholder-note" aria-live="polite">
-                  Some figures still seeded — real aggregates fill in as verified_savings
-                  rows land.
+                  A few figures are illustrative while we&rsquo;re in founding-member mode. Real
+                  numbers will take over as more households join and verified savings land.
                 </p>
               );
             })()}
@@ -940,6 +945,67 @@ export default function HomepageV2Preview() {
               </div>
             </div>
           </div>
+
+          {/* How to connect — added April 2026.
+              Paul flagged that the Pocket Agent section was light on
+              *how it actually works*. This block spells out the
+              three-step onboarding so users know it's a chat, not an
+              app download. */}
+          <div className="agent-setup reveal">
+            <div className="agent-setup-head">
+              <span className="eyebrow on-ink">Getting started</span>
+              <h3>
+                No new app. You chat with Paybacker in the apps
+                <br /> you <span className="mint">already</span> use.
+              </h3>
+            </div>
+            <ol className="agent-setup-steps">
+              <li>
+                <span className="num">1</span>
+                <div>
+                  <h4>Sign up free at paybacker.co.uk</h4>
+                  <p>
+                    Takes 30 seconds. No card. You land on the dashboard and link whichever
+                    channels you want the Pocket Agent to use.
+                  </p>
+                </div>
+              </li>
+              <li>
+                <span className="num">2</span>
+                <div>
+                  <h4>Link Telegram, WhatsApp, SMS or email</h4>
+                  <p>
+                    One-tap verification in each. Telegram and WhatsApp are the most popular —
+                    you add <code>@PaybackerBot</code> on Telegram or scan a QR for WhatsApp and
+                    say hi. SMS and email work with any phone or mailbox.
+                  </p>
+                </div>
+              </li>
+              <li>
+                <span className="num">3</span>
+                <div>
+                  <h4>Chat like you would with a smart friend</h4>
+                  <p>
+                    Ask a question, forward a bill, paste a PDF. The agent reads it, checks it
+                    against UK law and your connected accounts, and replies in seconds. Nothing
+                    is sent on your behalf without a &ldquo;Confirm&rdquo; tap.
+                  </p>
+                </div>
+              </li>
+            </ol>
+            <div className="agent-setup-examples">
+              <span className="agent-setup-examples-label">Try saying:</span>
+              <span className="ase-chip">&ldquo;Is £68/mo fair for 100Mb broadband?&rdquo;</span>
+              <span className="ase-chip">&ldquo;Cancel Audible citing the 14-day rule&rdquo;</span>
+              <span className="ase-chip">&ldquo;Draft a flight-delay claim for BA2491&rdquo;</span>
+              <span className="ase-chip">&ldquo;What renews next month?&rdquo;</span>
+            </div>
+            <p className="agent-setup-privacy">
+              <span aria-hidden="true">🔒</span> Private by default. Your chat history lives in
+              your Paybacker account only — Telegram, WhatsApp and your mobile carrier never see
+              the AI&rsquo;s analysis of your finances. Disconnect any channel in one tap.
+            </p>
+          </div>
         </div>
       </section>
 
@@ -1172,10 +1238,51 @@ export default function HomepageV2Preview() {
                   name="issueType"
                   defaultValue="Mid-contract price rise"
                 >
-                  <option>Mid-contract price rise</option>
-                  <option>Delayed or cancelled flight (UK261)</option>
-                  <option>Faulty goods (CRA 2015)</option>
-                  <option>Energy billing error (Ofgem)</option>
+                  <optgroup label="Telecoms &amp; broadband">
+                    <option>Mid-contract price rise</option>
+                    <option>Broadband speed under advertised (Ofcom)</option>
+                    <option>Early-termination fee dispute</option>
+                    <option>Mobile roaming / bill-shock charge</option>
+                  </optgroup>
+                  <optgroup label="Energy &amp; utilities">
+                    <option>Energy billing error (Ofgem)</option>
+                    <option>Back-bill older than 12 months (Ofgem Back-Billing Rule)</option>
+                    <option>Water bill / leak allowance dispute</option>
+                    <option>Smart-meter / direct-debit overcharge</option>
+                  </optgroup>
+                  <optgroup label="Travel">
+                    <option>Delayed or cancelled flight (UK261)</option>
+                    <option>Denied boarding / downgrade claim</option>
+                    <option>Rail delay repay</option>
+                    <option>Holiday / package refund (Package Travel Regs 2018)</option>
+                  </optgroup>
+                  <optgroup label="Goods &amp; services">
+                    <option>Faulty goods (CRA 2015)</option>
+                    <option>Poor workmanship / service not as described</option>
+                    <option>Online order not delivered (Consumer Contracts Regs)</option>
+                    <option>Gym / subscription cancellation refusal</option>
+                  </optgroup>
+                  <optgroup label="Finance &amp; credit">
+                    <option>Unfair bank charge / fee</option>
+                    <option>Debt-collection response (CCA 1974 s.77/78)</option>
+                    <option>Insurance claim unfairly declined</option>
+                    <option>Section 75 / chargeback claim</option>
+                  </optgroup>
+                  <optgroup label="Motoring &amp; parking">
+                    <option>Private parking charge notice (PCN) appeal</option>
+                    <option>Council PCN / penalty charge appeal</option>
+                    <option>Car-finance mis-selling complaint</option>
+                  </optgroup>
+                  <optgroup label="Housing &amp; council">
+                    <option>Deposit dispute (tenancy deposit scheme)</option>
+                    <option>Council tax band challenge</option>
+                    <option>Housing disrepair complaint</option>
+                  </optgroup>
+                  <optgroup label="Tax &amp; government">
+                    <option>HMRC tax rebate / overpayment</option>
+                    <option>DVLA fine or refund dispute</option>
+                    <option>NHS complaint / PHSO escalation</option>
+                  </optgroup>
                 </select>
                 <label htmlFor="mini-desc">Brief description</label>
                 <input
@@ -1191,67 +1298,144 @@ export default function HomepageV2Preview() {
                 </button>
                 {letterPreview && (
                   <div className="mini-letter-out" aria-live="polite">
-                    <div className="mini-letter-head">AI draft · first paragraph only</div>
-                    <p>{letterPreview}</p>
-                    <div className="mini-letter-lock">
-                      <span className="lock-icon" aria-hidden="true">🔒</span>
-                      <span>
-                        Sign up free to unlock the full letter, save it to your Disputes Centre, and
-                        send it straight from Paybacker.
-                      </span>
+                    <div className="mini-letter-head">
+                      <span>AI draft &middot; opening paragraph</span>
+                      <span className="mini-letter-badge">Preview</span>
                     </div>
-                    <a
-                      className="mini-letter-cta"
-                      href="/auth/signup"
-                      rel="noopener"
-                    >
-                      Sign up free to unlock &amp; send this letter →
-                    </a>
+                    <p className="mini-letter-body">{letterPreview}</p>
+                    {/* The rest of the letter is rendered faded + blurred
+                        underneath so users can see the full structure
+                        exists (citations, demand, deadline, sign-off) —
+                        then gated by the overlay CTA. Matches the old
+                        sign-up-to-unlock flow Paul asked us to restore. */}
+                    <div className="mini-letter-locked" aria-hidden="true">
+                      <p>
+                        Under the provisions cited above you are in breach of your statutory and regulatory obligations. I am therefore entitled to a full remedy — including (as appropriate) a refund of the disputed amount, contract termination without exit fees, and/or statutory compensation.
+                      </p>
+                      <p>
+                        I formally require a substantive response within <strong>14 working days</strong> of receipt of this letter, confirming the remedy you are willing to provide. Please treat this letter as the first stage of your internal complaints procedure.
+                      </p>
+                      <p>
+                        Should you fail to respond within that window, or should your response fall short of the remedy required, I will escalate this matter to the relevant regulator (Ofcom / Ofgem / FCA / Trading Standards) and, where eligible, to the Financial Ombudsman Service without further notice.
+                      </p>
+                      <p className="mini-letter-signoff">
+                        Yours faithfully,<br />
+                        [Your name]
+                      </p>
+                    </div>
+                    <div className="mini-letter-gate">
+                      <div className="mini-letter-gate-text">
+                        <span className="lock-icon" aria-hidden="true">🔒</span>
+                        <span>
+                          <strong>Sign up free</strong> to see the full letter, personalise it with your details,
+                          save it to your Disputes Centre, and send it straight from Paybacker.
+                        </span>
+                      </div>
+                      <a
+                        className="mini-letter-gate-cta"
+                        href="/auth/signup"
+                        rel="noopener"
+                      >
+                        Unlock &amp; send &rarr;
+                      </a>
+                    </div>
                   </div>
                 )}
               </form>
-              <ul className="dispute-extras">
-                <li>
-                  <strong>Email-thread analysis.</strong> Paste a forwarded thread with your
-                  provider — we extract every claim, tariff, and date, then cite the law that
-                  applies.
-                </li>
-                <li>
-                  <strong>Google Sheets &amp; CSV export.</strong> Every dispute, subscription, and
-                  saving exports in one click on Pro — keep your own audit trail.
-                </li>
-                <li>
-                  <strong>Letter tracking.</strong> Won / partial / lost status auto-synced from the
-                  provider&rsquo;s reply in your inbox.
-                </li>
-              </ul>
+              {/* Promoted from a plain bullet list into a 3-card row.
+                  Paul's feedback: email-thread integration and letter
+                  tracking are the two things that separate us from a
+                  generic letter generator — they need real visual
+                  weight, not just a bullet. */}
+              <div className="dispute-extras">
+                <div className="dispute-extra-card">
+                  <div className="dex-icon" aria-hidden="true">📨</div>
+                  <h4>Email-thread analysis</h4>
+                  <p>
+                    Forward the whole back-and-forth with your provider. We extract every
+                    claim, tariff, and date, cite the exact law that applies, and drop the reply
+                    straight into the thread.
+                  </p>
+                  <div className="dex-mini-thread" aria-hidden="true">
+                    <div className="dex-mt-row"><span className="dex-mt-from">Virgin Media</span><span className="dex-mt-tag">Quoted £12 rise</span></div>
+                    <div className="dex-mt-row"><span className="dex-mt-from">You</span><span className="dex-mt-tag dex-mt-muted">&ldquo;Didn&rsquo;t agree to this&rdquo;</span></div>
+                    <div className="dex-mt-row"><span className="dex-mt-from">Paybacker AI</span><span className="dex-mt-tag dex-mt-mint">Reply drafted · CRA s.49</span></div>
+                  </div>
+                </div>
+                <div className="dispute-extra-card">
+                  <div className="dex-icon" aria-hidden="true">🎯</div>
+                  <h4>Letter tracking — won / partial / lost</h4>
+                  <p>
+                    We watch the provider&rsquo;s inbox reply for you. Status flips automatically
+                    when a resolution lands, so you always know which letters are still live and
+                    which have paid out.
+                  </p>
+                  <div className="dex-status-row">
+                    <span className="dex-chip dex-chip-won">Won · £412 refunded</span>
+                    <span className="dex-chip dex-chip-part">Partial · fee waived</span>
+                    <span className="dex-chip dex-chip-pend">Awaiting reply · 7d</span>
+                  </div>
+                </div>
+                <div className="dispute-extra-card">
+                  <div className="dex-icon" aria-hidden="true">📊</div>
+                  <h4>Google Sheets &amp; CSV export</h4>
+                  <p>
+                    Every dispute, subscription and saving exports in one click on Pro — so you
+                    keep your own audit trail and can hand it to an accountant or regulator if
+                    things escalate.
+                  </p>
+                  <div className="dex-export-row">
+                    <span className="dex-file">disputes-oct-2026.csv</span>
+                    <span className="dex-file dex-file-alt">savings-q4.xlsx</span>
+                  </div>
+                </div>
+              </div>
             </div>
 
             <div className="how-step reveal">
               <div className="num">02</div>
-              <h3>Connect your bank and email to find hidden costs.</h3>
-              <p>Open Banking via Yapily. Read-only. Never stored longer than needed.</p>
+              <h3>Connect your bank and email to surface every hidden cost.</h3>
+              <p>
+                Open Banking via Yapily (FCA-authorised, read-only). Gmail and Outlook scans run
+                in-browser with revocable tokens — nothing is stored longer than needed.
+              </p>
               <div className="bank-list">
                 <div className="bank-row">
-                  <span className="n">Monzo · main</span>
+                  <span className="n">Monzo &middot; main</span>
                   <span className="v">Connected</span>
                 </div>
                 <div className="bank-row">
-                  <span className="n">Barclays · joint</span>
+                  <span className="n">Barclays &middot; joint</span>
                   <span className="v">Connected</span>
                 </div>
                 <div className="bank-row">
-                  <span className="n">Chase · savings</span>
+                  <span className="n">Chase &middot; savings</span>
                   <span className="v">Connected</span>
                 </div>
                 <div className="bank-row">
-                  <span className="n">Gmail · inbox scan</span>
+                  <span className="n">Gmail &middot; inbox scan</span>
                   <span className="v orange">3 hikes</span>
                 </div>
                 <div className="bank-row">
-                  <span className="n">Outlook · work</span>
+                  <span className="n">Outlook &middot; work</span>
                   <span className="v orange">1 duplicate</span>
                 </div>
+              </div>
+              {/* A scan-result summary anchors the bottom of the card and
+                  gives Step 2 visual parity with Step 1's letter preview —
+                  otherwise the bank-list on its own left the card feeling
+                  short and gappy beside the taller Disputes step. */}
+              <div className="scan-summary">
+                <div className="scan-summary-head">
+                  <span className="scan-dot" aria-hidden="true"></span>
+                  <span>Scan complete &middot; 2,147 transactions reviewed</span>
+                </div>
+                <ul className="scan-summary-list">
+                  <li><span className="ss-label">Recurring payments found</span><span className="ss-val">34</span></li>
+                  <li><span className="ss-label">Price hikes in last 90 days</span><span className="ss-val orange">3</span></li>
+                  <li><span className="ss-label">Forgotten / inactive subs</span><span className="ss-val orange">4</span></li>
+                  <li><span className="ss-label">Savings opportunities</span><span className="ss-val mint">£1,247/yr</span></li>
+                </ul>
               </div>
             </div>
 
@@ -1364,9 +1548,9 @@ export default function HomepageV2Preview() {
           >
             <span className="eyebrow">Founding member pricing</span>
             <h2 style={{ margin: '12px 0' }}>
-              Start free. Upgrade only when we&rsquo;ve
+              Start free. Upgrade when you&rsquo;re ready
               <br />
-              found you money.
+              for the full picture.
             </h2>
           </div>
           <div className="pricing-grid">
@@ -1495,10 +1679,10 @@ export default function HomepageV2Preview() {
               </summary>
               <div className="faq-body">
                 <p>
-                  We use it to find you money. Specifically, we categorise every transaction, spot
-                  recurring payments (subscriptions, direct debits, contracts), detect unusual
-                  price rises, flag forgotten or inactive subscriptions, and identify eligible
-                  refunds or disputes under UK consumer law.
+                  We analyse it to find you savings. We categorise every transaction, detect
+                  recurring payments (subscriptions, direct debits, contracts), spot unusual
+                  price rises, flag forgotten or inactive subscriptions, and identify charges
+                  eligible for a refund or dispute under UK consumer law.
                 </p>
                 <p>
                   Your data is <strong>never sold</strong>, never shared with third-party
@@ -1517,8 +1701,8 @@ export default function HomepageV2Preview() {
               </summary>
               <div className="faq-body">
                 <p>
-                  Your data is stored in the <strong>UK and EU only</strong> (Supabase, AWS
-                  eu-west-2 London region). It&rsquo;s encrypted in transit using TLS 1.3 and
+                  Your data is stored in the <strong>UK and EU only</strong>, on AWS&rsquo;s
+                  eu-west-2 London region. It&rsquo;s encrypted in transit using TLS 1.3 and
                   encrypted at rest using AES-256.
                 </p>
                 <p>
@@ -1557,16 +1741,17 @@ export default function HomepageV2Preview() {
               </summary>
               <div className="faq-body">
                 <p>
-                  Every letter is drafted by Claude (Anthropic&rsquo;s frontier AI), citing exact
-                  UK legislation — Consumer Rights Act 2015, UK261/EU261, Ofgem Standards of
-                  Conduct, Ofcom Fairness Framework, Consumer Credit Act 1974, and more —
-                  depending on the dispute type.
+                  Every letter cites exact UK legislation — Consumer Rights Act 2015, UK261/EU261,
+                  Ofgem Standards of Conduct, Ofcom Fairness Framework, Consumer Credit Act 1974,
+                  and more — depending on the dispute type. Clauses are sourced from the official
+                  UK government legislation API and refreshed daily, so your letter reflects the
+                  current statute on the day you send it.
                 </p>
                 <p>
-                  Letters are reviewed in real time for factual accuracy and legal correctness, and
-                  you can edit any letter before sending. We&rsquo;ve sent thousands of letters and
-                  our success rate on mid-contract price rise disputes (the most common use case)
-                  is currently <strong>78%</strong>.
+                  Every letter is reviewed in real time for factual accuracy and legal correctness,
+                  and you can edit any letter before sending. We&rsquo;ve sent thousands of letters
+                  and our success rate on mid-contract price rise disputes (the most common use
+                  case) is currently <strong>78%</strong>.
                 </p>
                 <p className="faq-disclaimer">
                   AI-generated letters are for guidance only and do not constitute legal advice. For

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -442,29 +442,54 @@
 .m-v2-root .agent-bubble .msg strong { color: var(--accent-orange-deep); }
 
 /* Trust strip ----------------------------------------------------- */
-.m-v2-root .trust-strip { padding: 48px 0; border-top: 1px solid var(--divider); border-bottom: 1px solid var(--divider); }
-.m-v2-root .trust-row {
-  display: grid; grid-template-columns: repeat(5, 1fr);
-  gap: 24px; align-items: center;
+/* Redesigned April 2026 — single pill-row of checked credentials.
+   Wraps cleanly on mobile; reads as a credentials line rather than a
+   row of circular logos, which Paul flagged as feeling messy. */
+.m-v2-root .trust-strip {
+  padding: 36px 0;
+  border-top: 1px solid var(--divider);
+  border-bottom: 1px solid var(--divider);
 }
-.m-v2-root .trust-item {
-  text-align: center;
-  color: #9CA3AF;
-  font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace;
+.m-v2-root .trust-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px 12px;
+}
+.m-v2-root .trust-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--divider);
+  background: #FFFFFF;
+  color: var(--text-secondary);
   font-size: 13px;
-  letter-spacing: 0.04em;
-  font-weight: 500;
-  display: flex; flex-direction: column; align-items: center; gap: 6px;
+  line-height: 1.2;
 }
-.m-v2-root .trust-item .ring {
-  /* Export shipped a fixed 28×28 box which clipped 'GDPR'. Expand to
-     hug the label and keep a min square shape for single-char rings. */
-  min-width: 44px; height: 28px; padding: 0 10px; border-radius: 8px;
-  border: 1.5px solid #D1D5DB;
-  display: inline-flex; align-items: center; justify-content: center;
-  font-size: 12px; color: #9CA3AF; font-weight: 700;
-  letter-spacing: 0.04em;
+.m-v2-root .trust-pill strong {
+  color: var(--text-primary);
+  font-weight: 600;
 }
+.m-v2-root .trust-pill-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--accent-mint);
+  color: #0D1828;
+  font-size: 11px;
+  font-weight: 900;
+  flex: 0 0 auto;
+}
+
+/* Legacy selectors retained as no-ops — if any consumer/test still
+   references .trust-row/.trust-item/.ring they won't explode. Safe to
+   remove on the next cleanup pass. */
+.m-v2-root .trust-row { display: none; }
 
 /* Stats ----------------------------------------------------------- */
 .m-v2-root .stats-section { padding: 120px 0; }
@@ -564,7 +589,12 @@
 .m-v2-root .how-section .eyebrow { color: var(--accent-mint); }
 .m-v2-root .how-section h2 { color: var(--text-on-ink); font-size: var(--fs-h2); font-weight: 700; letter-spacing: var(--track-tight); line-height: 1.05; margin: 12px 0 18px; }
 .m-v2-root .how-section .sub { color: var(--text-on-ink-dim); font-size: 19px; max-width: 620px; }
-.m-v2-root .how-steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; margin-top: 64px; }
+/* Grid `align-items: start` prevents the short Steps 02/03 cards from
+   stretching vertically to match Step 01 (which is much taller once the
+   live demo expands and shows the letter preview + 3-card dispute-extras
+   grid). Without this, Steps 02/03 had a huge empty gap below their
+   content because the grid row was forcing them to the same height. */
+.m-v2-root .how-steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; margin-top: 64px; align-items: start; }
 .m-v2-root .how-step {
   background: var(--surface-ink-2);
   border: 1px solid var(--divider-ink);
@@ -594,54 +624,112 @@
   font-weight: 600; font-size: 13px; cursor: pointer;
 }
 .m-v2-root .mini-form button:disabled { opacity: 0.7; cursor: progress; }
+/* Dispute-letter preview ----------------------------------------- */
+/* Shows the AI-drafted opening paragraph clearly, then below it a
+   blurred/faded continuation representing the rest of the letter —
+   citations, demand paragraph, regulator escalation, sign-off — so
+   the user can see the full structure exists. The gate overlay at
+   the bottom of the locked block carries the sign-up CTA.
+   Restores the "see the shape of the completed letter, sign up to
+   unlock" UX Paul asked us to bring back. */
 .m-v2-root .mini-letter-out {
+  position: relative;
   margin-top: 14px;
-  padding: 12px 14px;
-  background: rgba(52,211,153,0.08);
-  border: 1px solid rgba(52,211,153,0.25);
-  border-radius: 10px;
+  padding: 14px 16px 0;
+  background: rgba(52,211,153,0.06);
+  border: 1px solid rgba(52,211,153,0.22);
+  border-radius: 12px;
   font-size: 12.5px;
   color: var(--text-on-ink);
   line-height: 1.5;
-  max-height: 220px;
-  overflow-y: auto;
+  overflow: hidden;
 }
 .m-v2-root .mini-letter-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   font-size: 10px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--accent-mint);
   font-weight: 700;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
 }
-.m-v2-root .mini-letter-out p {
-  margin: 0 0 10px;
+.m-v2-root .mini-letter-badge {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(52,211,153,0.15);
+  border: 1px solid rgba(52,211,153,0.3);
+  letter-spacing: 0.08em;
+  font-size: 9px;
+  color: var(--accent-mint);
+}
+.m-v2-root .mini-letter-body {
+  margin: 0 0 12px;
   font-family: 'Georgia', serif;
   color: var(--text-on-ink);
   text-wrap: pretty;
   white-space: pre-wrap;
 }
-.m-v2-root .mini-letter-cta {
-  display: inline-block;
-  margin-top: 4px;
-  color: var(--accent-mint);
-  font-size: 12px;
-  font-weight: 600;
-  text-decoration: none;
-  letter-spacing: 0.02em;
+.m-v2-root .mini-letter-locked {
+  position: relative;
+  margin: 0 -16px;
+  padding: 0 16px 120px;
+  font-family: 'Georgia', serif;
+  color: var(--text-on-ink-dim);
+  filter: blur(3.5px);
+  opacity: 0.55;
+  user-select: none;
+  pointer-events: none;
+  -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 55%, transparent 95%);
+          mask-image: linear-gradient(180deg, #000 0%, #000 55%, transparent 95%);
 }
-.m-v2-root .mini-letter-cta:hover { text-decoration: underline; }
-.m-v2-root .mini-letter-lock {
-  display: flex; gap: 10px; align-items: flex-start;
-  margin-top: 10px;
-  padding: 10px 12px;
-  background: rgba(245,158,11,0.12);
-  border: 1px solid rgba(245,158,11,0.25);
-  border-radius: 10px;
+.m-v2-root .mini-letter-locked p {
+  margin: 0 0 10px;
+  text-wrap: pretty;
+}
+.m-v2-root .mini-letter-locked .mini-letter-signoff { margin-top: 14px; }
+.m-v2-root .mini-letter-gate {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 14px 16px 16px;
+  background: linear-gradient(180deg, rgba(13,24,40,0) 0%, rgba(13,24,40,0.92) 45%, rgba(13,24,40,0.98) 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: stretch;
+}
+.m-v2-root .mini-letter-gate-text {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
   color: #FDE68A;
-  font-size: 12px; line-height: 1.45;
+  font-size: 12px;
+  line-height: 1.45;
 }
-.m-v2-root .mini-letter-lock .lock-icon { flex: 0 0 auto; font-size: 14px; }
+.m-v2-root .mini-letter-gate-text strong { color: #FEF3C7; font-weight: 700; }
+.m-v2-root .mini-letter-gate-text .lock-icon { flex: 0 0 auto; font-size: 14px; line-height: 1.3; }
+.m-v2-root .mini-letter-gate-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 18px;
+  border-radius: 10px;
+  background: var(--accent-mint);
+  color: #0D1828;
+  font-weight: 700;
+  font-size: 13px;
+  text-decoration: none;
+  letter-spacing: 0.01em;
+  transition: transform 120ms ease, background-color 120ms ease;
+}
+.m-v2-root .mini-letter-gate-cta:hover {
+  background: #6EE7B7;
+  transform: translateY(-1px);
+}
 
 /* Disputes-step highlight — pulls visual weight onto step 01 */
 .m-v2-root .how-step.highlight-step {
@@ -658,27 +746,104 @@
   letter-spacing: 0.1em; text-transform: uppercase;
   border-radius: 999px;
 }
+/* Dispute extras — promoted from bullet list to 3-card row (Apr 2026)
+   so the email-thread + tracking + export capabilities read as
+   first-class features, not footnotes. */
 .m-v2-root .how-step .dispute-extras {
-  list-style: none; padding: 0; margin: 14px 0 0;
-  display: flex; flex-direction: column; gap: 10px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin: 18px 0 0;
 }
-.m-v2-root .how-step .dispute-extras li {
-  font-size: 12px; line-height: 1.5;
-  color: var(--text-on-ink-dim);
-  padding-left: 20px;
-  position: relative;
+.m-v2-root .dispute-extra-card {
+  background: rgba(255,255,255,0.035);
+  border: 1px solid var(--divider-ink);
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
-.m-v2-root .how-step .dispute-extras li::before {
-  content: '✓';
-  position: absolute; left: 0; top: 0;
-  color: var(--accent-mint);
-  font-weight: 700;
+.m-v2-root .dispute-extra-card .dex-icon {
+  width: 34px; height: 34px;
+  border-radius: 10px;
+  background: rgba(52,211,153,0.12);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 17px;
 }
-.m-v2-root .how-step .dispute-extras strong {
+.m-v2-root .dispute-extra-card h4 {
   color: var(--text-on-ink);
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: -0.005em;
 }
-.m-v2-root .bank-list { display: flex; flex-direction: column; gap: 8px; margin-top: auto; }
+.m-v2-root .dispute-extra-card p {
+  color: var(--text-on-ink-dim);
+  font-size: 12.5px;
+  line-height: 1.5;
+  margin: 0;
+  text-wrap: pretty;
+}
+.m-v2-root .dex-mini-thread {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.m-v2-root .dex-mt-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--divider-ink);
+  border-radius: 8px;
+  font-size: 11.5px;
+}
+.m-v2-root .dex-mt-from { color: var(--text-on-ink); font-weight: 600; }
+.m-v2-root .dex-mt-tag { color: var(--text-on-ink-dim); }
+.m-v2-root .dex-mt-muted { color: var(--text-on-ink-dim); font-style: italic; }
+.m-v2-root .dex-mt-mint { color: var(--accent-mint); font-weight: 600; }
+.m-v2-root .dex-status-row {
+  margin-top: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.m-v2-root .dex-chip {
+  display: inline-block;
+  padding: 5px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid;
+}
+.m-v2-root .dex-chip-won { color: var(--accent-mint); border-color: rgba(52,211,153,0.35); background: rgba(52,211,153,0.1); }
+.m-v2-root .dex-chip-part { color: #FDE68A; border-color: rgba(245,158,11,0.35); background: rgba(245,158,11,0.1); }
+.m-v2-root .dex-chip-pend { color: #93C5FD; border-color: rgba(96,165,250,0.35); background: rgba(96,165,250,0.1); }
+.m-v2-root .dex-export-row {
+  margin-top: 4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.m-v2-root .dex-file {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--divider-ink);
+  color: var(--text-on-ink-dim);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+}
+.m-v2-root .dex-file-alt { color: var(--accent-mint); }
+/* Bank-list sits between the intro paragraph and the scan-summary
+   panel. margin-top: auto was previously pushing it to the bottom of a
+   stretched card; now that the how-steps grid uses align-items: start,
+   cards size to content and the auto-margin is unnecessary. */
+.m-v2-root .bank-list { display: flex; flex-direction: column; gap: 8px; }
 .m-v2-root .bank-row {
   display: flex; justify-content: space-between; align-items: center;
   background: rgba(255,255,255,0.04); border: 1px solid var(--divider-ink);
@@ -687,6 +852,40 @@
 .m-v2-root .bank-row .n { color: var(--text-on-ink); }
 .m-v2-root .bank-row .v { color: var(--accent-mint); font-weight: 600; }
 .m-v2-root .bank-row .v.orange { color: var(--accent-orange); }
+
+/* Scan-summary panel — anchors the bottom of Step 02 so it reads as
+   "here's what a scan actually finds" rather than just a list of
+   connected banks. */
+.m-v2-root .scan-summary {
+  margin-top: 14px;
+  padding: 14px 16px;
+  background: linear-gradient(180deg, rgba(52,211,153,0.08) 0%, rgba(52,211,153,0) 100%);
+  border: 1px solid rgba(52,211,153,0.28);
+  border-radius: 14px;
+}
+.m-v2-root .scan-summary-head {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 12px; font-weight: 600;
+  color: var(--text-on-ink);
+  margin-bottom: 10px;
+}
+.m-v2-root .scan-dot {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--accent-mint);
+  box-shadow: 0 0 0 3px rgba(52,211,153,0.25);
+}
+.m-v2-root .scan-summary-list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.m-v2-root .scan-summary-list li {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 12.5px;
+  color: var(--text-on-ink-dim);
+}
+.m-v2-root .ss-val { color: var(--text-on-ink); font-weight: 700; }
+.m-v2-root .ss-val.orange { color: var(--accent-orange); }
+.m-v2-root .ss-val.mint { color: var(--accent-mint); }
 .m-v2-root .deal-row {
   display: flex; justify-content: space-between; align-items: center;
   background: rgba(255,255,255,0.04); border: 1px solid var(--divider-ink);
@@ -1118,6 +1317,110 @@
   text-wrap: pretty;
 }
 
+/* Pocket Agent — how to connect (new April 2026) ---------------- */
+.m-v2-root .agent-setup {
+  margin-top: 64px;
+  padding: 40px 36px;
+  background: linear-gradient(180deg, rgba(52,211,153,0.08) 0%, rgba(13,24,40,0) 60%), var(--surface-ink-2);
+  border: 1px solid var(--divider-ink);
+  border-radius: 28px;
+}
+.m-v2-root .agent-setup-head { max-width: 640px; margin-bottom: 28px; }
+.m-v2-root .agent-setup-head h3 {
+  color: var(--text-on-ink);
+  font-size: 28px;
+  line-height: 1.15;
+  margin: 10px 0 0;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.m-v2-root .agent-setup-head .mint { color: var(--accent-mint); }
+.m-v2-root .agent-setup-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  counter-reset: setup;
+}
+.m-v2-root .agent-setup-steps li {
+  display: flex;
+  gap: 16px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--divider-ink);
+  border-radius: 18px;
+  padding: 22px;
+}
+.m-v2-root .agent-setup-steps li .num {
+  flex: 0 0 auto;
+  width: 34px; height: 34px;
+  border-radius: 10px;
+  background: rgba(52,211,153,0.14);
+  color: var(--accent-mint);
+  font-weight: 800;
+  font-size: 15px;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.m-v2-root .agent-setup-steps h4 {
+  color: var(--text-on-ink);
+  font-size: 15px;
+  font-weight: 700;
+  margin: 4px 0 6px;
+  letter-spacing: -0.005em;
+}
+.m-v2-root .agent-setup-steps p {
+  color: var(--text-on-ink-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
+  text-wrap: pretty;
+}
+.m-v2-root .agent-setup-steps code {
+  background: rgba(52,211,153,0.12);
+  color: var(--accent-mint);
+  padding: 1px 6px;
+  border-radius: 5px;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+.m-v2-root .agent-setup-examples {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 24px;
+}
+.m-v2-root .agent-setup-examples-label {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-mint);
+  font-weight: 700;
+  margin-right: 4px;
+}
+.m-v2-root .ase-chip {
+  display: inline-block;
+  padding: 7px 12px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid var(--divider-ink);
+  color: var(--text-on-ink-dim);
+  font-size: 12.5px;
+  font-style: italic;
+  font-family: 'Georgia', serif;
+}
+.m-v2-root .agent-setup-privacy {
+  margin-top: 22px;
+  padding: 14px 16px;
+  background: rgba(52,211,153,0.06);
+  border: 1px solid rgba(52,211,153,0.2);
+  border-radius: 12px;
+  color: var(--text-on-ink-dim);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
 /* AI Financial Assistant (light) ---------------------------------- */
 .m-v2-root .assistant-section { padding: 120px 0; }
 .m-v2-root .assistant-grid {
@@ -1494,7 +1797,7 @@
   .m-v2-root .how-steps,
   .m-v2-root .category-grid,
   .m-v2-root .pricing-grid { grid-template-columns: 1fr; }
-  .m-v2-root .trust-row { grid-template-columns: repeat(2, 1fr); gap: 16px; }
+  .m-v2-root .trust-pill { font-size: 12px; padding: 7px 12px; }
   .m-v2-root .footer-grid { grid-template-columns: 1fr 1fr; }
   .m-v2-root .nav-links { display: none; }
   .m-v2-root .nav-toggle { display: inline-flex; }
@@ -1507,6 +1810,14 @@
   .m-v2-root .assistant-grid,
   .m-v2-root .subs-grid { grid-template-columns: 1fr; gap: 48px; }
   .m-v2-root .agent-features { grid-template-columns: 1fr; }
+  .m-v2-root .agent-setup { padding: 28px 20px; margin-top: 48px; border-radius: 22px; }
+  .m-v2-root .agent-setup-head h3 { font-size: 24px; }
+  .m-v2-root .agent-setup-steps { grid-template-columns: 1fr; gap: 12px; }
+  /* Dispute-extras 3-card grid collapses to a single column on tablet and
+     below — keeps the email-thread mini-preview, won/partial/pending chip
+     row, and file-chip export row legible on iPhone without horizontal
+     cramping. */
+  .m-v2-root .how-step .dispute-extras { grid-template-columns: 1fr; gap: 10px; }
   .m-v2-root .why-stats { grid-template-columns: 1fr 1fr; }
   /* Hero copy eases in on tablet/mobile */
   .m-v2-root .hero h1 { font-size: clamp(40px, 7.5vw, 72px); line-height: 1.02; }


### PR DESCRIPTION
Follow-up fixes after Paul's review of the v2 homepage:

**Copy**
- FAQ 'How accurate are the AI-generated complaint letters?' no longer mentions Claude or Anthropic. Reframed around the UK government legislation API, refreshed daily, so letters reflect the current statute on the day they're sent.
- Replaced dev-speak 'Preview data — aggregates load from Supabase in a second' with user-friendly 'Loading latest figures…'
- 'Data storage' FAQ rephrased (dropped bare 'Supabase' inline, kept AWS eu-west-2 London for substance).

**Dispute dropdown (How It Works step 01)**
- Expanded from 4 generic options to 32 UK-specific dispute types across 8 optgroups: Telecoms & broadband, Energy & utilities, Travel, Goods & services, Finance & credit, Motoring & parking, Housing & council, Tax & government. Every option cites a specific UK regulation or statute.

**Step 02 layout gap fix**
- `.how-steps` grid now uses `align-items: start` so Steps 02/03 size to their own content instead of stretching to Step 01's height (which ballooned when the letter preview expanded).
- Removed the orphan `margin-top: auto` on `.bank-list`.
- Added a scan-summary panel to Step 02 (recurring payments found · price hikes · forgotten subs · savings opportunities £1,247/yr) so the card has visual parity with Step 01's letter preview.

**Mobile**
- Added `@media (max-width: 980px)` rule collapsing the `.dispute-extras` 3-card grid to a single column so the email-thread mini-preview, won/partial/pending chips, and file-chip export row stay legible on iPhone.