### PR TITLE
feat(money-hub): transaction search bar + category badges in drill-down modal

### DIFF
--- a/src/app/api/cron/contract-expiry-alerts/route.ts
+++ b/src/app/api/cron/contract-expiry-alerts/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { sendContractEndAlert } from '@/lib/email/contract-end-alerts';
 import { canSendEmail } from '@/lib/email-rate-limit';
+// NOTE: we must insert into `tasks` after every successful send so that
+// canSendEmail()'s query correctly counts this send toward the daily cap.
 
 export const maxDuration = 60;
 
@@ -212,6 +214,14 @@ export async function GET(request: NextRequest) {
           await updateFilter.eq('subscription_id', contract.subscriptionId);
         }
 
+        // Record the send so canSendEmail() counts it toward today's cap
+        await supabase.from('tasks').insert({
+          user_id: userId,
+          type: 'contract_expiry_alert',
+          title: `Contract expiry alert: ${contract.providerName} (${threshold}d)`,
+          description: `${threshold}d expiry alert sent for ${contract.providerName}`,
+          status: 'completed',
+        });
         emailsSent++;
       }
     }

--- a/src/app/api/cron/contract-expiry/route.ts
+++ b/src/app/api/cron/contract-expiry/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { sendContractEndAlert } from '@/lib/email/contract-end-alerts';
 import { canSendEmail } from '@/lib/email-rate-limit';
+// NOTE: we must insert into `tasks` after every successful send so that
+// canSendEmail()'s query correctly counts this send toward the daily cap.
 
 export const maxDuration = 60;
 
@@ -211,6 +213,14 @@ export async function GET(request: NextRequest) {
             .eq('user_id', userId)
             .eq('alert_type', alertType)
             .eq('alert_channel', 'email');
+          // Record the send so canSendEmail() counts it toward today's cap
+          await supabase.from('tasks').insert({
+            user_id: userId,
+            type: 'contract_end_alert',
+            title: `Contract end alert: ${sub.provider_name} (${window}d)`,
+            description: `${window}d contract end alert sent for ${sub.provider_name} — £${monthlyAmount.toFixed(2)}/mo`,
+            status: 'completed',
+          });
           emailsSent++;
         }
       }

--- a/src/app/api/cron/overcharge-assessment/route.ts
+++ b/src/app/api/cron/overcharge-assessment/route.ts
@@ -3,6 +3,8 @@ import { createClient } from '@supabase/supabase-js';
 import { runAssessment } from '@/lib/overcharge-engine';
 import { sendOverchargeAlert } from '@/lib/email/overcharge-alerts';
 import { canSendEmail } from '@/lib/email-rate-limit';
+// NOTE: we must insert into `tasks` after every successful send so that
+// canSendEmail()'s query correctly counts this send toward the daily cap.
 
 export const maxDuration = 120;
 
