### PR TITLE
feat(telegram): generate real spending charts via QuickChart.io

### DIFF
--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -64,6 +64,7 @@ export interface PendingAction {
 export interface ToolResult {
   text: string;
   pendingAction?: PendingAction;
+  chartUrl?: string;
 }
 
 function fmt(amount: number | string | null | undefined): string {
@@ -244,6 +245,12 @@ export async function executeToolCall(
         amount: toolInput.amount as number | undefined,
         paid_date: toolInput.paid_date as string | undefined,
       });
+    case 'generate_spending_chart':
+      return generateSpendingChart(supabase, userId, {
+        chart_type: (toolInput.chart_type as 'pie' | 'bar') ?? 'pie',
+        period: (toolInput.period as string | undefined) ?? 'this_month',
+        group_by: (toolInput.group_by as 'category' | 'provider') ?? 'category',
+      });
     case 'get_loyalty_status':
       return getLoyaltyStatus(supabase, userId);
     case 'get_referral_link':
@@ -371,6 +378,160 @@ async function getSpendingSummary(
   }
 
   return { text };
+}
+
+// Colour palette for chart slices (brand gold first, then complementary colours)
+const CHART_PALETTE = [
+  '#f59e0b', // gold (brand)
+  '#3b82f6', // blue
+  '#10b981', // emerald
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#f97316', // orange
+  '#06b6d4', // cyan
+  '#84cc16', // lime
+  '#ec4899', // pink
+  '#6366f1', // indigo
+  '#14b8a6', // teal
+  '#fb923c', // light orange
+];
+
+async function generateSpendingChart(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  params: { chart_type: 'pie' | 'bar'; period: string; group_by: 'category' | 'provider' },
+): Promise<ToolResult> {
+  const now = new Date();
+
+  // Resolve period to date range
+  let startDate: Date;
+  let endDate: Date;
+  let periodLabel: string;
+
+  if (params.period === 'last_month') {
+    startDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    endDate = new Date(now.getFullYear(), now.getMonth(), 1);
+    periodLabel = new Date(now.getFullYear(), now.getMonth() - 1)
+      .toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
+  } else if (params.period === 'last_3_months') {
+    startDate = new Date(now.getFullYear(), now.getMonth() - 3, 1);
+    endDate = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    periodLabel = 'Last 3 Months';
+  } else {
+    startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+    endDate = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    periodLabel = now.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
+  }
+
+  let labels: string[];
+  let values: number[];
+  let total: number;
+  let chartTitle: string;
+  let summaryLines: string[];
+
+  if (params.group_by === 'provider') {
+    // Use tracked subscriptions for provider-level chart
+    const { data: subs } = await supabase
+      .from('subscriptions')
+      .select('provider_name, amount, billing_cycle')
+      .eq('user_id', userId)
+      .eq('status', 'active');
+
+    if (!subs || subs.length === 0) {
+      return { text: 'No active subscriptions found. Add subscriptions at paybacker.co.uk/dashboard/subscriptions to track your recurring payments.' };
+    }
+
+    const monthly = subs
+      .map((s) => ({
+        name: s.provider_name as string,
+        monthly:
+          s.billing_cycle === 'yearly' ? Number(s.amount) / 12 :
+          s.billing_cycle === 'weekly' ? Number(s.amount) * 4.33 :
+          Number(s.amount),
+      }))
+      .filter((s) => s.monthly > 0)
+      .sort((a, b) => b.monthly - a.monthly)
+      .slice(0, 15);
+
+    labels = monthly.map((s) => s.name);
+    values = monthly.map((s) => parseFloat(s.monthly.toFixed(2)));
+    total = values.reduce((a, b) => a + b, 0);
+    chartTitle = 'Monthly Subscription Spend';
+    summaryLines = monthly.map((s) => `${s.name}: ${fmt(s.monthly)}/mo`);
+  } else {
+    // Use classified bank transactions for category chart
+    const classified = await classifyTransactions(
+      supabase, userId,
+      startDate.toISOString(),
+      endDate.toISOString(),
+    );
+
+    const spending = classified.filter(
+      (t) => t.resolved.kind === 'spending' && t.effectiveCategory !== 'transfers',
+    );
+
+    if (spending.length === 0) {
+      return { text: `No spending data found for ${periodLabel}. Connect a bank account at paybacker.co.uk/dashboard/money-hub to start tracking.` };
+    }
+
+    const totals: Record<string, number> = {};
+    spending.forEach((t) => {
+      const cat = t.effectiveCategory;
+      totals[cat] = (totals[cat] ?? 0) + (-Number(t.amount));
+    });
+
+    const sorted = Object.entries(totals)
+      .sort(([, a], [, b]) => b - a)
+      .filter(([, v]) => v > 0)
+      .slice(0, 12);
+
+    labels = sorted.map(([cat]) => CATEGORY_LABELS[cat] || cat);
+    values = sorted.map(([, v]) => parseFloat(v.toFixed(2)));
+    total = values.reduce((a, b) => a + b, 0);
+    chartTitle = `Spending — ${periodLabel}`;
+    summaryLines = sorted.map(([cat, v]) => `${CATEGORY_LABELS[cat] || cat}: ${fmt(v)}`);
+  }
+
+  // Build Chart.js config for QuickChart.io
+  const horizontal = params.chart_type === 'bar' && labels.length > 6;
+  const chartConfig =
+    params.chart_type === 'pie'
+      ? {
+          type: 'pie',
+          data: {
+            labels,
+            datasets: [{ data: values, backgroundColor: CHART_PALETTE.slice(0, labels.length) }],
+          },
+          options: {
+            plugins: {
+              title: { display: true, text: chartTitle, font: { size: 16 } },
+              legend: { position: 'bottom' },
+            },
+          },
+        }
+      : {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [{ label: 'Spend (£)', data: values, backgroundColor: '#f59e0b' }],
+          },
+          options: {
+            ...(horizontal ? { indexAxis: 'y' } : {}),
+            plugins: {
+              title: { display: true, text: chartTitle, font: { size: 16 } },
+              legend: { display: false },
+            },
+          },
+        };
+
+  const h = horizontal ? Math.max(350, labels.length * 30 + 100) : 400;
+  const chartUrl = `https://quickchart.io/chart?w=600&h=${h}&bkg=white&c=${encodeURIComponent(JSON.stringify(chartConfig))}`;
+
+  const dataText =
+    `Chart generated: ${chartTitle}\nTotal: ${fmt(total)}\n` +
+    summaryLines.join('\n');
+
+  return { text: dataText, chartUrl };
 }
 
 async function listTransactions(

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -454,6 +454,10 @@ async function generateSpendingChart(
       .sort((a, b) => b.monthly - a.monthly)
       .slice(0, 15);
 
+    if (monthly.length === 0) {
+      return { text: 'No subscription spend data found for this period.' };
+    }
+
     labels = monthly.map((s) => s.name);
     values = monthly.map((s) => parseFloat(s.monthly.toFixed(2)));
     total = values.reduce((a, b) => a + b, 0);

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -415,7 +415,7 @@ async function generateSpendingChart(
       .toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
   } else if (params.period === 'last_3_months') {
     startDate = new Date(now.getFullYear(), now.getMonth() - 3, 1);
-    endDate = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    endDate = new Date();
     periodLabel = 'Last 3 Months';
   } else {
     startDate = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -446,6 +446,7 @@ async function generateSpendingChart(
         name: s.provider_name as string,
         monthly:
           s.billing_cycle === 'yearly' ? Number(s.amount) / 12 :
+          s.billing_cycle === 'quarterly' ? Number(s.amount) / 3 :
           s.billing_cycle === 'weekly' ? Number(s.amount) * 4.33 :
           Number(s.amount),
       }))

--- a/src/lib/telegram/tools.ts
+++ b/src/lib/telegram/tools.ts
@@ -1001,4 +1001,30 @@ export const telegramTools: Tool[] = [
       required: ['provider_name'],
     },
   },
