### PR TITLE
fix(sheets): paginate DB query + dedup by transaction_id — idempotent export

### DIFF
--- a/src/app/api/google-sheets/export/route.ts
+++ b/src/app/api/google-sheets/export/route.ts
@@ -1,18 +1,26 @@
 // src/app/api/google-sheets/export/route.ts
 //
+// Exports bank_transactions to a user's connected Google Sheet.
+//
 // Two modes:
-//   full_export: true  — writes ALL historical transactions (used on first connect)
-//   full_export: false — appends only transactions newer than last_synced_timestamp (daily cron)
+//   full_export: true  — considers ALL historical transactions (used on first connect)
+//   full_export: false — only considers transactions near/after last_synced_timestamp
+//                         (daily cron / Sync Now button)
+//
+// In BOTH modes, writes are deduplicated against transaction IDs already present
+// in the sheet (column H). This makes the export idempotent — running it twice in
+// a row never produces duplicate rows, and it self-heals gaps from previous runs.
 //
 // Sheet structure: one tab per bank account (account_display_name from bank_connections)
-//   Columns: Date | Description | Merchant | Amount | Category | Type | Recurring | Reference
+//   Columns: Date | Description | Merchant | Amount | Category | Type | Recurring | Transaction ID
 //
-// This endpoint is called:
-//   1. By the OAuth callback (full_export: true) after initial connection
-//   2. By the daily cron /api/cron/google-sheets-sync (full_export: false)
+// Called by:
+//   1. /api/google-sheets/sync-now (user-triggered Sync Now button)
+//   2. /api/cron/google-sheets-sync (daily 6am safety-net cron)
+//   3. triggerSheetsExport helper (post bank-sync)
 
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!
@@ -21,6 +29,18 @@ const INTERNAL_KEY = process.env.INTERNAL_API_KEY ?? ''
 const SHEET_HEADERS = [
   'Date', 'Description', 'Merchant', 'Amount (£)', 'Category', 'Type', 'Recurring', 'Transaction ID',
 ]
