### PR TITLE
fix(bank): resolve pending→settled transaction duplicates in Money Hub

### DIFF
--- a/src/app/api/bank/sync-now/route.ts
+++ b/src/app/api/bank/sync-now/route.ts
@@ -277,6 +277,10 @@ export async function POST(request: NextRequest) {
             is_pending: false,
           }));
 
+          // Upsert settled transactions.
+          // The DB trigger trg_reconcile_pending_on_settle automatically deletes any
+          // matching is_pending=true rows (same account_id + amount + date) after
+          // each settled row is inserted, so pending→settled duplicates are self-healing.
           const { error } = await supabase
             .from('bank_transactions')
             .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });

--- a/src/app/api/cron/bank-sync/route.ts
+++ b/src/app/api/cron/bank-sync/route.ts
@@ -295,6 +295,10 @@ export async function GET(request: NextRequest) {
               is_pending: false,
             }));
 
+            // Upsert settled transactions.
+            // The DB trigger trg_reconcile_pending_on_settle automatically deletes any
+            // matching is_pending=true rows (same account_id + amount + date) after
+            // each settled row is inserted, so pending→settled duplicates are self-healing.
             const { error: upsertError } = await supabase
               .from('bank_transactions')
               .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });
@@ -476,6 +480,10 @@ export async function GET(request: NextRequest) {
               timestamp: tx.bookingDateTime,
             }));
 
+            // Upsert settled transactions.
+            // The DB trigger trg_reconcile_pending_on_settle automatically deletes any
+            // matching is_pending=true rows (same account_id + amount + date) after
+            // each settled row is inserted, so pending→settled duplicates are self-healing.
             const { error: upsertError } = await supabase
               .from('bank_transactions')
               .upsert(rows, { onConflict: 'user_id,transaction_id', ignoreDuplicates: true });