+  {
+    name: 'generate_spending_chart',
+    description:
+      "Generate a visual spending chart (pie or bar) and send it as an image. Use when the user asks to 'show me', 'visualise', 'chart', 'graph', or 'pie/bar chart' their spending, subscriptions, or bills. Produces a real chart image — use this instead of get_spending_summary for any chart or visualisation request.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        chart_type: {
+          type: 'string',
+          enum: ['pie', 'bar'],
+          description: "Chart type. Use 'pie' for share/breakdown questions, 'bar' for comparison or ranked questions.",
+        },
+        period: {
+          type: 'string',
+          enum: ['this_month', 'last_month', 'last_3_months'],
+          description: "Time period for the chart. Defaults to 'this_month'.",
+        },
+        group_by: {
+          type: 'string',
+          enum: ['category', 'provider'],
+          description: "'category' groups bank transactions by spending category (groceries, streaming, broadband, etc.). 'provider' groups active tracked subscriptions by provider name (Netflix, Spotify, etc.).",
+        },
+      },
+      required: ['chart_type', 'group_by'],
+    },
+  },
 ];

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -157,6 +157,7 @@ WRITE TOOLS:
 - draft_dispute_letter — Draft a complaint letter citing exact UK consumer law (TERMINAL — call once, nothing before or after)
 - generate_cancellation_email — Generate a formal cancellation letter with correct UK legal references for the service type
 - create_support_ticket — Create a help ticket when the user needs the Paybacker support team
+- generate_spending_chart — Generate and send a real chart image (pie or bar) of spending or subscriptions. Use whenever the user asks to visualise, chart, or graph their spending or subscriptions. Do NOT use get_spending_summary for chart requests — use this instead. The chart image is sent automatically; write a brief summary as your text response.
 
 RULES:
 - ALWAYS call the relevant tool before answering — never make up numbers or say "I can't access that"
