### PR TITLE
fix(gmail-scan): stamp last_scanned_at + session guard to stop per-load re-scans

### DIFF
--- a/shared-context/task-queue.md
+++ b/shared-context/task-queue.md
@@ -13,7 +13,7 @@
 - [x] daily-ceo-report updated — Now includes open GitHub PRs and sprint completions (needs GITHUB_TOKEN)
 
 ## URGENT - Email Spam Fix
-- [ ] Implement global email rate limiter (max 2 emails per user per day)
+- [~PR#99] Implement global email rate limiter (max 2 emails per user per day) — rate limiter exists in email-rate-limit.ts; PR#99 fixes missing types (contract_expiry_alert, contract_end_alert, overcharge_alert) that were bypassing the cap (PR created 2026-04-20)
 - [ ] Consolidate deal alerts + targeted deals + price increases into single daily digest
 - [ ] Add user email preference settings (daily digest / weekly / off)
 - [ ] Audit and restructure all 11 email cron triggers (see email-audit below)

--- a/src/app/api/gmail/scan/route.ts
+++ b/src/app/api/gmail/scan/route.ts
@@ -444,6 +444,14 @@ export async function POST(request: NextRequest) {
       opportunities = allNew;
     }
 
+    // Stamp last_scanned_at so the dashboard staleness check won't re-fire on the next page load.
+    // Scoped to provider_type=google so Outlook/IMAP connections are not incorrectly marked as scanned.
+    await admin.from('email_connections')
+      .update({ last_scanned_at: new Date().toISOString() })
+      .eq('user_id', user.id)
+      .eq('provider_type', 'google')
+      .eq('status', 'active');
+
     return NextResponse.json({
       opportunities,
       emailsFound: scanResult.emailsFound,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -550,7 +550,11 @@ export default function DashboardPage() {
    * invoke without awaiting (callers may `.catch(() => {})`).
    */
   const scanInboxNow = async () => {
+    // Explicit manual re-scan: clear the session guard so auto-trigger bookkeeping stays accurate
+    sessionStorage.removeItem('gmailScanFired');
     setEmailScanning(true);
+    // Set guard immediately (before await) so any parallel auto-trigger sees the flag even while in-flight
+    sessionStorage.setItem('gmailScanFired', '1');
     try {
       const res = await fetch('/api/gmail/scan', { method: 'POST' });
       const data = await res.json();

--- a/src/lib/email-rate-limit.ts
+++ b/src/lib/email-rate-limit.ts
@@ -30,6 +30,8 @@ const MARKETING_EMAIL_TYPES = [
   'founding_reminder',
   'weekly_money_digest',
   'onboarding_email',
+  // Contract and overcharge alerts are marketing-adjacent — they count toward
+  // the daily cap so users can't receive both a deal email AND a contract alert
   'contract_expiry_alert',
   'contract_end_alert',
   'overcharge_alert',


### PR DESCRIPTION
## Problem

`/api/gmail/scan` never wrote `last_scanned_at` back to `email_connections` after completing. The dashboard staleness check therefore always evaluated to true, causing a full inbox scan (and `incrementUsage` / Claude API call) on every single dashboard page load for Gmail-connected users.

## Fixes

### 1. `src/app/api/gmail/scan/route.ts`
After the scan succeeds, update `email_connections.last_scanned_at = now()` for the authenticated user's active connection(s). Runs unconditionally (outside the `if (opportunities.length > 0)` block) so the timestamp is stamped even when no new findings are returned.

### 2. `src/app/dashboard/page.tsx`
Added a `sessionStorage` guard in `handleEmailScan`:
- Flag is **set immediately** before the `fetch` call so any parallel auto-trigger sees it even while the request is in-flight (before `last_scanned_at` has been persisted).
- Flag is **cleared** at the very start of `handleEmailScan` so an explicit manual "Scan Emails" click always goes through, regardless of any prior auto-trigger in the same session.

## Test plan
- [ ] Connect Gmail, load dashboard — confirm no automatic scan fires (no new `agent_runs` / `email_scan_findings` rows, no `incrementUsage` hit)
- [ ] Click "Scan Emails" manually — scan fires, `last_scanned_at` is updated in `email_connections`
- [ ] Reload dashboard after scan — confirm scan does not fire again
- [ ] Click "Scan Emails" again — confirm manual re-scan still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)