+
+// Supabase PostgREST caps selects at 1000 rows by default. Paginate by this size.
+const DB_PAGE_SIZE = 1000
+
+// When running incrementally, how far back to look when re-fetching from the DB.
+// This is a safety overlap — bank syncs sometimes back-date transactions by a day
+// or two after initial settle. Dedup by transaction_id means overlap is harmless.
+const INCREMENTAL_OVERLAP_DAYS = 2
+
+// ---------------------------------------------------------------------------
+// OAuth token refresh
+// ---------------------------------------------------------------------------
 
 async function refreshAccessToken(refreshToken: string): Promise<string | null> {
   const res = await fetch('https://oauth2.googleapis.com/token', {
@@ -38,7 +58,7 @@ async function refreshAccessToken(refreshToken: string): Promise<string | null> 
 }
 
 async function getOrRefreshToken(
-  supabase: any,
+  supabase: SupabaseClient,
   connection: {
     user_id: string
     access_token: string
@@ -47,7 +67,7 @@ async function getOrRefreshToken(
   }
 ): Promise<string | null> {
   const expiry = connection.token_expiry ? new Date(connection.token_expiry) : null
-  const isExpired = !expiry || expiry < new Date(Date.now() + 60_000) // refresh if < 1 min left
+  const isExpired = !expiry || expiry < new Date(Date.now() + 60_000)
 
   if (!isExpired) return connection.access_token
 
@@ -56,7 +76,6 @@ async function getOrRefreshToken(
   const newToken = await refreshAccessToken(connection.refresh_token)
   if (!newToken) return null
 
-  // Update token in DB
   await supabase
     .from('google_sheets_connections')
     .update({
@@ -69,60 +88,23 @@ async function getOrRefreshToken(
   return newToken
 }
 
-async function ensureAccountTab(
-  token: string,
-  spreadsheetId: string,
-  accountName: string,
-  existingSheets: { title: string; sheetId: number }[]
-): Promise<void> {
-  const exists = existingSheets.find(s => s.title === accountName)
-  if (exists) return
-
-  // Add the tab
-  await fetch(`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}:batchUpdate`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      requests: [{ addSheet: { properties: { title: accountName } } }],
-    }),
-  })
-
-  // Write headers on the new tab
-  await appendRows(token, spreadsheetId, accountName, [SHEET_HEADERS])
-}
-
-async function appendRows(
-  token: string,
-  spreadsheetId: string,
-  sheetName: string,
-  rows: (string | number)[][]
-): Promise<void> {
-  if (rows.length === 0) return
-
-  await fetch(
-    `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(sheetName)}!A1:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ values: rows }),
-    }
-  )
-}
+// ---------------------------------------------------------------------------
+// Google Sheets helpers (all check response status — no silent failures)
+// ---------------------------------------------------------------------------
 
 async function getExistingSheets(
   token: string,
   spreadsheetId: string
-): Promise<{ title: string; sheetId: number }[]> {
+): Promise<{ title: string; sheetId: number }[] | null> {
   const res = await fetch(
     `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}?fields=sheets.properties`,
     { headers: { Authorization: `Bearer ${token}` } }
   )
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    console.error(`[sheets-export] getExistingSheets ${res.status}: ${body.slice(0, 300)}`)
+    return null
+  }
   const data = await res.json()
   return (data.sheets ?? []).map((s: { properties: { title: string; sheetId: number } }) => ({
     title: s.properties.title,
@@ -130,7 +112,103 @@ async function getExistingSheets(
   }))
 }
 
-function formatTransaction(tx: {
+async function ensureAccountTab(
+  token: string,
+  spreadsheetId: string,
+  accountName: string,
+  existingSheets: { title: string; sheetId: number }[]
+): Promise<boolean> {
+  const exists = existingSheets.find(s => s.title === accountName)
+  if (exists) return true
+
+  const addRes = await fetch(
+    `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}:batchUpdate`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requests: [{ addSheet: { properties: { title: accountName } } }],
+      }),
+    }
+  )
+  if (!addRes.ok) {
+    const body = await addRes.text().catch(() => '')
+    console.error(`[sheets-export] addSheet "${accountName}" ${addRes.status}: ${body.slice(0, 300)}`)
+    return false
+  }
+
+  // Track the newly-created tab so subsequent lookups on the same run see it.
+  const addData = await addRes.json().catch(() => null)
+  const newSheetId = addData?.replies?.[0]?.addSheet?.properties?.sheetId ?? 0
+  existingSheets.push({ title: accountName, sheetId: newSheetId })
+
+  // Write the header row.
+  const headerOk = await appendRows(token, spreadsheetId, accountName, [SHEET_HEADERS])
+  return headerOk
+}
+
+async function appendRows(
+  token: string,
+  spreadsheetId: string,
+  sheetName: string,
+  rows: (string | number)[][]
+): Promise<boolean> {
+  if (rows.length === 0) return true
+
+  const res = await fetch(
+    `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(sheetName)}!A1:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ values: rows }),
+    }
+  )
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    console.error(`[sheets-export] appendRows "${sheetName}" (${rows.length} rows) ${res.status}: ${body.slice(0, 300)}`)
+    return false
+  }
+  return true
+}
+
+/**
+ * Read column H (Transaction ID) from the given tab and return a Set of IDs
+ * already present in the sheet. Returns null on read failure — callers must
+ * treat null as "unsafe to write" and skip appending, otherwise we'd risk
+ * creating duplicates.
+ */
+async function readExistingTransactionIds(
+  token: string,
+  spreadsheetId: string,
+  tabName: string
+): Promise<Set<string> | null> {
+  const res = await fetch(
+    `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(tabName)}!H:H?majorDimension=COLUMNS`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  )
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    console.error(`[sheets-export] readExistingTransactionIds "${tabName}" ${res.status}: ${body.slice(0, 300)}`)
+    return null
+  }
+  const data = await res.json()
+  // values is an array of columns; with COLUMNS major dim and a single column
+  // request, values[0] is the list of cell values in column H.
+  const col: string[] = data.values?.[0] ?? []
+  const ids = new Set<string>()
+  for (const v of col) {
+    if (v && v !== 'Transaction ID') ids.add(v)
+  }
+  return ids
+}
+
+// ---------------------------------------------------------------------------
+// Transaction fetch (paginated — Supabase's default 1000-row cap would
+// otherwise silently truncate large accounts)
+// ---------------------------------------------------------------------------
+
+type TxRow = {
+  transaction_id: string
   timestamp: string
   description: string | null
   merchant_name: string | null
@@ -139,12 +217,49 @@ function formatTransaction(tx: {
   user_category: string | null
   income_type: string | null
   is_recurring: boolean | null
-  transaction_id: string
-}): (string | number)[] {
+}
+
+async function fetchAllTransactions(
+  supabase: SupabaseClient,
+  userId: string,
+  accountId: string,
+  sinceTimestamp: string | null
+): Promise<TxRow[]> {
+  const all: TxRow[] = []
+  let from = 0
+  while (true) {
+    let q = supabase
+      .from('bank_transactions')
+      .select('transaction_id, timestamp, description, merchant_name, amount, category, user_category, income_type, is_recurring')
+      .eq('user_id', userId)
+      .eq('account_id', accountId)
+      .eq('is_pending', false)
+      .order('timestamp', { ascending: true })
+      .range(from, from + DB_PAGE_SIZE - 1)
+    if (sinceTimestamp) q = q.gte('timestamp', sinceTimestamp)
+
+    const { data, error } = await q
+    if (error) {
+      console.error(`[sheets-export] fetchAllTransactions user=${userId} acct=${accountId}:`, error.message)
+      break
+    }
+    if (!data || data.length === 0) break
+    all.push(...(data as TxRow[]))
+    if (data.length < DB_PAGE_SIZE) break
+    from += DB_PAGE_SIZE
+  }
+  return all
+}
+
+// ---------------------------------------------------------------------------
+// Row formatting
+// ---------------------------------------------------------------------------
+
+function formatTransaction(tx: TxRow): (string | number)[] {
   const date = new Date(tx.timestamp).toLocaleDateString('en-GB') // DD/MM/YYYY
   const description = tx.description ?? ''
   const merchant = tx.merchant_name ?? ''
-  const amount = Number(tx.amount.toFixed(2)) // positive = credit, negative = debit
+  const amount = Number(tx.amount.toFixed(2))
   const category = tx.user_category ?? tx.category ?? ''
   const type = tx.income_type ?? (tx.amount > 0 ? 'Income' : 'Expense')
   const recurring = tx.is_recurring ? 'Yes' : 'No'
@@ -153,8 +268,12 @@ function formatTransaction(tx: {
   return [date, description, merchant, amount, category, type, recurring, ref]
 }
 
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
 export async function POST(req: NextRequest) {
-  // Auth: internal key only (called by cron or callback)
+  // Auth: internal key only (called by cron, callback, or sync-now wrapper)
   const key = req.headers.get('x-internal-key')
   if (key !== INTERNAL_KEY) {
     return NextResponse.json({ error: 'Unauthorised' }, { status: 401 })
@@ -165,7 +284,6 @@ export async function POST(req: NextRequest) {
 
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY)
 
-  // Load connection(s) — either one user or all (for cron)
   let query = supabase.from('google_sheets_connections').select('*')
   if (user_id) query = query.eq('user_id', user_id)
 
@@ -174,7 +292,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ synced: 0 })
   }
 
-  const results: { user_id: string; rows_written: number; error?: string }[] = []
+  const results: { user_id: string; rows_written: number; skipped_tabs?: number; error?: string }[] = []
 
   for (const conn of connections) {
     try {
@@ -184,15 +302,8 @@ export async function POST(req: NextRequest) {
         continue
       }
 
-      // Get all user's bank accounts (one tab per account).
-      //
-      // Status filter: include both 'active' and 'token_expired'. We are only
-      // READING cached transactions out of bank_transactions here — we never
-      // call the bank's API — so an expired refresh token doesn't matter.
-      // Excluding token_expired previously meant a user whose bank reconnect
-      // had lapsed got an empty sheet, even though months of cached
-      // transactions were sitting in the DB. Revoked stays excluded
-      // (the user actively disconnected and presumably wants the data gone).
+      // All bank_connections EXCEPT revoked. Revoked = user deliberately disconnected.
+      // token_expired is fine: we only read cached bank_transactions, never the bank API.
       const { data: bankConns } = await supabase
         .from('bank_connections')
         .select('id, bank_name, account_ids, account_display_names')
@@ -205,10 +316,27 @@ export async function POST(req: NextRequest) {
       }
 
       const existingSheets = await getExistingSheets(token, conn.spreadsheet_id)
+      if (existingSheets === null) {
+        results.push({ user_id: conn.user_id, rows_written: 0, error: 'sheets_metadata_read_failed' })
+        continue
+      }
+
+      // Incremental: fetch rows from (last_synced - overlap) onwards. The sheet-side
+      // dedup (readExistingTransactionIds) catches anything we re-fetch.
+      // Full export: sinceTimestamp = null → pull every transaction for the account.
+      let sinceTimestamp: string | null = null
+      if (!full_export && conn.last_synced_timestamp) {
+        const lowerBound = new Date(
+          new Date(conn.last_synced_timestamp).getTime() - INCREMENTAL_OVERLAP_DAYS * 24 * 60 * 60 * 1000
+        )
+        sinceTimestamp = lowerBound.toISOString()
+      }
+
       let totalRows = 0
+      let skippedTabs = 0
+      let latestTimestampWritten: string | null = conn.last_synced_timestamp ?? null
 
       for (const bank of bankConns) {
-        // Each account_id in the connection gets its own tab
         const accountIds: string[] = bank.account_ids ?? []
         const displayNames: string[] = bank.account_display_names ?? []
 
@@ -218,51 +346,76 @@ export async function POST(req: NextRequest) {
             ? `${bank.bank_name} — ${displayNames[i]}`
             : bank.bank_name
 
-          // Fetch transactions for this account
-          let txQuery = supabase
-            .from('bank_transactions')
-            .select('transaction_id, timestamp, description, merchant_name, amount, category, user_category, income_type, is_recurring')
-            .eq('user_id', conn.user_id)
-            .eq('account_id', accountId)
-            .eq('is_pending', false)
-            .order('timestamp', { ascending: true })
+          // Pull transactions (paginated) for this account.
+          const transactions = await fetchAllTransactions(
+            supabase,
+            conn.user_id,
+            accountId,
+            sinceTimestamp
+          )
+          if (transactions.length === 0) continue
 
-          // Incremental sync: only new transactions
-          if (!full_export && conn.last_synced_timestamp) {
-            txQuery = txQuery.gt('timestamp', conn.last_synced_timestamp)
+          // Make sure the tab (and header row) exist before we try to read column H.
+          const tabOk = await ensureAccountTab(token, conn.spreadsheet_id, tabName, existingSheets)
+          if (!tabOk) {
+            console.error(`[sheets-export] skipping "${tabName}" — could not ensure tab`)
+            skippedTabs++
+            continue
           }
 
-          const { data: transactions } = await txQuery
+          // Dedup by transaction_id. If we can't read the existing IDs, skip
+          // this tab rather than risk writing duplicates.
+          const existingIds = await readExistingTransactionIds(
+            token,
+            conn.spreadsheet_id,
+            tabName
+          )
+          if (existingIds === null) {
+            console.error(`[sheets-export] skipping "${tabName}" — could not read existing transaction IDs`)
+            skippedTabs++
+            continue
+          }
 
-          if (!transactions?.length) continue
+          const newTxs = transactions.filter(tx => !existingIds.has(tx.transaction_id))
+          if (newTxs.length === 0) continue
 
-          await ensureAccountTab(token, conn.spreadsheet_id, tabName, existingSheets)
-
-          const rows = transactions.map(formatTransaction)
-          await appendRows(token, conn.spreadsheet_id, tabName, rows)
+          const rows = newTxs.map(formatTransaction)
+          const appendOk = await appendRows(token, conn.spreadsheet_id, tabName, rows)
+          if (!appendOk) {
+            skippedTabs++
+            continue
+          }
           totalRows += rows.length
 
-          // Track newest timestamp written
-          const newestTs = transactions[transactions.length - 1].timestamp
-          if (!conn.last_synced_timestamp || newestTs > conn.last_synced_timestamp) {
-            conn.last_synced_timestamp = newestTs
+          // Track newest timestamp actually written across all accounts.
+          const newestTs = newTxs[newTxs.length - 1].timestamp
+          if (!latestTimestampWritten || newestTs > latestTimestampWritten) {
+            latestTimestampWritten = newestTs
           }
         }
       }
 
-      // Update sync metadata
+      // Update sync metadata. We only bump last_synced_timestamp forward, never
+      // backwards — this is defensive against a partial-failure run where we
+      // only wrote a subset of accounts.
+      const updates: Record<string, string> = {
+        last_synced_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+      if (latestTimestampWritten && latestTimestampWritten !== conn.last_synced_timestamp) {
+        updates.last_synced_timestamp = latestTimestampWritten
+      }
       await supabase
         .from('google_sheets_connections')
-        .update({
-          last_synced_at: new Date().toISOString(),
-          last_synced_timestamp: conn.last_synced_timestamp,
-          updated_at: new Date().toISOString(),
-        })
+        .update(updates)
         .eq('user_id', conn.user_id)
 
-      results.push({ user_id: conn.user_id, rows_written: totalRows })
+      console.log(
+        `[sheets-export] user=${conn.user_id} wrote=${totalRows} skipped_tabs=${skippedTabs} full=${!!full_export}`
+      )
+      results.push({ user_id: conn.user_id, rows_written: totalRows, skipped_tabs: skippedTabs })
     } catch (err) {
-      console.error(`Sheets export failed for user ${conn.user_id}:`, err)
+      console.error(`[sheets-export] failed for user ${conn.user_id}:`, err)
       results.push({ user_id: conn.user_id, rows_written: 0, error: String(err) })
     }
   }


### PR DESCRIPTION
## Why

Paul's NatWest Premier tab was missing ~1,408 transactions. Root cause: Supabase's PostgREST caps selects at 1000 rows by default, and the export's per-account transaction query never called `.range()`. Any account with >1000 settled transactions was silently truncated. Worse, the endpoint then stamped `last_synced_at` as if the sync had succeeded, so the UI reported success while the sheet was incomplete.

Separately, there was no dedup safety net: if the same transaction_id was already in the sheet, the export would happily write it a second time.

## What

- **Paginate DB reads**: `fetchAllTransactions()` walks the `bank_transactions` table in 1000-row chunks until empty. No more silent truncation.
- **Dedup by transaction_id**: before appending to a tab, read column H (Transaction ID) from the tab, build a `Set<string>`, filter the DB result set against it. Skip any row already present.
- **Fail safe on read failure**: if `readExistingTransactionIds()` errors, SKIP the tab. Better to write nothing than risk duplicates.
- **Error checking on every Sheets API call**: `ensureAccountTab`, `appendRows`, `getExistingSheets`, `readExistingTransactionIds` all now check response status and log the body on failure. Previously failures were silently swallowed.
- **Watermark is now advisory**: correctness comes from sheet-side dedup. The incremental window uses `(last_synced_timestamp - 2 days)` as a lower bound to catch late-settling bank transactions. Partial failures no longer corrupt the watermark — we only bump it forward if we actually wrote something newer.

## Effect

The export is now fully idempotent. Users can click Sync Now as often as they like without producing duplicate rows. After this ships, Paul's existing sheet needs `last_synced_at` + `last_synced_timestamp` reset to NULL, then a single Sync Now click will backfill the missing ~1,408 rows without touching the 2,183 already there.

## Test plan

- [ ] Reset Paul's `google_sheets_connections` watermarks to NULL
- [ ] Click Sync Now → expect ~1,408 new rows in NatWest Premier, 0 in Lloyds, 0–11 in NatWest Business
- [ ] Click Sync Now again → expect 0 rows written (idempotent)