### PR TITLE
feat(sheets): Sync Now button + first-sync backfill

### DIFF
--- a/src/app/api/google-sheets/sync-now/route.ts
+++ b/src/app/api/google-sheets/sync-now/route.ts
@@ -1,0 +1,99 @@
+// src/app/api/google-sheets/sync-now/route.ts
+//
+// User-triggered sync. Called from the Sync Now button on the Export page.
+//
+// Behaviour:
+//   - If last_synced_at is null → full_export: true (backfill all history).
+//   - Otherwise → full_export: false (incremental — only new transactions
+//     since last_synced_timestamp).
+//
+// Unlike the fire-and-forget triggerSheetsExport helper, this endpoint
+// AWAITS the export call and returns rows_written so the UI can show a
+// "Synced N rows" confirmation. Still uses the internal-key flow against
+// /api/google-sheets/export under the hood.
+//
+// Session-authed (cookies). Works for the logged-in user only.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export async function POST(_req: NextRequest) {
+  const cookieStore = await cookies()
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (name: string) => cookieStore.get(name)?.value } }
+  )
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+  }
+
+  // Is a sheet connected? If so, decide full vs incremental.
+  const { data: conn } = await supabase
+    .from('google_sheets_connections')
+    .select('last_synced_at')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (!conn) {
+    return NextResponse.json(
+      { error: 'No Google Sheet connected. Connect one first.' },
+      { status: 400 }
+    )
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL
+  const internalKey = process.env.INTERNAL_API_KEY
+
+  if (!appUrl || !internalKey) {
+    console.error('sync-now: missing NEXT_PUBLIC_APP_URL or INTERNAL_API_KEY')
+    return NextResponse.json(
+      { error: 'Server misconfigured — please contact support.' },
+      { status: 500 }
+    )
+  }
+
+  // First sync ever? Do a full history backfill. Otherwise incremental.
+  const fullExport = conn.last_synced_at === null
+
+  try {
+    const res = await fetch(`${appUrl}/api/google-sheets/export`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-internal-key': internalKey,
+      },
+      body: JSON.stringify({
+        user_id: user.id,
+        full_export: fullExport,
+      }),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      console.error(`sync-now: export returned ${res.status}`, text)
+      return NextResponse.json(
+        { error: `Export failed (${res.status}). Please try again shortly.` },
+        { status: 502 }
+      )
+    }
+
+    const data = await res.json()
+    const rows = data?.results?.[0]?.rows_written ?? 0
+
+    return NextResponse.json({
+      ok: true,
+      rows_written: rows,
+      full_export: fullExport,
+    })
+  } catch (err) {
+    console.error('sync-now: fetch failed', err)
+    return NextResponse.json(
+      { error: 'Could not reach the export service. Please try again.' },
+      { status: 502 }
+    )
+  }
+}

--- a/src/components/GoogleSheetsConnect.tsx
+++ b/src/components/GoogleSheetsConnect.tsx
@@ -1,10 +1,12 @@
 'use client'
 // src/components/GoogleSheetsConnect.tsx
 // Google Sheets destination card — rendered on /dashboard/export.
-// Handles: not-connected → OAuth flow → connected state with sheet link + last sync.
+// Handles: not-connected → OAuth flow → connected state with sheet link,
+// last-sync timestamp, Sync Now button, and Disconnect.
 
 import { useState, useEffect } from 'react'
 import { createBrowserClient } from '@supabase/ssr'
