### PR TITLE
fix(privacy): remove pixel ID and Claude reference from public pages

### DIFF
--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -45,7 +45,7 @@ export default function CookiePolicyPage() {
             <h3 className="text-lg font-medium text-white mt-4 mb-2">Marketing cookies</h3>
             <p className="mb-2">Used for advertising and affiliate tracking. Only set with your consent.</p>
             <ul className="list-disc list-inside space-y-1 text-slate-400">
-              <li><strong className="text-slate-300">Meta Pixel</strong> — measures ad effectiveness and enables retargeting. Pixel ID: 722806327584909</li>
+              <li><strong className="text-slate-300">Meta Pixel</strong> — measures ad effectiveness and enables retargeting</li>
               <li><strong className="text-slate-300">Meta Conversions API</strong> — server-side event tracking for ad optimisation</li>
               <li><strong className="text-slate-300">Awin</strong> — affiliate tracking for partner deals</li>
             </ul>

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -358,7 +358,7 @@ export default function LegalRefsAdminPage() {
       </div>
 
       <p className="text-slate-600 text-xs mt-4 text-center">
-        Verification runs automatically on the 1st of each month. Statutes are checked via legislation.gov.uk. Regulator rules are compared with Claude Haiku.
+        Verification runs automatically on the 1st of each month. Statutes are checked via legislation.gov.uk. Regulator rules are compared with our AI engine.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removed Meta Pixel ID (`722806327584909`) from the cookie policy page — it was exposed as visible text in the marketing cookies section
- Replaced "Claude Haiku" with "our AI engine" in the admin legal-refs page footer text

## Test plan
- [ ] Visit `/cookie-policy` and confirm pixel ID is no longer visible in the marketing cookies list
- [ ] Visit `/dashboard/admin/legal-refs` and confirm footer no longer mentions "Claude Haiku"

🤖 Generated with [Claude Code](https://claude.com/claude-code)