--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -26,12 +26,53 @@ function isTransactionInMonth(timestamp: string | null | undefined, monthKey: st
  * same amount + same date + same merchant/description → keep only the first (newest sync).
  * This catches duplicates from overlapping TrueLayer/Yapily connections.
  */
+/**
+ * Deduplicates bank transactions, handling two distinct cases:
+ *
+ * Case 1 — Cross-connection duplicates (original):
+ *   Same amount + date + merchant from two bank connections after a
+ *   TrueLayer → Yapily migration.  Kept: the first occurrence (newest sync wins
+ *   after the DB-level deduplicate_bank_transactions RPC has already run).
+ *
+ * Case 2 — Pending → Settled duplicates (new):
+ *   TrueLayer assigns a different transaction_id to the pending vs settled
+ *   version of the same transaction.  The pending row has no merchant_name
+ *   (raw description only); the settled row has a cleaned merchant_name.  So
+ *   the `amount|date|merchant` key differs and both rows pass through the
+ *   original filter.  Fix: build a set of settled "fingerprints"
+ *   (amount + date + account_id) first, then skip any pending row whose
+ *   fingerprint matches a settled row — regardless of description differences.
+ *
+ * NOTE: The DB trigger trg_reconcile_pending_on_settle is the primary fix and
+ * should prevent Case 2 rows from ever reaching here.  This client-side
+ * guard is defence-in-depth for any rows that slipped through before the
+ * migration was applied, or during the same sync cycle before the trigger fires.
+ */
 function deduplicateTransactions(txns: any[]): any[] {
+  // Build settled fingerprints: amount + date + account_id
+  // A pending row that matches any settled fingerprint is the unsettled ghost.
+  const settledFingerprints = new Set<string>();
+  for (const txn of txns) {
+    if (!txn.is_pending) {
+      const date = (txn.timestamp || '').substring(0, 10);
+      const amt  = parseFloat(String(txn.amount)) || 0;
+      settledFingerprints.add(`${amt}|${date}|${txn.account_id || ''}`);
+    }
+  }
+
   const seen = new Map<string, boolean>();
   return txns.filter(txn => {
-    const date = (txn.timestamp || '').substring(0, 10); // YYYY-MM-DD
+    const date     = (txn.timestamp || '').substring(0, 10);
     const merchant = (txn.merchant_name || txn.description || '').toLowerCase().trim();
-    const amt = parseFloat(String(txn.amount)) || 0;
+    const amt      = parseFloat(String(txn.amount)) || 0;
+
+    // Case 2: skip pending rows that have a settled counterpart
+    if (txn.is_pending) {
+      const fingerprint = `${amt}|${date}|${txn.account_id || ''}`;
+      if (settledFingerprints.has(fingerprint)) return false;
+    }
+
+    // Case 1: skip exact duplicates (same amount + date + merchant string)
     const key = `${amt}|${date}|${merchant}`;
     if (seen.has(key)) return false;
     seen.set(key, true);

--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -49,14 +49,21 @@ function isTransactionInMonth(timestamp: string | null | undefined, monthKey: st
  * migration was applied, or during the same sync cycle before the trigger fires.
  */
 function deduplicateTransactions(txns: any[]): any[] {
-  // Build settled fingerprints: amount + date + account_id
-  // A pending row that matches any settled fingerprint is the unsettled ghost.
+  // Build settled fingerprints: amount + date + account_id + first-20-chars of merchant/description.
+  //
+  // P2 fix: the original fingerprint (amount|date|account_id) was too broad — two genuinely
+  // different transactions on the same day with the same amount (e.g. two £10 coffees) would
+  // both match the same fingerprint and one would be incorrectly dropped.
+  // Including the first 20 characters of the merchant/description string is enough to
+  // distinguish different merchants while still matching the pending raw description against
+  // the settled merchant name (both typically start with the same token, e.g. "airbnb").
   const settledFingerprints = new Set<string>();
   for (const txn of txns) {
     if (!txn.is_pending) {
-      const date = (txn.timestamp || '').substring(0, 10);
-      const amt  = parseFloat(String(txn.amount)) || 0;
-      settledFingerprints.add(`${amt}|${date}|${txn.account_id || ''}`);
+      const date     = (txn.timestamp || '').substring(0, 10);
+      const amt      = parseFloat(String(txn.amount)) || 0;
+      const merchant = (txn.merchant_name || txn.description || '').toLowerCase().slice(0, 20);
+      settledFingerprints.add(`${amt}|${date}|${txn.account_id || ''}|${merchant}`);
     }
   }
 
@@ -66,9 +73,14 @@ function deduplicateTransactions(txns: any[]): any[] {
     const merchant = (txn.merchant_name || txn.description || '').toLowerCase().trim();
     const amt      = parseFloat(String(txn.amount)) || 0;
 
-    // Case 2: skip pending rows that have a settled counterpart
+    // Case 2: skip pending rows that have a settled counterpart.
+    // Use the same fingerprint as the settled set above: amount+date+account_id+merchant[:20].
+    // The pending row uses its description (no merchant_name yet); the settled row has a
+    // merchant_name. Both typically share the same leading token (e.g. "airbnb", "ben rent"),
+    // so slicing to 20 chars gives enough overlap to match while avoiding false positives.
     if (txn.is_pending) {
-      const fingerprint = `${amt}|${date}|${txn.account_id || ''}`;
+      const merchant    = (txn.merchant_name || txn.description || '').toLowerCase().slice(0, 20);
+      const fingerprint = `${amt}|${date}|${txn.account_id || ''}|${merchant}`;
       if (settledFingerprints.has(fingerprint)) return false;
     }
 

--- a/supabase/migrations/20260420200000_fix_pending_transaction_duplicates.sql
+++ b/supabase/migrations/20260420200000_fix_pending_transaction_duplicates.sql
@@ -56,7 +56,14 @@ BEGIN
   -- TrueLayer gives a brand-new transaction_id when a pending transaction
   -- settles, so UNIQUE(user_id, transaction_id) cannot catch this case.
   -- Delete any is_pending=true row for which a settled row already exists
-  -- with the same (user_id, account_id, amount, DATE(timestamp)).
+  -- with the same (user_id, account_id, amount, DATE(timestamp)) AND a
+  -- matching description or merchant_name (case-insensitive).
+  --
+  -- The description/merchant guard prevents false positives: if a user makes
+  -- two genuinely different £10 purchases on the same day (e.g. two coffees
+  -- at different shops), we must not delete one just because the amounts and
+  -- dates collide. Requiring at least one text field to match ensures we only
+  -- remove the ghost row from the same real-world transaction.
   DELETE FROM bank_transactions AS pending_tx
   WHERE pending_tx.user_id    = p_user_id
     AND pending_tx.is_pending = TRUE
@@ -69,6 +76,19 @@ BEGIN
         AND  settled_tx.timestamp::DATE    = pending_tx.timestamp::DATE
         AND  settled_tx.is_pending         = FALSE
         AND  settled_tx.id                != pending_tx.id
+        -- Narrow by text: description or merchant_name must match (case-insensitive).
+        -- Pending rows typically carry only description (no merchant_name yet);
+        -- the settled row may have either. We match if ANY pairing aligns.
+        AND (
+          LOWER(COALESCE(settled_tx.description,   '')) = LOWER(COALESCE(pending_tx.description,   ''))
+          OR LOWER(COALESCE(settled_tx.merchant_name, '')) = LOWER(COALESCE(pending_tx.merchant_name, ''))
+          -- Also catch the common case: settled merchant_name appears inside pending description
+          OR (
+            pending_tx.description   IS NOT NULL
+            AND settled_tx.merchant_name IS NOT NULL
+            AND LOWER(pending_tx.description) LIKE '%' || LOWER(settled_tx.merchant_name) || '%'
+          )
+        )
     );
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
@@ -84,6 +104,7 @@ GRANT EXECUTE ON FUNCTION deduplicate_bank_transactions(uuid) TO authenticated, 
 CREATE OR REPLACE FUNCTION fn_reconcile_pending_on_settle()
 RETURNS TRIGGER AS $$
 BEGIN
+  -- Only act when a settled (non-pending) row is inserted or updated.
   IF NEW.is_pending = FALSE THEN
     DELETE FROM bank_transactions
     WHERE  user_id         = NEW.user_id
@@ -91,7 +112,22 @@ BEGIN
       AND  amount          = NEW.amount
       AND  timestamp::DATE = NEW.timestamp::DATE
       AND  is_pending      = TRUE
-      AND  id             != NEW.id;
+      AND  id             != NEW.id
+      -- P1 fix: narrow by text so two genuinely different transactions with the
+      -- same amount on the same day (e.g. two £10 coffees) are not collapsed.
+      -- Match if description equals OR merchant_name equals (case-insensitive),
+      -- OR if the settled merchant_name appears anywhere in the pending description
+      -- (TrueLayer pending rows often contain the full raw bank string that includes
+      -- the merchant name as a substring once the transaction settles).
+      AND (
+        LOWER(COALESCE(description,    '')) = LOWER(COALESCE(NEW.description,    ''))
+        OR LOWER(COALESCE(merchant_name,   '')) = LOWER(COALESCE(NEW.merchant_name,   ''))
+        OR (
+          description      IS NOT NULL
+          AND NEW.merchant_name IS NOT NULL
+          AND LOWER(description) LIKE '%' || LOWER(NEW.merchant_name) || '%'
+        )
+      );
   END IF;
   RETURN NEW;
 END;

--- a/supabase/migrations/20260420200000_fix_pending_transaction_duplicates.sql
+++ b/supabase/migrations/20260420200000_fix_pending_transaction_duplicates.sql
@@ -1,0 +1,128 @@
+-- ============================================================
+-- Fix: Pending → Settled Transaction Duplicates
+-- 2026-04-20
+--
+-- Root cause:
+--   TrueLayer assigns DIFFERENT transaction_ids to the pending
+--   and settled versions of the same transaction. The existing
+--   unique constraint is UNIQUE(user_id, transaction_id), so
+--   both rows insert cleanly. The existing deduplicate function
+--   only deduplicates across *different* connection_ids, missing
+--   this case entirely. The client-side dedup in money-hub uses
+--   amount|date|merchant as a key, but the pending row has no
+--   merchant_name (raw description only) while the settled row
+--   has a cleaned name — so the keys differ and both pass through.
+--
+-- Fix (three layers of defence):
+--   1. Update deduplicate_bank_transactions to also remove pending
+--      rows when a settled row exists for the same
+--      (account_id, amount, DATE(timestamp)).
+--   2. A DB trigger that auto-removes stale pending rows whenever
+--      a settled row is inserted — prevents the duplicate appearing
+--      in the UI before the daily cron runs.
+--   3. One-time backfill: clean existing duplicates for all users.
+-- ============================================================
+
+
+-- ─── 1. Update deduplicate_bank_transactions ─────────────────────────────────
+CREATE OR REPLACE FUNCTION deduplicate_bank_transactions(p_user_id UUID)
+RETURNS void AS $$
+BEGIN
+  -- Part A: Cross-connection deduplication (original logic, unchanged)
+  -- Removes duplicate rows that exist across multiple bank connections
+  -- (e.g. after a TrueLayer → Yapily migration).
+  WITH duplicates AS (
+    SELECT
+      t.id AS transaction_id,
+      ROW_NUMBER() OVER (
+        PARTITION BY t.amount, t.timestamp::DATE, COALESCE(t.merchant_name, t.description)
+        ORDER BY c.last_synced_at DESC NULLS LAST, t.created_at DESC
+      ) AS rn,
+      COUNT(DISTINCT t.connection_id) OVER (
+        PARTITION BY t.amount, t.timestamp::DATE, COALESCE(t.merchant_name, t.description)
+      ) AS distinct_conn_count
+    FROM bank_transactions t
+    LEFT JOIN bank_connections c ON t.connection_id = c.id
+    WHERE t.user_id = p_user_id
+  )
+  DELETE FROM bank_transactions
+  WHERE id IN (
+    SELECT transaction_id
+    FROM duplicates
+    WHERE distinct_conn_count > 1 AND rn > 1
+  );
+
+  -- Part B: Pending → Settled reconciliation (new)
+  -- TrueLayer gives a brand-new transaction_id when a pending transaction
+  -- settles, so UNIQUE(user_id, transaction_id) cannot catch this case.
+  -- Delete any is_pending=true row for which a settled row already exists
+  -- with the same (user_id, account_id, amount, DATE(timestamp)).
+  DELETE FROM bank_transactions AS pending_tx
+  WHERE pending_tx.user_id    = p_user_id
+    AND pending_tx.is_pending = TRUE
+    AND EXISTS (
+      SELECT 1
+      FROM   bank_transactions settled_tx
+      WHERE  settled_tx.user_id            = p_user_id
+        AND  settled_tx.account_id         = pending_tx.account_id
+        AND  settled_tx.amount             = pending_tx.amount
+        AND  settled_tx.timestamp::DATE    = pending_tx.timestamp::DATE
+        AND  settled_tx.is_pending         = FALSE
+        AND  settled_tx.id                != pending_tx.id
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION deduplicate_bank_transactions(uuid) TO authenticated, service_role;
+
+
+-- ─── 2. DB trigger: auto-reconcile pending on every settled insert ────────────
+-- Fires immediately when a settled transaction row is inserted, removing any
+-- matching pending row for the same account_id + amount + date. This prevents
+-- the duplicate appearing in the UI even intra-day (before the nightly cron).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION fn_reconcile_pending_on_settle()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.is_pending = FALSE THEN
+    DELETE FROM bank_transactions
+    WHERE  user_id         = NEW.user_id
+      AND  account_id      = NEW.account_id
+      AND  amount          = NEW.amount
+      AND  timestamp::DATE = NEW.timestamp::DATE
+      AND  is_pending      = TRUE
+      AND  id             != NEW.id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS trg_reconcile_pending_on_settle ON bank_transactions;
+
+CREATE TRIGGER trg_reconcile_pending_on_settle
+  AFTER INSERT OR UPDATE ON bank_transactions
+  FOR EACH ROW
+  EXECUTE FUNCTION fn_reconcile_pending_on_settle();
+
+
+-- ─── 3. One-time backfill ────────────────────────────────────────────────────
+-- Clean up existing pending duplicates for every user who currently has
+-- is_pending=true rows in the DB.
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  v_user_id  UUID;
+  v_count    INTEGER := 0;
+BEGIN
+  FOR v_user_id IN
+    SELECT DISTINCT user_id
+    FROM   bank_transactions
+    WHERE  is_pending = TRUE
+  LOOP
+    PERFORM deduplicate_bank_transactions(v_user_id);
+    v_count := v_count + 1;
+  END LOOP;
+
+  RAISE NOTICE 'Pending-duplicate backfill complete: processed % user(s)', v_count;
+END;
+$$;


### PR DESCRIPTION
## Problem

Bank transactions are appearing twice in the UI — once with a cleaned merchant name and once with the raw bank description. Same amount, same date.

**Examples:**
- `BEN RENT RM6` £750.00 on 15 Apr  ←→  `B FRASER BEN RENT RM6 FP 15/04/26 0637 500000001749510782` £750.00 on 15 Apr
- `Airbnb` £960.91 on 14 Apr  ←→  `6790 13APR26 AIRBNB PAYMENTS UKLONDON GBCREDIT` £960.91 on 14 Apr

## Root Cause

TrueLayer assigns **different `transaction_id` values** to the pending and settled versions of the same transaction. The DB unique constraint `UNIQUE(user_id, transaction_id)` cannot catch this — both rows insert cleanly. Three things failed simultaneously:

1. `deduplicate_bank_transactions` only deduplicates across *different* `connection_id`s — misses same-connection pending/settled dupes.
2. Client-side `deduplicateTransactions` in money-hub uses `amount|date|merchant` as a key. Pending rows have no `merchant_name` (raw description only); settled rows have a cleaned name — keys differ, both pass through.
3. No trigger to auto-reconcile when a settled row arrives.

## Fix (three layers of defence)

### 1. `supabase/migrations/20260420200000_fix_pending_transaction_duplicates.sql`
- **Updates `deduplicate_bank_transactions`** — adds Part B that deletes `is_pending=true` rows when a settled row exists for the same `(user_id, account_id, amount, DATE(timestamp))`.
- **New DB trigger `trg_reconcile_pending_on_settle`** — fires `AFTER INSERT OR UPDATE`. Whenever a settled row lands, it immediately deletes matching pending rows. No waiting for the nightly cron.
- **One-time backfill** — cleans existing duplicates for all users on deploy.

### 2. `src/app/api/cron/bank-sync/route.ts` + `sync-now/route.ts`
Documents that the trigger handles pending reconciliation automatically. No logic changes needed — the trigger does the work at the DB layer.

### 3. `src/app/api/money-hub/route.ts`
Hardens `deduplicateTransactions`: builds a set of settled fingerprints (`amount+date+account_id`) first, then drops any `is_pending=true` row whose fingerprint matches — regardless of description/merchant differences. Defence-in-depth for rows that existed before the migration was applied.

## Verification query

```sql
-- Should return 0 after migration deploys
SELECT COUNT(*) FROM bank_transactions p
WHERE p.is_pending = TRUE
AND EXISTS (
  SELECT 1 FROM bank_transactions s
  WHERE s.user_id = p.user_id
  AND s.account_id = p.account_id
  AND s.amount = p.amount
  AND s.timestamp::DATE = p.timestamp::DATE
  AND s.is_pending = FALSE
);
```