+import RotatingCaptionsLoader, { LoaderCaption } from './RotatingCaptionsLoader'
 
 interface SheetsConnection {
   spreadsheet_url: string | null
@@ -14,30 +16,46 @@ interface SheetsConnection {
   email: string
 }
 
+// Captions shown while a sync is in flight. Full-history backfills are slow
+// (thousands of rows → Sheets API batching), so we want the user to know
+// the app hasn't frozen.
+const SYNC_CAPTIONS: LoaderCaption[] = [
+  { icon: '📥', text: 'Gathering your transactions…' },
+  { icon: '🧮', text: 'Sorting by account and date…' },
+  { icon: '📊', text: 'Writing rows to your Google Sheet…' },
+  { icon: '🔗', text: 'Linking categories and merchants…' },
+  { icon: '✨', text: 'Almost done — tidying the last tab…' },
+]
+
 export default function GoogleSheetsConnect() {
   const [connection, setConnection] = useState<SheetsConnection | null>(null)
   const [loading, setLoading] = useState(true)
   const [disconnecting, setDisconnecting] = useState(false)
+  const [syncing, setSyncing] = useState(false)
+  const [syncMessage, setSyncMessage] = useState<
+    { kind: 'success' | 'error'; text: string } | null
+  >(null)
 
   const supabase = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   )
 
+  async function loadConnection() {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) { setLoading(false); return }
+
+    const { data } = await supabase
+      .from('google_sheets_connections')
+      .select('spreadsheet_url, spreadsheet_id, last_synced_at, last_synced_timestamp, email')
+      .eq('user_id', user.id)
+      .maybeSingle()
+
+    setConnection(data ?? null)
+    setLoading(false)
+  }
+
   useEffect(() => {
-    async function loadConnection() {
-      const { data: { user } } = await supabase.auth.getUser()
-      if (!user) { setLoading(false); return }
-
-      const { data } = await supabase
-        .from('google_sheets_connections')
-        .select('spreadsheet_url, spreadsheet_id, last_synced_at, last_synced_timestamp, email')
-        .eq('user_id', user.id)
-        .maybeSingle()
-
-      setConnection(data ?? null)
-      setLoading(false)
-    }
     loadConnection()
 
     // Check for success/error params after OAuth redirect
@@ -54,6 +72,47 @@ export default function GoogleSheetsConnect() {
     await fetch('/api/google-sheets/disconnect', { method: 'POST' })
     setConnection(null)
     setDisconnecting(false)
+  }
+
+  async function handleSyncNow() {
+    setSyncing(true)
+    setSyncMessage(null)
+    try {
+      const res = await fetch('/api/google-sheets/sync-now', { method: 'POST' })
+      const data = await res.json()
+
+      if (!res.ok) {
+        setSyncMessage({
+          kind: 'error',
+          text: data?.error || 'Sync failed. Please try again.',
+        })
+      } else {
+        const rows = data?.rows_written ?? 0
+        const isBackfill = data?.full_export === true
+        if (rows === 0) {
+          setSyncMessage({
+            kind: 'success',
+            text: 'All caught up — no new transactions to sync.',
+          })
+        } else {
+          setSyncMessage({
+            kind: 'success',
+            text: isBackfill
+              ? `Backfill complete — ${rows.toLocaleString()} rows written.`
+              : `Synced ${rows.toLocaleString()} new row${rows === 1 ? '' : 's'}.`,
+          })
+        }
+        // Reload connection to pick up fresh last_synced_at
+        await loadConnection()
+      }
+    } catch {
+      setSyncMessage({
+        kind: 'error',
+        text: 'Could not reach the sync service. Please try again.',
+      })
+    } finally {
+      setSyncing(false)
+    }
   }
 
   if (loading) {
@@ -119,21 +178,55 @@ export default function GoogleSheetsConnect() {
             </div>
           </div>
 
-          <div className="flex gap-2">
+          {/* Sync progress / result */}
+          {syncing && (
+            <RotatingCaptionsLoader
+              active={syncing}
+              variant="card"
+              heading={
+                connection.last_synced_at
+                  ? 'Syncing new transactions…'
+                  : 'Backfilling your full history…'
+              }
+              captions={SYNC_CAPTIONS}
+            />
+          )}
+
+          {!syncing && syncMessage && (
+            <div
+              className={
+                'rounded-lg px-3 py-2 text-xs ' +
+                (syncMessage.kind === 'success'
+                  ? 'bg-green-500/10 text-green-300 border border-green-500/20'
+                  : 'bg-red-500/10 text-red-300 border border-red-500/20')
+              }
+            >
+              {syncMessage.text}
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={handleSyncNow}
+              disabled={syncing}
+              className="flex-1 min-w-[140px] text-center text-sm font-semibold text-navy-950 bg-mint-400 hover:bg-mint-500 disabled:bg-mint-400/40 disabled:cursor-not-allowed transition-colors rounded-lg py-2.5"
+            >
+              {syncing ? 'Syncing…' : 'Sync Now'}
+            </button>
             {connection.spreadsheet_url && (
               <a
                 href={connection.spreadsheet_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex-1 text-center text-sm font-semibold text-white bg-green-600 hover:bg-green-500 transition-colors rounded-lg py-2.5"
+                className="flex-1 min-w-[140px] text-center text-sm font-semibold text-white bg-green-600 hover:bg-green-500 transition-colors rounded-lg py-2.5"
               >
                 Open Sheet ↗
               </a>
             )}
             <button
               onClick={handleDisconnect}
-              disabled={disconnecting}
-              className="text-sm text-slate-400 hover:text-red-400 transition-colors px-3 py-2 rounded-lg border border-navy-700 hover:border-red-400/50"
+              disabled={disconnecting || syncing}
+              className="text-sm text-slate-400 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors px-3 py-2 rounded-lg border border-navy-700 hover:border-red-400/50"
             >
               {disconnecting ? 'Disconnecting…' : 'Disconnect'}
             </button>


### PR DESCRIPTION
## Summary
- Adds a **Sync Now** button to the Google Sheets card on /dashboard/export (matches Lunchflow's UX).
- On first click (last_synced_at = null) it triggers a **full history backfill**. Subsequent clicks are incremental.
- Shows RotatingCaptionsLoader while in flight and a success/error pill when done.
- New session-authed endpoint `/api/google-sheets/sync-now` wraps the existing internal `/api/google-sheets/export`.

Unblocks: Paul's blank sheet — after deploy he can backfill 3,535 transactions himself by pressing the button.

## Test plan
- [ ] Open /dashboard/export — Sync Now button visible on the Sheets card.
- [ ] Click Sync Now — rotating captions cycle, success pill shows "Backfill complete — N rows written."
- [ ] Open the connected sheet — one tab per bank account, all historical rows present.
- [ ] Click Sync Now again — shows "All caught up" or "Synced N new rows".
- [ ] Disconnect + reconnect still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)