@@ -94,14 +96,24 @@ export async function GET(request: NextRequest) {
         .single();
 
       if (profile && ['essential', 'pro'].includes(profile.subscription_tier || '')) {
-        const allowed = await canSendEmail(supabase, userId, 'overcharge_alert');
-        if (allowed && highScore.length > 0) {
+        const rateCheck = await canSendEmail(supabase, userId, 'overcharge_alert');
+        if (rateCheck.allowed && highScore.length > 0) {
           const sent = await sendOverchargeAlert(
             profile.email,
             profile.name || 'there',
             assessments.filter(a => a.overchargeScore >= 40) // Include medium+ in email
           );
-          if (sent) totalEmails++;
+          if (sent) {
+            // Record the send so canSendEmail() counts it toward today's cap
+            await supabase.from('tasks').insert({
+              user_id: userId,
+              type: 'overcharge_alert',
+              title: `Overcharge alert: ${highScore.length} item${highScore.length === 1 ? '' : 's'}`,
+              description: `Overcharge assessment email sent — top score: ${highScore[0]?.overchargeScore ?? 0}/100`,
+              status: 'completed',
+            });
+            totalEmails++;
+          }
         }
       }
     } catch (err) {

--- a/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
+++ b/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
@@ -1,7 +1,32 @@
-import { useState, useEffect } from 'react';
-import { X, Search, ChevronDown, CheckCircle2, Loader2, ArrowRight } from 'lucide-react';
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { X, Search, ChevronDown, Loader2 } from 'lucide-react';
 import { fmtNum } from '@/lib/format';
-import { cleanMerchantName } from '@/lib/merchant-utils';
+import { CATEGORIES, USER_SELECTABLE_CATEGORIES } from '@/lib/categories';
+
+// ── Canonical category lookup ─────────────────────────────────────────────────
+const CAT_MAP = Object.fromEntries(CATEGORIES.map(c => [c.id, c]));
+
+function getCatDisplay(id: string | null | undefined): { label: string; emoji: string } {
+  if (!id) return { label: 'Uncategorised', emoji: '📋' };
+  const found = CAT_MAP[id];
+  return found
+    ? { label: found.label, emoji: found.emoji }
+    : { label: id.replace(/_/g, ' '), emoji: '📋' };
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+interface Transaction {
+  id: string;
+  merchant_name?: string;
+  description?: string;
+  amount: number;
+  category?: string;
+  timestamp: string;
+  account_id?: string;
+  kind?: string;
+}
 
 interface CategoryDrillDownModalProps {
   isOpen: boolean;
@@ -13,31 +38,70 @@ interface CategoryDrillDownModalProps {
   onRecategorised: () => void;
 }
 
-const ALL_CATEGORIES = [
-  'bills', 'broadband', 'cash', 'charity', 'childcare', 'council_tax', 'credit',
-  'eating_out', 'education', 'energy', 'fees', 'fitness', 'food', 'fuel',
-  'gambling', 'groceries', 'healthcare', 'insurance', 'loans', 'mobile',
-  'mortgage', 'motoring', 'other', 'parking', 'pets', 'professional',
-  'property_management', 'shopping', 'software', 'streaming', 'transport',
-  'transfers', 'travel', 'utility', 'water',
-];
-
-export default function CategoryDrillDownModal({ isOpen, onClose, category, incomeType, searchQuery, selectedMonth, onRecategorised }: CategoryDrillDownModalProps) {
-  const [data, setData] = useState<{ transactions: any[]; merchants: any[]; totalSpent: number } | null>(null);
+// ── Component ─────────────────────────────────────────────────────────────────
+export default function CategoryDrillDownModal({
+  isOpen,
+  onClose,
+  category,
+  incomeType,
+  searchQuery,
+  selectedMonth,
+  onRecategorised,
+}: CategoryDrillDownModalProps) {
+  const [data, setData] = useState<{ transactions: Transaction[]; merchants: any[]; totalSpent: number } | null>(null);
   const [loading, setLoading] = useState(false);
-  const [recatDropdown, setRecatDropdown] = useState<string | null>(null);
+  const [recatDropdown, setRecatDropdown] = useState<string | null>(null); // transaction id
   const [merchantRecatIdx, setMerchantRecatIdx] = useState<number | null>(null);
   const [recatLoading, setRecatLoading] = useState(false);
 
+  // In-modal transaction search
+  const [txnSearch, setTxnSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Debounce the in-modal search (300 ms)
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(txnSearch), 300);
+    return () => clearTimeout(t);
+  }, [txnSearch]);
+
+  // Reset local state when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setTxnSearch('');
+      setDebouncedSearch('');
+      setMobileSearchOpen(false);
+      setRecatDropdown(null);
+      setMerchantRecatIdx(null);
+    }
+  }, [isOpen]);
+
+  // Load transactions whenever the modal opens or filters change
   useEffect(() => {
     if (isOpen && (category || incomeType || searchQuery)) {
       loadData();
     } else {
       setData(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, category, incomeType, searchQuery, selectedMonth]);
 
-  const loadData = async () => {
+  // Close dropdowns when clicking outside
+  useEffect(() => {
+    if (!recatDropdown && merchantRecatIdx === null) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('[data-recat-dropdown]')) {
+        setRecatDropdown(null);
+        setMerchantRecatIdx(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [recatDropdown, merchantRecatIdx]);
+
+  const loadData = useCallback(async () => {
     setLoading(true);
     try {
       const monthParam = selectedMonth ? `&month=${selectedMonth}` : '';
@@ -50,12 +114,13 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
       const d = await res.json();
       setData(d);
     } catch {
-      // silent
+      // silent — network errors leave stale data in place
     }
     setLoading(false);
-  };
+  }, [category, incomeType, searchQuery, selectedMonth]);
 
-  const handleRecategorise = async (merchantPattern: string, newCategory: string) => {
+  // ── Recategorise: merchant pattern (applies to all matching) ─────────────
+  const handleMerchantRecategorise = async (merchantPattern: string, newCategory: string) => {
     setRecatLoading(true);
     try {
       await fetch('/api/money-hub/recategorise', {
@@ -78,45 +143,114 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
     setRecatLoading(false);
   };
 
+  // ── Recategorise: single transaction by ID ───────────────────────────────
+  const handleTxnRecategorise = async (txnId: string, newCategory: string) => {
+    setRecatLoading(true);
+    try {
+      await fetch('/api/money-hub/recategorise', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ transactionId: txnId, newCategory }),
+      });
+      // Optimistic local update so the badge reflects the new category immediately
+      setData(prev =>
+        prev
+          ? {
+              ...prev,
+              transactions: prev.transactions.map(t =>
+                t.id === txnId ? { ...t, category: newCategory } : t,
+              ),
+            }
+          : prev,
+      );
+      onRecategorised();
+    } catch {
+      // silent
+    }
+    setRecatDropdown(null);
+    setRecatLoading(false);
+  };
+
   if (!isOpen || !(category || incomeType || searchQuery)) return null;
 
-  let displayTitle = '';
-  if (searchQuery) displayTitle = `Search: "${searchQuery}"`;
-  else displayTitle = (incomeType || category!).replace(/_/g, ' ');
+  // ── Client-side filter for the in-modal search ───────────────────────────
+  const filteredTxns = (data?.transactions ?? []).filter(txn => {
+    if (!debouncedSearch) return true;
+    // Strip leading £ so "£750" and "750" both match
+    const q = debouncedSearch.toLowerCase().replace(/^£/, '').trim();
+    const merchant = (txn.merchant_name ?? '').toLowerCase();
+    const desc = (txn.description ?? '').toLowerCase();
+    const amt = String(Math.abs(txn.amount ?? 0));
+    const catId = (txn.category ?? '').toLowerCase().replace(/_/g, ' ');
+    const catLabel = getCatDisplay(txn.category).label.toLowerCase();
+    return (
+      merchant.includes(q) ||
+      desc.includes(q) ||
+      amt.includes(q) ||
+      catId.includes(q) ||
+      catLabel.includes(q)
+    );
+  });
+
+  const displayTitle = searchQuery
+    ? `Search: "${searchQuery}"`
+    : (incomeType || category!).replace(/_/g, ' ');
+
+  const hasTransactions = (data?.transactions.length ?? 0) > 0;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
       <div className="absolute inset-0 bg-navy-950/80 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Modal panel */}
       <div className="relative bg-navy-900 border border-navy-700 rounded-2xl w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl">
+        {/* ── Header ──────────────────────────────────────────────────── */}
         <div className="flex items-center justify-between p-6 border-b border-navy-800">
           <div>
             <h2 className="text-xl font-bold text-white capitalize">{displayTitle}</h2>
-            <p className="text-slate-400 text-sm mt-1">{selectedMonth ? new Date(`${selectedMonth}-01`).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }) : 'This month'}</p>
+            <p className="text-slate-400 text-sm mt-1">
+              {selectedMonth
+                ? new Date(`${selectedMonth}-01`).toLocaleDateString('en-GB', {
+                    month: 'long',
+                    year: 'numeric',
+                  })
+                : 'This month'}
+            </p>
           </div>
-          <button onClick={onClose} className="text-slate-500 hover:text-white p-2 rounded-lg hover:bg-navy-800 transition-colors">
+          <button
+            onClick={onClose}
+            className="text-slate-500 hover:text-white p-2 rounded-lg hover:bg-navy-800 transition-colors"
+          >
             <X className="h-5 w-5" />
           </button>
         </div>
 
+        {/* ── Body ────────────────────────────────────────────────────── */}
         <div className="p-6 overflow-y-auto flex-1 custom-scrollbar">
           {loading ? (
             <div className="flex items-center justify-center py-20">
               <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
             </div>
-          ) : !data || data.transactions.length === 0 ? (
+          ) : !hasTransactions ? (
             <div className="text-center py-20">
               <p className="text-slate-400">No transactions found for this category.</p>
             </div>
           ) : (
             <div className="space-y-8">
-              {/* TOP MERCHANTS SUMMARY */}
+              {/* ── Top Merchants ─────────────────────────────────────── */}
               <div>
-                <p className="text-xs text-slate-500 uppercase tracking-wider mb-4 font-semibold">Top Merchants</p>
+                <p className="text-xs text-slate-500 uppercase tracking-wider mb-4 font-semibold">
+                  Top Merchants
+                </p>
                 <div className="space-y-3">
-                  {data.merchants.slice(0, 5).map((m, idx) => (
-                    <div key={m.merchant} className="bg-navy-950/50 rounded-xl p-4 flex items-center justify-between group relative">
+                  {data!.merchants.slice(0, 5).map((m, idx) => (
+                    <div
+                      key={m.merchant}
+                      className="bg-navy-950/50 rounded-xl p-4 flex items-center justify-between group relative"
+                    >
                       <div className="flex items-center gap-3">
-                        <div className="h-10 w-10 rounded-full bg-navy-800 flex items-center justify-center border border-navy-700 font-bold text-white uppercase">
+                        <div className="h-10 w-10 rounded-full bg-navy-800 flex items-center justify-center border border-navy-700 font-bold text-white uppercase text-sm">
                           {m.merchant.substring(0, 2)}
                         </div>
                         <div>
@@ -126,28 +260,34 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                       </div>
                       <div className="text-right">
                         <p className="text-white font-bold">£{fmtNum(m.total)}</p>
-                        <button 
-                          onClick={() => setMerchantRecatIdx(merchantRecatIdx === idx ? null : idx)}
+                        <button
+                          onClick={() =>
+                            setMerchantRecatIdx(merchantRecatIdx === idx ? null : idx)
+                          }
                           className="text-[10px] text-purple-400 hover:text-purple-300 transition-colors"
                         >
                           Recategorise Rule
                         </button>
                       </div>
-                      
+
                       {merchantRecatIdx === idx && (
-                        <div className="absolute top-16 right-0 w-48 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
+                        <div
+                          data-recat-dropdown
+                          className="absolute top-16 right-0 w-56 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden"
+                        >
                           <div className="p-2 border-b border-navy-700 bg-navy-900/50">
-                            <p className="text-xs text-slate-400 font-medium">Reassign to...</p>
+                            <p className="text-xs text-slate-400 font-medium">Reassign all to…</p>
                           </div>
                           <div className="max-h-60 overflow-y-auto custom-scrollbar p-1">
-                            {ALL_CATEGORIES.map(c => (
+                            {USER_SELECTABLE_CATEGORIES.map(cat => (
                               <button
-                                key={c}
-                                onClick={() => handleRecategorise(m.merchant, c)}
+                                key={cat.id}
+                                onClick={() => handleMerchantRecategorise(m.merchant, cat.id)}
                                 disabled={recatLoading}
-                                className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
+                                className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded flex items-center gap-2 disabled:opacity-50 transition-colors"
                               >
-                                {c.replace(/_/g, ' ')}
+                                <span>{cat.emoji}</span>
+                                <span>{cat.label}</span>
                               </button>
                             ))}
                           </div>
@@ -158,49 +298,184 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                 </div>
               </div>
 
-              {/* INDIVIDUAL TRANSACTIONS */}
+              {/* ── Transactions ──────────────────────────────────────── */}
               <div>
-                <p className="text-xs text-slate-500 uppercase tracking-wider mb-4 font-semibold">Transactions</p>
-                <div className="bg-navy-950/20 rounded-xl border border-navy-800 divide-y divide-navy-800">
-                  {data.transactions.map((txn, idx) => {
-                    const dt = new Date(txn.timestamp);
-                    const isRecatOpen = recatDropdown === txn.id;
-                    return (
-                      <div key={txn.id || idx} className="p-4 flex items-center justify-between group relative">
-                        <div>
-                          <p className="text-white text-sm font-medium">{txn.merchant_name || txn.description}</p>
-                          <p className="text-slate-500 text-xs mt-0.5">{dt.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}</p>
-                        </div>
-                        <div className="text-right">
-                          <p className="text-white text-sm font-medium">£{fmtNum(Math.abs(txn.amount))}</p>
-                          <button 
-                            onClick={() => setRecatDropdown(isRecatOpen ? null : txn.id)}
-                            className="text-[10px] text-slate-500 hover:text-purple-400 transition-colors"
-                          >
-                            Change category
-                          </button>
-                        </div>
-
-                        {isRecatOpen && (
-                          <div className="absolute top-12 right-4 w-48 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
-                            <div className="max-h-60 overflow-y-auto custom-scrollbar p-1">
-                              {ALL_CATEGORIES.map(c => (
-                                <button
-                                  key={c}
-                                  onClick={() => handleRecategorise(cleanMerchantName(txn.description || ''), c)}
-                                  disabled={recatLoading}
-                                  className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
-                                >
-                                  {c.replace(/_/g, ' ')}
-                                </button>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
+                {/* Section header + mobile search toggle */}
+                <div className="flex items-center justify-between mb-3">
+                  <p className="text-xs text-slate-500 uppercase tracking-wider font-semibold">
+                    Transactions
+                    {debouncedSearch && (
+                      <span className="ml-2 normal-case text-slate-600 font-normal">
+                        {filteredTxns.length} of {data!.transactions.length}
+                      </span>
+                    )}
+                  </p>
+                  {/* Mobile: icon toggles the search bar */}
+                  <button
+                    className="sm:hidden text-slate-400 hover:text-mint-400 p-1 rounded transition-colors"
+                    onClick={() => {
+                      setMobileSearchOpen(v => !v);
+                      if (!mobileSearchOpen) {
+                        setTimeout(() => searchInputRef.current?.focus(), 80);
+                      }
+                    }}
+                    aria-label={mobileSearchOpen ? 'Close search' : 'Search transactions'}
+                  >
+                    {mobileSearchOpen ? (
+                      <X className="h-4 w-4" />
+                    ) : (
+                      <Search className="h-4 w-4" />
+                    )}
+                  </button>
                 </div>
+
+                {/* Search input — always visible on ≥sm, toggled on mobile */}
+                <div className={`mb-4 relative ${mobileSearchOpen ? 'block' : 'hidden sm:block'}`}>
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <Search className="h-4 w-4 text-slate-500" />
+                  </div>
+                  <input
+                    ref={searchInputRef}
+                    type="text"
+                    value={txnSearch}
+                    onChange={e => setTxnSearch(e.target.value)}
+                    placeholder="Filter by merchant, amount (e.g. £50), or category…"
+                    className="w-full bg-navy-950/60 border border-navy-700 rounded-xl pl-9 pr-9 py-2 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-mint-400/50 focus:ring-1 focus:ring-mint-400/30 transition-all"
+                  />
+                  {txnSearch && (
+                    <button
+                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-slate-500 hover:text-white transition-colors"
+                      onClick={() => {
+                        setTxnSearch('');
+                        searchInputRef.current?.focus();
+                      }}
+                      aria-label="Clear search"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+
+                {/* Transaction list / empty state */}
+                {filteredTxns.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center py-10 text-slate-400 text-sm bg-navy-950/20 rounded-xl border border-navy-800">
+                    <Search className="h-6 w-6 mb-2 text-slate-600" />
+                    <p>No transactions match your search</p>
+                    <button
+                      onClick={() => setTxnSearch('')}
+                      className="mt-2 text-xs text-mint-400 hover:text-mint-300 transition-colors"
+                    >
+                      Clear filter
+                    </button>
+                  </div>
+                ) : (
+                  <div className="bg-navy-950/20 rounded-xl border border-navy-800 divide-y divide-navy-800">
+                    {filteredTxns.map((txn, idx) => {
+                      const dt = new Date(txn.timestamp);
+                      const isRecatOpen = recatDropdown === txn.id;
+                      const catDisplay = getCatDisplay(txn.category);
+                      const isIncome = (txn.amount ?? 0) > 0;
+
+                      return (
+                        <div
+                          key={txn.id ?? idx}
+                          className="p-4 flex items-center gap-3 group relative"
+                        >
+                          {/* Merchant + date */}
+                          <div className="flex-1 min-w-0">
+                            <p className="text-white text-sm font-medium truncate">
+                              {txn.merchant_name ?? txn.description}
+                            </p>
+                            <p className="text-slate-500 text-xs mt-0.5">
+                              {dt.toLocaleDateString('en-GB', {
+                                day: 'numeric',
+                                month: 'short',
+                              })}
+                            </p>
+                          </div>
+
+                          {/* Category badge — desktop (hidden on mobile, shown below amount) */}
+                          <button
+                            data-recat-dropdown
+                            onClick={() =>
+                              setRecatDropdown(isRecatOpen ? null : txn.id)
+                            }
+                            title="Click to change category"
+                            className="hidden sm:inline-flex items-center gap-1 px-2 py-1 rounded-full text-[11px] bg-navy-800 border border-navy-700 text-slate-300 hover:border-mint-400/40 hover:text-mint-300 transition-all whitespace-nowrap shrink-0"
+                          >
+                            <span>{catDisplay.emoji}</span>
+                            <span>{catDisplay.label}</span>
+                            <ChevronDown className="h-3 w-3 text-slate-500" />
+                          </button>
+
+                          {/* Amount + mobile category */}
+                          <div className="text-right shrink-0">
+                            <p
+                              className={`text-sm font-medium ${
+                                isIncome ? 'text-mint-400' : 'text-white'
+                              }`}
+                            >
+                              {isIncome ? '+' : ''}£{fmtNum(Math.abs(txn.amount ?? 0))}
+                            </p>
+                            {/* Mobile category badge (tap to recategorise) */}
+                            <button
+                              data-recat-dropdown
+                              onClick={() =>
+                                setRecatDropdown(isRecatOpen ? null : txn.id)
+                              }
+                              className="sm:hidden inline-flex items-center gap-0.5 mt-0.5 text-[10px] text-slate-500 hover:text-purple-400 transition-colors"
+                            >
+                              <span>{catDisplay.emoji}</span>
+                              <span className="max-w-[72px] truncate">{catDisplay.label}</span>
+                            </button>
+                          </div>
+
+                          {/* Category change dropdown */}
+                          {isRecatOpen && (
+                            <div
+                              data-recat-dropdown
+                              className="absolute top-full right-0 mt-1 w-56 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden"
+                            >
+                              <div className="p-2 border-b border-navy-700 bg-navy-900/50 flex items-center justify-between">
+                                <p className="text-xs text-slate-400 font-medium">
+                                  Change category
+                                </p>
+                                <span className="text-[10px] text-slate-500">
+                                  This transaction only
+                                </span>
+                              </div>
+                              <div className="max-h-60 overflow-y-auto custom-scrollbar p-1">
+                                {USER_SELECTABLE_CATEGORIES.map(cat => {
+                                  const isCurrent = cat.id === txn.category;
+                                  return (
+                                    <button
+                                      key={cat.id}
+                                      onClick={() =>
+                                        handleTxnRecategorise(txn.id, cat.id)
+                                      }
+                                      disabled={recatLoading || isCurrent}
+                                      className={`w-full text-left px-3 py-2 text-sm rounded flex items-center gap-2 transition-colors ${
+                                        isCurrent
+                                          ? 'text-mint-400 bg-mint-400/10 cursor-default'
+                                          : 'text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 disabled:opacity-50'
+                                      }`}
+                                    >
+                                      <span>{cat.emoji}</span>
+                                      <span className="flex-1">{cat.label}</span>
+                                      {isCurrent && (
+                                        <span className="text-[10px] text-mint-400">✓</span>
+                                      )}
+                                    </button>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/src/app/dashboard/money-hub/SpendingPanel.tsx
+++ b/src/app/dashboard/money-hub/SpendingPanel.tsx
@@ -3,8 +3,8 @@
 import { fmtNum } from '@/lib/format';
 import { Lock, FileText, BarChart3 } from 'lucide-react';
 import Link from 'next/link';
-import { useState } from 'react';
-import { ChevronDown, ChevronUp, Search } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
 import CategoryDrillDownModal from './CategoryDrillDownModal';
 
 const CATEGORY_LABELS: Record<string, { label: string; icon: string; color: string }> = {
@@ -51,6 +51,17 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
   const [searchInput, setSearchInput] = useState('');
   const [showAll, setShowAll] = useState(false);
 
+  // Debounce the cross-category search: open the drill-down modal after 400 ms
+  // of inactivity (only when the user has typed something meaningful).
+  useEffect(() => {
+    if (!searchInput.trim()) {
+      setSearchQuery(null);
+      return;
+    }
+    const t = setTimeout(() => setSearchQuery(searchInput.trim()), 400);
+    return () => clearTimeout(t);
+  }, [searchInput]);
+
   const categories = data.spending.categories || [];
   const topMerchants = data.spending.topMerchants || [];
   const totalSpent = categories.reduce((s: number, c: any) => s + c.total, 0);
@@ -75,14 +86,18 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
           type="text"
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && searchInput.trim()) {
-              setSearchQuery(searchInput.trim());
-            }
-          }}
-          placeholder="Search transactions..."
-          className="w-full bg-navy-950/50 border border-navy-700 rounded-xl pl-10 pr-4 py-2.5 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-purple-500/50 focus:ring-1 focus:ring-purple-500/50 transition-all font-medium"
+          placeholder="Search transactions…"
+          className="w-full bg-navy-950/50 border border-navy-700 rounded-xl pl-10 pr-9 py-2.5 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-purple-500/50 focus:ring-1 focus:ring-purple-500/50 transition-all font-medium"
         />
+        {searchInput && (
+          <button
+            className="absolute inset-y-0 right-0 pr-3 flex items-center text-slate-500 hover:text-white transition-colors"
+            onClick={() => { setSearchInput(''); setSearchQuery(null); }}
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
       </div>
       
       <div className="space-y-4 flex-1">
@@ -160,13 +175,13 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
         </div>
       </div>
       
-      <CategoryDrillDownModal 
-        isOpen={!!drillCategory || !!searchQuery} 
-        onClose={() => { setDrillCategory(null); setSearchQuery(null); }} 
+      <CategoryDrillDownModal
+        isOpen={!!drillCategory || !!searchQuery}
+        onClose={() => { setDrillCategory(null); setSearchQuery(null); setSearchInput(''); }}
         category={drillCategory}
         searchQuery={searchQuery}
         selectedMonth={selectedMonth}
-        onRecategorised={() => { setDrillCategory(null); setSearchQuery(null); refreshData(); }}
+        onRecategorised={() => { setDrillCategory(null); setSearchQuery(null); setSearchInput(''); refreshData(); }}
       />
     </div>
   );

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,0 +1,353 @@
+/**
+ * categories.ts — Single source of truth for Paybacker's canonical category taxonomy.
+ *
+ * TWO-TIER STRUCTURE:
+ *   Tier 1: Fixed top-level categories (this file) — same for all users, used for
+ *           cross-user spend analysis, budgets, and RPCs.
+ *   Tier 2: User-created subcategories — stored per-user in `user_category_custom`
+ *           table, always linked to a parent category ID from this list.
+ *
+ * Rules:
+ *   - Never add a new category without also writing a migration to update
+ *     auto_categorise_transactions and detectFallbackSpendingCategory.
+ *   - `income` and `transfers` are SYSTEM categories — managed by the classification
+ *     pipeline. Do not offer them in user-facing recategorisation flows.
+ *   - Budget RPCs and spend analysis ALWAYS aggregate at Tier 1 (parent category).
+ *     Subcategory drill-down is for personal organisation only.
+ */
+
+// ────────────────────────────────────────────────────────────────────────────
+// Canonical category definitions
+// ────────────────────────────────────────────────────────────────────────────
+
+export const CATEGORIES = [
+  // ── Home & Bills ────────────────────────────────────────────────────────
+  { id: 'mortgage',      label: 'Mortgage',              emoji: '🏠', group: 'Home & Bills' },
+  { id: 'housing',       label: 'Rent & Housing',         emoji: '🔑', group: 'Home & Bills' },
+  { id: 'council_tax',   label: 'Council Tax',            emoji: '🏛️', group: 'Home & Bills' },
+  { id: 'energy',        label: 'Energy',                 emoji: '⚡', group: 'Home & Bills' },
+  { id: 'water',         label: 'Water',                  emoji: '💧', group: 'Home & Bills' },
+  { id: 'broadband',     label: 'Broadband',              emoji: '📡', group: 'Home & Bills' },
+  { id: 'mobile',        label: 'Mobile',                 emoji: '📱', group: 'Home & Bills' },
+  { id: 'bills',         label: 'Bills & Utilities',      emoji: '📄', group: 'Home & Bills' },
+
+  // ── Food & Drink ─────────────────────────────────────────────────────────
+  { id: 'groceries',     label: 'Groceries',              emoji: '🛒', group: 'Food & Drink' },
+  { id: 'eating_out',    label: 'Eating Out',             emoji: '🍽️', group: 'Food & Drink' },
+
+  // ── Transport ───────────────────────────────────────────────────────────
+  { id: 'transport',     label: 'Transport',              emoji: '🚗', group: 'Transport' },
+  { id: 'travel',        label: 'Travel & Holidays',      emoji: '✈️', group: 'Transport' },
+
+  // ── Shopping & Lifestyle ─────────────────────────────────────────────────
+  { id: 'shopping',      label: 'Shopping',               emoji: '🛍️', group: 'Shopping & Lifestyle' },
+  { id: 'entertainment', label: 'Entertainment',          emoji: '🎬', group: 'Shopping & Lifestyle' },
+  { id: 'streaming',     label: 'Streaming',              emoji: '📺', group: 'Shopping & Lifestyle' },
+  { id: 'software',      label: 'Software & Apps',        emoji: '💻', group: 'Shopping & Lifestyle' },
+  { id: 'health',        label: 'Health & Fitness',       emoji: '🏥', group: 'Shopping & Lifestyle' },
+  { id: 'personal_care', label: 'Personal Care',          emoji: '💅', group: 'Shopping & Lifestyle' },
+
+  // ── Finance ─────────────────────────────────────────────────────────────
+  { id: 'insurance',     label: 'Insurance',              emoji: '🛡️', group: 'Finance' },
+  { id: 'loans',         label: 'Loans & Credit',         emoji: '💳', group: 'Finance' },
+  { id: 'savings',       label: 'Savings & Investments',  emoji: '💰', group: 'Finance' },
+  { id: 'fees',          label: 'Fees & Charges',         emoji: '🏦', group: 'Finance' },
+  { id: 'tax',           label: 'Tax & Government',       emoji: '📊', group: 'Finance' },
+
+  // ── Personal ────────────────────────────────────────────────────────────
+  { id: 'education',     label: 'Education',              emoji: '📚', group: 'Personal' },
+  { id: 'family',        label: 'Family & Childcare',     emoji: '👶', group: 'Personal' },
+  { id: 'pets',          label: 'Pets',                   emoji: '🐾', group: 'Personal' },
+  { id: 'charity',       label: 'Charity & Donations',    emoji: '❤️', group: 'Personal' },
+  { id: 'gambling',      label: 'Gambling',               emoji: '🎰', group: 'Personal' },
+
+  // ── System (not user-selectable in recategorisation flows) ───────────────
+  { id: 'income',        label: 'Income',                 emoji: '💵', group: 'System' },
+  { id: 'transfers',     label: 'Transfers',              emoji: '🔄', group: 'System' },
+
+  // ── Catch-all ────────────────────────────────────────────────────────────
+  { id: 'other',         label: 'Other',                  emoji: '📦', group: 'Other' },
+] as const;
+
+// ────────────────────────────────────────────────────────────────────────────
+// Derived types & constants
+// ────────────────────────────────────────────────────────────────────────────
+
+export type Category = (typeof CATEGORIES)[number]['id'];
+
+/** All canonical category IDs — used for DB CHECK constraints and validation. */
+export const CATEGORY_IDS: ReadonlyArray<Category> = CATEGORIES.map(c => c.id);
+
+/** Human-readable label for each category. */
+export const CATEGORY_LABELS: Record<Category, string> = Object.fromEntries(
+  CATEGORIES.map(c => [c.id, c.label]),
+) as Record<Category, string>;
+
+/** Emoji for each category. */
+export const CATEGORY_EMOJI: Record<Category, string> = Object.fromEntries(
+  CATEGORIES.map(c => [c.id, c.emoji]),
+) as Record<Category, string>;
+
+/** Group name for each category. */
+export const CATEGORY_GROUPS: Record<Category, string> = Object.fromEntries(
+  CATEGORIES.map(c => [c.id, c.group]),
+) as Record<Category, string>;
+
+/**
+ * Categories the user can manually select.
+ * Excludes `income` and `transfers` — those are managed by the
+ * classification pipeline and should not appear in recategorisation UIs.
+ */
+export const USER_SELECTABLE_CATEGORIES = CATEGORIES.filter(
+  c => c.group !== 'System',
+);
+
+export const USER_SELECTABLE_IDS: ReadonlyArray<Category> = USER_SELECTABLE_CATEGORIES.map(
+  c => c.id,
+);
+
+/**
+ * Categories grouped by their group name, in display order.
+ * Used for building Telegram inline keyboards.
+ */
+export const CATEGORIES_BY_GROUP: Record<string, typeof USER_SELECTABLE_CATEGORIES> =
+  USER_SELECTABLE_CATEGORIES.reduce(
+    (acc, cat) => {
+      const g = cat.group;
+      if (!acc[g]) acc[g] = [];
+      acc[g].push(cat);
+      return acc;
+    },
+    {} as Record<string, typeof USER_SELECTABLE_CATEGORIES>,
+  );
+
+// ────────────────────────────────────────────────────────────────────────────
+// Alias / migration mapping — maps legacy messy values → canonical IDs.
+// Used in the DB migration and the classification normaliser.
+// ────────────────────────────────────────────────────────────────────────────
+
+export const CATEGORY_ALIASES: Record<string, Category> = {
+  // Food / groceries
+  food:                   'groceries',
+  supermarket:            'groceries',
+  supermarkets:           'groceries',
+
+  // Transport
+  fuel:                   'transport',
+  motoring:               'transport',
+  parking:                'transport',
+  vehicle:                'transport',
+
+  // Health & Fitness
+  fitness:                'health',
+  healthcare:             'health',
+  medical:                'health',
+  pharmacy:               'health',
+  gym:                    'health',
+
+  // Loans & Credit
+  loan:                   'loans',
+  credit:                 'loans',
+  debt:                   'loans',
+  finance:                'loans',
+
+  // Fees & Charges (professional services — too vague for its own category)
+  fee:                    'fees',
+  professional:           'fees',
+  'bank charge':          'fees',
+  'bank charges':         'fees',
+  charges:                'fees',
+  expenses:               'fees',
+
+  // Bills & Utilities (generic utility catch-all)
+  utility:                'bills',
+  utilities:              'bills',
+
+  // Entertainment
+  music:                  'entertainment',
+  gaming:                 'entertainment',
+  games:                  'entertainment',
+  cinema:                 'entertainment',
+  sport:                  'entertainment',
+  sports:                 'entertainment',
+
+  // Software & Apps
+  storage:                'software',
+  subscriptions:          'software',
+  apps:                   'software',
+
+  // Housing — both underscore and space variants
+  property_management:    'housing',
+  'property management':  'housing',
+  rent:                   'housing',
+  letting:                'housing',
+  landlord:               'housing',
+
+  // Transfers — singular form (TrueLayer raw, older data)
+  transfer:               'transfers',
+  'internal transfer':    'transfers',
+  'bank transfer':        'transfers',
+
+  // Eating Out — space and word variants
+  'eating out':           'eating_out',
+  restaurants:            'eating_out',
+  restaurant:             'eating_out',
+  takeaway:               'eating_out',
+  takeaways:              'eating_out',
+
+  // Council Tax — space variant
+  'council tax':          'council_tax',
+  council:                'council_tax',
+
+  // Personal Care — space variant
+  'personal care':        'personal_care',
+  beauty:                 'personal_care',
+  haircare:               'personal_care',
+
+  // Family & Childcare
+  childcare:              'family',
+  'child care':           'family',
+  children:               'family',
+  kids:                   'family',
+
+  // Tax & Government
+  hmrc:                   'tax',
+  vat:                    'tax',
+  'tax payment':          'tax',
+  'self assessment':      'tax',
+
+  // Shopping
+  retail:                 'shopping',
+  clothes:                'shopping',
+  clothing:               'shopping',
+  fashion:                'shopping',
+
+  // Travel & Holidays
+  holiday:                'travel',
+  holidays:               'travel',
+  flights:                'travel',
+  hotel:                  'travel',
+  hotels:                 'travel',
+  accommodation:          'travel',
+
+  // Other / catch-alls
+  security:               'other',
+  cash:                   'other',
+  misc:                   'other',
+  miscellaneous:          'other',
+  unknown:                'other',
+
+  // Identity mappings — already canonical, keep for safety
+  transport:              'transport',
+  transfers:              'transfers',
+  income:                 'income',
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// TrueLayer / Yapily merchant_category → canonical mapping
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maps the raw `category` value sent by TrueLayer / Yapily in the transaction
+ * payload to a canonical Paybacker category ID.
+ *
+ * TrueLayer uses upper-case strings like "BILLS", "EATING_OUT", "TRANSPORT".
+ * Yapily uses similar strings. Any unrecognised value falls through to 'other'.
+ */
+export const TRUELAYER_CATEGORY_MAP: Record<string, Category> = {
+  // TrueLayer categories (upper-case)
+  BILLS:            'bills',
+  CASH:             'other',
+  CHARITY:          'charity',
+  EATING_OUT:       'eating_out',
+  ENTERTAINMENT:    'entertainment',
+  EXPENSES:         'fees',
+  FAMILY:           'family',
+  GENERAL:          'other',
+  GROCERIES:        'groceries',
+  HOLIDAYS:         'travel',
+  HOME:             'housing',
+  INCOME:           'income',
+  INSURANCE:        'insurance',
+  PERSONAL_CARE:    'personal_care',
+  PURCHASE:         'shopping',
+  SAVINGS:          'savings',
+  SHOPPING:         'shopping',
+  TRANSPORT:        'transport',
+  TRAVEL:           'travel',
+  TRANSFER:         'transfers',
+  CREDIT:           'income',
+  INTEREST:         'income',
+  // Yapily categories (similar but may vary)
+  Bills:            'bills',
+  'Eating Out':     'eating_out',
+  Entertainment:    'entertainment',
+  Expenses:         'fees',
+  Groceries:        'groceries',
+  Holidays:         'travel',
+  Home:             'housing',
+  Income:           'income',
+  Insurance:        'insurance',
+  'Personal Care':  'personal_care',
+  Shopping:         'shopping',
+  Transport:        'transport',
+  Travel:           'travel',
+  Transfer:         'transfers',
+  Savings:          'savings',
+  Charity:          'charity',
+  Family:           'family',
+  General:          'other',
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helper functions
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Returns true if the value is a valid canonical category ID. */
+export function isValidCategory(value: unknown): value is Category {
+  return typeof value === 'string' && (CATEGORY_IDS as ReadonlyArray<string>).includes(value);
+}
+
+/**
+ * Normalises a raw string to a canonical category ID.
+ * Resolves aliases, lowercases, and falls through to 'other'.
+ */
+export function normaliseCategory(raw: string | null | undefined): Category {
+  if (!raw) return 'other';
+  const key = raw.toLowerCase().trim();
+  if (isValidCategory(key)) return key;
+  const aliased = CATEGORY_ALIASES[key];
+  if (aliased) return aliased;
+  return 'other';
+}
+
+/**
+ * Maps a TrueLayer / Yapily raw `category` field to a canonical category ID.
+ */
+export function mapBankCategory(raw: string | null | undefined): Category {
+  if (!raw) return 'other';
+  const mapped = TRUELAYER_CATEGORY_MAP[raw.trim()] ?? TRUELAYER_CATEGORY_MAP[raw.trim().toUpperCase()];
+  if (mapped) return mapped;
+  return normaliseCategory(raw);
+}
+
+/**
+ * Returns a compact, flat list of user-selectable category IDs as a string
+ * suitable for inclusion in AI system prompts.
+ * e.g. "mortgage, housing, council_tax, energy, ..."
+ */
+export function categoryListForPrompt(): string {
+  return USER_SELECTABLE_IDS.join(', ');
+}
+
+/**
+ * Returns a formatted multi-line list of categories for AI prompts.
+ * Groups by category group.
+ */
+export function categoryListFormatted(): string {
+  const lines: string[] = [];
+  for (const [group, cats] of Object.entries(CATEGORIES_BY_GROUP)) {
+    lines.push(`${group}: ${cats.map(c => `${c.emoji} ${c.id} (${c.label})`).join(' | ')}`);
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Money Hub — transaction search bar + category badges

### What this PR does

Adds a **real-time search bar** inside the Category Drill-Down Modal (the transactions view that opens when you click a category in the Spending Breakdown panel), plus **clickable category badges** on every transaction row.

---

### Changes

#### `CategoryDrillDownModal.tsx`

- **In-modal search bar** sits above the Transactions section. Typing filters the already-loaded list client-side with a **300 ms debounce** — no extra API calls needed.
- Matches against: merchant name, description, amount (`£750` or `750`), and category label.
- **Category badge** (`🛒 Groceries`) on every transaction row. Desktop shows it between the merchant name and amount; mobile shows it below the amount.
- **Quick-change dropdown** opens on badge click. Uses `USER_SELECTABLE_CATEGORIES` from the canonical `src/lib/categories.ts` (emoji + label, grouped). Calls `POST /api/money-hub/recategorise` with `transactionId` — single-transaction scope only, not a merchant-pattern sweep.
- **Optimistic update** — the badge reflects the new category immediately without a full reload.
- **Empty state**: "No transactions match your search" with a Clear filter link.
- **Mobile**: search collapses behind a 🔍 icon; tapping it expands the input and auto-focuses.
- Click-outside handler closes any open dropdown.
- Replaces the old hardcoded `ALL_CATEGORIES` flat string list with the canonical `USER_SELECTABLE_CATEGORIES` in both the merchant and transaction dropdowns.

#### `SpendingPanel.tsx`

- Added a **clear ×** button to the cross-category search input (appears when the field is non-empty).
- Switched from Enter-to-submit to a **400 ms debounced auto-trigger** so the drill-down modal opens as you type.
- Closing the modal now also clears the search input (prevents the debounce from immediately re-opening it).

---

### Not changed

- The transactions API (`/api/money-hub/transactions`) — no modifications needed since the filter is client-side.
- The recategorise API (`/api/money-hub/recategorise`) — already supported `transactionId` param.
- All existing category drill-down behaviour (clicking a category row, top merchants summary, merchant-pattern recategorise rule) is preserved.

---

### Testing

1. Open Money Hub → click any spending category
2. In the modal, type a merchant name, partial amount (`15`), or category (`groceries`) — list should filter in real time
3. Type `£` prefix — should still match (e.g. `£750` finds `750.00`)
4. Tap a category badge → dropdown opens showing all canonical categories with emoji
5. Select a different category → badge updates immediately; no full page reload
6. Mobile: search bar should be hidden behind the 🔍 icon; tapping expands it
