### PR TITLE
fix(email): contract/overcharge alerts now count toward daily rate limit

### DIFF
--- a/shared-context/active-sessions.md
+++ b/shared-context/active-sessions.md
@@ -1,4 +1,16 @@
-# Active Sessions — Last Updated 11 Apr 2026 13:20 UTC
+# Active Sessions — Last Updated 20 Apr 2026 18:00 UTC
+
+## Latest: Business Monitor — 20 Apr 2026 (evening)
+- 4 PRs merged to production today:
+  - #100: Homepage hero live saved-this-month figure (no more "coming soon")
+  - #101: Google Sheets export tab live, parallelised dashboard overview
+  - #103: Sheets Sync Now button + first-sync backfill
+  - #104: Sheets DB query pagination + dedup by transaction_id (idempotent)
+- 3 new PRs opened: #99 (email rate limit types), #102 (gmail scan guard), #105 (homepage redesign preview)
+- 30 open PRs in queue — review backlog building
+- Evening Telegram check-in sent to Paul
+
+
 
 ## Latest: Cowork Session — 11 Apr 2026
 - Fixed Telegram bot (was dead — fire-and-forget root cause)

--- a/shared-context/task-queue.md
+++ b/shared-context/task-queue.md
@@ -13,7 +13,7 @@
 - [x] daily-ceo-report updated — Now includes open GitHub PRs and sprint completions (needs GITHUB_TOKEN)
 
 ## URGENT - Email Spam Fix
-- [ ] Implement global email rate limiter (max 2 emails per user per day)
+- [~PR#99] Implement global email rate limiter (max 2 emails per user per day) — rate limiter exists in email-rate-limit.ts; PR#99 fixes missing types (contract_expiry_alert, contract_end_alert, overcharge_alert) that were bypassing the cap (PR created 2026-04-20)
 - [ ] Consolidate deal alerts + targeted deals + price increases into single daily digest
 - [ ] Add user email preference settings (daily digest / weekly / off)
 - [ ] Audit and restructure all 11 email cron triggers (see email-audit below)

--- a/src/lib/email-rate-limit.ts
+++ b/src/lib/email-rate-limit.ts
@@ -30,6 +30,11 @@ const MARKETING_EMAIL_TYPES = [
   'founding_reminder',
   'weekly_money_digest',
   'onboarding_email',
+  // Contract and overcharge alerts are marketing-adjacent — they count toward
+  // the daily cap so users can't receive both a deal email AND a contract alert
+  'contract_expiry_alert',
+  'contract_end_alert',
+  'overcharge_alert',
 ];
 
 // These are transactional and bypass the limit


### PR DESCRIPTION
## What
- Added `contract_expiry_alert`, `contract_end_alert`, and `overcharge_alert` to `MARKETING_EMAIL_TYPES` in `src/lib/email-rate-limit.ts`

## Why
These three types were calling `canSendEmail()` but were missing from the `MARKETING_EMAIL_TYPES` list. This caused a two-sided bypass:
1. They were never blocked by prior sends (the count query ignored them)
2. They didn't count for subsequent email checks (deal alerts could still fire after a contract alert)

A user could receive a `contract_expiry_alert` AND a `deal_alert_email` on the same day without the limiter stopping either — effectively doubling the daily email load.

## Test plan
- [ ] Send a `deal_alert_email` to a test user (manually insert task row or trigger cron)
- [ ] Verify `contract_expiry_alert` is then blocked for the same user on the same day
- [ ] Verify `overcharge_alert` is blocked after 1 marketing email is already sent
- [ ] Transactional emails (welcome, password reset, dispute reply) still bypass the limit

From task queue: Implement global email rate limiter (max 2 emails per user per day)
🤖 Paybacker Dev Sprint Runner
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>