@@ -262,7 +263,7 @@ async function callClaudeWithTools(
   userId: string,
   userMessage: string,
   chatId: number,
-): Promise<{ text: string; pendingAction?: PendingAction }> {
+): Promise<{ text: string; pendingAction?: PendingAction; chartUrl?: string }> {
   const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
   const supabase = getAdmin();
 
@@ -299,6 +300,7 @@ async function callClaudeWithTools(
   let iterations = 0;
   const HARD_TIMEOUT_MS = 230_000; // 230s — leaves 70s buffer before Vercel's 300s kill
   const loopStart = Date.now();
+  let chartUrl: string | undefined;
 
   while (response.stop_reason === 'tool_use' && iterations < MAX_ITERATIONS) {
     // Hard timeout check — abort before Vercel kills the function
@@ -311,7 +313,7 @@ async function callClaudeWithTools(
 
     for (const block of response.content) {
       if (block.type === 'tool_use') {
-        let result: { text: string; pendingAction?: PendingAction };
+        let result: { text: string; pendingAction?: PendingAction; chartUrl?: string };
         try {
           result = await executeToolCall(
             block.name,
@@ -329,6 +331,8 @@ async function callClaudeWithTools(
           // and generate duplicate letters. Return directly, bypassing both loops.
           return { text: result.text, pendingAction: result.pendingAction };
         }
+
+        if (result.chartUrl) chartUrl = result.chartUrl;
 
         toolResults.push({
           type: 'tool_result',
@@ -359,7 +363,7 @@ async function callClaudeWithTools(
     finalText = "I'm having trouble retrieving that information right now. Could you please specify exactly what you need in a different way?";
   }
 
-  return { text: finalText };
+  return { text: finalText, chartUrl };
 }
 
 // ============================================================
@@ -1604,7 +1608,7 @@ Return JSON: { "subject": "...", "body": "..." }`;
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('TIMEOUT: Claude processing exceeded 250s')), CLAUDE_TIMEOUT_MS)
       );
-      const { text, pendingAction } = await Promise.race([claudePromise, timeoutPromise]);
+      const { text, pendingAction, chartUrl } = await Promise.race([claudePromise, timeoutPromise]);
 
       // Log outbound
       supabase
@@ -1642,6 +1646,15 @@ Return JSON: { "subject": "...", "body": "..." }`;
           } else {
             await ctx.reply(chunks[i]);
           }
+        }
+      } else if (chartUrl) {
+        // Send chart image — use text as caption if short enough, otherwise follow-up message
+        const CAPTION_LIMIT = 1024;
+        if (text.length <= CAPTION_LIMIT) {
+          await ctx.replyWithPhoto(chartUrl, { caption: text, parse_mode: 'Markdown' });
+        } else {
+          await ctx.replyWithPhoto(chartUrl);
+          await sendChunked(ctx, text);
         }
       } else {
         await sendChunked(ctx, text);


### PR DESCRIPTION
## Summary

- Adds a `generate_spending_chart` tool to the Pocket Agent bot. When the user asks for a pie or bar chart of their spending or subscriptions, the bot fetches live data, renders a chart via QuickChart.io, and sends it as a Telegram photo with Claude's analysis as the caption.
- No new dependencies — QuickChart.io is a free HTTP API, no auth required.
- Zero-downtime: the feature is purely additive.

## How it works

1. **Tool call**: Claude calls `generate_spending_chart(chart_type, period, group_by)`
2. **Data fetch**:
   - `group_by: 'category'` → classifies bank transactions via the existing Money Hub engine and groups by effective category
   - `group_by: 'provider'` → reads the subscriptions tracker and normalises to monthly cost per provider
3. **Chart URL**: Builds a Chart.js config and encodes it as a `https://quickchart.io/chart?c=...` URL
4. **Telegram delivery**: `chartUrl` is threaded through `ToolResult` → `callClaudeWithTools` → webhook handler, which calls `ctx.replyWithPhoto(chartUrl, { caption: text })`. If Claude's text response is >1024 chars, photo and text are sent separately.

## Test cases

- "Show me a pie chart of my subscription spend last month" → `chart_type: pie, period: last_month, group_by: provider`
- "Show me a bar chart of my spending by category this month" → `chart_type: bar, period: this_month, group_by: category`
- "Show my spending over the last 3 months" → `chart_type: bar, period: last_3_months, group_by: category`

## Test plan

- [ ] Connect a test Telegram account with Pro tier and real bank transactions
- [ ] Send "Show me a pie chart of my subscription spend last month" — verify photo arrives with caption
- [ ] Send "Show me a bar chart of my spending by category this month" — verify horizontal bars for >6 categories
- [ ] Send the same requests when no bank is connected — verify graceful error message (no photo crash)
- [ ] Verify `npx tsc --noEmit` passes (✅ confirmed clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)