### PR TITLE
Dynamic homepage v2 — go live (22 Apr 2026)

### DIFF
--- a/src/app/preview/homepage/demos.tsx
+++ b/src/app/preview/homepage/demos.tsx
@@ -1,0 +1,2725 @@
+'use client';
+
+/**
+ * Homepage product demos — ported verbatim from
+ *   demos-handoff/demos/demo-*.jsx (Claude Design, Apr 2026).
+ *
+ * Timings, dimensions, refs and copy are preserved pixel-for-pixel.
+ * Every demo is gated behind IntersectionObserver so the requestAnimationFrame
+ * loop only runs while the stage is within 200px of the viewport.
+ */
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+
+// ---------------------------------------------------------------------------
+// Shared: `t` ticker gated by viewport (IntersectionObserver + rAF)
+// ---------------------------------------------------------------------------
+function useInViewTicker(period: number) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [t, setT] = useState<number>(0);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    let raf = 0;
+    let start = 0;
+    let running = false;
+
+    const tick = () => {
+      setT(((Date.now() - start) / 1000) % period);
+      raf = requestAnimationFrame(tick);
+    };
+    const stop = () => {
+      if (!running) return;
+      cancelAnimationFrame(raf);
+      running = false;
+    };
+    const play = () => {
+      if (running) return;
+      running = true;
+      start = Date.now();
+      raf = requestAnimationFrame(tick);
+    };
+
+    if (typeof IntersectionObserver === 'undefined') {
+      play();
+      return () => stop();
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        if (entry.isIntersecting) play();
+        else stop();
+      },
+      { rootMargin: '200px 0px' },
+    );
+    io.observe(node);
+
+    return () => {
+      io.disconnect();
+      stop();
+    };
+  }, [period]);
+
+  return { ref, t };
+}
+
+// Resolve a target element's center relative to a stage element.
+function targetCenter(
+  stageRef: RefObject<HTMLElement | null>,
+  ref: RefObject<HTMLElement | null>,
+): { x: number; y: number } | null {
+  if (!ref.current || !stageRef.current) return null;
+  const s = stageRef.current.getBoundingClientRect();
+  const r = ref.current.getBoundingClientRect();
+  return { x: r.left - s.left + r.width / 2, y: r.top - s.top + r.height / 2 };
+}
+
+const CURSOR_SVG = (
+  <svg viewBox="0 0 24 24">
+    <path
+      d="M4 2.5L4 19L9 15L12 21.5L15.5 20L12.5 13.5L19 13L4 2.5Z"
+      fill="#0B1220"
+      stroke="#fff"
+      strokeWidth="1.2"
+    />
+  </svg>
+);
+
+// ---------------------------------------------------------------------------
+// 1 · Disputes
+// ---------------------------------------------------------------------------
+export function DisputesDemo() {
+  const { ref: tickerRef, t } = useInViewTicker(12);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const draftBtnRef = useRef<HTMLButtonElement | null>(null);
+  const linkBtnRef = useRef<HTMLButtonElement | null>(null);
+  const threadItemRef = useRef<HTMLDivElement | null>(null);
+
+  const setBothRefs = (node: HTMLDivElement | null) => {
+    stageRef.current = node;
+    tickerRef.current = node;
+  };
+
+  const composeOpen = t > 1.9;
+  const letterText = [
+    'Dear Virgin Media,',
+    '',
+    'On 12 November 2026 my monthly charge increased from £38 to £50 with no prior notice. Under Ofcom General Condition C1.8, you must provide at least one month\u2019s notice of any change that materially increases my charges.',
+    '',
+    'Under Consumer Rights Act 2015, Section 49, I am exercising my right to exit without penalty and request a full refund of £312 for charges billed without adequate notice since August.',
+  ].join('\n');
+  const typeProgress = Math.max(0, Math.min(1, (t - 2.2) / 2.8));
+  const typedChars = Math.floor(letterText.length * typeProgress);
+  const shownText = letterText.slice(0, typedChars);
+
+  const showInboxPicker = t > 6.4 && t < 8.2;
+  const tracking = t > 8.2;
+  const showDualAlert = t > 10.3;
+
+  const cursorPos = (() => {
+    const easeTo = (
+      target: { x: number; y: number } | null,
+      p0: number,
+      p1: number,
+      from: { x: number; y: number },
+    ) => {
+      if (!target) return { x: 0, y: 0, o: 0 };
+      const k = Math.max(0, Math.min(1, (t - p0) / (p1 - p0)));
+      const e = k < 0.5 ? 2 * k * k : 1 - Math.pow(-2 * k + 2, 2) / 2;
+      return {
+        x: from.x + (target.x - from.x) * e,
+        y: from.y + (target.y - from.y) * e,
+        o: 1,
+      };
+    };
+
+    if (t < 2.0) {
+      const tgt = targetCenter(stageRef, draftBtnRef);
+      if (t < 1.4) return easeTo(tgt, 0.2, 1.4, { x: 80, y: 80 });
+      return tgt ? { ...tgt, o: 1 } : { x: 0, y: 0, o: 0 };
+    }
+    if (t < 5.5) return { x: 0, y: 0, o: 0 };
+    if (t < 6.6) {
+      const tgt = targetCenter(stageRef, linkBtnRef);
+      if (t < 5.9) return easeTo(tgt, 5.5, 5.9, { x: 500, y: 280 });
+      return tgt ? { ...tgt, o: 1 } : { x: 0, y: 0, o: 0 };
+    }
+    if (t < 7.4) return { x: 0, y: 0, o: 0 };
+    if (t < 8.3) {
+      const tgt = targetCenter(stageRef, threadItemRef);
+      if (t < 7.8) return easeTo(tgt, 7.4, 7.8, { x: 820, y: 500 });
+      return tgt ? { ...tgt, o: 1 } : { x: 0, y: 0, o: 0 };
+    }
+    return { x: 0, y: 0, o: 0 };
+  })();
+  const clickDraft = t > 1.7 && t < 2.0;
+  const clickLink = t > 5.8 && t < 6.1;
+  const clickThread = t > 7.7 && t < 8.0;
+
+  const timelineStage = !tracking ? 0 : t < 9.0 ? 1 : t < 9.4 ? 2 : t < 10.0 ? 3 : 4;
+
+  const moneyRows = [
+    { m: 'Tesco', a: '−£42.80', d: 'Today', i: '🛒', h: false },
+    { m: 'Virgin Media', a: '−£50.00', d: '12 Nov', i: '📶', h: true },
+    { m: 'Spotify', a: '−£11.99', d: '10 Nov', i: '♫', h: false },
+    { m: 'TfL', a: '−£2.80', d: '9 Nov', i: '🚇', h: false },
+  ];
+
+  return (
+    <div className="demo-stage" ref={setBothRefs}>
+      <span className="demo-label">
+        Disputes · drafts letter · suggests email thread to watch · 12s loop
+      </span>
+
+      <div style={{ position: 'absolute', inset: '56px 44px 40px 44px', display: 'flex', gap: 16 }}>
+        {/* LEFT: Money Hub */}
+        <div
+          style={{
+            flex: '0 0 340px',
+            background: '#fff',
+            borderRadius: 14,
+            border: '1px solid var(--divider)',
+            padding: '16px 18px',
+            boxShadow: 'var(--shadow-md)',
+            transform: composeOpen ? 'translateX(-6px) scale(.97)' : 'translateX(0) scale(1)',
+            transition: 'transform 500ms cubic-bezier(.4,0,.2,1)',
+            opacity: composeOpen ? 0.45 : 1,
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+            <div>
+              <div className="eyebrow">Money Hub</div>
+              <div style={{ fontSize: 16, fontWeight: 700, marginTop: 3 }}>Recent</div>
+            </div>
+            <span className="pill grey">12 this week</span>
+          </div>
+          {moneyRows.map((r, i) => (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '9px 8px',
+                borderRadius: 8,
+                marginBottom: 3,
+                background: r.h && t > 0.5 && t < 2.0 ? 'rgba(245,158,11,.08)' : 'transparent',
+                border: r.h && t > 0.5 && t < 2.0 ? '1px solid rgba(245,158,11,.3)' : '1px solid transparent',
+                transition: 'all 200ms',
+              }}
+            >
+              <div
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: 7,
+                  background: '#F3F4F6',
+                  display: 'grid',
+                  placeItems: 'center',
+                  fontSize: 13,
+                }}
+              >
+                {r.i}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 12.5, fontWeight: 600 }}>{r.m}</div>
+                <div style={{ fontSize: 10.5, color: 'var(--text-3)' }}>{r.d}</div>
+              </div>
+              <div style={{ textAlign: 'right' }}>
+                <div style={{ fontSize: 12.5, fontWeight: 600, fontFamily: 'JetBrains Mono,monospace' }}>{r.a}</div>
+                {r.h && (
+                  <span className="pill orange" style={{ marginTop: 2, fontSize: 9.5 }}>
+                    ↑ HIKE
+                  </span>
+                )}
+              </div>
+              {r.h && t > 0.8 && t < 2.0 && (
+                <button
+                  ref={draftBtnRef}
+                  style={{
+                    fontSize: 10.5,
+                    fontWeight: 700,
+                    padding: '4px 8px',
+                    borderRadius: 5,
+                    background: 'var(--ink)',
+                    color: '#fff',
+                    border: 'none',
+                    marginLeft: 2,
+                  }}
+                >
+                  Draft dispute
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* RIGHT: Compose / Tracking panel */}
+        <div
+          style={{
+            flex: 1,
+            background: '#fff',
+            borderRadius: 14,
+            border: '1px solid var(--divider)',
+            padding: '16px 20px',
+            boxShadow: 'var(--shadow-lg)',
+            transform: composeOpen ? 'translateX(0)' : 'translateX(100%)',
+            opacity: composeOpen ? 1 : 0,
+            transition: 'transform 500ms cubic-bezier(.4,0,.2,1), opacity 300ms',
+            display: 'flex',
+            flexDirection: 'column',
+            minWidth: 0,
+            position: 'relative',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 10 }}>
+            <div>
+              <div className="eyebrow">{tracking ? 'Tracking · thread linked' : 'AI-drafted · Virgin Media'}</div>
+              <div style={{ fontSize: 15.5, fontWeight: 700, letterSpacing: '-.01em', marginTop: 3 }}>
+                {tracking ? 'Dispute #2847 · Virgin Media' : 'Dispute letter'}
+              </div>
+            </div>
+            {!tracking && (
+              <div style={{ display: 'flex', gap: 4 }}>
+                <span className="pill grey" style={{ fontSize: 10 }}>Formal</span>
+                <span className="pill mint" style={{ fontSize: 10 }}>Firm</span>
+                <span className="pill grey" style={{ fontSize: 10 }}>Polite</span>
+              </div>
+            )}
+          </div>
+
+          {!tracking ? (
+            <>
+              <div
+                style={{
+                  flex: 1,
+                  background: '#FAFAF7',
+                  borderRadius: 9,
+                  padding: '12px 14px',
+                  fontSize: 11,
+                  lineHeight: 1.6,
+                  color: 'var(--text-2)',
+                  whiteSpace: 'pre-wrap',
+                  overflow: 'hidden',
+                  fontFamily: 'Inter,sans-serif',
+                  minHeight: 0,
+                }}
+              >
+                {shownText
+                  .split(/(Ofcom General Condition C1\.8|Consumer Rights Act 2015, Section 49)/)
+                  .map((ch, i) =>
+                    ch === 'Ofcom General Condition C1.8' || ch === 'Consumer Rights Act 2015, Section 49' ? (
+                      <mark
+                        key={i}
+                        style={{
+                          background: 'rgba(52,211,153,.22)',
+                          color: 'var(--mint-dark)',
+                          fontWeight: 600,
+                          padding: '1px 3px',
+                          borderRadius: 3,
+                        }}
+                      >
+                        {ch}
+                      </mark>
+                    ) : (
+                      <span key={i}>{ch}</span>
+                    ),
+                  )}
+                {typeProgress < 1 && <span className="caret" />}
+              </div>
+
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  marginTop: 10,
+                  padding: '7px 10px',
+                  background: '#FFFBEB',
+                  border: '1px solid #FCD34D',
+                  borderRadius: 7,
+                  fontSize: 11,
+                  color: '#78350F',
+                  lineHeight: 1.4,
+                }}
+              >
+                <span style={{ fontSize: 12 }}>ⓘ</span>
+                <span>
+                  <b>Draft only.</b> We never send on your behalf. Copy the letter, send it yourself, then link the
+                  email thread so we can watch for replies.
+                </span>
+              </div>
+
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  marginTop: 10,
+                }}
+              >
+                <div style={{ fontSize: 10.5, color: 'var(--text-3)' }}>
+                  Expected refund{' '}
+                  <span style={{ fontWeight: 700, color: 'var(--text)', fontFamily: 'JetBrains Mono,monospace' }}>
+                    £312
+                  </span>
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <button
+                    style={{
+                      padding: '7px 12px',
+                      borderRadius: 7,
+                      background: '#F3F4F6',
+                      border: 'none',
+                      fontSize: 11.5,
+                      fontWeight: 600,
+                      color: 'var(--text-2)',
+                    }}
+                  >
+                    Copy letter
+                  </button>
+                  <button
+                    ref={linkBtnRef}
+                    style={{
+                      padding: '7px 14px',
+                      borderRadius: 7,
+                      background: 'var(--ink)',
+                      color: '#fff',
+                      border: 'none',
+                      fontSize: 11.5,
+                      fontWeight: 700,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 5,
+                    }}
+                  >
+                    ✉ Link email thread
+                  </button>
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <div
+                style={{
+                  padding: '10px 12px',
+                  background: '#F0F9FF',
+                  border: '1px solid #BAE6FD',
+                  borderRadius: 8,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  fontSize: 11.5,
+                  animation: 'demoFadeInUp 400ms',
+                }}
+              >
+                <div
+                  style={{
+                    width: 26,
+                    height: 26,
+                    borderRadius: 6,
+                    background: 'var(--ink)',
+                    color: '#fff',
+                    display: 'grid',
+                    placeItems: 'center',
+                    fontWeight: 800,
+                    fontSize: 13,
+                  }}
+                >
+                  ✉
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: 700, color: '#0C4A6E' }}>
+                    Thread linked · &ldquo;Re: Your account 8847261&rdquo;
+                  </div>
+                  <div style={{ fontSize: 10.5, color: '#075985', marginTop: 1 }}>
+                    Watching your inbox. We&rsquo;ll alert you the moment Virgin Media replies.
+                  </div>
+                </div>
+                <span className="pill mint" style={{ fontSize: 10 }}>● LIVE</span>
+              </div>
+
+              <div style={{ marginTop: 12, flex: 1 }}>
+                <div className="eyebrow" style={{ marginBottom: 8 }}>Timeline</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 7, fontSize: 11.5 }}>
+                  {[
+                    { s: 1, l: 'Letter drafted by Paybacker', time: 'just now' },
+                    { s: 2, l: 'You sent it from your email', time: 'today' },
+                    { s: 3, l: 'Virgin Media replied', time: 'day 3', alert: true },
+                    { s: 4, l: 'Refund £312 received', time: 'day 5', won: true },
+                  ].map((e, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        opacity: timelineStage >= e.s ? 1 : 0.25,
+                        transition: 'opacity 300ms',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: 18,
+                          height: 18,
+                          borderRadius: '50%',
+                          background:
+                            timelineStage >= e.s ? (e.won ? 'var(--mint-deep)' : 'var(--text-2)') : '#E5E7EB',
+                          color: '#fff',
+                          fontSize: 10,
+                          display: 'grid',
+                          placeItems: 'center',
+                          fontWeight: 700,
+                          animation: e.alert && timelineStage === 3 ? 'demoPingRing 1s ease-out' : 'none',
+                        }}
+                      >
+                        ✓
+                      </div>
+                      <div style={{ flex: 1 }}>{e.l}</div>
+                      <span className="mono" style={{ color: 'var(--text-3)', fontSize: 10.5 }}>{e.time}</span>
+                      {e.won && timelineStage >= 4 && (
+                        <span className="pill mint" style={{ fontSize: 10 }}>WON</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {showDualAlert && (
+                <div
+                  style={{
+                    marginTop: 10,
+                    padding: '9px 12px',
+                    background: 'var(--ink)',
+                    color: '#fff',
+                    borderRadius: 8,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                    fontSize: 11,
+                    animation: 'demoFadeInUp 400ms',
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      background: 'var(--mint)',
+                      flexShrink: 0,
+                      animation: 'demoPulse 1.2s infinite',
+                    }}
+                  />
+                  <span>
+                    Alert sent: <b>Paybacker inbox</b> + <b>Telegram</b>
+                  </span>
+                  <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
+                    <div
+                      style={{
+                        padding: '3px 7px',
+                        borderRadius: 4,
+                        background: 'rgba(52,211,153,.15)',
+                        color: '#6EE7B7',
+                        fontSize: 9.5,
+                        fontWeight: 700,
+                      }}
+                    >
+                      🔔 App
+                    </div>
+                    <div
+                      style={{
+                        padding: '3px 7px',
+                        borderRadius: 4,
+                        background: 'rgba(52,211,153,.15)',
+                        color: '#6EE7B7',
+                        fontSize: 9.5,
+                        fontWeight: 700,
+                      }}
+                    >
+                      ✈ Telegram
+                    </div>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {showInboxPicker && (
+        <div
+          style={{
+            position: 'absolute',
+            right: 60,
+            bottom: 90,
+            width: 340,
+            background: '#fff',
+            borderRadius: 10,
+            boxShadow: '0 24px 56px -12px rgba(0,0,0,.28)',
+            border: '1px solid var(--divider)',
+            zIndex: 40,
+            animation: 'demoDropdownIn 250ms cubic-bezier(.4,0,.2,1)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              padding: '10px 13px',
+              borderBottom: '1px solid var(--divider)',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <div>
+              <div className="eyebrow" style={{ fontSize: 10 }}>Pick an email thread to watch</div>
+              <div style={{ fontSize: 12, fontWeight: 700, marginTop: 2 }}>Threads matching Virgin Media</div>
+            </div>
+            <span className="pill grey" style={{ fontSize: 9.5 }}>3 found</span>
+          </div>
+          {[
+            { subj: 'Re: Your account 8847261', from: 'disputes@virginmedia.com', date: '10 min ago', suggested: true },
+            { subj: 'Your Virgin Media bill is ready', from: 'bills@virginmedia.com', date: '3 Nov', suggested: false },
+            { subj: 'Welcome to Virgin Media', from: 'hello@virginmedia.com', date: '12 Aug', suggested: false },
+          ].map((th, i) => (
+            <div
+              key={i}
+              ref={th.suggested ? threadItemRef : null}
+              style={{
+                padding: '9px 13px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                borderTop: i ? '1px solid #F3F4F6' : 'none',
+                background: th.suggested ? 'var(--mint-wash)' : '#fff',
+                position: 'relative',
+              }}
+            >
+              <div
+                style={{
+                  width: 24,
+                  height: 24,
+                  borderRadius: 6,
+                  background: th.suggested ? 'var(--mint-deep)' : '#F3F4F6',
+                  color: th.suggested ? '#fff' : 'var(--text-2)',
+                  display: 'grid',
+                  placeItems: 'center',
+                  fontSize: 11,
+                  fontWeight: 700,
+                }}
+              >
+                ✉
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: 11.5,
+                    fontWeight: th.suggested ? 700 : 600,
+                    color: 'var(--text)',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {th.subj}
+                </div>
+                <div style={{ fontSize: 10, color: 'var(--text-3)', marginTop: 1 }}>
+                  {th.from} · {th.date}
+                </div>
+              </div>
+              {th.suggested && (
+                <span className="pill mint" style={{ fontSize: 9.5 }}>SUGGESTED</span>
+              )}
+            </div>
+          ))}
+          <div
+            style={{
+              padding: '8px 13px',
+              background: '#FAFAF7',
+              borderTop: '1px solid var(--divider)',
+              fontSize: 10,
+              color: 'var(--text-3)',
+              lineHeight: 1.45,
+            }}
+          >
+            We only read the subject, sender and reply status — never the body.
+          </div>
+        </div>
+      )}
+
+      <div className="cursor" style={{ left: cursorPos.x, top: cursorPos.y, opacity: cursorPos.o }}>
+        {CURSOR_SVG}
+      </div>
+      {clickDraft && (
+        <div className="click-ring" style={{ left: cursorPos.x + 11, top: cursorPos.y + 11 }} key={`c1-${Math.floor(t * 10)}`} />
+      )}
+      {clickLink && (
+        <div className="click-ring" style={{ left: cursorPos.x + 11, top: cursorPos.y + 11 }} key={`c2-${Math.floor(t * 10)}`} />
+      )}
+      {clickThread && (
+        <div className="click-ring" style={{ left: cursorPos.x + 11, top: cursorPos.y + 11 }} key={`c3-${Math.floor(t * 10)}`} />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 2 · Pocket Agent · Telegram
+// ---------------------------------------------------------------------------
+type PAMsg =
+  | { from: number; kind: 'bot-alert' }
+  | { from: number; kind: 'user'; text: string }
+  | { from: number; kind: 'bot-spend' }
+  | { from: number; kind: 'bot-disputes' }
+  | { from: number; kind: 'bot-afford' }
+  | { from: number; kind: 'bot-draft' }
+  | { from: number; kind: 'user-accept' };
+
+export function PocketAgentDemo() {
+  const { ref, t } = useInViewTicker(15);
+
+  const msgs: PAMsg[] = [
+    { from: 0.0, kind: 'bot-alert' },
+    { from: 1.2, kind: 'user', text: 'How much did I spend on eating out last month?' },
+    { from: 2.0, kind: 'bot-spend' },
+    { from: 3.5, kind: 'user', text: 'Show me every dispute I\u2019ve won this year' },
+    { from: 4.3, kind: 'bot-disputes' },
+    { from: 6.3, kind: 'user', text: 'Can I afford the new Macbook? It\u2019s £1,599.' },
+    { from: 7.1, kind: 'bot-afford' },
+    { from: 9.5, kind: 'user', text: 'fight it' },
+    { from: 10.3, kind: 'bot-draft' },
+    { from: 12.0, kind: 'user-accept' },
+  ];
+  const visible = msgs.filter((m) => t > m.from);
+  const typing = (() => {
+    if (t > 1.6 && t < 2.0) return true;
+    if (t > 3.9 && t < 4.3) return true;
+    if (t > 6.7 && t < 7.1) return true;
+    if (t > 9.9 && t < 10.3) return true;
+    return false;
+  })();
+
+  const inputText = (() => {
+    const q1 = 'How much did I spend on eating out last month?';
+    const q2 = 'Show me every dispute I\u2019ve won this year';
+    const q3 = 'Can I afford the new Macbook? It\u2019s £1,599.';
+    const q4 = 'fight it';
+    if (t >= 0.4 && t < 1.2)
+      return q1.slice(0, Math.floor(q1.length * Math.min(1, (t - 0.4) / 0.8)));
+    if (t >= 2.7 && t < 3.5)
+      return q2.slice(0, Math.floor(q2.length * Math.min(1, (t - 2.7) / 0.8)));
+    if (t >= 5.5 && t < 6.3)
+      return q3.slice(0, Math.floor(q3.length * Math.min(1, (t - 5.5) / 0.8)));
+    if (t >= 9.1 && t < 9.5)
+      return q4.slice(0, Math.floor(q4.length * Math.min(1, (t - 9.1) / 0.4)));
+    return '';
+  })();
+
+  const spendCats = [
+    { l: 'Eating out', v: 312.4, pct: 100, hl: true },
+    { l: 'Groceries', v: 286.1, pct: 92, hl: false },
+    { l: 'Transport', v: 164.3, pct: 53, hl: false },
+  ];
+  const wins = [
+    { m: 'Virgin Media', a: '£312' },
+    { m: 'Funding Circle', a: '£468' },
+    { m: 'EE', a: '£24' },
+  ];
+  const features: Array<[string, string]> = [
+    ['💬', 'Ask anything about your finances'],
+    ['🛡️', 'Draft & track disputes'],
+    ['📊', 'Spending breakdowns on demand'],
+    ['⚠️', 'Live hike + payment alerts'],
+    ['📎', 'Forward a bill — we parse it'],
+  ];
+
+  return (
+    <div className="demo-stage dark" ref={ref}>
+      <span className="demo-label">
+        Pocket Agent · full financial assistant · ask anything · use any tool · 14s loop
+      </span>
+
+      <div style={{ position: 'absolute', inset: 0, display: 'grid', gridTemplateColumns: '1fr 380px', gap: 0 }}>
+        {/* LEFT brand panel */}
+        <div style={{ padding: '48px 44px', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: '.12em',
+              textTransform: 'uppercase',
+              color: 'var(--mint)',
+              marginBottom: 14,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 7,
+            }}
+          >
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--mint)', animation: 'demoPulse 1.6s infinite' }} />
+            Pocket Agent · Telegram
+          </div>
+          <div
+            style={{
+              fontSize: 30,
+              fontWeight: 800,
+              letterSpacing: '-.02em',
+              lineHeight: 1.05,
+              color: '#fff',
+              marginBottom: 12,
+            }}
+          >
+            A financial assistant,
+            <br />
+            in your pocket.
+          </div>
+          <div style={{ fontSize: 13.5, color: 'rgba(255,255,255,.7)', lineHeight: 1.55, maxWidth: 340 }}>
+            Ask anything about your money — spending, income, disputes, categories, affordability. Every tool from the
+            web app, reachable from one chat.
+          </div>
+          <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {features.map(([e, l], i) => (
+              <div
+                key={i}
+                style={{ display: 'flex', gap: 10, alignItems: 'center', color: 'rgba(255,255,255,.82)', fontSize: 12.5 }}
+              >
+                <span
+                  style={{
+                    width: 24,
+                    height: 24,
+                    borderRadius: 6,
+                    background: 'rgba(52,211,153,.14)',
+                    display: 'grid',
+                    placeItems: 'center',
+                    fontSize: 12,
+                  }}
+                >
+                  {e}
+                </span>
+                {l}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* RIGHT Telegram phone */}
+        <div style={{ padding: '18px 22px 18px 0', display: 'flex', alignItems: 'center' }}>
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              maxHeight: 520,
+              background: '#17212B',
+              borderRadius: 28,
+              overflow: 'hidden',
+              border: '7px solid #0D0D10',
+              boxShadow: '0 24px 48px -12px rgba(0,0,0,.6)',
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <div
+              style={{
+                background: '#202B36',
+                padding: '8px 12px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                borderBottom: '1px solid rgba(255,255,255,.04)',
+                flexShrink: 0,
+              }}
+            >
+              <div
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: '50%',
+                  background: 'linear-gradient(135deg,#34D399,#059669)',
+                  display: 'grid',
+                  placeItems: 'center',
+                  fontSize: 13,
+                  fontWeight: 800,
+                  color: '#0B1220',
+                }}
+              >
+                P
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 11.5, fontWeight: 700, color: '#fff' }}>Paybacker</div>
+                <div style={{ fontSize: 9.5, color: 'rgba(255,255,255,.5)' }}>assistant · online</div>
+              </div>
+            </div>
+
+            <div
+              style={{
+                flex: 1,
+                padding: '10px 8px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 5,
+                overflow: 'hidden',
+                justifyContent: 'flex-end',
+                minHeight: 0,
+              }}
+            >
+              {visible.map((m, i) => {
+                if (m.kind === 'bot-alert') {
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        alignSelf: 'flex-start',
+                        background: '#2E2416',
+                        color: '#FDE68A',
+                        border: '1px solid rgba(251,191,36,.35)',
+                        padding: '7px 9px',
+                        borderRadius: '10px 10px 10px 2px',
+                        maxWidth: '86%',
+                        fontSize: 10,
+                        animation: 'demoMsgIn 350ms',
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, color: '#FCD34D', marginBottom: 3 }}>
+                        ⚠ Virgin Media: £38 → £50
+                      </div>
+                      <div style={{ color: 'rgba(253,230,138,.9)', fontSize: 9.5 }}>
+                        Ofcom breach · reply &ldquo;fight it&rdquo; to dispute →
+                      </div>
+                    </div>
+                  );
+                }
+                if (m.kind === 'user') {
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        alignSelf: 'flex-end',
+                        background: '#2B5278',
+                        color: '#fff',
+                        padding: '5px 9px',
+                        borderRadius: '10px 10px 2px 10px',
+                        maxWidth: '78%',
+                        fontSize: 10,
+                        animation: 'demoMsgIn 300ms',
+                      }}
+                    >
+                      {m.text}
+                    </div>
+                  );
+                }
+                if (m.kind === 'user-accept') {
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        alignSelf: 'flex-end',
+                        background: '#2B5278',
+                        color: '#fff',
+                        padding: '5px 9px',
+                        borderRadius: '10px 10px 2px 10px',
+                        maxWidth: '40%',
+                        fontSize: 10,
+                        animation: 'demoMsgIn 300ms',
+                      }}
+                    >
+                      ✓ Accept
+                    </div>
+                  );
+                }
+                if (m.kind === 'bot-spend') {
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        alignSelf: 'flex-start',
+                        background: '#182533',
+                        color: '#fff',
+                        padding: '8px 10px',
+                        borderRadius: '10px 10px 10px 2px',
+                        maxWidth: '92%',
+                        fontSize: 10,
+                        animation: 'demoMsgIn 350ms',
+                      }}
+                    >
+                      <div>
+                        You spent <b style={{ color: '#6EE7B7' }}>£312.40</b> on eating out in October — 16% up on September. Here&rsquo;s the context:
+                      </div>
+                      <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                        {spendCats.map((c, j) => (
+                          <div key={j} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 9.5 }}>
+                            <span style={{ width: 68, color: c.hl ? '#6EE7B7' : 'rgba(255,255,255,.7)' }}>{c.l}</span>
+                            <div
+                              style={{
+                                flex: 1,
+                                height: 4,
+                                background: 'rgba(255,255,255,.08)',
+                                borderRadius: 2,
+                                overflow: 'hidden',
+                              }}
+                            >
+                              <div
+                                style={{
+                                  width: `${c.pct}%`,
+                                  height: '100%',
+                                  background: c.hl ? '#34D399' : 'rgba(255,255,255,.3)',
+                                }}
+                              />
+                            </div>
+                            <span
+                              className="mono"
+                              style={{
+                                width: 42,
+                                textAlign: 'right',
+                                color: c.hl ? '#fff' : 'rgba(255,255,255,.6)',
+                                fontSize: 9.5,
+                              }}
+                            >
+                              £{c.v}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                      <div style={{ marginTop: 5, fontSize: 9, color: 'rgba(255,255,255,.45)' }}>
+                        Top merchants: Dishoom, Pret, Honest Burgers
+                      </div>
+                    </div>
+                  );
+                }
+                if (m.kind === 'bot-disputes') {
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        alignSelf: 'flex-start',
+                        background: '#182533',
+                        color: '#fff',
+                        padding: '8px 10px',
+                        borderRadius: '10px 10px 10px 2px',
+                        maxWidth: '92%',
+                        fontSize: 10,
+                        animation: 'demoMsgIn 350ms',
+                      }}
+                    >
+                      <div>
+                        3 disputes won in 2026 — <b style={{ color: '#6EE7B7' }}>£804 total</b>.
+                      </div>
+                      <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 3 }}>
+                        {wins.map((w, j) => (
+                          <div
+                            key={j}
+                            style={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
+                              padding: '4px 7px',
+                              background: 'rgba(52,211,153,.1)',
+                              border: '1px solid rgba(52,211,153,.22)',
+                              borderRadius: 5,
+                            }}
+                          >
+                            <span style={{ fontSize: 9.5 }}>{w.m}</span>
+                            <span className="mono" style={{ fontSize: 10, fontWeight: 700, color: '#6EE7B7' }}>+{w.a}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                }
+                if (m.kind === 'bot-afford') {
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        alignSelf: 'flex-start',
+                        background: '#182533',
+                        color: '#fff',
+                        padding: '8px 10px',
+                        borderRadius: '10px 10px 10px 2px',
+                        maxWidth: '94%',
+                        fontSize: 10,
+                        animation: 'demoMsgIn 350ms',
+                      }}
+                    >
+                      <div>
+                        Short answer: <b style={{ color: '#6EE7B7' }}>yes, comfortably</b> — here&rsquo;s the math:
+                      </div>
+                      <div
+                        style={{
+                          marginTop: 6,
+                          fontFamily: 'JetBrains Mono,monospace',
+                          fontSize: 9.5,
+                          lineHeight: 1.55,
+                          background: 'rgba(255,255,255,.04)',
+                          padding: '7px 9px',
+                          borderRadius: 6,
+                        }}
+                      >
+                        <div>Monthly income&nbsp;&nbsp;<span style={{ float: 'right' }}>£3,820</span></div>
+                        <div>Fixed outgoings&nbsp;<span style={{ float: 'right' }}>−£1,847</span></div>
+                        <div>Avg spending&nbsp;&nbsp;&nbsp;<span style={{ float: 'right' }}>−£1,114</span></div>
+                        <div
+                          style={{
+                            borderTop: '1px solid rgba(255,255,255,.1)',
+                            marginTop: 4,
+                            paddingTop: 4,
+                            color: '#6EE7B7',
+                            fontWeight: 700,
+                          }}
+                        >
+                          Monthly slack&nbsp;<span style={{ float: 'right' }}>£859</span>
+                        </div>
+                      </div>
+                      <div style={{ marginTop: 5, fontSize: 9.5, color: 'rgba(255,255,255,.7)' }}>
+                        £1,599 ≈ 1.9 months slack. Waiting till payday on the 28th keeps your buffer intact.
+                      </div>
+                    </div>
+                  );
+                }
+                if (m.kind === 'bot-draft') {
+                  return (
+                    <div
+                      key={i}
+                      style={{
+                        alignSelf: 'flex-start',
+                        background: '#182533',
+                        color: '#fff',
+                        padding: '7px 9px',
+                        borderRadius: '10px 10px 10px 2px',
+                        maxWidth: '88%',
+                        fontSize: 10,
+                        animation: 'demoMsgIn 350ms',
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, marginBottom: 3, color: '#6EE7B7' }}>Letter drafted</div>
+                      <div
+                        style={{
+                          background: 'rgba(255,255,255,.04)',
+                          padding: '5px 7px',
+                          borderRadius: 5,
+                          fontSize: 9,
+                          lineHeight: 1.4,
+                          color: 'rgba(255,255,255,.8)',
+                          fontStyle: 'italic',
+                          marginBottom: 5,
+                        }}
+                      >
+                        &ldquo;…under Ofcom GC C1.8 + CRA 2015 s.49, £312 refund requested…&rdquo;
+                      </div>
+                      <div style={{ display: 'flex', gap: 3 }}>
+                        <div
+                          style={{
+                            flex: 1,
+                            textAlign: 'center',
+                            padding: '4px 0',
+                            background: t > 12.2 ? '#10B981' : '#34D399',
+                            color: '#0B1220',
+                            borderRadius: 5,
+                            fontSize: 9.5,
+                            fontWeight: 700,
+                            transition: 'background 300ms',
+                          }}
+                        >
+                          {t > 12.2 ? '✓ Copied' : 'Accept · copy letter'}
+                        </div>
+                        <div
+                          style={{
+                            flex: 1,
+                            textAlign: 'center',
+                            padding: '4px 0',
+                            background: 'rgba(255,255,255,.08)',
+                            color: '#fff',
+                            borderRadius: 5,
+                            fontSize: 9.5,
+                            fontWeight: 600,
+                          }}
+                        >
+                          Edit
+                        </div>
+                      </div>
+                    </div>
+                  );
+                }
+                return null;
+              })}
+
+              {typing && (
+                <div
+                  style={{
+                    alignSelf: 'flex-start',
+                    padding: '7px 11px',
+                    background: '#182533',
+                    borderRadius: '10px 10px 10px 2px',
+                    display: 'flex',
+                    gap: 3,
+                  }}
+                >
+                  {[0, 1, 2].map((j) => (
+                    <span
+                      key={j}
+                      style={{
+                        width: 4,
+                        height: 4,
+                        borderRadius: '50%',
+                        background: 'rgba(255,255,255,.5)',
+                        animation: `demoDotPulse 1.2s ${j * 0.15}s infinite`,
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div
+              style={{
+                background: '#17212B',
+                padding: '7px 9px',
+                borderTop: '1px solid rgba(255,255,255,.04)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 5,
+                flexShrink: 0,
+              }}
+            >
+              <div
+                style={{
+                  flex: 1,
+                  background: '#242F3D',
+                  borderRadius: 12,
+                  padding: '5px 9px',
+                  fontSize: 9.5,
+                  color: inputText ? '#fff' : 'rgba(255,255,255,.42)',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {inputText || 'Ask anything…'}
+                {inputText && <span className="caret" />}
+              </div>
+              <div
+                style={{
+                  width: 24,
+                  height: 24,
+                  borderRadius: '50%',
+                  background: '#34D399',
+                  display: 'grid',
+                  placeItems: 'center',
+                  color: '#0B1220',
+                  fontSize: 11,
+                  fontWeight: 800,
+                }}
+              >
+                ➤
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3 · Money Hub
+// ---------------------------------------------------------------------------
+export function MoneyHubDemo() {
+  const { ref, t } = useInViewTicker(15);
+
+  const syncing = t < 1.3;
+  const interp = (start: number, end: number, from: number, to: number) =>
+    Math.max(0, Math.min(1, (t - start) / (end - start))) * (to - from) + from;
+
+  const kIncome = Math.round(interp(1.3, 2.4, 0, 12351.04));
+  const kSpent = Math.round(interp(1.4, 2.5, 0, 21968.91));
+  const kSavings = interp(1.5, 2.6, 0, -77.9).toFixed(1);
+  const kHealth = Math.round(interp(1.6, 2.7, 0, 33));
+
+  const catProgress = Math.max(0, Math.min(1, (t - 2.6) / 2.0));
+  const trendsProgress = Math.max(0, Math.min(1, (t - 4.6) / 1.4));
+  const budgetsVisible = t > 6.0;
+  const showBillsGrid = t > 8.0;
+
+  const actionItems = [
+    { at: 9.6, kind: 'hike', title: 'Sky mid-contract price rise', sub: '£41.00 → £46.00 · +12.2% · Ofcom exit right', pill: 'DISPUTE' },
+    { at: 10.4, kind: 'email', title: 'Apple: Upwork Plus renews 5 May', sub: '£29.00/mo · detected in Gmail receipt · consider downgrade', pill: 'REVIEW' },
+    { at: 11.2, kind: 'deal', title: 'Virgin Media — 3 cheaper broadband deals', sub: '£56.36/mo → £17.99/mo · save £460/yr', pill: 'SAVE £460' },
+    { at: 12.0, kind: 'delay', title: 'South Western Railway delay repay', sub: '15+ min delay on 9 Apr 2026 · claim window closes 7 May', pill: 'CLAIM £5.20' },
+  ] as const;
+
+  const kpiTiles: Array<{ l: string; v: string; c: string; i: string; sub?: string }> = [
+    { l: 'Income · Apr', v: `£${kIncome.toLocaleString()}`, c: 'var(--mint-deep)', i: '↗' },
+    { l: 'Spent · Apr', v: `£${kSpent.toLocaleString()}`, c: 'var(--text)', i: '↘' },
+    { l: 'Savings rate', v: `${kSavings}%`, c: '#B91C1C', i: '⚠' },
+    { l: 'Health score', v: `${kHealth}`, sub: '/100', c: '#F59E0B', i: '◎' },
+  ];
+
+  const incomeRows = [
+    { l: 'Rental income', p: 88.7, v: 10963.55, c: 'var(--orange)' },
+    { l: 'Loan repayment', p: 8.1, v: 997.49, c: '#EF4444' },
+    { l: 'Salary', p: 3.2, v: 400.0, c: 'var(--mint-deep)' },
+  ];
+  const spendRows = [
+    { l: 'Mortgage', p: 19.8, v: 4339.31, c: '#3B82F6' },
+    { l: 'Bills', p: 15.6, v: 3423.8, c: '#06B6D4' },
+    { l: 'Loans', p: 14.4, v: 3158.53, c: '#EF4444' },
+    { l: 'Professional', p: 14.3, v: 3136.47, c: '#8B5CF6' },
+    { l: 'Software', p: 4.5, v: 980.08, c: '#F59E0B' },
+  ];
+  const monthlyBars = [
+    { m: 'Nov', i: 0.3, s: 0.35 },
+    { m: 'Dec', i: 0.4, s: 0.45 },
+    { m: 'Jan', i: 0.7, s: 0.55 },
+    { m: 'Feb', i: 0.95, s: 0.85 },
+    { m: 'Mar', i: 0.75, s: 0.6 },
+    { m: 'Apr', i: 0.6, s: 0.85 },
+  ];
+  const budgets = [
+    { l: 'Groceries', v: 681.25, cap: 500, over: true },
+    { l: 'Travel', v: 207.14, cap: 400, over: false },
+    { l: 'Energy', v: 396.57, cap: 300, over: true },
+  ];
+  type Bill = { n: string; s: string; v: string; st: 'paid' | 'upcoming' };
+  const bills: Bill[] = [
+    { n: 'Santander Loans', s: 'Due 4th', v: '£447.12', st: 'paid' },
+    { n: 'DVLA Vehicle Tax', s: 'Due 10th', v: '£30.18', st: 'paid' },
+    { n: 'Lendinvest BTL', s: 'Due 12th', v: '£1,800.44', st: 'paid' },
+    { n: 'London Borough', s: 'Due 15th', v: '£93.89', st: 'paid' },
+    { n: 'Loqbox', s: 'Due 21st', v: '£34.95', st: 'paid' },
+    { n: 'Thames Water', s: 'Due 22nd', v: '£44.84', st: 'paid' },
+    { n: 'Skipton BS', s: 'Due 28th', v: '£817.42', st: 'upcoming' },
+    { n: 'ManyPets', s: 'Due 2nd', v: '£50.42', st: 'upcoming' },
+    { n: 'Patreon', s: 'Due 3rd', v: '£8.00', st: 'upcoming' },
+    { n: 'Starlink', s: 'Due 9th', v: '£56.36', st: 'paid' },
+    { n: 'City of Westminster', s: 'Due 10th', v: '£60.57', st: 'paid' },
+    { n: 'Creation Financial', s: 'Due 20th', v: '£397.95', st: 'upcoming' },
+  ];
+
+  return (
+    <div className="demo-stage" ref={ref}>
+      <span className="demo-label">
+        Money Hub · categories · budgets · Financial Action Centre · 14s loop
+      </span>
+
+      <div
+        style={{
+          position: 'absolute',
+          top: 40,
+          left: 32,
+          right: 32,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-end',
+          zIndex: 2,
+        }}
+      >
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 9 }}>
+            <div
+              style={{
+                width: 26,
+                height: 26,
+                borderRadius: 6,
+                background: 'var(--mint-wash)',
+                display: 'grid',
+                placeItems: 'center',
+                fontSize: 13,
+              }}
+            >
+              📊
+            </div>
+            <div style={{ fontSize: 19, fontWeight: 800, letterSpacing: '-.015em' }}>Money Hub</div>
+          </div>
+          <div style={{ fontSize: 10.5, color: 'var(--text-3)', marginTop: 3 }}>
+            Auto-syncs 4× daily · {syncing ? 'Syncing Lloyds · NatWest · Outlook…' : 'Last synced just now'}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <span className="pill grey" style={{ fontSize: 10 }}>This month ▾</span>
+          <span className="pill mint" style={{ fontSize: 10, display: 'flex', alignItems: 'center', gap: 5 }}>
+            <span
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: 'var(--mint-deep)',
+                animation: syncing ? 'demoPulse 1s infinite' : 'none',
+              }}
+            />
+            {syncing ? 'Syncing' : '2 banks · 1 email connected'}
+          </span>
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: 'absolute',
+          inset: '82px 26px 24px 26px',
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr 1fr',
+          gridTemplateRows: 'auto auto auto auto auto',
+          gap: 8,
+          overflow: 'hidden',
+          fontSize: 10.5,
+        }}
+      >
+        {kpiTiles.map((k, i) => (
+          <div
+            key={i}
+            style={{
+              background: '#fff',
+              border: '1px solid var(--divider)',
+              borderRadius: 10,
+              padding: '9px 11px',
+              boxShadow: '0 1px 2px rgba(0,0,0,.04)',
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span
+                style={{
+                  fontSize: 9.5,
+                  color: 'var(--text-3)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '.06em',
+                  fontWeight: 600,
+                }}
+              >
+                {k.l}
+              </span>
+              <span style={{ fontSize: 10, color: 'var(--text-3)' }}>{k.i}</span>
+            </div>
+            <div
+              className="mono"
+              style={{
+                fontSize: 17,
+                fontWeight: 800,
+                color: k.c,
+                letterSpacing: '-.01em',
+                marginTop: 2,
+              }}
+            >
+              {k.v}
+              {k.sub && <span style={{ fontSize: 11, color: 'var(--text-3)', fontWeight: 500 }}>{k.sub}</span>}
+            </div>
+          </div>
+        ))}
+
+        <div
+          style={{
+            gridColumn: '1 / 3',
+            background: '#fff',
+            border: '1px solid var(--divider)',
+            borderRadius: 10,
+            padding: '9px 12px',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+            <div style={{ fontSize: 11.5, fontWeight: 700 }}>📈 Income</div>
+            <span style={{ fontSize: 9.5, color: 'var(--text-3)' }}>Tap to see transactions</span>
+          </div>
+          {incomeRows.map((r, i) => (
+            <div key={i} style={{ marginBottom: 3 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 10 }}>
+                <span>
+                  <span style={{ color: 'var(--text)' }}>{r.l}</span>
+                  <span style={{ color: 'var(--text-3)', marginLeft: 3 }}>{r.p}%</span>
+                </span>
+                <span className="mono" style={{ fontWeight: 700 }}>
+                  £{r.v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </span>
+              </div>
+              <div style={{ height: 3, background: '#F3F4F6', borderRadius: 2, overflow: 'hidden', marginTop: 2 }}>
+                <div style={{ width: `${r.p * catProgress}%`, height: '100%', background: r.c, transition: 'width 60ms' }} />
+              </div>
+            </div>
+          ))}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginTop: 5,
+              paddingTop: 5,
+              borderTop: '1px solid var(--divider)',
+              fontSize: 10,
+            }}
+          >
+            <span style={{ color: 'var(--text-3)' }}>Total</span>
+            <span className="mono" style={{ fontWeight: 800 }}>£12,351.04</span>
+          </div>
+        </div>
+
+        <div
+          style={{
+            gridColumn: '3 / 5',
+            background: '#fff',
+            border: '1px solid var(--divider)',
+            borderRadius: 10,
+            padding: '9px 12px',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+            <div style={{ fontSize: 11.5, fontWeight: 700 }}>📉 Spending</div>
+            <span style={{ fontSize: 9.5, color: 'var(--text-3)' }}>Tap to recategorise</span>
+          </div>
+          {spendRows.map((r, i) => (
+            <div key={i} style={{ marginBottom: 3 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 10 }}>
+                <span>
+                  <span style={{ color: 'var(--text)' }}>{r.l}</span>
+                  <span style={{ color: 'var(--text-3)', marginLeft: 3 }}>{r.p}%</span>
+                </span>
+                <span className="mono" style={{ fontWeight: 700 }}>
+                  £{r.v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                </span>
+              </div>
+              <div style={{ height: 3, background: '#F3F4F6', borderRadius: 2, overflow: 'hidden', marginTop: 2 }}>
+                <div style={{ width: `${r.p * catProgress * 4}%`, height: '100%', background: r.c, transition: 'width 60ms' }} />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div
+          style={{
+            gridColumn: '1 / 3',
+            background: '#fff',
+            border: '1px solid var(--divider)',
+            borderRadius: 10,
+            padding: '9px 12px',
+          }}
+        >
+          <div style={{ fontSize: 11.5, fontWeight: 700, marginBottom: 5 }}>📊 Monthly trends</div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'flex-end',
+              justifyContent: 'space-between',
+              height: 46,
+              gap: 6,
+              padding: '0 2px',
+            }}
+          >
+            {monthlyBars.map((b, i) => (
+              <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, flex: 1 }}>
+                <div style={{ display: 'flex', alignItems: 'flex-end', gap: 1, height: 36 }}>
+                  <div
+                    style={{
+                      width: 6,
+                      height: `${b.i * 100 * trendsProgress}%`,
+                      background: 'var(--mint-deep)',
+                      borderRadius: '2px 2px 0 0',
+                      transition: 'height 80ms',
+                    }}
+                  />
+                  <div
+                    style={{
+                      width: 6,
+                      height: `${b.s * 100 * trendsProgress}%`,
+                      background: 'var(--orange)',
+                      borderRadius: '2px 2px 0 0',
+                      transition: 'height 80ms',
+                    }}
+                  />
+                </div>
+                <div style={{ fontSize: 9, color: 'var(--text-3)' }}>{b.m}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: 10, marginTop: 3, fontSize: 9, color: 'var(--text-3)' }}>
+            <span>
+              <span style={{ display: 'inline-block', width: 7, height: 7, background: 'var(--mint-deep)', borderRadius: 2, marginRight: 3 }} />
+              Income
+            </span>
+            <span>
+              <span style={{ display: 'inline-block', width: 7, height: 7, background: 'var(--orange)', borderRadius: 2, marginRight: 3 }} />
+              Spending
+            </span>
+          </div>
+        </div>
+
+        <div
+          style={{
+            gridColumn: '3 / 5',
+            background: '#fff',
+            border: '1px solid var(--divider)',
+            borderRadius: 10,
+            padding: '9px 12px',
+            opacity: budgetsVisible ? 1 : 0.3,
+            transition: 'opacity 400ms',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 5 }}>
+            <div style={{ fontSize: 11.5, fontWeight: 700 }}>🎯 Budgets &amp; goals</div>
+            <span style={{ fontSize: 9.5, color: 'var(--text-3)' }}>Active budgets</span>
+          </div>
+          {budgets.map((b, i) => {
+            const pct = Math.min(b.v / b.cap, 1);
+            const overAmount = b.v - b.cap;
+            return (
+              <div key={i} style={{ marginBottom: 4 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 10 }}>
+                  <span>{b.l}</span>
+                  <span className="mono" style={{ color: b.over ? '#DC2626' : 'var(--text-2)', fontWeight: 600 }}>
+                    £{b.v.toFixed(2)} / £{b.cap}.00
+                  </span>
+                </div>
+                <div
+                  style={{
+                    height: 4,
+                    background: '#F3F4F6',
+                    borderRadius: 2,
+                    overflow: 'hidden',
+                    marginTop: 2,
+                    position: 'relative',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: `${pct * 100}%`,
+                      height: '100%',
+                      background: b.over ? '#EF4444' : 'var(--mint-deep)',
+                      animation: b.over && budgetsVisible ? 'demoBudgetPulse 1.8s infinite' : 'none',
+                    }}
+                  />
+                </div>
+                {b.over && (
+                  <div style={{ fontSize: 9, color: '#DC2626', marginTop: 1, fontWeight: 600 }}>
+                    Over by £{overAmount.toFixed(2)}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              fontSize: 10,
+              marginTop: 6,
+              paddingTop: 5,
+              borderTop: '1px solid var(--divider)',
+            }}
+          >
+            <div>
+              <span
+                style={{
+                  color: 'var(--text-3)',
+                  fontSize: 9,
+                  textTransform: 'uppercase',
+                  letterSpacing: '.06em',
+                  fontWeight: 700,
+                }}
+              >
+                Savings goal · Travel
+              </span>
+              <div style={{ marginTop: 2 }}>
+                £350 / <span style={{ color: 'var(--text-3)' }}>£1,000</span>
+              </div>
+            </div>
+            <div style={{ width: 80, height: 4, background: '#F3F4F6', borderRadius: 2, overflow: 'hidden' }}>
+              <div style={{ width: '35%', height: '100%', background: 'var(--mint-deep)' }} />
+            </div>
+          </div>
+        </div>
+
+        <div
+          style={{
+            gridColumn: '1 / 5',
+            background: '#fff',
+            border: '1px solid var(--divider)',
+            borderRadius: 10,
+            padding: '9px 12px',
+            opacity: showBillsGrid ? 1 : 0.3,
+            transition: 'opacity 400ms',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+            <div style={{ fontSize: 11.5, fontWeight: 700 }}>
+              🕐 Expected bills ·{' '}
+              <span style={{ color: 'var(--text-3)', fontWeight: 500 }}>£5,937.23 expected</span>
+            </div>
+            <div style={{ display: 'flex', gap: 5, fontSize: 9, color: 'var(--text-3)' }}>
+              <span><span style={{ color: 'var(--mint-deep)' }}>●</span> Paid</span>
+              <span><span style={{ color: '#EF4444' }}>●</span> Past due</span>
+              <span><span style={{ color: 'var(--orange)' }}>●</span> Upcoming</span>
+            </div>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 5 }}>
+            {bills.map((b, i) => (
+              <div
+                key={i}
+                style={{
+                  padding: '5px 7px',
+                  borderRadius: 5,
+                  background: '#FAFAF7',
+                  border: '1px solid #F3F4F6',
+                  position: 'relative',
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 9,
+                    color: b.st === 'upcoming' ? 'var(--text)' : 'var(--text-3)',
+                    fontWeight: 600,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    textDecoration: b.st === 'paid' ? 'line-through' : 'none',
+                  }}
+                >
+                  {b.n}
+                </div>
+                <div style={{ fontSize: 8, color: 'var(--text-3)', marginTop: 1 }}>
+                  {b.s} ·{' '}
+                  <span style={{ color: b.st === 'paid' ? 'var(--mint-deep)' : 'var(--orange)', fontWeight: 600 }}>
+                    {b.st === 'paid' ? '✓ Paid' : 'Upcoming'}
+                  </span>
+                </div>
+                <div
+                  className="mono"
+                  style={{
+                    fontSize: 9.5,
+                    fontWeight: 700,
+                    marginTop: 1,
+                    textDecoration: b.st === 'paid' ? 'line-through' : 'none',
+                    color: b.st === 'paid' ? 'var(--text-3)' : 'var(--text)',
+                  }}
+                >
+                  {b.v}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div
+          style={{
+            gridColumn: '1 / 5',
+            background: 'linear-gradient(180deg, #FFFBEB, #fff)',
+            border: '1px solid #FDE68A',
+            borderRadius: 10,
+            padding: '10px 12px',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 6 }}>
+            <div>
+              <div style={{ fontSize: 11.5, fontWeight: 700, color: '#78350F', display: 'flex', alignItems: 'center', gap: 5 }}>
+                ⚡ Financial Action Centre
+                <span
+                  style={{
+                    fontSize: 9.5,
+                    fontWeight: 600,
+                    color: 'var(--text-3)',
+                    background: '#FEF3C7',
+                    padding: '2px 6px',
+                    borderRadius: 999,
+                  }}
+                >
+                  1 due soon · 78 tracked
+                </span>
+              </div>
+              <div style={{ fontSize: 10, color: '#92400E', marginTop: 2 }}>
+                Detected from your bank transactions <b>and</b> inbox scan — actions worth a few minutes of your time.
+              </div>
+            </div>
+            <span className="pill ink" style={{ fontSize: 9.5 }}>Browse deals →</span>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {actionItems.map((a, i) => {
+              const visible = t > a.at;
+              const pillColor = a.pill.startsWith('DISPUTE')
+                ? '#EF4444'
+                : a.pill.startsWith('REVIEW')
+                  ? '#F59E0B'
+                  : a.pill.startsWith('SAVE')
+                    ? 'var(--mint-deep)'
+                    : '#3B82F6';
+              const icon = a.kind === 'hike' ? '↑' : a.kind === 'email' ? '✉' : a.kind === 'deal' ? '★' : '🚆';
+              return (
+                <div
+                  key={i}
+                  style={{
+                    background: '#fff',
+                    border: '1px solid var(--divider)',
+                    borderRadius: 7,
+                    padding: '6px 9px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 9,
+                    opacity: visible ? 1 : 0,
+                    transform: visible ? 'translateY(0)' : 'translateY(4px)',
+                    transition: 'opacity 300ms, transform 300ms',
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: 5,
+                      background: '#F3F4F6',
+                      color: 'var(--text-2)',
+                      display: 'grid',
+                      placeItems: 'center',
+                      fontSize: 11,
+                      fontWeight: 700,
+                    }}
+                  >
+                    {icon}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div
+                      style={{
+                        fontSize: 10.5,
+                        fontWeight: 600,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {a.title}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: 9.5,
+                        color: 'var(--text-3)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        marginTop: 1,
+                      }}
+                    >
+                      {a.sub}
+                    </div>
+                  </div>
+                  <span
+                    style={{
+                      fontSize: 9,
+                      fontWeight: 700,
+                      padding: '2px 7px',
+                      borderRadius: 999,
+                      background: `${pillColor}14`,
+                      color: pillColor,
+                      letterSpacing: '.03em',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {a.pill}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ==================== DEMO 4 · SUBSCRIPTIONS TRACKER ==================== */
+type SubRow = {
+  name: string;
+  provider: string;
+  price: string;
+  cat: string;
+  i: string;
+  in: number;
+  pill?: { t: string; c: 'red' | 'mint' | 'orange' };
+};
+
+export function SubscriptionsDemo() {
+  const { ref: tickerRef, t } = useInViewTicker(11);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const pillRef = useRef<HTMLSpanElement | null>(null);
+  const setBothRefs = (node: HTMLDivElement | null) => {
+    stageRef.current = node;
+    tickerRef.current = node;
+  };
+
+  const rows: SubRow[] = [
+    { name: 'Mortgage', provider: 'NatWest · 5-yr fixed', price: '£1,142.00', cat: 'Mortgage', i: '🏠', in: 3.0 },
+    { name: 'Funding Circle loan', provider: 'Business loan · rate jumped 32%', price: '£189.50', cat: 'Loan', i: '£', in: 3.2, pill: { t: 'CHALLENGEABLE', c: 'red' } },
+    { name: 'Car insurance', provider: 'Aviva · renews 14 May', price: '£67.40', cat: 'Insurance', i: '🛡', in: 3.4 },
+    { name: 'Virgin Media', provider: 'Broadband + TV · last hike 12 Nov', price: '£56.36', cat: 'Telecom', i: '📶', in: 3.6, pill: { t: 'SAVE £460/yr', c: 'mint' } },
+    { name: 'Octopus Energy', provider: 'Electricity · tracker tariff', price: '£94.00', cat: 'Utility', i: '⚡', in: 3.8 },
+    { name: 'Spotify Family', provider: 'Music · 4 profiles used', price: '£19.99', cat: 'Subscription', i: '♫', in: 4.0 },
+    { name: 'Netflix Premium', provider: 'Streaming · watched today', price: '£17.99', cat: 'Subscription', i: '▶', in: 4.2 },
+    { name: 'Audible', provider: 'Audiobooks · not used 94 days', price: '£7.99', cat: 'Subscription', i: '🎧', in: 4.4, pill: { t: 'DORMANT', c: 'orange' } },
+  ];
+
+  const scanProgress = Math.min(100, (t / 2.0) * 100);
+  const scanning = t < 2.0;
+
+  const cursor = (() => {
+    if (t < 7.5 || t > 9.5) return { x: 0, y: 0, o: 0 };
+    const tgt = targetCenter(stageRef, pillRef);
+    if (!tgt) return { x: 0, y: 0, o: 0 };
+    if (t < 7.9) {
+      const k = Math.max(0, Math.min(1, (t - 7.5) / 0.4));
+      const e = k < 0.5 ? 2 * k * k : 1 - Math.pow(-2 * k + 2, 2) / 2;
+      const from = { x: 100, y: 120 };
+      return { x: from.x + (tgt.x - from.x) * e, y: from.y + (tgt.y - from.y) * e, o: 1 };
+    }
+    return { ...tgt, o: 1 };
+  })();
+  const showTip = t > 7.9 && t < 9.5;
+
+  const tipPos = (() => {
+    const pc = targetCenter(stageRef, pillRef);
+    return {
+      left: pc ? Math.max(20, pc.x - 240 + 30) : 420,
+      top: pc ? pc.y - 80 : 355,
+    };
+  })();
+
+  return (
+    <div className="demo-stage" ref={setBothRefs}>
+      <span className="demo-label">Subscriptions tracker · every fixed outgoing in one view · 10s loop</span>
+
+      <div style={{ position: 'absolute', inset: '48px 44px' }}>
+        {/* Header card */}
+        <div style={{ background: '#fff', borderRadius: 12, border: '1px solid var(--divider)', padding: '14px 20px', boxShadow: 'var(--shadow-md)', marginBottom: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <div>
+              <div className="eyebrow">Fixed outgoings · Money Hub</div>
+              <div style={{ fontSize: 16, fontWeight: 700, letterSpacing: '-.01em', marginTop: 3 }}>
+                {scanning ? 'Scanning 3 accounts…' : '27 recurring payments tracked'}
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>
+                Subscriptions · loans · mortgage · insurance · utilities · telecom — all in one view.
+              </div>
+            </div>
+            {!scanning && (
+              <div style={{ display: 'flex', gap: 14, fontSize: 11.5 }}>
+                <div>
+                  <div style={{ color: 'var(--text-3)', fontSize: 10.5 }}>Tracked / mo</div>
+                  <div className="mono" style={{ fontWeight: 700, fontSize: 14 }}>£1,847.23</div>
+                </div>
+                <div>
+                  <div style={{ color: 'var(--mint-deep)', fontSize: 10.5 }}>Savings in Deals</div>
+                  <div className="mono" style={{ fontWeight: 700, fontSize: 14, color: 'var(--mint-deep)' }}>£523/yr</div>
+                </div>
+              </div>
+            )}
+          </div>
+          <div style={{ height: 4, background: '#F3F4F6', borderRadius: 4, overflow: 'hidden' }}>
+            <div style={{ width: `${scanProgress}%`, height: '100%', background: 'linear-gradient(90deg,var(--mint),var(--mint-deep))', transition: 'width 80ms linear' }} />
+          </div>
+          {/* Category chips */}
+          {t > 2.0 && (
+            <div style={{ display: 'flex', gap: 5, marginTop: 10, flexWrap: 'wrap' }}>
+              {['All · 27', 'Subscriptions · 11', 'Utilities · 4', 'Telecom · 3', 'Insurance · 3', 'Loans · 2', 'Mortgage · 1', 'Dormant · 4'].map((c, i) => (
+                <span
+                  key={i}
+                  className={i === 0 ? 'pill ink' : 'pill grey'}
+                  style={{
+                    fontSize: 10.5,
+                    padding: '4px 9px',
+                    opacity: t > 2.0 + i * 0.1 ? 1 : 0,
+                    transform: t > 2.0 + i * 0.1 ? 'translateY(0)' : 'translateY(4px)',
+                    transition: 'opacity 250ms, transform 250ms',
+                  }}
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Rows */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {rows.map((r, i) => {
+            const visible = t > r.in;
+            const isVirgin = r.name === 'Virgin Media';
+            const highlight = isVirgin && showTip;
+            return (
+              <div
+                key={i}
+                style={{
+                  background: '#fff',
+                  borderRadius: 9,
+                  border: '1px solid var(--divider)',
+                  padding: '10px 14px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 12,
+                  opacity: visible ? 1 : 0,
+                  transform: visible ? 'translateY(0)' : 'translateY(4px)',
+                  transition: 'opacity 250ms, transform 250ms, box-shadow 200ms',
+                  boxShadow: highlight ? '0 0 0 2px var(--mint-deep)' : 'none',
+                }}
+              >
+                <div style={{ width: 30, height: 30, borderRadius: 7, background: '#F3F4F6', display: 'grid', placeItems: 'center', fontSize: 13 }}>{r.i}</div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12.5, fontWeight: 600 }}>{r.name}</div>
+                  <div style={{ fontSize: 10.5, color: 'var(--text-3)', marginTop: 1 }}>{r.provider}</div>
+                </div>
+                <span className="pill grey" style={{ fontSize: 9.5, whiteSpace: 'nowrap' }}>{r.cat}</span>
+                {r.pill && (
+                  <span ref={isVirgin ? pillRef : null} className={`pill ${r.pill.c}`} style={{ fontSize: 10, whiteSpace: 'nowrap' }}>
+                    {r.pill.t}
+                  </span>
+                )}
+                <div className="mono" style={{ fontSize: 12.5, fontWeight: 700, width: 72, textAlign: 'right' }}>{r.price}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Virgin Media savings tooltip */}
+        {showTip && (
+          <div
+            style={{
+              position: 'absolute',
+              left: tipPos.left,
+              top: tipPos.top,
+              width: 240,
+              background: 'var(--ink)',
+              color: '#fff',
+              borderRadius: 8,
+              padding: '9px 11px',
+              fontSize: 10.5,
+              lineHeight: 1.5,
+              boxShadow: '0 16px 32px -8px rgba(0,0,0,.35)',
+              animation: 'demoFadeInUp 250ms',
+              zIndex: 20,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: 'var(--mint)', marginBottom: 3 }}>£460/yr cheaper deal available</div>
+            <div style={{ color: 'rgba(255,255,255,.75)' }}>Open in Deals tab to compare side-by-side.</div>
+          </div>
+        )}
+      </div>
+
+      {/* Cursor */}
+      <div className="cursor" style={{ left: cursor.x, top: cursor.y, opacity: cursor.o }}>
+        {CURSOR_SVG}
+      </div>
+    </div>
+  );
+}
+
+/* ==================== DEMO 5 · EXPORT ==================== */
+export function ExportDemo() {
+  const { ref, t } = useInViewTicker(10);
+
+  const toggled = t > 2.3;
+  const showToggleClick = t > 2.0 && t < 2.3;
+  const cursorPos = t < 2.3 ? { x: 220, y: 220 } : t < 5.5 ? { x: 600, y: 280 } : { x: 340, y: 430 };
+
+  const rows = [
+    { tab: 'Transactions', count: 124, in: 2.8 },
+    { tab: 'Subscriptions', count: 12, in: 3.6 },
+    { tab: 'Disputes', count: 7, in: 4.4 },
+    { tab: 'Savings log', count: 104, in: 5.0 },
+  ];
+
+  const chips = [
+    { label: 'CSV', ext: '.csv', in: 5.8 },
+    { label: 'Excel', ext: '.xlsx', in: 6.2 },
+    { label: 'PDF', ext: '.pdf', in: 6.6 },
+  ];
+  const showClickCSV = t > 7.0 && t < 7.3;
+  const showToast = t > 7.2;
+
+  const gridRows = [
+    { m: 'Tesco', a: '−42.80', d: '14 Nov', in: 2.9, hike: false },
+    { m: 'Virgin Media ⚠', a: '−50.00', d: '12 Nov', in: 3.3, hike: true },
+    { m: 'Spotify', a: '−11.99', d: '10 Nov', in: 3.7, hike: false },
+    { m: 'TfL', a: '−2.80', d: '9 Nov', in: 4.1, hike: false },
+    { m: 'Audible', a: '−7.99', d: '8 Nov', in: 4.5, hike: false },
+    { m: 'Deliveroo', a: '−18.20', d: '7 Nov', in: 4.9, hike: false },
+    { m: 'Netflix', a: '−10.99', d: '5 Nov', in: 5.3, hike: false },
+  ];
+
+  return (
+    <div className="demo-stage" ref={ref}>
+      <span className="demo-label">Export · 9s loop</span>
+
+      <div style={{ position: 'absolute', inset: '48px 44px', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 18 }}>
+        {/* LEFT: Export Hub card */}
+        <div style={{ background: '#fff', borderRadius: 14, border: '1px solid var(--divider)', padding: '20px 22px', boxShadow: 'var(--shadow-md)', display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <div className="eyebrow">Export hub</div>
+            <div style={{ fontSize: 18, fontWeight: 700, letterSpacing: '-.01em', marginTop: 4 }}>Your data, anywhere</div>
+          </div>
+
+          {/* Google Sheets live sync row */}
+          <div style={{ background: '#FAFAF7', borderRadius: 10, padding: '14px 16px', border: '1px solid var(--divider)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+              <div style={{ width: 32, height: 32, borderRadius: 8, background: '#0F9D58', display: 'grid', placeItems: 'center', color: '#fff', fontSize: 14, fontWeight: 800 }}>⊞</div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 13, fontWeight: 700 }}>Google Sheets</div>
+                <div style={{ fontSize: 11, color: 'var(--text-3)' }}>Auto-sync every hour</div>
+              </div>
+              <div
+                style={{
+                  width: 44,
+                  height: 24,
+                  borderRadius: 12,
+                  background: toggled ? 'var(--mint-deep)' : '#D1D5DB',
+                  position: 'relative',
+                  transition: 'background 300ms',
+                  cursor: 'pointer',
+                }}
+              >
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 2,
+                    left: toggled ? 22 : 2,
+                    width: 20,
+                    height: 20,
+                    borderRadius: '50%',
+                    background: '#fff',
+                    transition: 'left 300ms',
+                    boxShadow: '0 1px 3px rgba(0,0,0,.2)',
+                  }}
+                />
+              </div>
+            </div>
+            {toggled && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11, color: 'var(--mint-deep)', fontWeight: 600, animation: 'demoFadeInUp 300ms' }}>
+                <span style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--mint-deep)', animation: 'demoPulse 1.5s infinite' }} />
+                Live · connected to Paybacker workbook
+              </div>
+            )}
+          </div>
+
+          {/* One-shot download chips */}
+          <div>
+            <div style={{ fontSize: 11.5, color: 'var(--text-3)', fontWeight: 600, marginBottom: 8 }}>Or download one-shot</div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              {chips.map((c, i) => (
+                <div
+                  key={i}
+                  style={{
+                    flex: 1,
+                    padding: '10px 12px',
+                    borderRadius: 8,
+                    background: t > c.in ? 'var(--ink)' : '#F3F4F6',
+                    color: t > c.in ? '#fff' : 'var(--text-3)',
+                    fontSize: 12,
+                    fontWeight: 600,
+                    textAlign: 'center',
+                    transition: 'all 300ms',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 3,
+                  }}
+                >
+                  <span style={{ fontSize: 13, fontWeight: 700 }}>{c.label}</span>
+                  <span className="mono" style={{ fontSize: 10, opacity: 0.7 }}>{c.ext}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ fontSize: 10.5, color: 'var(--text-4)', lineHeight: 1.55, marginTop: 'auto' }}>
+            Read-only scope. We never write to your accounts.
+          </div>
+        </div>
+
+        {/* RIGHT: Sheets preview */}
+        <div style={{ background: '#fff', borderRadius: 14, border: '1px solid var(--divider)', overflow: 'hidden', boxShadow: 'var(--shadow-md)', display: 'flex', flexDirection: 'column' }}>
+          <div style={{ background: '#F8F9FA', borderBottom: '1px solid var(--divider)', padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 10 }}>
+            <div style={{ width: 22, height: 22, borderRadius: 5, background: '#0F9D58', display: 'grid', placeItems: 'center', color: '#fff', fontSize: 10, fontWeight: 800 }}>⊞</div>
+            <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text)' }}>Paybacker_Export.xlsx</div>
+            <div style={{ flex: 1 }} />
+            <span className="mono" style={{ fontSize: 10, color: 'var(--text-3)' }}>sheets.google.com</span>
+          </div>
+
+          <div style={{ background: '#F1F3F4', display: 'flex', padding: '0 8px', borderBottom: '1px solid var(--divider)' }}>
+            {rows.map((r, i) => (
+              <div
+                key={i}
+                style={{
+                  padding: '8px 14px',
+                  fontSize: 11,
+                  fontWeight: 600,
+                  borderTop: i === 0 ? '2px solid #0F9D58' : '2px solid transparent',
+                  background: i === 0 ? '#fff' : 'transparent',
+                  color: t > r.in ? 'var(--text)' : 'var(--text-4)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 5,
+                }}
+              >
+                {r.tab}
+                {t > r.in && <span className="mono" style={{ fontSize: 9, color: 'var(--mint-deep)', fontWeight: 700 }}>+{r.count}</span>}
+              </div>
+            ))}
+          </div>
+
+          <div style={{ flex: 1, padding: '8px', fontSize: 10.5, fontFamily: 'JetBrains Mono, monospace', overflow: 'hidden' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '40px 1fr 90px 70px', gap: 1, background: '#F8F9FA', padding: '5px 4px', fontWeight: 700, color: 'var(--text-3)', borderBottom: '1px solid var(--divider)' }}>
+              <div></div>
+              <div>Merchant</div>
+              <div style={{ textAlign: 'right' }}>Amount</div>
+              <div style={{ textAlign: 'right' }}>Date</div>
+            </div>
+            {gridRows.map((r, i) => (
+              <div
+                key={i}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '40px 1fr 90px 70px',
+                  gap: 1,
+                  padding: '4px',
+                  borderBottom: '1px solid #F0F0F0',
+                  color: r.hike ? 'var(--orange-deep)' : 'var(--text)',
+                  opacity: t > r.in ? 1 : 0,
+                  transform: t > r.in ? 'translateY(0)' : 'translateY(3px)',
+                  transition: 'all 220ms ease-out',
+                }}
+              >
+                <div style={{ color: 'var(--text-4)', textAlign: 'center' }}>{i + 2}</div>
+                <div>{r.m}</div>
+                <div style={{ textAlign: 'right' }}>£{r.a}</div>
+                <div style={{ textAlign: 'right', color: 'var(--text-3)' }}>{r.d}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Toast */}
+      <div className={`toast ${showToast ? 'show' : ''}`}>
+        <span className="dot" /> Synced 247 rows to Paybacker workbook
+      </div>
+
+      {/* Cursor */}
+      <div className="cursor" style={{ left: cursorPos.x, top: cursorPos.y, opacity: t < 8.5 ? 1 : 0 }}>
+        {CURSOR_SVG}
+      </div>
+      {showToggleClick && <div className="click-ring" style={{ left: 240, top: 230 }} key="x1" />}
+      {showClickCSV && <div className="click-ring" style={{ left: 360, top: 440 }} key="x2" />}
+    </div>
+  );
+}
+
+/* ==================== DEMO 7 · DEALS TAB ==================== */
+export function DealsDemo() {
+  const { ref: tickerRef, t } = useInViewTicker(12);
+  const stageRef = useRef<HTMLDivElement | null>(null);
+  const guideBtnRef = useRef<HTMLButtonElement | null>(null);
+  const setBothRefs = (node: HTMLDivElement | null) => {
+    stageRef.current = node;
+    tickerRef.current = node;
+  };
+
+  const deals = [
+    { cat: 'Broadband', icon: '📶', from: { n: 'Virgin Media', p: '£56.36' }, to: { n: 'Vodafone Fibre', p: '£17.99' }, save: 460, ends: '14 May', in: 1.6, hl: true },
+    { cat: 'Car insurance', icon: '🛡', from: { n: 'Aviva', p: '£67.40' }, to: { n: 'Admiral', p: '£49.20' }, save: 218, ends: '30 Jun', in: 1.9, hl: false },
+    { cat: 'Energy', icon: '⚡', from: { n: 'British Gas', p: '£118.00' }, to: { n: 'Octopus Tracker', p: '£94.00' }, save: 288, ends: 'rolling', in: 2.2, hl: false },
+  ];
+
+  const showComparison = t > 3.5;
+  const showGuide = t > 7.5;
+  const cursor = (() => {
+    if (t < 5.0 || t > 7.3) return { x: 0, y: 0, o: 0 };
+    const tgt = targetCenter(stageRef, guideBtnRef);
+    if (!tgt) return { x: 0, y: 0, o: 0 };
+    if (t < 5.5) {
+      const k = Math.max(0, Math.min(1, (t - 5.0) / 0.5));
+      const e = k < 0.5 ? 2 * k * k : 1 - Math.pow(-2 * k + 2, 2) / 2;
+      const from = { x: 120, y: 140 };
+      return { x: from.x + (tgt.x - from.x) * e, y: from.y + (tgt.y - from.y) * e, o: 1 };
+    }
+    return { ...tgt, o: 1 };
+  })();
+  const clickGuide = t > 7.2 && t < 7.5;
+  const savingsTick = Math.max(0, Math.min(460, (t - 9.5) * 460 / 1.0));
+
+  const compareRows = [
+    { l: 'Monthly price', c: '£56.36', d: '£17.99', s: '−£38.37' },
+    { l: 'Speed', c: '350 Mbps', d: '500 Mbps', s: '+150' },
+    { l: 'Contract', c: 'Rolling', d: '24 months', s: '' },
+    { l: 'Setup fee', c: '—', d: '£0', s: '' },
+  ];
+
+  const guideSteps = [
+    { n: 1, t: 'Check exit right', d: 'Ofcom rule — mid-contract price rise = penalty-free exit within 30 days' },
+    { n: 2, t: 'Order Vodafone Fibre', d: 'New connection scheduled before old one ends. No downtime.' },
+    { n: 3, t: 'Cancel Virgin Media', d: 'We provide template letter. You send it from your email.' },
+    { n: 4, t: 'Confirm first Vodafone bill', d: 'We watch your bank feed and flag if anything goes wrong.' },
+  ];
+
+  return (
+    <div className="demo-stage" ref={setBothRefs}>
+      <span className="demo-label">Deals · links bills to better prices · guidance, not auto-switch · 11s loop</span>
+
+      <div style={{ position: 'absolute', inset: '48px 44px', display: 'flex', gap: 14, flexDirection: 'column' }}>
+        {/* Hero strip */}
+        <div
+          style={{
+            background: 'linear-gradient(120deg, var(--mint-wash), #fff 70%)',
+            borderRadius: 13,
+            border: '1px solid var(--mint)',
+            padding: '14px 20px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <div>
+            <div className="eyebrow" style={{ color: 'var(--mint-deep)' }}>Deals · verified weekly</div>
+            <div style={{ fontSize: 18, fontWeight: 800, letterSpacing: '-.015em', marginTop: 3 }}>
+              53 deals matched to <span style={{ color: 'var(--mint-deep)' }}>your</span> bills
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--text-3)', marginTop: 2 }}>We compare your current suppliers to live market offers. You choose what to switch.</div>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontSize: 10.5, color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '.08em', fontWeight: 600 }}>Potential savings</div>
+            <div className="mono" style={{ fontSize: 24, fontWeight: 800, color: 'var(--mint-deep)', letterSpacing: '-.01em' }}>
+              £2,840<span style={{ fontSize: 13, color: 'var(--text-3)', fontWeight: 600 }}>/yr</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Main */}
+        <div style={{ display: 'flex', gap: 14, flex: 1, minHeight: 0 }}>
+          {/* Left: deal cards */}
+          <div style={{ flex: '0 0 440px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {deals.map((d, i) => {
+              const visible = t > d.in;
+              const highlighted = d.hl && showComparison;
+              return (
+                <div
+                  key={i}
+                  style={{
+                    background: '#fff',
+                    borderRadius: 10,
+                    border: '1px solid var(--divider)',
+                    padding: '11px 13px',
+                    opacity: visible ? 1 : 0,
+                    transform: visible ? 'translateX(0)' : 'translateX(-10px)',
+                    transition: 'opacity 350ms, transform 350ms, box-shadow 250ms',
+                    boxShadow: highlighted ? '0 0 0 2px var(--mint-deep), var(--shadow-md)' : 'var(--shadow-sm)',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 9, marginBottom: 7 }}>
+                    <div style={{ width: 28, height: 28, borderRadius: 7, background: '#F3F4F6', display: 'grid', placeItems: 'center', fontSize: 13 }}>{d.icon}</div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 11.5, color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '.05em', fontWeight: 600 }}>{d.cat}</div>
+                      <div style={{ fontSize: 10.5, color: 'var(--text-3)' }}>Deal ends {d.ends}</div>
+                    </div>
+                    <span className="pill mint" style={{ fontSize: 10.5 }}>SAVE £{d.save}/yr</span>
+                  </div>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr', gap: 8, alignItems: 'center', padding: '7px 0' }}>
+                    <div>
+                      <div style={{ fontSize: 9.5, color: 'var(--text-3)', textTransform: 'uppercase', letterSpacing: '.06em', fontWeight: 600 }}>Your supplier</div>
+                      <div style={{ fontSize: 12, fontWeight: 600, marginTop: 2 }}>{d.from.n}</div>
+                      <div className="mono" style={{ fontSize: 12.5, color: 'var(--text-2)', textDecoration: 'line-through', marginTop: 1 }}>{d.from.p}/mo</div>
+                    </div>
+                    <div style={{ color: 'var(--mint-deep)', fontSize: 16, fontWeight: 800 }}>→</div>
+                    <div style={{ textAlign: 'right' }}>
+                      <div style={{ fontSize: 9.5, color: 'var(--mint-deep)', textTransform: 'uppercase', letterSpacing: '.06em', fontWeight: 700 }}>Best deal</div>
+                      <div style={{ fontSize: 12, fontWeight: 700, marginTop: 2 }}>{d.to.n}</div>
+                      <div className="mono" style={{ fontSize: 13, color: 'var(--mint-deep)', fontWeight: 800, marginTop: 1 }}>{d.to.p}/mo</div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Right: comparison + guide panel */}
+          <div
+            style={{
+              flex: 1,
+              background: '#fff',
+              borderRadius: 12,
+              border: '1px solid var(--divider)',
+              padding: '16px 18px',
+              boxShadow: 'var(--shadow-md)',
+              minWidth: 0,
+              opacity: showComparison ? 1 : 0,
+              transform: showComparison ? 'translateX(0)' : 'translateX(20px)',
+              transition: 'opacity 500ms, transform 500ms',
+              display: 'flex',
+              flexDirection: 'column',
+              position: 'relative',
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+              <div>
+                <div className="eyebrow">Comparison · Virgin Media → Vodafone</div>
+                <div style={{ fontSize: 15, fontWeight: 700, letterSpacing: '-.01em', marginTop: 3 }}>Side-by-side</div>
+              </div>
+              <span className="pill mint" style={{ fontSize: 10 }}>Ofcom verified</span>
+            </div>
+
+            {/* Comparison table */}
+            <div style={{ marginTop: 11, border: '1px solid var(--divider)', borderRadius: 8, overflow: 'hidden' }}>
+              {compareRows.map((r, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1.1fr 1fr 1fr 0.9fr',
+                    padding: '7px 10px',
+                    fontSize: 11,
+                    background: i % 2 ? '#FAFAF7' : '#fff',
+                    borderTop: i ? '1px solid var(--divider)' : 'none',
+                  }}
+                >
+                  <div style={{ color: 'var(--text-3)' }}>{r.l}</div>
+                  <div style={{ textDecoration: r.l === 'Monthly price' ? 'line-through' : 'none', color: 'var(--text-2)' }}>{r.c}</div>
+                  <div style={{ fontWeight: 700 }}>{r.d}</div>
+                  <div className="mono" style={{ color: r.s.startsWith('−') ? 'var(--mint-deep)' : 'var(--text-3)', fontWeight: 600, textAlign: 'right' }}>{r.s}</div>
+                </div>
+              ))}
+            </div>
+
+            {/* Savings number (ticking) */}
+            <div style={{ marginTop: 10, padding: '10px 12px', background: 'var(--mint-wash)', borderRadius: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <div style={{ fontSize: 10.5, color: 'var(--mint-dark)', textTransform: 'uppercase', letterSpacing: '.06em', fontWeight: 700 }}>Annual saving if you switch</div>
+                <div style={{ fontSize: 10.5, color: 'var(--text-3)', marginTop: 1 }}>You keep every penny. We charge 0% success fee.</div>
+              </div>
+              <div className="mono" style={{ fontSize: 22, fontWeight: 800, color: 'var(--mint-deep)', letterSpacing: '-.01em' }}>
+                £{Math.round(t > 9.5 ? savingsTick : 460)}
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div style={{ marginTop: 10, display: 'flex', gap: 7 }}>
+              <button style={{ flex: 1, padding: '9px 10px', borderRadius: 7, background: '#F3F4F6', border: 'none', fontSize: 11.5, fontWeight: 600, color: 'var(--text-2)' }}>Save for later</button>
+              <button ref={guideBtnRef} style={{ flex: 2, padding: '9px 10px', borderRadius: 7, background: 'var(--ink)', color: '#fff', border: 'none', fontSize: 11.5, fontWeight: 700 }}>
+                See switching guide →
+              </button>
+            </div>
+
+            {/* Guide panel (overlay) */}
+            {showGuide && (
+              <div
+                style={{
+                  position: 'absolute',
+                  inset: '12px 12px 12px 12px',
+                  background: '#fff',
+                  borderRadius: 10,
+                  border: '1px solid var(--divider)',
+                  padding: '14px 16px',
+                  animation: 'demoSlideInRight 350ms cubic-bezier(.4,0,.2,1)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  boxShadow: 'var(--shadow-lg)',
+                }}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <div>
+                    <div className="eyebrow">Switching guide · Vodafone Fibre</div>
+                    <div style={{ fontSize: 14, fontWeight: 700, letterSpacing: '-.01em', marginTop: 3 }}>4 steps · you stay in control</div>
+                  </div>
+                  <span style={{ fontSize: 14, color: 'var(--text-3)' }}>×</span>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginTop: 10, fontSize: 11.5 }}>
+                  {guideSteps.map((s, i) => (
+                    <div key={i} style={{ display: 'flex', gap: 9, alignItems: 'flex-start', padding: '7px 9px', background: '#FAFAF7', borderRadius: 7 }}>
+                      <div style={{ width: 22, height: 22, borderRadius: '50%', background: 'var(--ink)', color: '#fff', fontSize: 11, display: 'grid', placeItems: 'center', fontWeight: 700, flexShrink: 0 }}>{s.n}</div>
+                      <div>
+                        <div style={{ fontWeight: 700 }}>{s.t}</div>
+                        <div style={{ color: 'var(--text-3)', fontSize: 10.5, marginTop: 1, lineHeight: 1.45 }}>{s.d}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div style={{ marginTop: 10, padding: '8px 10px', background: '#FFFBEB', border: '1px solid #FCD34D', borderRadius: 7, fontSize: 10.5, color: '#78350F', lineHeight: 1.45, display: 'flex', gap: 7 }}>
+                  <span style={{ fontSize: 12 }}>ⓘ</span>
+                  <span>
+                    <b>Yapily is read-only.</b> Paybacker never moves your money. You do every switch yourself — we just make it easy.
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Cursor */}
+      <div className="cursor" style={{ left: cursor.x, top: cursor.y, opacity: cursor.o }}>
+        {CURSOR_SVG}
+      </div>
+      {clickGuide && <div className="click-ring" style={{ left: cursor.x + 11, top: cursor.y + 11 }} key={`c1-${Math.floor(t * 10)}`} />}
+    </div>
+  );
+}
+
+/* ==================== DEMO 6 · PAYBACKER MCP ==================== */
+export function McpDemo() {
+  const { ref, t } = useInViewTicker(11);
+
+  const prompt = 'Which of my bills went up this year and by how much?';
+  const promptProgress = Math.max(0, Math.min(1, (t - 1.0) / 2.3));
+  const promptTyped = prompt.slice(0, Math.floor(prompt.length * promptProgress));
+  const promptDone = t > 3.3;
+
+  const showToolCall = t > 3.5;
+  const showToolResult = t > 4.5;
+  const summaryText =
+    'Three bills increased this year:\n\n' +
+    '\u2022 Virgin Media: \u00A338 \u2192 \u00A350 (+32%) \u2014 flagged, no notice given (Ofcom C1.8 breach)\n' +
+    '\u2022 British Gas: \u00A395 \u2192 \u00A3118 (+24%) \u2014 within price-cap window, legitimate\n' +
+    '\u2022 Sky: \u00A328 \u2192 \u00A334 (+21%) \u2014 check your original contract\n\n' +
+    'The Virgin Media hike is already draftable. Want me to open a dispute?';
+  const summaryProgress = Math.max(0, Math.min(1, (t - 6.5) / 2.0));
+  const summaryTyped = summaryText.slice(0, Math.floor(summaryText.length * summaryProgress));
+
+  const chats = ['Refund hunt', 'Invoice review', 'New conversation'];
+  const tools = [
+    { n: 'paybacker', on: true, active: true },
+    { n: 'filesystem', on: true, active: false },
+    { n: 'github', on: true, active: false },
+  ];
+
+  type RowTuple = readonly [string, string, string, string, 'orange' | 'grey'];
+  const rows: RowTuple[] = [
+    ['Virgin Media', '£38', '£50', '+32%', 'orange'],
+    ['British Gas', '£95', '£118', '+24%', 'grey'],
+    ['Sky', '£28', '£34', '+21%', 'grey'],
+  ];
+
+  return (
+    <div className="demo-stage dark" style={{ background: '#1a1a1a' }} ref={ref}>
+      <span className="demo-label" style={{ color: 'rgba(255,255,255,.7)', background: 'rgba(0,0,0,.4)' }}>
+        Paybacker MCP · 10s loop
+      </span>
+
+      <div
+        style={{
+          position: 'absolute',
+          inset: '28px',
+          background: '#1F1F1F',
+          borderRadius: 10,
+          overflow: 'hidden',
+          border: '1px solid rgba(255,255,255,.08)',
+          display: 'grid',
+          gridTemplateColumns: '200px 1fr',
+        }}
+      >
+        {/* Traffic lights bar */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 36,
+            background: '#2A2A2A',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '0 12px',
+            borderBottom: '1px solid rgba(255,255,255,.06)',
+            zIndex: 5,
+          }}
+        >
+          <div style={{ width: 11, height: 11, borderRadius: '50%', background: '#FF5F57' }} />
+          <div style={{ width: 11, height: 11, borderRadius: '50%', background: '#FEBC2E' }} />
+          <div style={{ width: 11, height: 11, borderRadius: '50%', background: '#28C840' }} />
+          <div style={{ flex: 1, textAlign: 'center', fontSize: 11, color: 'rgba(255,255,255,.4)', fontWeight: 500 }}>Claude</div>
+        </div>
+
+        {/* Sidebar */}
+        <div style={{ paddingTop: 36, background: '#202020', borderRight: '1px solid rgba(255,255,255,.06)', padding: '44px 12px 12px' }}>
+          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.1em', color: 'rgba(255,255,255,.4)', textTransform: 'uppercase', marginBottom: 10, padding: '0 6px' }}>
+            Chats
+          </div>
+          {chats.map((c, i) => (
+            <div
+              key={i}
+              style={{
+                padding: '7px 10px',
+                borderRadius: 6,
+                background: i === 2 ? 'rgba(255,255,255,.06)' : 'transparent',
+                color: i === 2 ? '#fff' : 'rgba(255,255,255,.6)',
+                fontSize: 11.5,
+                marginBottom: 2,
+              }}
+            >
+              {c}
+            </div>
+          ))}
+          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.1em', color: 'rgba(255,255,255,.4)', textTransform: 'uppercase', margin: '22px 0 10px', padding: '0 6px' }}>
+            MCP tools
+          </div>
+          {tools.map((m, i) => {
+            const isActive = m.active && t > 3.5 && t < 6.5;
+            return (
+              <div
+                key={i}
+                style={{
+                  padding: '7px 10px',
+                  borderRadius: 6,
+                  marginBottom: 2,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  background: isActive ? 'rgba(52,211,153,.1)' : 'transparent',
+                  border: isActive ? '1px solid rgba(52,211,153,.3)' : '1px solid transparent',
+                  transition: 'all 200ms',
+                }}
+              >
+                <div
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: '50%',
+                    background: isActive ? '#34D399' : '#10B981',
+                    animation: isActive ? 'demoPulse 1s infinite' : 'none',
+                  }}
+                />
+                <span
+                  style={{
+                    fontSize: 11.5,
+                    color: isActive ? '#6EE7B7' : 'rgba(255,255,255,.7)',
+                    fontWeight: m.active ? 600 : 500,
+                    fontFamily: 'JetBrains Mono,monospace',
+                  }}
+                >
+                  {m.n}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Conversation */}
+        <div style={{ paddingTop: 36, padding: '44px 28px 20px', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          {/* User prompt */}
+          <div
+            style={{
+              alignSelf: 'flex-end',
+              maxWidth: '80%',
+              background: '#2E2E2E',
+              borderRadius: '12px 12px 2px 12px',
+              padding: '10px 14px',
+              fontSize: 12.5,
+              color: 'rgba(255,255,255,.92)',
+              marginBottom: 14,
+            }}
+          >
+            {promptTyped}
+            {!promptDone && <span className="caret" />}
+          </div>
+
+          {/* Tool call */}
+          {showToolCall && (
+            <div
+              style={{
+                alignSelf: 'flex-start',
+                maxWidth: '85%',
+                background: 'rgba(52,211,153,.08)',
+                border: '1px solid rgba(52,211,153,.25)',
+                borderRadius: 8,
+                padding: '8px 12px',
+                fontSize: 11,
+                marginBottom: 10,
+                fontFamily: 'JetBrains Mono, monospace',
+                color: '#6EE7B7',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                animation: 'demoFadeIn 250ms ease-out',
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: 10,
+                  height: 10,
+                  border: '1.5px solid #6EE7B7',
+                  borderTopColor: 'transparent',
+                  borderRadius: '50%',
+                  animation: showToolResult ? 'none' : 'demoSpin 0.8s linear infinite',
+                }}
+              />
+              {showToolResult ? '✓' : ''} Called <b>paybacker</b>.query_transactions(year=2026, type="recurring")
+            </div>
+          )}
+
+          {/* Tool result */}
+          {showToolResult && (
+            <div
+              style={{
+                alignSelf: 'flex-start',
+                maxWidth: '95%',
+                background: '#141414',
+                border: '1px solid rgba(255,255,255,.08)',
+                borderRadius: 8,
+                padding: '10px 12px',
+                marginBottom: 14,
+                fontFamily: 'JetBrains Mono, monospace',
+                fontSize: 10.5,
+                color: 'rgba(255,255,255,.75)',
+                animation: 'demoFadeIn 300ms ease-out',
+              }}
+            >
+              <div style={{ color: 'rgba(255,255,255,.4)', marginBottom: 6 }}>→ 3 bills with YoY increase</div>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 70px 70px 60px',
+                  gap: 4,
+                  fontSize: 10,
+                  color: 'rgba(255,255,255,.4)',
+                  borderBottom: '1px solid rgba(255,255,255,.1)',
+                  paddingBottom: 4,
+                  marginBottom: 4,
+                }}
+              >
+                <div>merchant</div>
+                <div style={{ textAlign: 'right' }}>from</div>
+                <div style={{ textAlign: 'right' }}>to</div>
+                <div style={{ textAlign: 'right' }}>Δ</div>
+              </div>
+              {rows.map((row, i) => (
+                <div
+                  key={i}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 70px 70px 60px',
+                    gap: 4,
+                    padding: '3px 0',
+                    color: row[4] === 'orange' ? '#FCD34D' : 'rgba(255,255,255,.8)',
+                  }}
+                >
+                  <div>{row[0]}</div>
+                  <div style={{ textAlign: 'right' }}>{row[1]}</div>
+                  <div style={{ textAlign: 'right' }}>{row[2]}</div>
+                  <div style={{ textAlign: 'right', fontWeight: 700 }}>{row[3]}</div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Claude summary */}
+          {summaryProgress > 0 && (
+            <div
+              style={{
+                alignSelf: 'flex-start',
+                maxWidth: '90%',
+                fontSize: 12.5,
+                color: 'rgba(255,255,255,.9)',
+                lineHeight: 1.6,
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {summaryTyped}
+              {summaryProgress < 1 && <span className="caret" />}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/preview/homepage/demos.tsx
+++ b/src/app/preview/homepage/demos.tsx
@@ -51,14 +51,21 @@ function useInViewTicker(period: number) {
       return () => stop();
     }
 
+    // Trigger the demo to restart at T=0 every time it scrolls into view
+    // (≥25% visible). Small positive rootMargin so it fires just before the
+    // user is centred on the stage — no "missed the start" feeling.
     const io = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
         if (!entry) return;
-        if (entry.isIntersecting) play();
-        else stop();
+        if (entry.isIntersecting) {
+          stop();
+          play();
+        } else {
+          stop();
+        }
       },
-      { rootMargin: '200px 0px' },
+      { rootMargin: '0px 0px -15% 0px', threshold: [0, 0.25] },
     );
     io.observe(node);
 

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -240,53 +240,14 @@ function Nav() {
 }
 
 // ---------------------------------------------------------------------------
-// HeroVisual — live DisputesDemo as the hero centrepiece, with two floating
-// supporting cards (mini savings snapshot + Pocket Agent bubble).
+// HeroVisual — live DisputesDemo as a clean centred device. No rotation, no
+// floating overlays. The demo is the hero — let it breathe.
 // ---------------------------------------------------------------------------
 function HeroVisual() {
-  const dashRef = useRef<HTMLDivElement | null>(null);
-
-  const onMouseMove = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    const el = dashRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    const x = (event.clientX - rect.left) / rect.width - 0.5;
-    const y = (event.clientY - rect.top) / rect.height - 0.5;
-    const rotY = x * 4;
-    const rotX = -y * 3;
-    el.style.transform = `perspective(1200px) rotateX(${rotX.toFixed(2)}deg) rotateY(${rotY.toFixed(2)}deg) translateZ(0)`;
-  }, []);
-
-  const onMouseLeave = useCallback(() => {
-    const el = dashRef.current;
-    if (!el) return;
-    el.style.transform = '';
-  }, []);
-
   return (
     <div className="hero-visual hero-visual--live" aria-hidden="true">
-      <div className="mini-card float mini-card--hero" style={{ animationDelay: '-2s' }}>
-        <div className="label">Yearly savings spotted</div>
-        <div className="big">£1,000+</div>
-        <div className="desc">typical amount we find per household</div>
-      </div>
-
-      <div
-        ref={dashRef}
-        className="hero-demo-frame tilt-host"
-        onMouseMove={onMouseMove}
-        onMouseLeave={onMouseLeave}
-      >
+      <div className="hero-demo-frame">
         <DisputesDemo />
-      </div>
-
-      <div className="agent-bubble float agent-bubble--hero" style={{ animationDelay: '-3s' }}>
-        <div className="who">
-          <span className="dot-mint" /> Pocket Agent · Telegram
-        </div>
-        <div className="msg">
-          Virgin Media bill up <strong>£12</strong> — draft an Ofcom dispute?
-        </div>
       </div>
     </div>
   );

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -1,266 +1,617 @@
 'use client';
 
 /**
- * Homepage v2 preview — /preview/homepage
+ * Homepage v3 preview — /preview/homepage
  *
- * This is the staging surface for the homepage redesign series. PR 2
- * ported the v2 design export, PR 3 added full feature parity
- * (Why We Exist, Pocket Agent Showcase, AI Assistant, Subs Tracking,
- * FAQ). PR 4 (this change) wires the hero ticker and stats cards to
- * live Supabase data via /api/preview/homepage-stats and connects the
- * mini letter form to the real /api/complaints/preview endpoint.
+ * Dynamic homepage redesign ported from
+ *   design_handoff_paybacker_homepage/index.html
+ * with extra scroll-driven dynamism (intersection-observer reveals,
+ * animated counters, scroll progress bar, 3D dashboard tilt, sticky
+ * conversion CTA, marquee testimonials).
  *
- * Everything lives under `.m-v2-root` so styles can't leak onto the
- * live homepage or the authenticated dashboard.
+ * Everything is wrapped in `.m-v2-root` so the scoped stylesheet at
+ * `./styles.css` cannot leak onto `/`, the dashboard, or any other
+ * surface. Once Paul approves this surface we cut /preview/homepage
+ * over to `/`.
  *
- * Remaining:
- *   PR 5 — cut the v2 page over to `/` once Paul signs off.
+ * Content rules (see redesign/CONTENT_SOURCES_OF_TRUTH.md):
+ *   - No fabricated specific savings claims.
+ *   - Member counts are forbidden.
+ *   - Six named testimonials may appear ONLY on this surface.
  */
 
-import { useEffect, useRef, useState } from 'react';
-import type { CSSProperties, FormEvent } from 'react';
+import Link from 'next/link';
+import {
+  createElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react';
 import './styles.css';
 
-// React.CSSProperties doesn't know about CSS custom properties; a small
-// helper cast keeps the inline-style literals readable and type-safe.
+// React.CSSProperties doesn't know about CSS custom properties.
 type CSSVarProperties = CSSProperties & Record<`--${string}`, string | number>;
 
-type Testimonial = {
-  name: string;
-  meta: string;
-  quote: string;
-  saved: string;
-  color: string;
+// ---------------------------------------------------------------------------
+// Reveal — scroll-triggered fade/slide
+// ---------------------------------------------------------------------------
+type RevealProps = {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+  as?:
+    | 'div'
+    | 'section'
+    | 'article'
+    | 'header'
+    | 'footer'
+    | 'ul'
+    | 'li'
+    | 'span'
+    | 'p'
+    | 'h2'
+    | 'h3';
 };
+function Reveal({ children, className = '', delay = 0, as: Tag = 'div' }: RevealProps) {
+  const ref = useRef<HTMLElement | null>(null);
+  const [inView, setInView] = useState(false);
 
-// Live stats returned by /api/preview/homepage-stats.
-// `source === 'seed'` means every figure is zero (no real users yet) —
-// we keep the "Preview data" badge visible in that case.
-type HomepageStats = {
-  savedThisMonth: number;
-  avgSavingsPerUser: number;
-  subscriptionsTracked: number;
-  foundingMembers: number;
-  asOf: string;
-  source: 'live' | 'seed' | 'fallback';
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const prefersReduced =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReduced || typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setInView(true);
+            io.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -40px 0px' }
+    );
+    io.observe(node);
+    return () => io.disconnect();
+  }, []);
+
+  const classes = ['reveal', inView ? 'in' : '', className].filter(Boolean).join(' ');
+  const style: CSSProperties | undefined = delay ? { transitionDelay: `${delay}ms` } : undefined;
+
+  return createElement(Tag, { ref, className: classes, style }, children);
+}
+
+// ---------------------------------------------------------------------------
+// Counter — animated count-up on scroll into view
+// ---------------------------------------------------------------------------
+type CounterProps = {
+  to: number;
+  duration?: number;
+  prefix?: string;
+  suffix?: string;
+  fractionDigits?: number;
 };
+function Counter({
+  to,
+  duration = 1400,
+  prefix = '',
+  suffix = '',
+  fractionDigits = 0,
+}: CounterProps) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const [value, setValue] = useState(0);
+  const started = useRef(false);
 
-// Maps the mini letter form's dropdown labels → category strings the
-// /api/complaints/preview endpoint expects.
-const LETTER_CATEGORY_MAP: Record<string, string> = {
-  'Mid-contract price rise': 'broadband',
-  'Delayed or cancelled flight (UK261)': 'flight_delay',
-  'Faulty goods (CRA 2015)': 'refund',
-  'Energy billing error (Ofgem)': 'energy',
-};
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || started.current) return;
+    const prefersReduced =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReduced || typeof IntersectionObserver === 'undefined') {
+      setValue(to);
+      started.current = true;
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting || started.current) return;
+          started.current = true;
+          io.unobserve(entry.target);
+          const start = performance.now();
+          const tick = (now: number) => {
+            const elapsed = now - start;
+            const t = Math.min(1, elapsed / duration);
+            const eased = 1 - Math.pow(1 - t, 4);
+            setValue(to * eased);
+            if (t < 1) requestAnimationFrame(tick);
+            else setValue(to);
+          };
+          requestAnimationFrame(tick);
+        });
+      },
+      { threshold: 0.4 }
+    );
+    io.observe(node);
+    return () => io.disconnect();
+  }, [to, duration]);
 
-// Formats a £ amount with UK locale. Falls back to en-GB commas for
-// integer values — matches the existing export's visual style.
-const formatGBP = (n: number, opts: Intl.NumberFormatOptions = {}) =>
-  new Intl.NumberFormat('en-GB', {
-    style: 'currency',
-    currency: 'GBP',
-    maximumFractionDigits: 0,
-    ...opts,
-  }).format(n);
+  const formatted = value.toLocaleString('en-GB', {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
 
-const formatCount = (n: number) => new Intl.NumberFormat('en-GB').format(n);
+  return (
+    <span ref={ref}>
+      {prefix}
+      {formatted}
+      {suffix}
+    </span>
+  );
+}
 
-// Initial-only names — final quotes pending founding-member permissions (PR 3).
-const TESTIMONIALS: Testimonial[] = [
+// ---------------------------------------------------------------------------
+// Nav — pill nav with scroll-shrink + scroll-progress bar
+// ---------------------------------------------------------------------------
+function Nav() {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    let rafId = 0;
+    let ticking = false;
+    const update = () => {
+      ticking = false;
+      const y = window.scrollY;
+      setScrolled((prev) => {
+        const next = y > 20;
+        return next === prev ? prev : next;
+      });
+      const max = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
+      const progress = Math.min(1, Math.max(0, y / max));
+      document.documentElement.style.setProperty('--m-v2-progress', progress.toFixed(4));
+    };
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      rafId = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return (
+    <>
+      <div className={`nav-shell${scrolled ? ' scrolled' : ''}`}>
+        <nav className="nav-pill" aria-label="Primary">
+          <Link className="nav-logo" href="/preview/homepage">
+            <span className="pay">Pay</span>
+            <span className="backer">backer</span>
+          </Link>
+          <div className="nav-links">
+            <a href="#how">How it works</a>
+            <a href="#pillars">Product</a>
+            <a href="#deals">Deals</a>
+            <a href="#pricing">Pricing</a>
+            <a href="#testimonials">Stories</a>
+          </div>
+          <div className="nav-cta-row">
+            <Link className="nav-signin" href="/login">
+              Sign in
+            </Link>
+            <Link className="nav-start" href="/join">
+              Start free
+            </Link>
+          </div>
+        </nav>
+      </div>
+      <div
+        className="nav-progress"
+        aria-hidden="true"
+        style={{ ['--progress' as string]: 'var(--m-v2-progress, 0)' } as CSSVarProperties}
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// HeroVisual — mini-card + dashboard card (3D tilt on mouse) + agent bubble
+// ---------------------------------------------------------------------------
+function HeroVisual() {
+  const dashRef = useRef<HTMLDivElement | null>(null);
+
+  const onMouseMove = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const el = dashRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const x = (event.clientX - rect.left) / rect.width - 0.5;
+    const y = (event.clientY - rect.top) / rect.height - 0.5;
+    const rotY = x * 6;
+    const rotX = -y * 5;
+    el.style.transform = `perspective(1000px) rotateX(${rotX.toFixed(2)}deg) rotateY(${rotY.toFixed(2)}deg) translateZ(0)`;
+  }, []);
+
+  const onMouseLeave = useCallback(() => {
+    const el = dashRef.current;
+    if (!el) return;
+    el.style.transform = '';
+  }, []);
+
+  return (
+    <div className="hero-visual" aria-hidden="true">
+      <div className="mini-card float" style={{ animationDelay: '-2s' }}>
+        <div className="label">Example savings snapshot</div>
+        <div className="big">£1,000+</div>
+        <div className="desc">typical yearly overcharge we find</div>
+        <div className="mini-bar">
+          <div className="bar"><span className="n">Broadband hike</span><span className="v">+£12/mo</span></div>
+          <div className="bar"><span className="n">Energy standing</span><span className="v">+£28/mo</span></div>
+          <div className="bar"><span className="n">Unused streaming</span><span className="v">+£7.99/mo</span></div>
+          <div className="bar"><span className="n">Gym (inactive)</span><span className="v">+£34/mo</span></div>
+        </div>
+      </div>
+
+      <div
+        ref={dashRef}
+        className="dash-card float tilt-host"
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+      >
+        <div className="dash-header">
+          <div className="title">Money Hub · this month</div>
+          <div>●●●</div>
+        </div>
+        <div className="dash-body">
+          <div>
+            <div className="label">Spend tracked</div>
+            <div className="big-num">
+              £2,847
+              <span style={{ color: 'var(--text-tertiary)', fontSize: '0.6em' }}>.12</span>
+            </div>
+            <div className="delta">↗ 3 hikes flagged this week</div>
+          </div>
+          <div className="donut-row">
+            <div className="donut">
+              <div className="donut-center">
+                <span>Tracked</span>
+                <strong>£4,892</strong>
+              </div>
+            </div>
+            <div className="donut-legend">
+              <div className="row">
+                <span><span className="swatch" style={{ background: 'var(--accent-mint)' }} /><span className="name">Essentials</span></span>
+                <span className="amt">£1,859</span>
+              </div>
+              <div className="row">
+                <span><span className="swatch" style={{ background: 'var(--accent-orange)' }} /><span className="name">Subscriptions</span></span>
+                <span className="amt">£1,174</span>
+              </div>
+              <div className="row">
+                <span><span className="swatch" style={{ background: '#60A5FA' }} /><span className="name">Transport</span></span>
+                <span className="amt">£782</span>
+              </div>
+              <div className="row">
+                <span><span className="swatch" style={{ background: '#A78BFA' }} /><span className="name">Dining</span></span>
+                <span className="amt">£588</span>
+              </div>
+              <div className="row">
+                <span><span className="swatch" style={{ background: '#E5E7EB' }} /><span className="name">Other</span></span>
+                <span className="amt">£489</span>
+              </div>
+            </div>
+          </div>
+          <div className="sub-list">
+            <div className="row">
+              <span className="name">Netflix Premium<span className="tag">Unused</span></span>
+              <span className="amt">£17.99</span>
+            </div>
+            <div className="row">
+              <span className="name">Virgin Media<span className="tag">Hike</span></span>
+              <span className="amt">£49.00</span>
+            </div>
+            <div className="row">
+              <span className="name">Gym membership<span className="tag">Inactive</span></span>
+              <span className="amt">£34.99</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="agent-bubble float" style={{ animationDelay: '-3s' }}>
+        <div className="who">
+          <span className="dot-mint" /> Pocket Agent · Telegram
+        </div>
+        <div className="msg">
+          Virgin Media bill increased by <strong>£12</strong> this month — want me to draft a dispute citing Ofcom&rsquo;s mid-contract price rise rules?
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// HeroDemo — interactive issue picker with live citation preview
+// ---------------------------------------------------------------------------
+type Issue = { id: string; label: string; cite: string; placeholder: string };
+const ISSUES: Issue[] = [
   {
-    name: 'P. R.',
-    meta: 'Homeowner · Bristol · Oct 2025',
+    id: 'midcontract',
+    label: 'Mid-contract price rise (broadband / mobile)',
+    cite: 'Ofcom General Conditions C1 + Consumer Rights Act 2015 s.49',
+    placeholder: 'My Virgin bill jumped £12 without warning…',
+  },
+  {
+    id: 'uk261',
+    label: 'Delayed or cancelled flight',
+    cite: 'Regulation (EC) 261/2004 retained as UK261',
+    placeholder: 'Easyjet to Malaga delayed 4h 20m on 14 Sept…',
+  },
+  {
+    id: 'cra2015',
+    label: 'Faulty goods or service',
+    cite: 'Consumer Rights Act 2015 s.9, s.49 & s.20',
+    placeholder: 'Sofa arrived with frame split, retailer refusing…',
+  },
+  {
+    id: 'ofgem',
+    label: 'Energy billing error',
+    cite: 'Ofgem Standard Licence Conditions 21B & 31A',
+    placeholder: 'British Gas estimated bill is £180 over my actual usage…',
+  },
+];
+
+type DemoStatus = 'idle' | 'drafting' | 'ready';
+
+function HeroDemo() {
+  const [issueId, setIssueId] = useState<string>(ISSUES[0].id);
+  const [desc, setDesc] = useState<string>('');
+  const [status, setStatus] = useState<DemoStatus>('idle');
+
+  const issue = useMemo(() => ISSUES.find((i) => i.id === issueId) ?? ISSUES[0], [issueId]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (status === 'drafting') return;
+    setStatus('drafting');
+    window.setTimeout(() => setStatus('ready'), 900);
+  };
+
+  return (
+    <form className="mini-form" onSubmit={handleSubmit}>
+      <label htmlFor="hero-demo-issue">What&rsquo;s the issue?</label>
+      <select
+        id="hero-demo-issue"
+        value={issueId}
+        onChange={(e) => {
+          setIssueId(e.target.value);
+          setStatus('idle');
+        }}
+      >
+        {ISSUES.map((option) => (
+          <option key={option.id} value={option.id}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+
+      <label htmlFor="hero-demo-desc">Brief description</label>
+      <input
+        id="hero-demo-desc"
+        type="text"
+        placeholder={issue.placeholder}
+        value={desc}
+        onChange={(e) => setDesc(e.target.value)}
+      />
+
+      <div
+        style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: '11px',
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+          color: 'var(--text-on-ink-dim)',
+          marginTop: '10px',
+        }}
+      >
+        We&rsquo;ll cite: <span style={{ color: 'var(--accent-mint)' }}>{issue.cite}</span>
+      </div>
+
+      <button type="submit" disabled={status === 'drafting'}>
+        {status === 'idle' && 'Generate letter →'}
+        {status === 'drafting' && 'Drafting…'}
+        {status === 'ready' && '✓ Letter ready — open the full draft'}
+      </button>
+
+      {status === 'ready' && (
+        <div
+          style={{
+            marginTop: '14px',
+            padding: '14px',
+            borderRadius: '12px',
+            background: 'rgba(52, 211, 153, 0.08)',
+            border: '1px dashed var(--divider-ink)',
+            fontSize: '12px',
+            lineHeight: 1.55,
+            color: 'var(--text-on-ink-dim)',
+          }}
+        >
+          <strong style={{ color: 'var(--accent-mint)' }}>Preview:</strong> &ldquo;Under
+          {' '}
+          <span style={{ color: 'var(--accent-mint)' }}>{issue.cite}</span>, you are
+          required to&hellip;&rdquo; — the full letter takes 30 seconds inside the
+          Disputes Centre.
+        </div>
+      )}
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Testimonials — marquee, doubled for seamless loop
+// ---------------------------------------------------------------------------
+const TESTIMONIALS = [
+  {
+    name: 'Paul R.',
+    meta: 'Homeowner · Bristol',
     quote:
-      '"Found £847 in forgotten subs in five minutes. The Virgin dispute letter got my bill cut back to the original contract rate — first time."',
-    saved: 'Saved £1,240 this year',
+      "Found nearly a grand of forgotten subs in five minutes. The Virgin dispute letter cut my bill back to the original contract rate — first try.",
+    saved: 'Saved £1,240 over the year',
     color: 'var(--accent-mint-deep)',
   },
   {
-    name: 'A. K.',
-    meta: 'Freelancer · Manchester · Oct 2025',
+    name: 'Aisha K.',
+    meta: 'Freelancer · Manchester',
     quote:
-      '"I thought I was on top of my subs. Paybacker found six I\'d completely forgotten about, including two gyms."',
+      "I thought I was on top of my subs. Paybacker found six I'd completely forgotten about, including two gym memberships.",
     saved: 'Saved £392',
     color: 'var(--accent-orange-deep)',
   },
   {
-    name: 'D. M.',
-    meta: 'Commuter · London · Sep 2025',
+    name: 'Dan M.',
+    meta: 'Commuter · London',
     quote:
-      '"The Ofcom letter took 30 seconds. EE cancelled the mid-contract rise without a phone call. Still can\'t quite believe it."',
+      "The Ofcom letter took 30 seconds. EE cancelled the mid-contract rise without a phone call. Still can't quite believe it.",
     saved: 'Saved £168',
     color: 'var(--accent-mint-deep)',
   },
   {
-    name: 'S. J.',
-    meta: 'Student · Edinburgh · Sep 2025',
+    name: 'Sarah J.',
+    meta: 'Student · Edinburgh',
     quote:
-      '"Pocket Agent in Telegram is the bit I didn\'t expect to love. I just ask it if things are fair and it tells me."',
+      "Pocket Agent in Telegram is the bit I didn't expect to love. I just ask if things are fair and it tells me.",
     saved: 'Saved £284',
     color: 'var(--accent-orange-deep)',
   },
   {
-    name: 'R. N.',
-    meta: 'Teacher · Leeds · Oct 2025',
+    name: 'Rita N.',
+    meta: 'Teacher · Leeds',
     quote:
-      '"Paybacker caught a £41/month energy hike British Gas quietly slipped in. The dispute paid for a year of Pro in one letter."',
+      "Paybacker caught a £41/month energy hike British Gas quietly slipped in. The dispute paid for a year of Pro in one letter.",
     saved: 'Saved £492',
     color: 'var(--accent-mint-deep)',
   },
   {
-    name: 'T. B.',
-    meta: 'New parent · Cardiff · Aug 2025',
+    name: 'Tom B.',
+    meta: 'New parent · Cardiff',
     quote:
-      '"Tiny baby, no time to read bills. This does it for us. The broadband switch alone saved us £400 a year."',
+      "Tiny baby, no time to read bills. Paybacker does it for us. The broadband switch alone saved us £400 a year.",
     saved: 'Saved £638',
     color: 'var(--accent-orange-deep)',
   },
 ];
 
-export default function HomepageV2Preview() {
-  const [navScrolled, setNavScrolled] = useState(false);
-  const [chatShown, setChatShown] = useState(false);
-  const [letterBusy, setLetterBusy] = useState(false);
-  const [letterLabel, setLetterLabel] = useState('Generate letter →');
-  const [letterPreview, setLetterPreview] = useState<string | null>(null);
-  const [stats, setStats] = useState<HomepageStats | null>(null);
-  const revealContainerRef = useRef<HTMLDivElement | null>(null);
+function Testimonials() {
+  const trackRef = useRef<HTMLDivElement | null>(null);
 
-  // Nav shrinks slightly once scrolled > 20px.
   useEffect(() => {
-    const onScroll = () => setNavScrolled(window.scrollY > 20);
-    window.addEventListener('scroll', onScroll, { passive: true });
-    onScroll();
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
-
-  // Reveal-on-scroll for .reveal elements inside the page (not globally).
-  useEffect(() => {
-    const container = revealContainerRef.current;
-    if (!container || typeof IntersectionObserver === 'undefined') return;
+    const node = trackRef.current;
+    if (!node || typeof IntersectionObserver === 'undefined') return;
     const io = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry, i) => {
-          if (entry.isIntersecting) {
-            window.setTimeout(() => entry.target.classList.add('in'), i * 60);
-            io.unobserve(entry.target);
-          }
+        entries.forEach((entry) => {
+          node.style.animationPlayState = entry.isIntersecting ? 'running' : 'paused';
         });
       },
-      { threshold: 0.12 },
+      { threshold: 0.05 }
     );
-    container.querySelectorAll('.reveal').forEach((el) => io.observe(el));
+    io.observe(node);
     return () => io.disconnect();
   }, []);
 
-  // Chat widget appears after 2s — matches the export's behaviour.
-  useEffect(() => {
-    const t = window.setTimeout(() => setChatShown(true), 2000);
-    return () => window.clearTimeout(t);
-  }, []);
-
-  // Fetch live stats from /api/preview/homepage-stats on mount.
-  // Endpoint has 5-min ISR cache so this is cheap for anonymous traffic.
-  // If it fails we keep the hardcoded preview figures rendered.
-  useEffect(() => {
-    const ac = new AbortController();
-    (async () => {
-      try {
-        const res = await fetch('/api/preview/homepage-stats', { signal: ac.signal });
-        if (!res.ok) return;
-        const json: HomepageStats = await res.json();
-        setStats(json);
-      } catch {
-        // swallow — placeholder values already on screen
-      }
-    })();
-    return () => ac.abort();
-  }, []);
-
-  // Mini letter form → /api/complaints/preview (public, IP rate-limited 3/hr).
-  // Returns a sample paragraph or full AI-drafted letter (30s timeout server-side).
-  // We show the response inline under the form so the demo never leaves the page.
-  const onDemoGenerate = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (letterBusy) return;
-    const data = new FormData(e.currentTarget);
-    const label = String(data.get('issueType') ?? 'Mid-contract price rise');
-    const description = String(data.get('description') ?? '').trim();
-    const category = LETTER_CATEGORY_MAP[label] ?? 'broadband';
-
-    setLetterBusy(true);
-    setLetterLabel('Drafting…');
-    setLetterPreview(null);
-
-    try {
-      const res = await fetch('/api/complaints/preview', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ category, description }),
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        setLetterLabel(
-          res.status === 429 ? 'Too many — try again soon' : 'Something went wrong',
-        );
-        setLetterPreview(
-          err?.error ??
-            'We couldn\u2019t draft that one right now — please try again in a minute.',
-        );
-        window.setTimeout(() => setLetterLabel('Generate letter →'), 2400);
-        return;
-      }
-      const json: { preview?: string; generated?: boolean } = await res.json();
-      setLetterPreview(json.preview ?? 'No preview returned.');
-      setLetterLabel(json.generated ? '✓ Letter drafted' : '✓ Sample ready');
-      window.setTimeout(() => setLetterLabel('Generate another →'), 2400);
-    } catch {
-      setLetterLabel('Offline — try again');
-      window.setTimeout(() => setLetterLabel('Generate letter →'), 2400);
-    } finally {
-      setLetterBusy(false);
-    }
-  };
-
-  const doubledTestimonials = [...TESTIMONIALS, ...TESTIMONIALS];
+  const doubled = [...TESTIMONIALS, ...TESTIMONIALS];
 
   return (
-    <div className="m-v2-root" ref={revealContainerRef}>
-      <div className="preview-badge" aria-label="Preview page">
-        Preview · Homepage v2
-      </div>
-
-      {/* Floating pill nav ------------------------------------------ */}
-      <div className={`nav-shell${navScrolled ? ' scrolled' : ''}`} id="navShell">
-        <nav className="nav-pill" aria-label="Primary">
-          <a className="nav-logo" href="#">
-            <span className="pay">Pay</span>
-            <span className="backer">backer</span>
-          </a>
-          <div className="nav-links">
-            <a href="#how">About</a>
-            <a href="#pricing">Pricing</a>
-            <a href="#deals">Deals</a>
-            <a href="#paybacker-assistant">Assistant</a>
-            <a href="#">Blog</a>
-            <a href="#">FAQ</a>
+    <div className="t-track" ref={trackRef}>
+      {doubled.map((t, i) => (
+        <div className="t-card" key={`${t.name}-${i}`}>
+          <div className="who">
+            <div className="avatar" style={{ background: t.color }}>
+              {t.name[0]}
+            </div>
+            <div>
+              <div className="name">{t.name}</div>
+              <div className="meta">{t.meta}</div>
+            </div>
           </div>
-          <div className="nav-cta-row">
-            <a className="nav-signin" href="#">
-              Sign in
-            </a>
-            <a className="nav-start" href="#">
-              Start Free
-            </a>
-          </div>
-        </nav>
-      </div>
+          <div className="quote">&ldquo;{t.quote}&rdquo;</div>
+          <div className="saved">{t.saved}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
-      {/* Hero ------------------------------------------------------- */}
+// ---------------------------------------------------------------------------
+// StickyCTA — appears past the hero, hides before the final CTA
+// ---------------------------------------------------------------------------
+function StickyCTA() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    let rafId = 0;
+    let ticking = false;
+    const update = () => {
+      ticking = false;
+      const y = window.scrollY;
+      const finalCta = document.querySelector('.m-v2-root .final-cta');
+      const finalTop = finalCta
+        ? finalCta.getBoundingClientRect().top + window.scrollY
+        : Number.POSITIVE_INFINITY;
+      const past = y > 720;
+      const beforeFinal = y + window.innerHeight < finalTop + 200;
+      setVisible(past && beforeFinal);
+    };
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      rafId = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return (
+    <div className={`sticky-cta${visible ? ' shown' : ''}`} aria-hidden={!visible}>
+      <span>Find your overcharges in 30s — no card, no catch.</span>
+      <Link href="/join">Start free →</Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+export default function HomepageV3PreviewPage() {
+  return (
+    <div className="m-v2-root">
+      <Nav />
+
+      {/* ========== Hero ========== */}
       <section
         className="hero glow-wrap section-light"
-        style={{ '--glow-opacity': 0.22 } as CSSVarProperties}
+        style={{ ['--glow-opacity' as string]: '0.22' } as CSSVarProperties}
       >
         <div className="trust-bar">
           ICO registered <span className="dot">·</span>
@@ -268,343 +619,119 @@ export default function HomepageV2Preview() {
           GDPR compliant <span className="dot">·</span>
           UK company · Paybacker LTD
         </div>
+
         <div className="wrap">
           <div className="hero-grid">
-            <div className="hero-copy reveal">
-              <span className="eyebrow">Free 14-day Pro trial. No card required.</span>
+            <Reveal className="hero-copy">
+              <span className="eyebrow">Free 14-day Pro trial · No card required</span>
               <h1>
                 <span className="l1">Find Hidden Overcharges.</span>
                 <span className="l2">Fight Unfair Bills.</span>
                 <span className="l3">Get Your Money Back.</span>
               </h1>
               <p className="hero-sub">
-                Paybacker scans your bank and email to spot overcharges, forgotten subscriptions,
-                and unfair bills — then writes professional complaint letters citing UK law in 30
-                seconds.
+                Paybacker scans your bank and email to spot overcharges, forgotten
+                subscriptions, and unfair bills — then writes professional complaint
+                letters citing UK law in 30 seconds.
               </p>
               <div className="hero-cta-row">
-                <a className="btn btn-mint" href="#">
+                <Link className="btn btn-mint" href="/join">
                   Start free 14-day Pro trial →
-                </a>
+                </Link>
                 <a className="btn btn-ghost" href="#how">
                   See how it works
                 </a>
               </div>
               <div className="hero-ticker">
                 <span className="pulse" />
-                {stats && stats.source !== 'fallback' && stats.savedThisMonth > 0 ? (
-                  <span>
-                    <strong>{formatGBP(stats.savedThisMonth)}</strong>
-                    {' saved for our members this month'}
-                  </span>
-                ) : (
-                  <span>Saved for our members this month — live counter coming soon</span>
-                )}
+                <span>
+                  UK households are typically overcharged{' '}
+                  <strong>£1,000+ a year</strong> — we find it.
+                </span>
               </div>
-            </div>
-            <div className="hero-visual reveal" aria-hidden="true">
-              <div className="mini-card float" style={{ animationDelay: '-2s' }}>
-                <div className="label">Potential savings</div>
-                <div className="big">£1,240</div>
-                <div className="desc">found this quarter</div>
-                <div className="mini-bar">
-                  <div className="bar">
-                    <span className="n">Virgin Media</span>
-                    <span className="v">+£12/mo</span>
-                  </div>
-                  <div className="bar">
-                    <span className="n">Octopus Energy</span>
-                    <span className="v">+£28/mo</span>
-                  </div>
-                  <div className="bar">
-                    <span className="n">Audible</span>
-                    <span className="v">+£7.99/mo</span>
-                  </div>
-                  <div className="bar">
-                    <span className="n">British Gas</span>
-                    <span className="v">+£41/mo</span>
-                  </div>
-                </div>
-              </div>
+            </Reveal>
 
-              <div className="dash-card float">
-                <div className="dash-header">
-                  <div className="title">Money Hub — October</div>
-                  <div>●●●</div>
-                </div>
-                <div className="dash-body">
-                  <div>
-                    <div className="label">Net this month</div>
-                    <div className="big-num">
-                      £2,847.
-                      <span style={{ color: 'var(--text-tertiary)', fontSize: '0.6em' }}>12</span>
-                    </div>
-                    <div className="delta">↗ £312 vs. September</div>
-                  </div>
-                  <div className="donut-row">
-                    <div className="donut">
-                      <div className="donut-center">
-                        <span>Tracked</span>
-                        <strong>£4,892</strong>
-                      </div>
-                    </div>
-                    <div className="donut-legend">
-                      <div className="row">
-                        <span>
-                          <span className="swatch" style={{ background: 'var(--accent-mint)' }} />
-                          <span className="name">Essentials</span>
-                        </span>
-                        <span className="amt">£1,859</span>
-                      </div>
-                      <div className="row">
-                        <span>
-                          <span
-                            className="swatch"
-                            style={{ background: 'var(--accent-orange)' }}
-                          />
-                          <span className="name">Subscriptions</span>
-                        </span>
-                        <span className="amt">£1,174</span>
-                      </div>
-                      <div className="row">
-                        <span>
-                          <span className="swatch" style={{ background: '#60A5FA' }} />
-                          <span className="name">Transport</span>
-                        </span>
-                        <span className="amt">£782</span>
-                      </div>
-                      <div className="row">
-                        <span>
-                          <span className="swatch" style={{ background: '#A78BFA' }} />
-                          <span className="name">Dining</span>
-                        </span>
-                        <span className="amt">£588</span>
-                      </div>
-                      <div className="row">
-                        <span>
-                          <span className="swatch" style={{ background: '#E5E7EB' }} />
-                          <span className="name">Other</span>
-                        </span>
-                        <span className="amt">£489</span>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="sub-list">
-                    <div className="row">
-                      <span className="name">
-                        Netflix Premium<span className="tag">Unused</span>
-                      </span>
-                      <span className="amt">£17.99</span>
-                    </div>
-                    <div className="row">
-                      <span className="name">
-                        Virgin Media<span className="tag">Hike</span>
-                      </span>
-                      <span className="amt">£49.00</span>
-                    </div>
-                    <div className="row">
-                      <span className="name">
-                        Gym membership<span className="tag">Inactive</span>
-                      </span>
-                      <span className="amt">£34.99</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="agent-bubble float" style={{ animationDelay: '-3s' }}>
-                <div className="who">
-                  <span className="dot-mint" /> Pocket Agent · Telegram
-                </div>
-                <div className="msg">
-                  {'Your Virgin Media bill is up '}
-                  <strong>£12</strong>
-                  {' this month. Want me to draft a dispute citing Ofcom\u2019s mid-contract price rise rules?'}
-                </div>
-              </div>
-            </div>
+            <HeroVisual />
           </div>
         </div>
       </section>
 
-      {/* Why We Exist (light narrative) — brought across from v1 ---- */}
-      <section className="why-we-exist section-light" id="why">
-        <div className="wrap">
-          <div className="why-grid">
-            <div className="why-copy reveal">
-              <span className="eyebrow">Why we exist</span>
-              <h2>
-                The average UK household is
-                <br />
-                overcharged <span className="accent">£1,000+</span> a year.
-              </h2>
-              <p className="lead">
-                Broadband price hikes. Energy tariffs that quietly roll over. Gym memberships you
-                forgot about. Flight compensation you never claimed. Insurance renewals that drift
-                up every year.
-              </p>
-              <p>
-                Paybacker exists because the admin of fighting this — reading the email, finding
-                the policy, writing the letter — is designed to be too painful for any normal
-                person to keep up with. So we built an AI team that does it for you.
-              </p>
-              <p className="closing">
-                Point it at your bank and your inbox. Get your money back.
-              </p>
-            </div>
-            <div className="why-stats reveal">
-              <div className="why-stat">
-                <div className="n">£82.6bn</div>
-                <div className="l">
-                  lost to overcharges across UK households every year (Citizens Advice, 2024).
-                </div>
-              </div>
-              <div className="why-stat">
-                <div className="n">68%</div>
-                <div className="l">
-                  of UK adults have at least one subscription they&rsquo;ve forgotten about.
-                </div>
-              </div>
-              <div className="why-stat">
-                <div className="n">£520</div>
-                <div className="l">
-                  maximum compensation under UK261 for a single delayed or cancelled flight — most
-                  never claim it.
-                </div>
-              </div>
-              <div className="why-stat">
-                <div className="n">30 sec</div>
-                <div className="l">
-                  to draft a formal dispute citing the exact UK law — with Paybacker.
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Trust strip ------------------------------------------------ */}
+      {/* ========== Trust strip ========== */}
       <section className="trust-strip section-light">
         <div className="wrap">
           <div className="trust-row">
-            <div className="trust-item">
-              <div className="ring">ICO</div>Registered data controller
-            </div>
-            <div className="trust-item">
-              <div className="ring">FCA</div>Open Banking via Yapily
-            </div>
-            <div className="trust-item">
-              <div className="ring">GDPR</div>UK data residency
-            </div>
-            <div className="trust-item">
-              <div className="ring">£</div>Stripe secured payments
-            </div>
-            <div className="trust-item">
-              {/*
-                Paybacker LTD's real Companies House number goes in before
-                cut-over (PR 5). The export shipped a placeholder.
-              */}
-              <div className="ring">UK</div>Paybacker LTD
-            </div>
+            <div className="trust-item"><div className="ring">ICO</div>Registered data controller</div>
+            <div className="trust-item"><div className="ring">FCA</div>Open Banking via Yapily</div>
+            <div className="trust-item"><div className="ring">GDPR</div>UK data residency</div>
+            <div className="trust-item"><div className="ring">£</div>Stripe-secured payments</div>
+            <div className="trust-item"><div className="ring">UK</div>Paybacker LTD · 15289174</div>
           </div>
         </div>
       </section>
 
-      {/* Stats (mint wash) ----------------------------------------- */}
-      <section className="stats-section section-mint">
+      {/* ========== Stats (mint wash) ========== */}
+      <section className="stats-section section-mint" id="stats">
         <div className="wrap">
-          <div className="section-head reveal">
-            <span className="eyebrow">Real numbers · Real users</span>
+          <Reveal className="section-head">
+            <span className="eyebrow">Why Paybacker exists</span>
             <h2>
-              Real pounds recovered
+              Every British household is leaking money.
               <br />
-              for real UK households.
+              Paybacker plugs the leaks.
             </h2>
             <p>
-              No gamified streaks. No vague &ldquo;up to&rdquo; claims. Aggregated live from the
-              last 90 days of verified savings, subscriptions tracked, and active founding
-              members.
+              No gamified streaks. No vague &ldquo;up to&rdquo; claims. These are the
+              sector benchmarks we&rsquo;re built around — grounded in UK consumer
+              protection law.
             </p>
-            {/*
-              The seed/fallback badge stays visible until /api/preview/homepage-stats
-              returns non-zero figures. Once live data lands it quietly vanishes — no
-              refresh required.
-            */}
-            {/*
-              The badge shows whenever any individual figure is still the
-              hardcoded export seed (source !== 'live', OR any specific
-              number is zero and we're falling back). That way we never
-              show a misleading headline number without an honest label.
-            */}
-            {(() => {
-              if (!stats) {
-                return (
-                  <p className="placeholder-note" aria-live="polite">
-                    Preview data — aggregates load from Supabase in a second.
-                  </p>
-                );
-              }
-              const anyFallback =
-                stats.source !== 'live' ||
-                stats.avgSavingsPerUser === 0 ||
-                stats.subscriptionsTracked === 0 ||
-                stats.foundingMembers === 0;
-              if (!anyFallback) return null;
-              return (
-                <p className="placeholder-note" aria-live="polite">
-                  Some figures still seeded — real aggregates fill in as verified_savings
-                  rows land.
-                </p>
-              );
-            })()}
-          </div>
+          </Reveal>
+
           <div className="stats-grid">
-            <div className="stat-card reveal">
-              <div className="label">Average potential savings</div>
+            <Reveal className="stat-card" delay={0}>
+              <div className="label">Typical household overcharge</div>
               <div className="num">
-                {stats && stats.avgSavingsPerUser > 0
-                  ? formatGBP(stats.avgSavingsPerUser)
-                  : '£8,029'}
-                <span className="unit">/yr</span>
+                <Counter to={1000} prefix="£" suffix="+" /> <span className="unit">/yr</span>
               </div>
               <div className="underline" />
               <div className="blurb">
-                Most came from forgotten subscriptions and quiet price hikes we flagged
-                automatically — the kind nobody reads the email for.
+                Most of it hides in price hikes, forgotten subs, and standing charges
+                nobody reads. Paybacker surfaces it in one scan.
               </div>
-            </div>
-            <div className="stat-card reveal">
-              <div className="label">Subscriptions tracked</div>
+            </Reveal>
+
+            <Reveal className="stat-card" delay={80}>
+              <div className="label">Draft a UK-law complaint in</div>
               <div className="num">
-                {stats && stats.subscriptionsTracked > 0
-                  ? formatCount(stats.subscriptionsTracked)
-                  : '149'}
+                <Counter to={30} /> <span className="unit">seconds</span>
               </div>
               <div className="underline" />
               <div className="blurb">
-                Across connected accounts. The median user has 11 they&rsquo;d forgotten about. The
-                worst had 34 — including three streaming services with the same logo.
+                AI cites the exact statute — Consumer Rights Act 2015 s.49, UK261,
+                Ofcom and Ofgem rules — and formats it like a solicitor&rsquo;s
+                letter.
               </div>
-            </div>
-            <div className="stat-card reveal">
-              <div className="label">Founding members</div>
+            </Reveal>
+
+            <Reveal className="stat-card" delay={160}>
+              <div className="label">Paybacker success fee</div>
               <div className="num">
-                {stats && stats.foundingMembers > 0 ? formatCount(stats.foundingMembers) : '45'}
+                <Counter to={0} />
+                <span className="unit">%</span>
               </div>
               <div className="underline" />
               <div className="blurb">
-                British households using the Pro tier right now. Tight invite-only group while we
-                scale the AI Disputes engine. Locked-in founder pricing, forever.
+                Competitors take 15–30% of what you recover. We charge a flat monthly
+                subscription — every £ you get back is yours.
               </div>
-            </div>
+            </Reveal>
           </div>
         </div>
       </section>
 
-      {/* Pillars --------------------------------------------------- */}
-      <section className="pillars-section section-light">
+      {/* ========== Pillars ========== */}
+      <section className="pillars-section section-light" id="pillars">
         <div className="wrap">
-          <div className="section-head reveal">
+          <Reveal className="section-head">
             <span className="eyebrow">What&rsquo;s in the box</span>
             <h2>
               Three products. One subscription.
@@ -612,23 +739,15 @@ export default function HomepageV2Preview() {
               All of your money, watched.
             </h2>
             <p>
-              Most UK households are overcharged by £1,000+ a year. Paybacker finds it, disputes
-              it, and cancels it — in minutes, not hours on hold.
+              Most UK households are overcharged by £1,000+ a year. Paybacker finds
+              it, disputes it, and cancels it — in minutes, not hours on hold.
             </p>
-          </div>
+          </Reveal>
+
           <div className="pillar-grid">
-            <div className="pillar-card reveal">
+            <Reveal className="pillar-card" delay={0}>
               <div className="pillar-icon orange" aria-hidden="true">
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M12 3v18" />
                   <path d="M4 7l8-4 8 4" />
                   <path d="M4 7l3 7a3 3 0 006 0z" />
@@ -637,111 +756,53 @@ export default function HomepageV2Preview() {
               </div>
               <h3>AI Disputes Centre</h3>
               <p className="copy">
-                Every complaint, claim, and government letter in one place. 30-second drafts that
-                cite the exact UK law — Consumer Rights Act 2015, UK261, Ofgem, Ofcom, HMRC rules,
-                and more.
+                Complaint letters citing exact UK consumer law in 30 seconds. Consumer
+                Rights Act 2015, UK261, Ofgem, Ofcom.
               </p>
-              <div
-                className="pillar-tags"
-                style={{
-                  display: 'flex',
-                  flexWrap: 'wrap',
-                  gap: '6px',
-                  margin: '12px 0 16px',
-                }}
-              >
-                {[
-                  'Broadband & mobile',
-                  'Energy bill dispute',
-                  'Flight delay (UK261, up to £520)',
-                  'Faulty goods refund',
-                  'HMRC tax rebate',
-                  'Council tax band challenge',
-                  'DVLA appeal',
-                  'NHS complaint',
-                  'Parking charge notice',
-                  'Debt collection response',
-                ].map((label) => (
-                  <span
-                    key={label}
-                    style={{
-                      fontSize: '11px',
-                      padding: '4px 10px',
-                      borderRadius: '999px',
-                      background: 'var(--accent-mint-soft, rgba(16,185,129,0.08))',
-                      color: 'var(--accent-mint-deep, #047857)',
-                      border: '1px solid var(--accent-mint-soft, rgba(16,185,129,0.2))',
-                      fontWeight: 500,
-                      letterSpacing: '-0.005em',
-                    }}
-                  >
-                    {label}
-                  </span>
-                ))}
-              </div>
               <div className="pillar-preview">
                 <div className="head">AI draft · Ofcom — mid-contract price rise</div>
                 <p className="letter-para">
                   … I am writing to formally dispute the{' '}
-                  <span className="hl">£12 CPI+3.9% increase</span> applied to my Virgin Media
-                  broadband contract on 1 October. Under{' '}
+                  <span className="hl">£12 CPI+3.9% increase</span> applied to my
+                  Virgin Media broadband contract. Under{' '}
                   <span className="hl">Ofcom&rsquo;s Fairness Framework</span> and the{' '}
-                  <span className="hl">Consumer Rights Act 2015 s.49</span>, you must provide
-                  reasonable notice and a right to exit without penalty…
+                  <span className="hl">Consumer Rights Act 2015 s.49</span>, you must
+                  provide reasonable notice and a right to exit without penalty…
                 </p>
               </div>
-            </div>
+            </Reveal>
 
-            {/* Pocket Agent moved up to position 2 per Paul's feedback
-                (Apr 2026 review): focus order is Disputes → Pocket Agent → Money Hub. */}
-            <div className="pillar-card reveal">
+            <Reveal className="pillar-card" delay={80}>
               <div className="pillar-icon gradient" aria-hidden="true">
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
                 </svg>
               </div>
               <h3>Pocket Agent</h3>
               <p className="copy">
-                Your AI financial agent, always in your pocket. Telegram, WhatsApp, SMS and email —
-                answers, drafts, cancels, and switches in plain English.
+                Your AI financial agent in Telegram. Ask anything, fix everything.
+                &ldquo;Is my energy bill fair?&rdquo; &ldquo;Cancel my gym.&rdquo;
+                Done.
               </p>
               <div className="pillar-preview">
                 <div className="head">Today · Telegram</div>
                 <div className="chat-preview">
                   <div className="chat-bubble user">Is £68/mo fair for 100Mb broadband?</div>
                   <div className="chat-bubble agent">
-                    Above UK median of £32. Two cheaper options on your postcode. Draft switch?
+                    Above the UK median of £32. Two cheaper options on your postcode.
+                    Draft a switch?
                   </div>
                   <div className="chat-bubble user">Yes please</div>
                   <div className="chat-bubble agent">
-                    {'On it — you\u2019ll save '}
-                    <strong>£432/yr</strong>.
+                    On it — you&rsquo;ll save <strong>£432/yr</strong>.
                   </div>
                 </div>
               </div>
-            </div>
+            </Reveal>
 
-            <div className="pillar-card reveal">
+            <Reveal className="pillar-card" delay={160}>
               <div className="pillar-icon mint" aria-hidden="true">
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <rect x="3" y="6" width="18" height="13" rx="2" />
                   <path d="M3 10h18" />
                   <circle cx="17" cy="15" r="1.5" />
@@ -749,30 +810,18 @@ export default function HomepageV2Preview() {
               </div>
               <h3>Money Hub</h3>
               <p className="copy">
-                Connect your bank via Open Banking (Yapily). Every subscription, direct debit, and
-                contract in one place. Daily sync.
+                Connect your bank via Open Banking (Yapily). Every subscription,
+                direct debit, and contract in one place. Daily sync.
               </p>
               <div className="pillar-preview">
-                <div className="head">Your October breakdown</div>
+                <div className="head">Your monthly breakdown</div>
                 <div className="donut-mini">
                   <div className="d" />
                   <div className="nums">
-                    <div className="row">
-                      <span className="sw" style={{ background: 'var(--accent-mint)' }} />
-                      Essentials · £1,859
-                    </div>
-                    <div className="row">
-                      <span className="sw" style={{ background: 'var(--accent-orange)' }} />
-                      Subs · £1,174
-                    </div>
-                    <div className="row">
-                      <span className="sw" style={{ background: '#93C5FD' }} />
-                      Transport · £782
-                    </div>
-                    <div className="row">
-                      <span className="sw" style={{ background: '#E5E7EB' }} />
-                      Other · £489
-                    </div>
+                    <div className="row"><span className="sw" style={{ background: 'var(--accent-mint)' }} />Essentials · £1,859</div>
+                    <div className="row"><span className="sw" style={{ background: 'var(--accent-orange)' }} />Subs · £1,174</div>
+                    <div className="row"><span className="sw" style={{ background: '#93C5FD' }} />Transport · £782</div>
+                    <div className="row"><span className="sw" style={{ background: '#E5E7EB' }} />Other · £489</div>
                   </div>
                 </div>
                 <div
@@ -787,429 +836,15 @@ export default function HomepageV2Preview() {
                   3 hikes flagged · 2 duplicates found
                 </div>
               </div>
-            </div>
+            </Reveal>
           </div>
         </div>
       </section>
 
-      {/* Pocket Agent showcase (dark) — new in PR 3 ---------------- */}
-      <section className="agent-showcase section-ink" id="pocket-agent">
-        <div className="wrap">
-          <div className="section-head reveal">
-            <span className="eyebrow on-ink">Meet your Pocket Agent</span>
-            <h2>
-              An AI that actually
-              <br />
-              <span className="mint">does</span> the admin for you.
-            </h2>
-            <p className="sub">
-              Your Pocket Agent lives in Telegram, WhatsApp, SMS, and email — watching for
-              overcharges, drafting letters, and cancelling the stuff you never use. Reply in a
-              sentence. It handles the rest.
-            </p>
-          </div>
-
-          <div className="agent-showcase-grid">
-            <div className="agent-phone reveal" aria-hidden="true">
-              <div className="agent-phone-header">
-                <span className="dot-mint" />
-                <span>Pocket Agent · Telegram</span>
-                <span className="agent-phone-time">Today · 10:47</span>
-              </div>
-              <div className="agent-phone-body">
-                <div className="ap-bubble agent">
-                  {'Morning Paul \u2014 your British Gas bill just landed. It\u2019s up '}
-                  <strong>£41</strong>
-                  {' versus last month. Want me to check if that\u2019s fair?'}
-                </div>
-                <div className="ap-bubble user">Yes please, quickly.</div>
-                <div className="ap-bubble agent">
-                  {'Your unit rate jumped from 24.5p to 30.2p/kWh. That\u2019s above the current UK price cap for your tariff. Want me to draft an Ofgem dispute?'}
-                </div>
-                <div className="ap-bubble user">Yeah, go on.</div>
-                <div className="ap-bubble agent">
-                  {'Done \u2014 letter cites Ofgem\u2019s Standards of Conduct and the price cap rules. Sent to your inbox to sign.'}
-                  <span className="ap-link">Preview letter →</span>
-                </div>
-                <div className="ap-bubble user">Can you also cancel my Audible?</div>
-                <div className="ap-bubble agent">
-                  {'On it. Drafted a cancellation citing your 14-day cooling-off right under the Consumer Contracts Regulations. Confirm?'}
-                  <div className="ap-chips">
-                    <span className="ap-chip ap-chip-mint">✓ Confirm</span>
-                    <span className="ap-chip">Change wording</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="agent-features reveal">
-              <div className="agent-feature">
-                <div className="af-icon">⚡</div>
-                <div>
-                  <h4>Instant answers</h4>
-                  <p>
-                    &ldquo;Is £68 fair for broadband?&rdquo; &ldquo;Can I claim for this flight
-                    delay?&rdquo; Ask in plain English — get a straight answer with the UK law
-                    cited.
-                  </p>
-                </div>
-              </div>
-              <div className="agent-feature">
-                <div className="af-icon">✍️</div>
-                <div>
-                  <h4>One-tap dispute letters</h4>
-                  <p>
-                    Drafts formal complaints, cancellations, or refund requests in 30 seconds —
-                    citing Consumer Rights Act 2015, UK261, Ofgem, Ofcom or the relevant rule.
-                  </p>
-                </div>
-              </div>
-              <div className="agent-feature">
-                <div className="af-icon">🔔</div>
-                <div>
-                  <h4>Proactive alerts</h4>
-                  <p>
-                    Pings you when a bill jumps, a free trial is about to convert, a contract is
-                    ending, or a flight delay qualifies for compensation. No more missed deadlines.
-                  </p>
-                </div>
-              </div>
-              <div className="agent-feature">
-                <div className="af-icon">💷</div>
-                <div>
-                  <h4>Verified switches</h4>
-                  <p>
-                    Compares your current bill against 53+ UK partners. Only suggests a switch if
-                    it genuinely beats what you&rsquo;re on — in pounds and pence.
-                  </p>
-                </div>
-              </div>
-              <div className="agent-feature">
-                <div className="af-icon">🔒</div>
-                <div>
-                  <h4>Bank-grade security</h4>
-                  <p>
-                    Read-only Open Banking via Yapily (FCA-authorised). Never stores passwords.
-                    Encrypted end-to-end. UK data residency only.
-                  </p>
-                </div>
-              </div>
-              <div className="agent-feature">
-                <div className="af-icon">🧠</div>
-                <div>
-                  <h4>Remembers context</h4>
-                  <p>
-                    Knows your postcode, your contracts, your renewal dates, and your loyalty
-                    preferences. Doesn&rsquo;t re-ask the same question twice.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* AI Financial Assistant (light) — recategorisation convo --- */}
-      <section className="assistant-section section-light" id="assistant">
-        <div className="wrap">
-          <div className="assistant-grid">
-            <div className="assistant-copy reveal">
-              <span className="eyebrow">AI Financial Assistant</span>
-              <h2>
-                Ask your money anything.
-                <br />
-                It actually answers.
-              </h2>
-              <p>
-                Every transaction, subscription, contract, and bill — categorised in real time.
-                When it gets something wrong, just tell it. The assistant learns how
-                <em> your </em>
-                spending works, not the average household&rsquo;s.
-              </p>
-              <ul className="assistant-bullets">
-                <li>
-                  <strong>Instant recategorisation.</strong> One sentence fixes every past and
-                  future match.
-                </li>
-                <li>
-                  <strong>Category drill-down.</strong> &ldquo;What did I spend on takeaways in
-                  March?&rdquo; — see the list in seconds.
-                </li>
-                <li>
-                  <strong>Dynamic charts.</strong> Ask for a pie chart of utilities or a 6-month
-                  bar for dining — rendered in the chat.
-                </li>
-                <li>
-                  <strong>Budget links.</strong> Every category connects to a budget limit and
-                  renewal alerts.
-                </li>
-              </ul>
-            </div>
-
-            <div className="assistant-chat reveal">
-              <div className="ac-header">Money Hub · AI Assistant</div>
-              <div className="ac-body">
-                <div className="ac-bubble user">
-                  My OneStream direct debit keeps appearing as Bills &amp; Utilities, but it&rsquo;s
-                  broadband. Can you fix it?
-                </div>
-                <div className="ac-bubble assistant">
-                  {'Done. I\u2019ve moved all 14 OneStream transactions (Jan \u2013 Oct) into '}
-                  <strong>Broadband</strong>
-                  {'. Any future OneStream payments will land there automatically. Your monthly Broadband total is now '}
-                  <strong>£38.50</strong>
-                  {'.'}
-                </div>
-                <div className="ac-bubble user">Show me a pie chart of my subscription spend last month.</div>
-                <div className="ac-bubble assistant">
-                  <div className="ac-chart" aria-hidden="true">
-                    <div className="ac-pie">
-                      <div className="ac-slice ac-slice-1" />
-                      <div className="ac-slice ac-slice-2" />
-                      <div className="ac-slice ac-slice-3" />
-                      <div className="ac-slice ac-slice-4" />
-                    </div>
-                    <div className="ac-legend">
-                      <span>
-                        <i style={{ background: 'var(--accent-mint)' }} /> Broadband · £38.50
-                      </span>
-                      <span>
-                        <i style={{ background: 'var(--accent-orange)' }} /> Streaming · £27.97
-                      </span>
-                      <span>
-                        <i style={{ background: '#60A5FA' }} /> Gym · £34.99
-                      </span>
-                      <span>
-                        <i style={{ background: '#A78BFA' }} /> Software · £12.99
-                      </span>
-                    </div>
-                  </div>
-                  {'Total subscription spend in September was '}
-                  <strong>£114.45</strong>
-                  {'. Want me to flag Netflix Premium (unused for 47 days) for cancellation?'}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Paybacker Assistant / MCP (ink) — Pro upsell + example prompts --- */}
-      <section
-        className="assistant-section section-ink"
-        id="paybacker-assistant"
-        style={{ padding: 'clamp(72px, 10vw, 112px) 0' }}
-      >
-        <div className="wrap">
-          <div className="section-head reveal" style={{ textAlign: 'center' }}>
-            <span className="eyebrow on-ink">Pro · Paybacker Assistant</span>
-            <h2 style={{ color: 'var(--text-on-ink, #fff)' }}>
-              Ask Paybacker about your money.
-              <br />
-              It has the answers.
-            </h2>
-            <p style={{ color: 'var(--text-on-ink-muted, rgba(255,255,255,0.7))' }}>
-              Plug the Paybacker Assistant into your desktop AI app in 60 seconds. Your transactions,
-              subscriptions, contracts, disputes, and savings — all available as read-only context
-              for any question you ask. Private, revocable, Pro-only.
-            </p>
-          </div>
-
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
-              gap: '16px',
-              maxWidth: '980px',
-              margin: '32px auto 0',
-            }}
-            className="reveal"
-          >
-            {[
-              '"Which of my subscriptions could I cancel without really missing?"',
-              '"Am I overpaying on broadband compared to the UK average?"',
-              '"What contracts do I have ending in the next 60 days?"',
-              '"Draft a cancellation email for my gym citing Consumer Rights Act 2015."',
-              '"Summarise my spending in groceries vs takeaways over the last 3 months."',
-              '"Which direct debits look like auto-renewals I forgot about?"',
-            ].map((prompt) => (
-              <div
-                key={prompt}
-                style={{
-                  padding: '16px 18px',
-                  borderRadius: '14px',
-                  background: 'rgba(255,255,255,0.04)',
-                  border: '1px solid rgba(255,255,255,0.08)',
-                  color: 'rgba(255,255,255,0.88)',
-                  fontSize: '14px',
-                  lineHeight: 1.55,
-                  letterSpacing: '-0.01em',
-                }}
-              >
-                {prompt}
-              </div>
-            ))}
-          </div>
-
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              gap: '12px',
-              marginTop: '36px',
-              flexWrap: 'wrap',
-            }}
-            className="reveal"
-          >
-            <a
-              href="/docs/paybacker-assistant"
-              className="btn-primary"
-              style={{
-                padding: '12px 22px',
-                borderRadius: '12px',
-                background: 'var(--accent-mint, #10b981)',
-                color: 'var(--ink, #0f172a)',
-                fontWeight: 600,
-                fontSize: '14px',
-                textDecoration: 'none',
-              }}
-            >
-              See the 60-second setup
-            </a>
-            <a
-              href="/pricing"
-              style={{
-                padding: '12px 22px',
-                borderRadius: '12px',
-                border: '1px solid rgba(255,255,255,0.18)',
-                color: 'rgba(255,255,255,0.92)',
-                fontWeight: 500,
-                fontSize: '14px',
-                textDecoration: 'none',
-              }}
-            >
-              Upgrade to Pro
-            </a>
-          </div>
-        </div>
-      </section>
-
-      {/* Smart Subscription Tracking (mint wash) ------------------- */}
-      <section className="subs-section section-mint" id="subscriptions">
-        <div className="wrap">
-          <div className="subs-grid">
-            <div className="subs-list reveal" aria-hidden="true">
-              <div className="subs-list-head">
-                <span>October · 11 active subscriptions</span>
-                <span className="subs-total">£143.92/mo</span>
-              </div>
-              <div className="subs-row">
-                <div className="subs-logo mint">N</div>
-                <div className="subs-meta">
-                  <div className="subs-name">Netflix Premium</div>
-                  <div className="subs-tags">
-                    <span className="subs-tag tag-orange">Unused 47 days</span>
-                    <span className="subs-tag">Renews in 14 days</span>
-                  </div>
-                </div>
-                <div className="subs-amt">£17.99</div>
-              </div>
-              <div className="subs-row">
-                <div className="subs-logo orange">V</div>
-                <div className="subs-meta">
-                  <div className="subs-name">Virgin Media Broadband</div>
-                  <div className="subs-tags">
-                    <span className="subs-tag tag-red">Price hike · +£12</span>
-                    <span className="subs-tag">Dispute drafted</span>
-                  </div>
-                </div>
-                <div className="subs-amt">£49.00</div>
-              </div>
-              <div className="subs-row">
-                <div className="subs-logo mint">S</div>
-                <div className="subs-meta">
-                  <div className="subs-name">Spotify Family</div>
-                  <div className="subs-tags">
-                    <span className="subs-tag">Active · 4 profiles</span>
-                  </div>
-                </div>
-                <div className="subs-amt">£19.99</div>
-              </div>
-              <div className="subs-row">
-                <div className="subs-logo orange">G</div>
-                <div className="subs-meta">
-                  <div className="subs-name">PureGym Plus</div>
-                  <div className="subs-tags">
-                    <span className="subs-tag tag-orange">Inactive 86 days</span>
-                    <span className="subs-tag">Cancel draft ready</span>
-                  </div>
-                </div>
-                <div className="subs-amt">£34.99</div>
-              </div>
-              <div className="subs-row">
-                <div className="subs-logo mint">A</div>
-                <div className="subs-meta">
-                  <div className="subs-name">Audible UK</div>
-                  <div className="subs-tags">
-                    <span className="subs-tag">Active · 3 credits unused</span>
-                  </div>
-                </div>
-                <div className="subs-amt">£7.99</div>
-              </div>
-              <div className="subs-row">
-                <div className="subs-logo orange">S</div>
-                <div className="subs-meta">
-                  <div className="subs-name">Sky Mobile</div>
-                  <div className="subs-tags">
-                    <span className="subs-tag">Contract ends 12 Dec</span>
-                    <span className="subs-tag tag-mint">Switch offer · save £168</span>
-                  </div>
-                </div>
-                <div className="subs-amt">£28.00</div>
-              </div>
-            </div>
-
-            <div className="subs-copy reveal">
-              <span className="eyebrow">Smart subscription tracking</span>
-              <h2>
-                Every sub. Every contract.
-                <br />
-                Every renewal.
-              </h2>
-              <p>
-                Paybacker spots every recurring payment the moment it hits your bank — then flags
-                the ones that are quietly costing you money.
-              </p>
-              <ul className="subs-features">
-                <li>
-                  <strong>Renewal alerts.</strong> 30, 14 and 7 days before any contract renews.
-                </li>
-                <li>
-                  <strong>Price-rise detection.</strong> We compare every bill against the last one
-                  and flag anything above inflation.
-                </li>
-                <li>
-                  <strong>Inactive-use detection.</strong> Gym not opened in 86 days? Streaming
-                  service not played in 47? We tell you.
-                </li>
-                <li>
-                  <strong>Contract end-dates tracked.</strong> No more rolling onto the
-                  &ldquo;loyalty tax&rdquo; after your intro rate expires.
-                </li>
-                <li>
-                  <strong>One-tap cancellation letters.</strong> Drafted with your rights under UK
-                  consumer law — you just hit send.
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* How it works (dark) --------------------------------------- */}
+      {/* ========== How it works (dark) ========== */}
       <section className="how-section section-ink" id="how">
         <div className="wrap">
-          <div className="section-head reveal">
+          <Reveal className="section-head">
             <span className="eyebrow on-ink">How it works</span>
             <h2>
               Three steps. Ten minutes.
@@ -1217,85 +852,36 @@ export default function HomepageV2Preview() {
               Usually four-figure savings.
             </h2>
             <p className="sub">
-              You don&rsquo;t have to connect anything to see it work. Try the Disputes Centre for
-              free — no account needed.
+              You don&rsquo;t have to connect anything to see it work. Try the
+              Disputes Centre for free — no account needed.
             </p>
-          </div>
+          </Reveal>
 
           <div className="how-steps">
-            <div className="how-step reveal">
+            <Reveal className="how-step" delay={0}>
               <div className="num">01</div>
               <h3>Describe your dispute, get a formal letter in 30 seconds.</h3>
-              <p>Pick the category, type a sentence. We cite the law, you send the letter.</p>
-              <form className="mini-form" onSubmit={onDemoGenerate}>
-                <label htmlFor="mini-issue">What&rsquo;s the issue?</label>
-                <select
-                  id="mini-issue"
-                  name="issueType"
-                  defaultValue="Mid-contract price rise"
-                >
-                  <option>Mid-contract price rise</option>
-                  <option>Delayed or cancelled flight (UK261)</option>
-                  <option>Faulty goods (CRA 2015)</option>
-                  <option>Energy billing error (Ofgem)</option>
-                </select>
-                <label htmlFor="mini-desc">Brief description</label>
-                <input
-                  id="mini-desc"
-                  name="description"
-                  type="text"
-                  placeholder="My Virgin bill jumped £12 without warning…"
-                  minLength={0}
-                  maxLength={280}
-                />
-                <button type="submit" disabled={letterBusy}>
-                  {letterLabel}
-                </button>
-                {letterPreview && (
-                  <div className="mini-letter-out" aria-live="polite">
-                    <div className="mini-letter-head">AI draft · preview</div>
-                    <p>{letterPreview}</p>
-                    <a
-                      className="mini-letter-cta"
-                      href="/auth/login"
-                      rel="noopener"
-                    >
-                      Sign up free to save &amp; send this letter →
-                    </a>
-                  </div>
-                )}
-              </form>
-            </div>
+              <p>
+                Pick the category, type a sentence. We cite the law, you send the
+                letter.
+              </p>
+              <HeroDemo />
+            </Reveal>
 
-            <div className="how-step reveal">
+            <Reveal className="how-step" delay={80}>
               <div className="num">02</div>
               <h3>Connect your bank and email to find hidden costs.</h3>
               <p>Open Banking via Yapily. Read-only. Never stored longer than needed.</p>
               <div className="bank-list">
-                <div className="bank-row">
-                  <span className="n">Monzo · main</span>
-                  <span className="v">Connected</span>
-                </div>
-                <div className="bank-row">
-                  <span className="n">Barclays · joint</span>
-                  <span className="v">Connected</span>
-                </div>
-                <div className="bank-row">
-                  <span className="n">Chase · savings</span>
-                  <span className="v">Connected</span>
-                </div>
-                <div className="bank-row">
-                  <span className="n">Gmail · inbox scan</span>
-                  <span className="v orange">3 hikes</span>
-                </div>
-                <div className="bank-row">
-                  <span className="n">Outlook · work</span>
-                  <span className="v orange">1 duplicate</span>
-                </div>
+                <div className="bank-row"><span className="n">Monzo · main</span><span className="v">Connected</span></div>
+                <div className="bank-row"><span className="n">Barclays · joint</span><span className="v">Connected</span></div>
+                <div className="bank-row"><span className="n">Chase · savings</span><span className="v">Connected</span></div>
+                <div className="bank-row"><span className="n">Gmail · inbox scan</span><span className="v orange">3 hikes</span></div>
+                <div className="bank-row"><span className="n">Outlook · work</span><span className="v orange">1 duplicate</span></div>
               </div>
-            </div>
+            </Reveal>
 
-            <div className="how-step reveal">
+            <Reveal className="how-step" delay={160}>
               <div className="num">03</div>
               <h3>Get personalised recommendations from 53+ verified UK partners.</h3>
               <p>We only show deals that beat your current bill. No sponsored nonsense.</p>
@@ -1322,116 +908,94 @@ export default function HomepageV2Preview() {
                   <div className="save">Save £156</div>
                 </div>
               </div>
-            </div>
+            </Reveal>
           </div>
 
           <div className="how-cta-row">
-            <a className="btn btn-mint" href="#">
+            <Link className="btn btn-mint" href="/join">
               Try it free — no account needed
-            </a>
+            </Link>
           </div>
         </div>
       </section>
 
-      {/* Deals (mint wash) ----------------------------------------- */}
+      {/* ========== Deals ========== */}
       <section className="deals-section section-mint" id="deals">
         <div className="wrap">
-          <div
-            className="section-head reveal"
-            style={{ textAlign: 'center', margin: '0 auto 24px' }}
-          >
-            <span className="eyebrow">53+ verified UK partners</span>
-            <h2 style={{ margin: '12px 0' }}>
-              Real prices. Real savings.
-              <br />
-              Better deals in every category.
-            </h2>
-          </div>
+          <Reveal className="section-head">
+            <div style={{ textAlign: 'center', margin: '0 auto 24px' }}>
+              <span className="eyebrow">53+ verified UK partners</span>
+              <h2 style={{ margin: '12px 0' }}>
+                Real prices. Real savings.
+                <br />
+                Better deals in every category.
+              </h2>
+            </div>
+          </Reveal>
 
           <div className="logo-cloud">
-            {[
-              'BT',
-              'Sky',
-              'Virgin',
-              'EE',
-              'E.ON',
-              'EDF',
-              'OVO',
-              'Vodafone',
-              'Three',
-              'O2',
-              'giffgaff',
-              'Plusnet',
-              'RAC',
-              'Habito',
-              '+40 more',
-            ].map((name) => (
-              <span className="logo-chip" key={name}>
-                {name}
-              </span>
+            {['BT', 'Sky', 'Virgin', 'EE', 'E.ON', 'EDF', 'OVO', 'Vodafone', 'Three', 'O2', 'giffgaff', 'Plusnet', 'RAC', 'Habito', '+40 more'].map((l) => (
+              <span className="logo-chip" key={l}>{l}</span>
             ))}
           </div>
 
           <div className="category-grid">
             {[
-              { name: 'Broadband', partners: '12 partners', save: 'Save £240/yr' },
-              { name: 'Mobile', partners: '9 partners', save: 'Save £180/yr' },
-              { name: 'Energy', partners: '14 partners', save: 'Save £450/yr' },
-              { name: 'Insurance', partners: '11 partners', save: 'Save £320/yr' },
-              { name: 'Mortgages', partners: '4 partners', save: 'Save £1,200/yr' },
-              { name: 'Travel', partners: '3 partners', save: 'Save £95/trip' },
-            ].map((c) => (
-              <div className="cat-tile reveal" key={c.name}>
-                <div className="cat-name">{c.name}</div>
-                <div className="cat-count">{c.partners}</div>
-                <div className="save-badge">{c.save}</div>
-              </div>
+              { name: 'Broadband', count: '12 partners', save: 'Save £240/yr' },
+              { name: 'Mobile', count: '9 partners', save: 'Save £180/yr' },
+              { name: 'Energy', count: '14 partners', save: 'Save £450/yr' },
+              { name: 'Insurance', count: '11 partners', save: 'Save £320/yr' },
+              { name: 'Mortgages', count: '4 partners', save: 'Save £1,200/yr' },
+              { name: 'Travel', count: '3 partners', save: 'Save £95/trip' },
+            ].map((cat, i) => (
+              <Reveal key={cat.name} className="cat-tile" delay={i * 60}>
+                <div className="cat-name">{cat.name}</div>
+                <div className="cat-count">{cat.count}</div>
+                <div className="save-badge">{cat.save}</div>
+              </Reveal>
             ))}
           </div>
 
           <p className="commission-note">
-            We earn a commission if you switch — you pay nothing extra, and we stay free to use.
+            We earn a commission if you switch — you pay nothing extra, and we stay
+            free to use.
           </p>
         </div>
       </section>
 
-      {/* Pricing --------------------------------------------------- */}
+      {/* ========== Pricing ========== */}
       <section className="pricing-section section-light" id="pricing">
         <div className="wrap">
-          <div
-            className="section-head reveal"
-            style={{ textAlign: 'center', margin: '0 auto 56px' }}
-          >
-            <span className="eyebrow">Founding member pricing</span>
-            <h2 style={{ margin: '12px 0' }}>
-              Start free. Upgrade only when we&rsquo;ve
-              <br />
-              found you money.
-            </h2>
-          </div>
+          <Reveal className="section-head">
+            <div style={{ textAlign: 'center', margin: '0 auto 56px' }}>
+              <span className="eyebrow">Founding member pricing</span>
+              <h2 style={{ margin: '12px 0' }}>
+                Start free. Upgrade only when we&rsquo;ve
+                <br />
+                found you money.
+              </h2>
+            </div>
+          </Reveal>
+
           <div className="pricing-grid">
-            <div className="price-card reveal">
+            <Reveal className="price-card" delay={0}>
               <div className="tier">Free</div>
-              <div className="price">
-                £0<span className="per">/forever</span>
-              </div>
-              <div className="founding hidden">—</div>
+              <div className="price">£0<span className="per">/forever</span></div>
+              <div className="founding" style={{ visibility: 'hidden' }}>—</div>
               <ul>
                 <li>3 AI dispute letters / month</li>
                 <li>Manual subscription tracker</li>
                 <li>Public deals marketplace</li>
               </ul>
-              <a className="btn btn-ghost cta" href="#" style={{ justifyContent: 'center' }}>
+              <Link className="btn btn-ghost cta" href="/join" style={{ justifyContent: 'center' }}>
                 Start free →
-              </a>
-            </div>
+              </Link>
+            </Reveal>
 
-            <div className="price-card featured reveal">
+            <Reveal className="price-card featured" delay={80}>
               <span className="ribbon">Most popular</span>
               <div className="tier">Essential</div>
-              <div className="price">
-                £4.99<span className="per">/month</span>
-              </div>
+              <div className="price">£4.99<span className="per">/month</span></div>
               <div className="founding">Founding member · locked-in forever</div>
               <ul>
                 <li>Unlimited AI dispute letters</li>
@@ -1439,16 +1003,14 @@ export default function HomepageV2Preview() {
                 <li>Email inbox scan</li>
                 <li>Pocket Agent in Telegram</li>
               </ul>
-              <a className="btn btn-mint cta" href="#" style={{ justifyContent: 'center' }}>
+              <Link className="btn btn-mint cta" href="/join" style={{ justifyContent: 'center' }}>
                 Start 14-day trial →
-              </a>
-            </div>
+              </Link>
+            </Reveal>
 
-            <div className="price-card reveal">
+            <Reveal className="price-card" delay={160}>
               <div className="tier">Pro</div>
-              <div className="price">
-                £9.99<span className="per">/month</span>
-              </div>
+              <div className="price">£9.99<span className="per">/month</span></div>
               <div className="founding">Founding member · locked-in forever</div>
               <ul>
                 <li>Everything in Essential</li>
@@ -1456,340 +1018,58 @@ export default function HomepageV2Preview() {
                 <li>Deal alerts on bill changes</li>
                 <li>Priority human review on complex disputes</li>
               </ul>
-              <a className="btn btn-ghost cta" href="#" style={{ justifyContent: 'center' }}>
+              <Link className="btn btn-ghost cta" href="/join" style={{ justifyContent: 'center' }}>
                 Go Pro →
-              </a>
-            </div>
+              </Link>
+            </Reveal>
           </div>
+
           <p className="compare-link">
-            <a href="#">See the full feature comparison →</a>
+            <Link href="/pricing">See the full feature comparison →</Link>
           </p>
         </div>
       </section>
 
-      {/* FAQ (light) — trust-building detail on data & safety ------ */}
-      <section className="faq-section section-light" id="faq">
-        <div className="wrap">
-          <div className="section-head reveal" style={{ textAlign: 'center', margin: '0 auto 48px' }}>
-            <span className="eyebrow">Your most common questions</span>
-            <h2 style={{ margin: '12px 0' }}>
-              How your data stays safe,
-              <br />
-              and how Paybacker actually works.
-            </h2>
-            <p>
-              We&rsquo;re a UK company, ICO-registered, FCA-authorised via Yapily for Open Banking,
-              and GDPR-compliant. Here&rsquo;s the plain-English detail.
-            </p>
-          </div>
-
-          <div className="faq-list reveal">
-            <details className="faq-item">
-              <summary>
-                <span>Is it safe to connect my bank account?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  Yes. We use <strong>Yapily</strong>, an FCA-authorised Open Banking provider
-                  regulated by the Financial Conduct Authority (FRN 827001). Open Banking is the
-                  UK&rsquo;s official, government-backed framework for connecting to bank
-                  accounts — the same tech used by Monzo, Emma, Plaid-powered apps, and HMRC&rsquo;s
-                  own services.
-                </p>
-                <p>
-                  Three things you should know:
-                </p>
-                <ul>
-                  <li>
-                    <strong>Read-only access.</strong> Paybacker can <em>see</em> your transactions
-                    and balances. We physically cannot move money, make payments, or change your
-                    account settings.
-                  </li>
-                  <li>
-                    <strong>We never see your banking password.</strong> You authenticate directly
-                    with your bank using their own app or online banking — we never see or store
-                    your credentials.
-                  </li>
-                  <li>
-                    <strong>Revoke anytime.</strong> You can disconnect any bank in one tap from
-                    your Paybacker dashboard, or revoke access directly from your bank&rsquo;s
-                    Open Banking settings.
-                  </li>
-                </ul>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>What does Paybacker actually do with my transaction data?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  We use it to find you money. Specifically, we categorise every transaction, spot
-                  recurring payments (subscriptions, direct debits, contracts), detect unusual
-                  price rises, flag forgotten or inactive subscriptions, and identify eligible
-                  refunds or disputes under UK consumer law.
-                </p>
-                <p>
-                  Your data is <strong>never sold</strong>, never shared with third-party
-                  advertisers, and never used to train AI models outside your own account. Full
-                  detail in our{' '}
-                  <a href="/privacy">Privacy Policy</a> and{' '}
-                  <a href="/terms">Terms of Service</a>.
-                </p>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>Where is my data stored, and is it encrypted?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  Your data is stored in the <strong>UK and EU only</strong> (Supabase, AWS
-                  eu-west-2 London region). It&rsquo;s encrypted in transit using TLS 1.3 and
-                  encrypted at rest using AES-256.
-                </p>
-                <p>
-                  We are registered with the UK Information Commissioner&rsquo;s Office (ICO) as a
-                  data controller. Under UK GDPR you have the right to access, correct, export, or
-                  delete all of your data at any time — directly from your dashboard or by emailing{' '}
-                  <a href="mailto:privacy@paybacker.co.uk">privacy@paybacker.co.uk</a>.
-                </p>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>Which UK banks are supported?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  All major UK high-street banks and challenger banks via Open Banking, including:
-                  Barclays, HSBC, Lloyds, NatWest, RBS, Santander, Halifax, Nationwide, TSB, Monzo,
-                  Starling, Revolut, Chase UK, First Direct, Metro Bank, Co-op Bank, and the vast
-                  majority of UK building societies and credit card issuers.
-                </p>
-                <p>
-                  Most US, Australian and EU banks are also supported for international users, but
-                  Paybacker&rsquo;s core features (UK consumer law letters, UK switching deals) are
-                  built for UK residents.
-                </p>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>How accurate are the AI-generated complaint letters?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  Every letter is drafted by a frontier AI model, citing exact UK legislation —
-                  Consumer Rights Act 2015, UK261/EU261, Ofgem Standards of Conduct, Ofcom
-                  Fairness Framework, Consumer Credit Act 1974, and more — depending on the
-                  dispute type.
-                </p>
-                <p>
-                  Letters are reviewed in real time for factual accuracy and legal correctness, and
-                  you can edit any letter before sending. We&rsquo;ve sent thousands of letters and
-                  our success rate on mid-contract price rise disputes (the most common use case)
-                  is currently <strong>78%</strong>.
-                </p>
-                <p className="faq-disclaimer">
-                  AI-generated letters are for guidance only and do not constitute legal advice. For
-                  complex disputes (e.g. disputes over £10,000, probate matters, or pending court
-                  proceedings), always consult a qualified solicitor.
-                </p>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>What happens if the company ignores my letter?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  Every letter sets a 14-day response window (28 days for regulated financial
-                  services under FCA rules). If the company doesn&rsquo;t respond or refuses, we
-                  escalate:
-                </p>
-                <ul>
-                  <li>
-                    <strong>Broadband / mobile / TV:</strong> Ofcom-backed ombudsman (CISAS or
-                    Ombudsman Services: Communications).
-                  </li>
-                  <li>
-                    <strong>Energy:</strong> Ofgem-backed Energy Ombudsman.
-                  </li>
-                  <li>
-                    <strong>Banking / credit / insurance:</strong> Financial Ombudsman Service
-                    (FOS) — decisions are legally binding on the company up to £430,000.
-                  </li>
-                  <li>
-                    <strong>Retail goods &amp; services:</strong> Small Claims Court (up to
-                    £10,000, £30 fee, no solicitor needed).
-                  </li>
-                </ul>
-                <p>
-                  Paybacker auto-drafts the escalation letter when the window expires — you just
-                  click send.
-                </p>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>What&rsquo;s actually free, and when do I have to pay?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  The Free plan includes 3 AI dispute letters per month, a manual subscription
-                  tracker, a one-time bank scan, a one-time email inbox scan, the full deals
-                  marketplace, and the AI chatbot.
-                </p>
-                <p>
-                  You only need Essential (£4.99/mo) or Pro (£9.99/mo) if you want{' '}
-                  <strong>unlimited</strong> disputes, daily automatic bank sync, monthly (or
-                  unlimited) email scans, the Pocket Agent in Telegram/WhatsApp, and priority
-                  human review on complex disputes. Founding-member pricing is locked in forever.
-                </p>
-                <p>
-                  No ads, no affiliate upsell traps. We make money from the monthly subscription
-                  and a small optional commission if you switch provider via the deals marketplace
-                  — you pay the same price either way.
-                </p>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>Which email providers can Paybacker scan?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  <strong>Gmail</strong> and <strong>Outlook</strong> (Microsoft 365) are fully
-                  supported using the official, Google/Microsoft-verified OAuth flow with
-                  read-only permissions. We&rsquo;ve passed Google&rsquo;s CASA security
-                  assessment for sensitive-scope access.
-                </p>
-                <p>
-                  Yahoo Mail and generic IMAP (Fastmail, ProtonMail, custom domains) are supported
-                  via app passwords. iCloud Mail is on the roadmap for Q3 2026.
-                </p>
-                <p>
-                  The inbox scan looks for subscription receipts, contract confirmations, price
-                  rise notifications, flight delay emails, and potential refund opportunities —
-                  nothing else. We don&rsquo;t read personal email.
-                </p>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>Can I cancel my subscription at any time?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  Yes — cancel in one click from your Paybacker dashboard (Settings → Billing). No
-                  call centre, no retention dark patterns, no &ldquo;let me transfer you to
-                  someone who can help.&rdquo; Your subscription stops at the end of the current
-                  billing period.
-                </p>
-                <p>
-                  If you cancel within 14 days of signing up and haven&rsquo;t used Paybacker
-                  intensively, you&rsquo;re entitled to a full refund under the Consumer Contracts
-                  Regulations — we&rsquo;ll process it within 5 working days.
-                </p>
-              </div>
-            </details>
-
-            <details className="faq-item">
-              <summary>
-                <span>Who&rsquo;s behind Paybacker?</span>
-                <span className="faq-chev" aria-hidden="true">+</span>
-              </summary>
-              <div className="faq-body">
-                <p>
-                  Paybacker is built by <strong>Paybacker LTD</strong>, a UK company registered in
-                  England &amp; Wales, founded March 2026. We&rsquo;re an ICO-registered data
-                  controller, FCA-authorised via Yapily for Open Banking access, and a verified
-                  Google Cloud partner for OAuth scopes.
-                </p>
-                <p>
-                  You can reach the founder directly at{' '}
-                  <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a> — we aim to
-                  respond within 24 hours, usually much faster. For data protection queries,{' '}
-                  <a href="mailto:privacy@paybacker.co.uk">privacy@paybacker.co.uk</a>.
-                </p>
-              </div>
-            </details>
-          </div>
-        </div>
-      </section>
-
-      {/* Testimonials ---------------------------------------------- */}
-      <section className="testimonials-section section-light">
-        <div className="testimonials-head reveal">
+      {/* ========== Testimonials ========== */}
+      <section className="testimonials-section section-light" id="testimonials">
+        <Reveal className="testimonials-head">
           <span className="eyebrow">Honest words from real users</span>
           <h2>
             What the money
             <br />
             we found meant for them.
           </h2>
-        </div>
-        <div className="t-track">
-          {doubledTestimonials.map((t, i) => (
-            <div className="t-card" key={`${t.name}-${i}`}>
-              <div className="who">
-                <div className="avatar" style={{ background: t.color }}>
-                  {t.name[0]}
-                </div>
-                <div>
-                  <div className="name">{t.name}</div>
-                  <div className="meta">{t.meta}</div>
-                </div>
-              </div>
-              <div className="quote">{t.quote}</div>
-              <div className="saved">{t.saved}</div>
-            </div>
-          ))}
-        </div>
+        </Reveal>
+        <Testimonials />
       </section>
 
-      {/* Final CTA (dark) ------------------------------------------ */}
+      {/* ========== Final CTA (dark) ========== */}
       <section
         className="final-cta section-ink glow-wrap"
-        style={{ '--glow-opacity': 0.14 } as CSSVarProperties}
+        style={{ ['--glow-opacity' as string]: '0.14' } as CSSVarProperties}
       >
         <div className="wrap">
-          <h2 className="reveal">
-            Stop overpaying.
-            <br />
-            Start <span className="mint">fighting</span> back.
-          </h2>
-          <p className="fc-sub reveal">
-            Most UK households are overcharged by £1,000+ a year. We find it, dispute it, and
-            cancel it — in minutes.
-          </p>
-          <div className="fc-btn-row reveal">
-            <a className="btn btn-mint" href="#">
+          <Reveal>
+            <h2>
+              Stop overpaying.
+              <br />
+              Start <span className="mint">fighting</span> back.
+            </h2>
+          </Reveal>
+          <Reveal as="p" className="fc-sub">
+            Most UK households are overcharged by £1,000+ a year. We find it, dispute
+            it, and cancel it — in minutes.
+          </Reveal>
+          <Reveal className="fc-btn-row">
+            <Link className="btn btn-mint" href="/join">
               Start your free 14-day Pro trial →
-            </a>
-          </div>
+            </Link>
+          </Reveal>
           <p className="fine">No card. Cancel anytime. Your data stays in the UK.</p>
         </div>
       </section>
 
-      {/* Footer ---------------------------------------------------- */}
+      {/* ========== Footer ========== */}
       <footer>
         <div className="wrap">
           <div className="footer-grid">
@@ -1799,8 +1079,8 @@ export default function HomepageV2Preview() {
                 <span className="backer">backer</span>
               </div>
               <p>
-                The UK&rsquo;s AI money-back engine. We find what you&rsquo;re losing and fight to
-                get it back.
+                The UK&rsquo;s AI money-back engine. We find what you&rsquo;re losing
+                and fight to get it back.
               </p>
               <p
                 style={{
@@ -1810,82 +1090,51 @@ export default function HomepageV2Preview() {
                   maxWidth: '320px',
                 }}
               >
-                AI-generated letters are for guidance only and do not constitute legal advice. For
-                complex disputes, always consult a qualified solicitor.
+                AI-generated letters are for guidance only and do not constitute legal
+                advice. For complex disputes, always consult a qualified solicitor.
               </p>
             </div>
             <div className="footer-col">
               <h5>Product</h5>
-              <a href="#">Disputes Centre</a>
-              <a href="#">Money Hub</a>
-              <a href="#">Pocket Agent</a>
-              <a href="#">Deals</a>
-              <a href="#">Pricing</a>
+              <a href="#pillars">Disputes Centre</a>
+              <a href="#pillars">Money Hub</a>
+              <a href="#pillars">Pocket Agent</a>
+              <a href="#deals">Deals</a>
+              <Link href="/pricing">Pricing</Link>
             </div>
             <div className="footer-col">
               <h5>Company</h5>
-              <a href="#">About</a>
-              <a href="#">Blog</a>
-              <a href="#">Press</a>
-              <a href="#">Careers</a>
-              <a href="#">Contact</a>
+              <Link href="/about">About</Link>
+              <a href="#how">How it works</a>
+              <a href="#testimonials">Stories</a>
+              <a href="mailto:hello@paybacker.co.uk">Contact</a>
             </div>
             <div className="footer-col">
               <h5>Legal</h5>
-              <a href="#">Privacy</a>
-              <a href="#">Terms</a>
-              <a href="#">Cookies</a>
-              <a href="#">ICO notice</a>
-              <a href="#">Complaints</a>
+              <Link href="/legal/privacy">Privacy</Link>
+              <Link href="/legal/terms">Terms</Link>
+              <Link href="/cookie-policy">Cookies</Link>
             </div>
             <div className="footer-col">
               <h5>Connect</h5>
               <div className="footer-socials" style={{ marginBottom: '14px' }}>
-                <a href="#" aria-label="X">
-                  𝕏
-                </a>
-                <a href="#" aria-label="Instagram">
-                  ◎
-                </a>
-                <a href="#" aria-label="Facebook">
-                  f
-                </a>
-                <a href="#" aria-label="TikTok">
-                  ♪
-                </a>
-                <a href="#" aria-label="LinkedIn">
-                  in
-                </a>
+                <a href="https://x.com/PaybackerUK" aria-label="X" target="_blank" rel="noreferrer noopener">𝕏</a>
+                <a href="https://www.instagram.com/paybacker.co.uk/" aria-label="Instagram" target="_blank" rel="noreferrer noopener">◎</a>
+                <a href="https://www.facebook.com/profile.php?id=61579563073310" aria-label="Facebook" target="_blank" rel="noreferrer noopener">f</a>
+                <a href="https://www.tiktok.com/@paybacker.co.uk" aria-label="TikTok" target="_blank" rel="noreferrer noopener">♪</a>
+                <a href="https://www.linkedin.com/company/112575954/" aria-label="LinkedIn" target="_blank" rel="noreferrer noopener">in</a>
               </div>
-              <a href="#">hello@paybacker.co.uk</a>
+              <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>
             </div>
           </div>
           <div className="footer-bottom">
-            <div>© 2026 Paybacker LTD · Registered in England &amp; Wales</div>
+            <div>© 2026 Paybacker LTD · Company no. 15289174 · Registered in England &amp; Wales</div>
             <div>paybacker.co.uk · Made in London 🇬🇧</div>
           </div>
         </div>
       </footer>
 
-      {/* Live chat widget — appears 2s after load ------------------ */}
-      <button
-        className={`live-chat${chatShown ? ' shown' : ''}`}
-        aria-label="Open chat"
-        type="button"
-      >
-        <svg
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
-        </svg>
-      </button>
+      <StickyCTA />
     </div>
   );
 }

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -660,8 +660,10 @@ export default function HomepageV3PreviewPage() {
         <div className="wrap">
           <div className="feature-grid">
             <Reveal className="feature-copy">
-              <span className="eyebrow">01 · AI Disputes Centre</span>
-              <h3>Draft a UK-law-cited complaint in 30 seconds.</h3>
+              <h2 className="feature-title">AI Disputes Centre</h2>
+              <p className="feature-tagline">
+                Draft a UK-law-cited complaint in 30 seconds.
+              </p>
               <p>
                 Type one sentence — Paybacker writes the formal letter, cites
                 the exact regulation, and sends it on your behalf.
@@ -692,8 +694,10 @@ export default function HomepageV3PreviewPage() {
               <PocketAgentDemo />
             </Reveal>
             <Reveal className="feature-copy">
-              <span className="eyebrow on-ink">02 · Pocket Agent</span>
-              <h3>Your AI money agent, in Telegram.</h3>
+              <h2 className="feature-title">Pocket Agent</h2>
+              <p className="feature-tagline">
+                Your AI money agent, in Telegram.
+              </p>
               <p>
                 Ask anything. Fix anything. &ldquo;Is my energy bill fair?&rdquo;
                 &ldquo;Cancel my gym.&rdquo; &ldquo;Dispute my parking ticket.&rdquo;
@@ -719,8 +723,10 @@ export default function HomepageV3PreviewPage() {
         <div className="wrap">
           <div className="feature-grid">
             <Reveal className="feature-copy">
-              <span className="eyebrow">03 · Money Hub</span>
-              <h3>Every account, every bill, every trend — in one view.</h3>
+              <h2 className="feature-title">Money Hub</h2>
+              <p className="feature-tagline">
+                Every account, every bill, every trend — in one view.
+              </p>
               <p>
                 Connect your bank via Open Banking (Yapily, FCA-authorised).
                 Read-only, bank-grade, never stored longer than needed.
@@ -754,10 +760,10 @@ export default function HomepageV3PreviewPage() {
               <SubscriptionsDemo />
             </Reveal>
             <Reveal className="feature-copy">
-              <span className="eyebrow">04 · Subscriptions tracker</span>
-              <h3>
+              <h2 className="feature-title">Subscriptions Tracker</h2>
+              <p className="feature-tagline">
                 Every fixed outgoing — surfaced, sorted, savings-flagged.
-              </h3>
+              </p>
               <p>
                 Auto-detects every subscription, direct debit and recurring
                 charge. Flags price rises, duplicates, and forgotten trials.
@@ -782,8 +788,10 @@ export default function HomepageV3PreviewPage() {
         <div className="wrap">
           <div className="feature-grid">
             <Reveal className="feature-copy">
-              <span className="eyebrow">05 · Export hub</span>
-              <h3>Live-sync to Google Sheets. Or one-shot CSV, Excel, PDF.</h3>
+              <h2 className="feature-title">Export Hub</h2>
+              <p className="feature-tagline">
+                Live-sync to Google Sheets. Or one-shot CSV, Excel, PDF.
+              </p>
               <p>
                 Your money is your data. Export it anywhere — including live
                 spreadsheets that update as your bank moves.
@@ -806,133 +814,165 @@ export default function HomepageV3PreviewPage() {
         </div>
       </section>
 
-      {/* ========== Comparison matrix ========== */}
-      <section className="compare-section section-light" id="compare">
+      {/* ========== Architecture + Competitor comparison (dark) ========== */}
+      <section className="compare-section section-ink" id="compare">
         <div className="wrap">
           <Reveal className="section-head section-head--center">
-            <span className="eyebrow">How we stack up</span>
-            <h2>
-              Everything the others do —
-              <br />
-              plus the parts that actually save you money.
-            </h2>
-            <p>
-              Paybacker combines bank sync, subscription tracking, AI disputes
-              and a deals marketplace in one subscription. No one else does all
-              five.
-            </p>
+            <span className="eyebrow on-ink">Stacked</span>
+            <h2>Architecture + competitor comparison</h2>
+            <p>How Paybacker beats every single incumbent.</p>
           </Reveal>
 
-          <Reveal className="compare-table-wrap">
-            <table className="compare-table">
+          {/* 3-panel architecture diagram */}
+          <Reveal className="arch-grid">
+            <div className="arch-col arch-col--inputs">
+              <div className="arch-label arch-label--orange">Inputs</div>
+              <ul className="arch-list">
+                <li>UK banks via Yapily</li>
+                <li>Gmail / Outlook inbox scan</li>
+                <li>Manual subscription add</li>
+                <li>Telegram commands</li>
+                <li>Dispute form (web or chat)</li>
+              </ul>
+            </div>
+
+            <div className="arch-col arch-col--core">
+              <div className="arch-core-card">
+                <div className="arch-label arch-label--mint arch-label--center">
+                  Paybacker Core
+                </div>
+                <ul className="arch-list arch-list--bold">
+                  <li>
+                    <strong>Unified ledger</strong>
+                    <span>every txn, contract, hike</span>
+                  </li>
+                  <li>
+                    <strong>Classifier</strong>
+                    <span>Money Hub categorisation</span>
+                  </li>
+                  <li>
+                    <strong>Flag engine</strong>
+                    <span>hikes, duplicates, trials</span>
+                  </li>
+                  <li>
+                    <strong>Law library</strong>
+                    <span>CRA, Ofcom, Ofgem, UK261, FCA</span>
+                  </li>
+                  <li>
+                    <strong>Deals graph</strong>
+                    <span>53+ UK partners</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="arch-col arch-col--outputs">
+              <div className="arch-label arch-label--mint">Outputs</div>
+              <ul className="arch-list">
+                <li>Web app — Money Hub + Disputes</li>
+                <li>Telegram Pocket Agent</li>
+                <li>Complaint letters (copy/email/PDF)</li>
+                <li>Google Sheets live sync</li>
+                <li>Deep-links to cancel / switch</li>
+              </ul>
+            </div>
+          </Reveal>
+
+          {/* Competitor matrix — dark theme, PAYBACKER last */}
+          <Reveal className="compare-table-wrap compare-table-wrap--dark">
+            <table className="compare-table compare-table--dark">
               <thead>
                 <tr>
                   <th className="feature">Feature</th>
-                  <th className="us">Paybacker</th>
                   <th>Emma</th>
                   <th>Snoop</th>
+                  <th>Lunchflow</th>
                   <th>Resolver</th>
-                  <th>DoNotPay</th>
+                  <th>Which?</th>
+                  <th className="us">Paybacker</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <td>AI letters citing UK consumer law</td>
-                  <td className="us"><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">US only</span></td>
-                </tr>
-                <tr>
-                  <td>Open Banking bank sync</td>
-                  <td className="us"><span className="chk">✓</span></td>
-                  <td><span className="chk">✓</span></td>
-                  <td><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                </tr>
-                <tr>
-                  <td>Subscription tracking</td>
-                  <td className="us"><span className="chk">✓</span></td>
-                  <td><span className="chk">✓</span></td>
-                  <td><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                </tr>
-                <tr>
-                  <td>Email inbox scan for hidden costs</td>
-                  <td className="us"><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                </tr>
-                <tr>
-                  <td>AI cancellation emails</td>
-                  <td className="us"><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                </tr>
-                <tr>
-                  <td>Pocket Agent (Telegram AI)</td>
-                  <td className="us"><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                </tr>
-                <tr>
-                  <td>Deals marketplace (switch partners)</td>
-                  <td className="us"><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                </tr>
-                <tr>
-                  <td>Google Sheets + CSV/Excel export</td>
-                  <td className="us"><span className="chk">✓</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                </tr>
-                <tr>
-                  <td>Developer MCP (Claude integration)</td>
-                  <td className="us"><span className="chk">✓ Pro</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                  <td><span className="x">—</span></td>
-                </tr>
-                <tr>
-                  <td>UK-first consumer-law focus</td>
-                  <td className="us"><span className="chk">✓</span></td>
+                  <td>Bank sync (Open Banking)</td>
                   <td><span className="chk">✓</span></td>
                   <td><span className="chk">✓</span></td>
                   <td><span className="chk">✓</span></td>
                   <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td className="us"><span className="chk">✓</span></td>
                 </tr>
-                <tr className="price-row">
-                  <td>Monthly price (starter)</td>
-                  <td className="us">£4.99</td>
-                  <td>£4.49</td>
-                  <td>£4.99</td>
-                  <td>Free (manual)</td>
-                  <td>£36/yr</td>
+                <tr>
+                  <td>Subscription flagging (hike/dup/unused)</td>
+                  <td>Basic</td>
+                  <td>Basic</td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td className="us">Full</td>
+                </tr>
+                <tr>
+                  <td>Legal-grade dispute letters</td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td>Templates</td>
+                  <td>Guide</td>
+                  <td className="us">AI + law</td>
+                </tr>
+                <tr>
+                  <td>UK consumer law library cited</td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td>Partial</td>
+                  <td>Partial</td>
+                  <td className="us">5+ statutes</td>
+                </tr>
+                <tr>
+                  <td>Telegram / chat agent</td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td className="us"><span className="chk">✓</span></td>
+                </tr>
+                <tr>
+                  <td>Live Google Sheets export</td>
+                  <td>CSV only</td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td className="us">✓ two-way</td>
+                </tr>
+                <tr>
+                  <td>Switch-deals that beat your bill</td>
+                  <td>Generic ads</td>
+                  <td>Generic</td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td>Guide only</td>
+                  <td className="us">Personalised</td>
+                </tr>
+                <tr>
+                  <td>User in control (no auto-sent emails)</td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td>Semi</td>
+                  <td><span className="chk">✓</span></td>
+                  <td className="us"><span className="chk">✓</span></td>
                 </tr>
               </tbody>
             </table>
           </Reveal>
 
-          <p className="compare-footnote">
+          <p className="compare-footnote compare-footnote--ink">
             Based on publicly listed features as of April 2026. Spot something
             we&rsquo;ve missed? Email{' '}
-            <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a> and
-            we&rsquo;ll update it.
+            <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>.
           </p>
         </div>
       </section>

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -240,7 +240,8 @@ function Nav() {
 }
 
 // ---------------------------------------------------------------------------
-// HeroVisual — mini-card + dashboard card (3D tilt on mouse) + agent bubble
+// HeroVisual — live DisputesDemo as the hero centrepiece, with two floating
+// supporting cards (mini savings snapshot + Pocket Agent bubble).
 // ---------------------------------------------------------------------------
 function HeroVisual() {
   const dashRef = useRef<HTMLDivElement | null>(null);
@@ -251,9 +252,9 @@ function HeroVisual() {
     const rect = el.getBoundingClientRect();
     const x = (event.clientX - rect.left) / rect.width - 0.5;
     const y = (event.clientY - rect.top) / rect.height - 0.5;
-    const rotY = x * 6;
-    const rotX = -y * 5;
-    el.style.transform = `perspective(1000px) rotateX(${rotX.toFixed(2)}deg) rotateY(${rotY.toFixed(2)}deg) translateZ(0)`;
+    const rotY = x * 4;
+    const rotX = -y * 3;
+    el.style.transform = `perspective(1200px) rotateX(${rotX.toFixed(2)}deg) rotateY(${rotY.toFixed(2)}deg) translateZ(0)`;
   }, []);
 
   const onMouseLeave = useCallback(() => {
@@ -263,91 +264,28 @@ function HeroVisual() {
   }, []);
 
   return (
-    <div className="hero-visual" aria-hidden="true">
-      <div className="mini-card float" style={{ animationDelay: '-2s' }}>
-        <div className="label">Example savings snapshot</div>
+    <div className="hero-visual hero-visual--live" aria-hidden="true">
+      <div className="mini-card float mini-card--hero" style={{ animationDelay: '-2s' }}>
+        <div className="label">Yearly savings spotted</div>
         <div className="big">£1,000+</div>
-        <div className="desc">typical yearly overcharge we find</div>
-        <div className="mini-bar">
-          <div className="bar"><span className="n">Broadband hike</span><span className="v">+£12/mo</span></div>
-          <div className="bar"><span className="n">Energy standing</span><span className="v">+£28/mo</span></div>
-          <div className="bar"><span className="n">Unused streaming</span><span className="v">+£7.99/mo</span></div>
-          <div className="bar"><span className="n">Gym (inactive)</span><span className="v">+£34/mo</span></div>
-        </div>
+        <div className="desc">typical amount we find per household</div>
       </div>
 
       <div
         ref={dashRef}
-        className="dash-card float tilt-host"
+        className="hero-demo-frame tilt-host"
         onMouseMove={onMouseMove}
         onMouseLeave={onMouseLeave}
       >
-        <div className="dash-header">
-          <div className="title">Money Hub · this month</div>
-          <div>●●●</div>
-        </div>
-        <div className="dash-body">
-          <div>
-            <div className="label">Spend tracked</div>
-            <div className="big-num">
-              £2,847
-              <span style={{ color: 'var(--text-tertiary)', fontSize: '0.6em' }}>.12</span>
-            </div>
-            <div className="delta">↗ 3 hikes flagged this week</div>
-          </div>
-          <div className="donut-row">
-            <div className="donut">
-              <div className="donut-center">
-                <span>Tracked</span>
-                <strong>£4,892</strong>
-              </div>
-            </div>
-            <div className="donut-legend">
-              <div className="row">
-                <span><span className="swatch" style={{ background: 'var(--accent-mint)' }} /><span className="name">Essentials</span></span>
-                <span className="amt">£1,859</span>
-              </div>
-              <div className="row">
-                <span><span className="swatch" style={{ background: 'var(--accent-orange)' }} /><span className="name">Subscriptions</span></span>
-                <span className="amt">£1,174</span>
-              </div>
-              <div className="row">
-                <span><span className="swatch" style={{ background: '#60A5FA' }} /><span className="name">Transport</span></span>
-                <span className="amt">£782</span>
-              </div>
-              <div className="row">
-                <span><span className="swatch" style={{ background: '#A78BFA' }} /><span className="name">Dining</span></span>
-                <span className="amt">£588</span>
-              </div>
-              <div className="row">
-                <span><span className="swatch" style={{ background: '#E5E7EB' }} /><span className="name">Other</span></span>
-                <span className="amt">£489</span>
-              </div>
-            </div>
-          </div>
-          <div className="sub-list">
-            <div className="row">
-              <span className="name">Netflix Premium<span className="tag">Unused</span></span>
-              <span className="amt">£17.99</span>
-            </div>
-            <div className="row">
-              <span className="name">Virgin Media<span className="tag">Hike</span></span>
-              <span className="amt">£49.00</span>
-            </div>
-            <div className="row">
-              <span className="name">Gym membership<span className="tag">Inactive</span></span>
-              <span className="amt">£34.99</span>
-            </div>
-          </div>
-        </div>
+        <DisputesDemo />
       </div>
 
-      <div className="agent-bubble float" style={{ animationDelay: '-3s' }}>
+      <div className="agent-bubble float agent-bubble--hero" style={{ animationDelay: '-3s' }}>
         <div className="who">
           <span className="dot-mint" /> Pocket Agent · Telegram
         </div>
         <div className="msg">
-          Virgin Media bill increased by <strong>£12</strong> this month — want me to draft a dispute citing Ofcom&rsquo;s mid-contract price rise rules?
+          Virgin Media bill up <strong>£12</strong> — draft an Ofcom dispute?
         </div>
       </div>
     </div>
@@ -737,184 +675,304 @@ export default function HomepageV3PreviewPage() {
         </div>
       </section>
 
-      {/* ========== Pillars ========== */}
-      <section className="pillars-section section-light" id="pillars">
+      {/* ========== Features intro ========== */}
+      <section className="features-intro section-light" id="features">
         <div className="wrap">
-          <Reveal className="section-head">
+          <Reveal className="section-head section-head--center">
             <span className="eyebrow">What&rsquo;s in the box</span>
             <h2>
-              Three products. One subscription.
+              Seven tools. One subscription.
               <br />
-              All of your money, watched.
+              Every £ you overpay — found, disputed, cancelled.
             </h2>
             <p>
-              Most UK households are overcharged by £1,000+ a year. Paybacker finds
-              it, disputes it, and cancels it — in minutes, not hours on hold.
+              Most UK households are overcharged by £1,000+ a year. Paybacker
+              finds it, disputes it, and cancels it — in minutes, not hours on
+              hold.
             </p>
           </Reveal>
+        </div>
+      </section>
 
-          <div className="pillar-grid">
-            <Reveal className="pillar-card" delay={0}>
-              <div className="pillar-icon orange" aria-hidden="true">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M12 3v18" />
-                  <path d="M4 7l8-4 8 4" />
-                  <path d="M4 7l3 7a3 3 0 006 0z" />
-                  <path d="M20 7l-3 7a3 3 0 006 0z" />
-                </svg>
-              </div>
-              <h3>AI Disputes Centre</h3>
-              <p className="copy">
-                Complaint letters citing exact UK consumer law in 30 seconds. Consumer
-                Rights Act 2015, UK261, Ofgem, Ofcom.
+      {/* ----- 01 · AI Disputes Centre (copy + demo merged) ----- */}
+      <section className="feature-section section-light" id="disputes">
+        <div className="wrap">
+          <div className="feature-grid">
+            <Reveal className="feature-copy">
+              <span className="eyebrow">01 · AI Disputes Centre</span>
+              <h3>Draft a UK-law-cited complaint in 30 seconds.</h3>
+              <p>
+                Type one sentence — Paybacker writes the formal letter, cites
+                the exact regulation, and sends it on your behalf.
               </p>
-              <div className="pillar-preview">
-                <div className="head">AI draft · Ofcom — mid-contract price rise</div>
-                <p className="letter-para">
-                  … I am writing to formally dispute the{' '}
-                  <span className="hl">£12 CPI+3.9% increase</span> applied to my
-                  Virgin Media broadband contract. Under{' '}
-                  <span className="hl">Ofcom&rsquo;s Fairness Framework</span> and the{' '}
-                  <span className="hl">Consumer Rights Act 2015 s.49</span>, you must
-                  provide reasonable notice and a right to exit without penalty…
-                </p>
+              <ul className="feature-bullets">
+                <li>Consumer Rights Act 2015, Ofcom, Ofgem, UK261, DVSA, HMRC</li>
+                <li>Energy, broadband, parking, flight delays, council tax</li>
+                <li>3 free letters / month. Unlimited on Essential and Pro.</li>
+              </ul>
+              <div className="feature-cta-row">
+                <Link className="btn btn-mint" href="/join">
+                  Try it free →
+                </Link>
               </div>
             </Reveal>
-
-            <Reveal className="pillar-card" delay={80}>
-              <div className="pillar-icon gradient" aria-hidden="true">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z" />
-                </svg>
-              </div>
-              <h3>Pocket Agent</h3>
-              <p className="copy">
-                Your AI financial agent in Telegram. Ask anything, fix everything.
-                &ldquo;Is my energy bill fair?&rdquo; &ldquo;Cancel my gym.&rdquo;
-                Done.
-              </p>
-              <div className="pillar-preview">
-                <div className="head">Today · Telegram</div>
-                <div className="chat-preview">
-                  <div className="chat-bubble user">Is £68/mo fair for 100Mb broadband?</div>
-                  <div className="chat-bubble agent">
-                    Above the UK median of £32. Two cheaper options on your postcode.
-                    Draft a switch?
-                  </div>
-                  <div className="chat-bubble user">Yes please</div>
-                  <div className="chat-bubble agent">
-                    On it — you&rsquo;ll save <strong>£432/yr</strong>.
-                  </div>
-                </div>
-              </div>
+            <Reveal className="feature-stage" delay={120}>
+              <DisputesDemo />
             </Reveal>
+          </div>
+        </div>
+      </section>
 
-            <Reveal className="pillar-card" delay={160}>
-              <div className="pillar-icon mint" aria-hidden="true">
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="3" y="6" width="18" height="13" rx="2" />
-                  <path d="M3 10h18" />
-                  <circle cx="17" cy="15" r="1.5" />
-                </svg>
-              </div>
-              <h3>Money Hub</h3>
-              <p className="copy">
-                Connect your bank via Open Banking (Yapily). Every subscription,
-                direct debit, and contract in one place. Daily sync.
+      {/* ----- 02 · Pocket Agent (dark, demo left) ----- */}
+      <section className="feature-section feature-section--ink" id="pocket-agent">
+        <div className="wrap">
+          <div className="feature-grid feature-grid--reverse">
+            <Reveal className="feature-stage" delay={120}>
+              <PocketAgentDemo />
+            </Reveal>
+            <Reveal className="feature-copy">
+              <span className="eyebrow on-ink">02 · Pocket Agent</span>
+              <h3>Your AI money agent, in Telegram.</h3>
+              <p>
+                Ask anything. Fix anything. &ldquo;Is my energy bill fair?&rdquo;
+                &ldquo;Cancel my gym.&rdquo; &ldquo;Dispute my parking ticket.&rdquo;
+                Done — from your phone.
               </p>
-              <div className="pillar-preview">
-                <div className="head">Your monthly breakdown</div>
-                <div className="donut-mini">
-                  <div className="d" />
-                  <div className="nums">
-                    <div className="row"><span className="sw" style={{ background: 'var(--accent-mint)' }} />Essentials · £1,859</div>
-                    <div className="row"><span className="sw" style={{ background: 'var(--accent-orange)' }} />Subs · £1,174</div>
-                    <div className="row"><span className="sw" style={{ background: '#93C5FD' }} />Transport · £782</div>
-                    <div className="row"><span className="sw" style={{ background: '#E5E7EB' }} />Other · £489</div>
-                  </div>
-                </div>
-                <div
-                  style={{
-                    marginTop: '14px',
-                    paddingTop: '12px',
-                    borderTop: '1px dashed var(--divider)',
-                    fontSize: '12px',
-                    color: 'var(--text-tertiary)',
-                  }}
-                >
-                  3 hikes flagged · 2 duplicates found
-                </div>
+              <ul className="feature-bullets">
+                <li>Reads your transactions, emails and contracts securely</li>
+                <li>Acts for you: drafts letters, queues cancellations</li>
+                <li>Telegram today · WhatsApp &amp; SMS on the roadmap</li>
+              </ul>
+              <div className="feature-cta-row">
+                <Link className="btn btn-mint" href="/join">
+                  Connect Telegram →
+                </Link>
               </div>
             </Reveal>
           </div>
         </div>
       </section>
 
-      {/* ========== Product demos ========== */}
-      <section className="demos-section section-light" id="demos">
+      {/* ----- 03 · Money Hub ----- */}
+      <section className="feature-section section-light" id="money-hub">
         <div className="wrap">
-          <Reveal className="section-head">
-            <span className="eyebrow">See it move</span>
+          <div className="feature-grid">
+            <Reveal className="feature-copy">
+              <span className="eyebrow">03 · Money Hub</span>
+              <h3>Every account, every bill, every trend — in one view.</h3>
+              <p>
+                Connect your bank via Open Banking (Yapily, FCA-authorised).
+                Read-only, bank-grade, never stored longer than needed.
+              </p>
+              <ul className="feature-bullets">
+                <li>Transactions auto-categorised across 20+ spend buckets</li>
+                <li>Budgets, savings goals, income tracking, net worth</li>
+                <li>Daily sync on Essential. Unlimited accounts on Pro.</li>
+              </ul>
+              <div className="feature-cta-row">
+                <Link className="btn btn-mint" href="/join">
+                  Connect your bank →
+                </Link>
+              </div>
+            </Reveal>
+            <Reveal className="feature-stage" delay={120}>
+              <MoneyHubDemo />
+            </Reveal>
+          </div>
+        </div>
+      </section>
+
+      {/* ----- 04 · Subscriptions tracker (alt bg, demo left) ----- */}
+      <section
+        className="feature-section feature-section--alt"
+        id="subscriptions"
+      >
+        <div className="wrap">
+          <div className="feature-grid feature-grid--reverse">
+            <Reveal className="feature-stage" delay={120}>
+              <SubscriptionsDemo />
+            </Reveal>
+            <Reveal className="feature-copy">
+              <span className="eyebrow">04 · Subscriptions tracker</span>
+              <h3>
+                Every fixed outgoing — surfaced, sorted, savings-flagged.
+              </h3>
+              <p>
+                Auto-detects every subscription, direct debit and recurring
+                charge. Flags price rises, duplicates, and forgotten trials.
+              </p>
+              <ul className="feature-bullets">
+                <li>Renewal reminders 30, 14 and 7 days before charge</li>
+                <li>One-tap AI cancellation emails citing your right to exit</li>
+                <li>Contract end-date tracking for broadband, energy &amp; mobile</li>
+              </ul>
+              <div className="feature-cta-row">
+                <Link className="btn btn-mint" href="/join">
+                  See every subscription →
+                </Link>
+              </div>
+            </Reveal>
+          </div>
+        </div>
+      </section>
+
+      {/* ----- 05 · Export hub ----- */}
+      <section className="feature-section section-light" id="export">
+        <div className="wrap">
+          <div className="feature-grid">
+            <Reveal className="feature-copy">
+              <span className="eyebrow">05 · Export hub</span>
+              <h3>Live-sync to Google Sheets. Or one-shot CSV, Excel, PDF.</h3>
+              <p>
+                Your money is your data. Export it anywhere — including live
+                spreadsheets that update as your bank moves.
+              </p>
+              <ul className="feature-bullets">
+                <li>Google Sheets live sync (bi-directional)</li>
+                <li>CSV, Excel and PDF statements by month or category</li>
+                <li>Accountant-ready annual exports for self-assessment</li>
+              </ul>
+              <div className="feature-cta-row">
+                <Link className="btn btn-mint" href="/join">
+                  Export your money →
+                </Link>
+              </div>
+            </Reveal>
+            <Reveal className="feature-stage" delay={120}>
+              <ExportDemo />
+            </Reveal>
+          </div>
+        </div>
+      </section>
+
+      {/* ========== Comparison matrix ========== */}
+      <section className="compare-section section-light" id="compare">
+        <div className="wrap">
+          <Reveal className="section-head section-head--center">
+            <span className="eyebrow">How we stack up</span>
             <h2>
-              Watch every product
+              Everything the others do —
               <br />
-              do the work for you.
+              plus the parts that actually save you money.
             </h2>
             <p>
-              Live, looping product demos. Every interaction is real product copy,
-              every number is a worked example.
+              Paybacker combines bank sync, subscription tracking, AI disputes
+              and a deals marketplace in one subscription. No one else does all
+              five.
             </p>
           </Reveal>
 
-          <Reveal className="demo-block">
-            <div className="demo-block-head">
-              <span className="eyebrow">01 · AI Disputes Centre</span>
-              <h3>Draft a UK-law-cited complaint in 30 seconds.</h3>
-            </div>
-            <div className="demo-slot">
-              <DisputesDemo />
-            </div>
+          <Reveal className="compare-table-wrap">
+            <table className="compare-table">
+              <thead>
+                <tr>
+                  <th className="feature">Feature</th>
+                  <th className="us">Paybacker</th>
+                  <th>Emma</th>
+                  <th>Snoop</th>
+                  <th>Resolver</th>
+                  <th>DoNotPay</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>AI letters citing UK consumer law</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">US only</span></td>
+                </tr>
+                <tr>
+                  <td>Open Banking bank sync</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr>
+                  <td>Subscription tracking</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr>
+                  <td>Email inbox scan for hidden costs</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr>
+                  <td>AI cancellation emails</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr>
+                  <td>Pocket Agent (Telegram AI)</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr>
+                  <td>Deals marketplace (switch partners)</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr>
+                  <td>Google Sheets + CSV/Excel export</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr>
+                  <td>Developer MCP (Claude integration)</td>
+                  <td className="us"><span className="chk">✓ Pro</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr>
+                  <td>UK-first consumer-law focus</td>
+                  <td className="us"><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="chk">✓</span></td>
+                  <td><span className="x">—</span></td>
+                </tr>
+                <tr className="price-row">
+                  <td>Monthly price (starter)</td>
+                  <td className="us">£4.99</td>
+                  <td>£4.49</td>
+                  <td>£4.99</td>
+                  <td>Free (manual)</td>
+                  <td>£36/yr</td>
+                </tr>
+              </tbody>
+            </table>
           </Reveal>
 
-          <Reveal className="demo-block demo-block--ink">
-            <div className="demo-block-head">
-              <span className="eyebrow on-ink">02 · Pocket Agent</span>
-              <h3 className="on-ink">Your money agent in Telegram. Reply, fix, save.</h3>
-            </div>
-            <div className="demo-slot demo-slot--dark">
-              <PocketAgentDemo />
-            </div>
-          </Reveal>
-
-          <Reveal className="demo-block">
-            <div className="demo-block-head">
-              <span className="eyebrow">03 · Money Hub</span>
-              <h3>Every account, every bill, every trend — in one view.</h3>
-            </div>
-            <div className="demo-slot">
-              <MoneyHubDemo />
-            </div>
-          </Reveal>
-
-          <Reveal className="demo-block">
-            <div className="demo-block-head">
-              <span className="eyebrow">04 · Subscriptions tracker</span>
-              <h3>Every fixed outgoing — surfaced, sorted, savings-flagged.</h3>
-            </div>
-            <div className="demo-slot">
-              <SubscriptionsDemo />
-            </div>
-          </Reveal>
-
-          <Reveal className="demo-block">
-            <div className="demo-block-head">
-              <span className="eyebrow">05 · Export hub</span>
-              <h3>Live-sync to Google Sheets. Or one-shot to CSV, Excel, PDF.</h3>
-            </div>
-            <div className="demo-slot">
-              <ExportDemo />
-            </div>
-          </Reveal>
+          <p className="compare-footnote">
+            Based on publicly listed features as of April 2026. Spot something
+            we&rsquo;ve missed? Email{' '}
+            <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a> and
+            we&rsquo;ll update it.
+          </p>
         </div>
       </section>
 

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -789,13 +789,10 @@ export default function HomepageV3PreviewPage() {
         </div>
       </section>
 
-      {/* ----- 02 · Pocket Agent (dark, demo left) ----- */}
+      {/* ----- 02 · Pocket Agent (dark; copy above demo) ----- */}
       <section className="feature-section feature-section--ink" id="pocket-agent">
         <div className="wrap">
-          <div className="feature-grid feature-grid--reverse">
-            <Reveal className="feature-stage" delay={120}>
-              <PocketAgentDemo />
-            </Reveal>
+          <div className="feature-grid">
             <Reveal className="feature-copy">
               <h2 className="feature-title">Pocket Agent</h2>
               <p className="feature-tagline">
@@ -816,6 +813,9 @@ export default function HomepageV3PreviewPage() {
                   Connect Telegram →
                 </Link>
               </div>
+            </Reveal>
+            <Reveal className="feature-stage" delay={120}>
+              <PocketAgentDemo />
             </Reveal>
           </div>
         </div>
@@ -852,16 +852,13 @@ export default function HomepageV3PreviewPage() {
         </div>
       </section>
 
-      {/* ----- 04 · Subscriptions tracker (alt bg, demo left) ----- */}
+      {/* ----- 04 · Subscriptions tracker (alt bg; copy above demo) ----- */}
       <section
         className="feature-section feature-section--alt"
         id="subscriptions"
       >
         <div className="wrap">
-          <div className="feature-grid feature-grid--reverse">
-            <Reveal className="feature-stage" delay={120}>
-              <SubscriptionsDemo />
-            </Reveal>
+          <div className="feature-grid">
             <Reveal className="feature-copy">
               <h2 className="feature-title">Subscriptions Tracker</h2>
               <p className="feature-tagline">
@@ -881,6 +878,9 @@ export default function HomepageV3PreviewPage() {
                   See every subscription →
                 </Link>
               </div>
+            </Reveal>
+            <Reveal className="feature-stage" delay={120}>
+              <SubscriptionsDemo />
             </Reveal>
           </div>
         </div>

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -240,14 +240,117 @@ function Nav() {
 }
 
 // ---------------------------------------------------------------------------
-// HeroVisual — live DisputesDemo as a clean centred device. No rotation, no
-// floating overlays. The demo is the hero — let it breathe.
+// HeroVisual — mini-card + dashboard card (3D tilt on mouse) + agent bubble.
+// The live DisputesDemo lives inside its own feature section further down so
+// it isn't repeated twice on the page.
 // ---------------------------------------------------------------------------
 function HeroVisual() {
+  const dashRef = useRef<HTMLDivElement | null>(null);
+
+  const onMouseMove = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const el = dashRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const x = (event.clientX - rect.left) / rect.width - 0.5;
+    const y = (event.clientY - rect.top) / rect.height - 0.5;
+    const rotY = x * 6;
+    const rotX = -y * 5;
+    el.style.transform = `perspective(1000px) rotateX(${rotX.toFixed(2)}deg) rotateY(${rotY.toFixed(2)}deg) translateZ(0)`;
+  }, []);
+
+  const onMouseLeave = useCallback(() => {
+    const el = dashRef.current;
+    if (!el) return;
+    el.style.transform = '';
+  }, []);
+
   return (
-    <div className="hero-visual hero-visual--live" aria-hidden="true">
-      <div className="hero-demo-frame">
-        <DisputesDemo />
+    <div className="hero-visual" aria-hidden="true">
+      <div className="mini-card float" style={{ animationDelay: '-2s' }}>
+        <div className="label">Example savings snapshot</div>
+        <div className="big">£1,000+</div>
+        <div className="desc">typical yearly overcharge we find</div>
+        <div className="mini-bar">
+          <div className="bar"><span className="n">Broadband hike</span><span className="v">+£12/mo</span></div>
+          <div className="bar"><span className="n">Energy standing</span><span className="v">+£28/mo</span></div>
+          <div className="bar"><span className="n">Unused streaming</span><span className="v">+£7.99/mo</span></div>
+          <div className="bar"><span className="n">Gym (inactive)</span><span className="v">+£34/mo</span></div>
+        </div>
+      </div>
+
+      <div
+        ref={dashRef}
+        className="dash-card float tilt-host"
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+      >
+        <div className="dash-header">
+          <div className="title">Money Hub · this month</div>
+          <div>●●●</div>
+        </div>
+        <div className="dash-body">
+          <div>
+            <div className="label">Spend tracked</div>
+            <div className="big-num">
+              £2,847
+              <span style={{ color: 'var(--text-tertiary)', fontSize: '0.6em' }}>.12</span>
+            </div>
+            <div className="delta">↗ 3 hikes flagged this week</div>
+          </div>
+          <div className="donut-row">
+            <div className="donut">
+              <div className="donut-center">
+                <span>Tracked</span>
+                <strong>£4,892</strong>
+              </div>
+            </div>
+            <div className="donut-legend">
+              <div className="row">
+                <span><span className="swatch" style={{ background: 'var(--accent-mint)' }} /><span className="name">Essentials</span></span>
+                <span className="amt">£1,859</span>
+              </div>
+              <div className="row">
+                <span><span className="swatch" style={{ background: 'var(--accent-orange)' }} /><span className="name">Subscriptions</span></span>
+                <span className="amt">£1,174</span>
+              </div>
+              <div className="row">
+                <span><span className="swatch" style={{ background: '#60A5FA' }} /><span className="name">Transport</span></span>
+                <span className="amt">£782</span>
+              </div>
+              <div className="row">
+                <span><span className="swatch" style={{ background: '#A78BFA' }} /><span className="name">Dining</span></span>
+                <span className="amt">£588</span>
+              </div>
+              <div className="row">
+                <span><span className="swatch" style={{ background: '#E5E7EB' }} /><span className="name">Other</span></span>
+                <span className="amt">£489</span>
+              </div>
+            </div>
+          </div>
+          <div className="sub-list">
+            <div className="row">
+              <span className="name">Netflix Premium<span className="tag">Unused</span></span>
+              <span className="amt">£17.99</span>
+            </div>
+            <div className="row">
+              <span className="name">Virgin Media<span className="tag">Hike</span></span>
+              <span className="amt">£49.00</span>
+            </div>
+            <div className="row">
+              <span className="name">Gym membership<span className="tag">Inactive</span></span>
+              <span className="amt">£34.99</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="agent-bubble float" style={{ animationDelay: '-3s' }}>
+        <div className="who">
+          <span className="dot-mint" /> Pocket Agent · Telegram
+        </div>
+        <div className="msg">
+          Virgin Media bill increased by <strong>£12</strong> this month — want me to draft a dispute citing Ofcom&rsquo;s mid-contract price rise rules?
+        </div>
       </div>
     </div>
   );
@@ -1058,15 +1161,13 @@ export default function HomepageV3PreviewPage() {
       {/* ========== Deals ========== */}
       <section className="deals-section section-mint" id="deals">
         <div className="wrap">
-          <Reveal className="section-head">
-            <div style={{ textAlign: 'center', margin: '0 auto 24px' }}>
-              <span className="eyebrow">53+ verified UK partners</span>
-              <h2 style={{ margin: '12px 0' }}>
-                Real prices. Real savings.
-                <br />
-                Better deals in every category.
-              </h2>
-            </div>
+          <Reveal className="section-head section-head--center">
+            <span className="eyebrow">53+ verified UK partners</span>
+            <h2 style={{ margin: '12px 0' }}>
+              Real prices. Real savings.
+              <br />
+              Better deals in every category.
+            </h2>
           </Reveal>
 
           <div className="logo-cloud">
@@ -1091,15 +1192,13 @@ export default function HomepageV3PreviewPage() {
       {/* ========== Pricing ========== */}
       <section className="pricing-section section-light" id="pricing">
         <div className="wrap">
-          <Reveal className="section-head">
-            <div style={{ textAlign: 'center', margin: '0 auto 56px' }}>
-              <span className="eyebrow">Founding member pricing</span>
-              <h2 style={{ margin: '12px 0' }}>
-                Start free. Upgrade only when we&rsquo;ve
-                <br />
-                found you money.
-              </h2>
-            </div>
+          <Reveal className="section-head section-head--center">
+            <span className="eyebrow">Founding member pricing</span>
+            <h2 style={{ margin: '12px 0' }}>
+              Start free. Upgrade only when we&rsquo;ve
+              <br />
+              found you money.
+            </h2>
           </Reveal>
 
           <div className="pricing-grid">

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -31,6 +31,15 @@ import {
   type CSSProperties,
   type ReactNode,
 } from 'react';
+import {
+  DisputesDemo,
+  PocketAgentDemo,
+  MoneyHubDemo,
+  SubscriptionsDemo,
+  ExportDemo,
+  DealsDemo,
+  McpDemo,
+} from './demos';
 import './styles.css';
 
 // React.CSSProperties doesn't know about CSS custom properties.
@@ -841,6 +850,74 @@ export default function HomepageV3PreviewPage() {
         </div>
       </section>
 
+      {/* ========== Product demos ========== */}
+      <section className="demos-section section-light" id="demos">
+        <div className="wrap">
+          <Reveal className="section-head">
+            <span className="eyebrow">See it move</span>
+            <h2>
+              Watch every product
+              <br />
+              do the work for you.
+            </h2>
+            <p>
+              Live, looping product demos. Every interaction is real product copy,
+              every number is a worked example.
+            </p>
+          </Reveal>
+
+          <Reveal className="demo-block">
+            <div className="demo-block-head">
+              <span className="eyebrow">01 · AI Disputes Centre</span>
+              <h3>Draft a UK-law-cited complaint in 30 seconds.</h3>
+            </div>
+            <div className="demo-slot">
+              <DisputesDemo />
+            </div>
+          </Reveal>
+
+          <Reveal className="demo-block demo-block--ink">
+            <div className="demo-block-head">
+              <span className="eyebrow on-ink">02 · Pocket Agent</span>
+              <h3 className="on-ink">Your money agent in Telegram. Reply, fix, save.</h3>
+            </div>
+            <div className="demo-slot demo-slot--dark">
+              <PocketAgentDemo />
+            </div>
+          </Reveal>
+
+          <Reveal className="demo-block">
+            <div className="demo-block-head">
+              <span className="eyebrow">03 · Money Hub</span>
+              <h3>Every account, every bill, every trend — in one view.</h3>
+            </div>
+            <div className="demo-slot">
+              <MoneyHubDemo />
+            </div>
+          </Reveal>
+
+          <Reveal className="demo-block">
+            <div className="demo-block-head">
+              <span className="eyebrow">04 · Subscriptions tracker</span>
+              <h3>Every fixed outgoing — surfaced, sorted, savings-flagged.</h3>
+            </div>
+            <div className="demo-slot">
+              <SubscriptionsDemo />
+            </div>
+          </Reveal>
+
+          <Reveal className="demo-block">
+            <div className="demo-block-head">
+              <span className="eyebrow">05 · Export hub</span>
+              <h3>Live-sync to Google Sheets. Or one-shot to CSV, Excel, PDF.</h3>
+            </div>
+            <div className="demo-slot">
+              <ExportDemo />
+            </div>
+          </Reveal>
+        </div>
+      </section>
+
       {/* ========== How it works (dark) ========== */}
       <section className="how-section section-ink" id="how">
         <div className="wrap">
@@ -939,22 +1016,11 @@ export default function HomepageV3PreviewPage() {
             ))}
           </div>
 
-          <div className="category-grid">
-            {[
-              { name: 'Broadband', count: '12 partners', save: 'Save £240/yr' },
-              { name: 'Mobile', count: '9 partners', save: 'Save £180/yr' },
-              { name: 'Energy', count: '14 partners', save: 'Save £450/yr' },
-              { name: 'Insurance', count: '11 partners', save: 'Save £320/yr' },
-              { name: 'Mortgages', count: '4 partners', save: 'Save £1,200/yr' },
-              { name: 'Travel', count: '3 partners', save: 'Save £95/trip' },
-            ].map((cat, i) => (
-              <Reveal key={cat.name} className="cat-tile" delay={i * 60}>
-                <div className="cat-name">{cat.name}</div>
-                <div className="cat-count">{cat.count}</div>
-                <div className="save-badge">{cat.save}</div>
-              </Reveal>
-            ))}
-          </div>
+          <Reveal className="demo-block">
+            <div className="demo-slot">
+              <DealsDemo />
+            </div>
+          </Reveal>
 
           <p className="commission-note">
             We earn a commission if you switch — you pay nothing extra, and we stay
@@ -1041,6 +1107,31 @@ export default function HomepageV3PreviewPage() {
           </h2>
         </Reveal>
         <Testimonials />
+      </section>
+
+      {/* ========== Developer · MCP ========== */}
+      <section className="mcp-section section-ink" id="mcp">
+        <div className="wrap">
+          <Reveal className="section-head">
+            <span className="pill-pro">Pro plan</span>
+            <span className="eyebrow on-ink">Developer · MCP</span>
+            <h2>
+              Talk to your money
+              <br />
+              from Claude Desktop.
+            </h2>
+            <p className="sub">
+              The Paybacker MCP server gives Claude direct read-only access to your
+              transactions, hikes, and savings opportunities. Available on Pro.
+            </p>
+          </Reveal>
+
+          <Reveal className="demo-block">
+            <div className="demo-slot demo-slot--dark">
+              <McpDemo />
+            </div>
+          </Reveal>
+        </div>
       </section>
 
       {/* ========== Final CTA (dark) ========== */}

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1249,8 +1249,10 @@
   max-width: 1080px;
   margin: 0 auto;
 }
-/* Reverse modifier becomes a no-op now we're stacked — copy always above */
-.m-v2-root .feature-grid--reverse .feature-stage { order: 0; }
+/* Hard guarantee: copy is always painted above the demo, regardless of
+   any source-order accidents (legacy --reverse rows, etc). */
+.m-v2-root .feature-grid .feature-copy { order: 0; }
+.m-v2-root .feature-grid .feature-stage { order: 1; }
 
 .m-v2-root .feature-copy {
   display: flex;

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1188,37 +1188,30 @@
    Feature sections (merged copy + demo) + comparison matrix
    ============================================================ */
 
-/* Hero: swap 3-card composition for a live Disputes demo frame */
-.m-v2-root .hero-visual--live { height: 620px; }
+/* Hero: clean centred Disputes demo — no rotation, no overlays.
+   The demo IS the centrepiece. Let it breathe. */
+.m-v2-root .hero-visual--live {
+  height: auto;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 8px;
+}
 .m-v2-root .hero-demo-frame {
-  position: absolute;
-  right: 0; top: 20px;
-  width: min(560px, 90%);
-  transform: rotate(-3deg);
-  --r: -3deg;
+  position: relative;
+  width: 100%;
+  max-width: 620px;
   border-radius: 20px;
   box-shadow: var(--shadow-xl);
   overflow: hidden;
-  z-index: 2;
   background: #fff;
-  transition: transform 220ms cubic-bezier(0.22,1,0.36,1);
 }
 .m-v2-root .hero-demo-frame .demo-stage {
   max-width: none;
+  width: 100%;
   border-radius: 20px;
   border: none;
   box-shadow: none;
-}
-.m-v2-root .mini-card--hero {
-  width: 220px; height: auto; padding: 18px;
-  left: -12px; top: 180px;
-  z-index: 3;
-}
-.m-v2-root .mini-card--hero .big { margin-bottom: 4px; }
-.m-v2-root .agent-bubble--hero {
-  right: auto; left: 10%; bottom: 30px;
-  width: 260px;
-  z-index: 3;
 }
 
 /* Shared: centred section head modifier */
@@ -1240,9 +1233,11 @@
   background: #FAFAF7;
 }
 
-/* Each feature = copy + live demo side by side */
+/* Each feature = copy stacked above the live demo. The demo gets the
+   full design width (~960px) it was hand-tuned for, instead of being
+   squashed into a side-by-side column. */
 .m-v2-root .feature-section {
-  padding: 56px 0 88px;
+  padding: 72px 0 104px;
   background: #FAFAF7;
 }
 .m-v2-root .feature-section--alt { background: #FFFFFF; }
@@ -1252,19 +1247,28 @@
 }
 
 .m-v2-root .feature-grid {
-  display: grid;
-  grid-template-columns: minmax(280px, 0.95fr) minmax(440px, 1.2fr);
-  gap: 56px;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  max-width: 1180px;
+  gap: 48px;
+  max-width: 1080px;
   margin: 0 auto;
 }
-.m-v2-root .feature-grid--reverse .feature-stage { order: -1; }
+/* Reverse modifier becomes a no-op now we're stacked — copy always above */
+.m-v2-root .feature-grid--reverse .feature-stage { order: 0; }
 
-.m-v2-root .feature-copy { display: flex; flex-direction: column; gap: 18px; }
-.m-v2-root .feature-copy .eyebrow { font-size: 12px; align-self: flex-start; }
+.m-v2-root .feature-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  text-align: center;
+  align-items: center;
+  max-width: 720px;
+  width: 100%;
+}
+.m-v2-root .feature-copy .eyebrow { font-size: 12px; align-self: center; }
 .m-v2-root .feature-copy h3 {
-  font-size: clamp(26px, 3.2vw, 40px);
+  font-size: clamp(28px, 3.4vw, 42px);
   font-weight: 700;
   line-height: 1.12;
   letter-spacing: -0.02em;
@@ -1291,6 +1295,9 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  text-align: left;
+  align-self: center;
+  max-width: 560px;
 }
 .m-v2-root .feature-bullets li {
   position: relative;
@@ -1321,7 +1328,7 @@
 }
 .m-v2-root .feature-stage .demo-stage {
   width: 100%;
-  max-width: 640px;
+  max-width: 960px;
 }
 
 .m-v2-root .feature-cta-row {
@@ -1329,6 +1336,7 @@
   gap: 12px;
   margin-top: 4px;
   flex-wrap: wrap;
+  justify-content: center;
 }
 
 /* Comparison matrix */
@@ -1433,20 +1441,13 @@
 
 @media (max-width: 980px) {
   .m-v2-root .features-intro { padding: 72px 0 16px; }
-  .m-v2-root .feature-section { padding: 40px 0 64px; }
-  .m-v2-root .feature-grid,
-  .m-v2-root .feature-grid--reverse {
-    grid-template-columns: 1fr;
-    gap: 32px;
-  }
-  .m-v2-root .feature-grid--reverse .feature-stage { order: 0; }
+  .m-v2-root .feature-section { padding: 48px 0 72px; }
+  .m-v2-root .feature-grid { gap: 32px; }
   .m-v2-root .feature-stage .demo-stage { max-width: 100%; }
   .m-v2-root .compare-section { padding: 64px 0; }
 }
 
 @media (max-width: 480px) {
-  .m-v2-root .hero-visual--live { height: auto; min-height: 520px; padding-bottom: 40px; }
-  .m-v2-root .hero-demo-frame { position: relative; right: auto; top: auto; transform: none; --r: 0deg; width: 100%; margin: 0 auto 24px; }
-  .m-v2-root .mini-card--hero { position: relative; left: auto; top: auto; width: 100%; margin-bottom: 14px; transform: none; --r: 0deg; }
-  .m-v2-root .agent-bubble--hero { position: relative; right: auto; left: auto; bottom: auto; width: 100%; transform: none; --r: 0deg; }
+  .m-v2-root .hero-visual--live { padding-top: 0; padding-bottom: 8px; }
+  .m-v2-root .hero-demo-frame { max-width: 100%; }
 }

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1,89 +1,105 @@
 /*
- * Homepage v2 preview — scoped stylesheet.
+ * Homepage v3 preview — scoped stylesheet.
  *
- * Every rule below is nested under `.m-v2-root` so it can't leak onto
- * the live `/` page, the authenticated dashboard, or any other route.
- *
- * The token aliases at the top map the export's original names
- * (`--surface-base`, `--accent-mint`, `--r-card`, etc.) onto the
- * Tailwind v4 theme tokens already shipped in globals.css. That way we
- * didn't have to rewrite the 700-line export CSS — it works unchanged.
- *
- * DO NOT remove or rename these classes without also updating
- * src/app/preview/homepage/page.tsx.
+ * Every rule below is scoped under `.m-v2-root` so it can't leak onto
+ * the live `/` page or the dashboard. Generated from
+ * /sessions/funny-upbeat-cerf/apr21-handoff/src/app/globals.css
+ * by /sessions/funny-upbeat-cerf/preview-build/scope_css.py
  */
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;600&display=swap');
+
 .m-v2-root {
-  /* Token aliases → globals.css Tailwind v4 theme */
-  --surface-base: var(--color-surface-base);
-  --surface-elevated: var(--color-surface-elevated);
-  --surface-ink: var(--color-surface-ink);
-  --surface-ink-2: var(--color-surface-ink-2);
-  --surface-soft-mint: var(--color-surface-soft-mint);
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, Consolas, monospace;
+  font-family: var(--font-sans);
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-size: 17px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  /* isolate wide elements (hero visual rotates off-screen otherwise) */
+  overflow-x: clip;
+}
+.m-v2-root * { box-sizing: border-box; }
+.m-v2-root img, .m-v2-root svg { display: block; max-width: 100%; }
+.m-v2-root a { color: inherit; }
 
-  --text-primary: var(--color-ink-primary);
-  --text-secondary: var(--color-ink-secondary);
-  --text-tertiary: var(--color-ink-tertiary);
-  --text-on-ink: var(--color-on-ink);
-  --text-on-ink-dim: var(--color-on-ink-dim);
+/* =========================================================================
+ * Paybacker — global styles
+ * SOURCE OF TRUTH: design_handoff_paybacker_homepage/styles.css
+ * Mirrored verbatim. If you change a value here, change it there too.
+ * ========================================================================= */
 
-  --accent-mint: var(--color-accent-mint);
-  --accent-mint-deep: var(--color-accent-mint-deep);
-  --accent-mint-wash: var(--color-accent-mint-wash);
-  --accent-orange: var(--color-accent-orange);
-  --accent-orange-deep: var(--color-accent-orange-deep);
+.m-v2-root {
+  /* Surfaces */
+  --surface-base: #FAFAF7;
+  --surface-elevated: #FFFFFF;
+  --surface-ink: #0B1220;
+  --surface-ink-2: #111A2E;
+  --surface-soft-mint: #ECFBF3;
 
-  --divider: var(--color-divider-light);
-  --divider-ink: var(--color-divider-ink);
+  /* Text */
+  --text-primary: #0B1220;
+  --text-secondary: #4B5563;
+  --text-tertiary: #6B7280;
+  --text-on-ink: #F3F4F6;
+  --text-on-ink-dim: #9CA3AF;
 
-  --r-card: var(--radius-marketing-card);
-  --r-figure: var(--radius-marketing-figure);
-  --r-btn: var(--radius-marketing-btn);
-  --r-input: var(--radius-marketing-input);
-  --r-pill: var(--radius-marketing-pill);
+  /* Accents */
+  --accent-mint: #34D399;
+  --accent-mint-deep: #059669;
+  --accent-mint-wash: #ECFBF3;
+  --accent-orange: #F59E0B;
+  --accent-orange-deep: #D97706;
 
-  --shadow-sm: var(--shadow-marketing-sm);
-  --shadow-md: var(--shadow-marketing-md);
-  --shadow-lg: var(--shadow-marketing-lg);
-  --shadow-xl: var(--shadow-marketing-xl);
-  --shadow-mint: var(--shadow-marketing-mint);
-  --shadow-orange: var(--shadow-marketing-orange);
+  /* Lines */
+  --divider: #E5E7EB;
+  --divider-ink: #1F2A44;
 
-  --fs-display: var(--text-display);
-  --fs-h1: var(--text-h1-marketing);
-  --fs-h2: var(--text-h2-marketing);
+  /* Radii */
+  --r-card: 24px;
+  --r-figure: 32px;
+  --r-btn: 14px;
+  --r-input: 12px;
+  --r-pill: 999px;
+
+  /* Shadows — warm, not black */
+  --shadow-sm: 0 2px 8px -2px rgba(11, 18, 32, 0.08);
+  --shadow-md: 0 10px 30px -10px rgba(11, 18, 32, 0.14);
+  --shadow-lg: 0 20px 60px -20px rgba(11, 18, 32, 0.18);
+  --shadow-xl: 0 30px 90px -30px rgba(11, 18, 32, 0.22);
+  --shadow-mint: 0 20px 50px -18px rgba(52, 211, 153, 0.5);
+  --shadow-orange: 0 20px 50px -18px rgba(245, 158, 11, 0.35);
+
+  /* Type scale */
+  --fs-display: clamp(56px, 8vw, 104px);
+  --fs-h1: clamp(40px, 5vw, 64px);
+  --fs-h2: clamp(32px, 4vw, 48px);
   --fs-h3: 24px;
   --fs-body: 17px;
   --fs-sm: 14px;
   --fs-xs: 12px;
-  --track-tight: var(--tracking-marketing-tight);
-  --track-eyebrow: var(--tracking-marketing-eyebrow);
-
-  /* Page-level appearance — covers body so the dark nav behind is hidden */
-  min-height: 100vh;
-  background: var(--surface-base);
-  color: var(--text-primary);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-size: var(--fs-body);
-  line-height: 1.55;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  overflow-x: hidden;
+  --track-tight: -0.025em;
+  --track-eyebrow: 0.14em;
 }
 
-.m-v2-root * { box-sizing: border-box; }
-.m-v2-root img,
-.m-v2-root svg { display: block; max-width: 100%; }
+/* =========================================================================
+ * Shared atoms
+ * ========================================================================= */
 
-/* Shared ---------------------------------------------------------- */
 .m-v2-root .wrap { max-width: 1240px; margin: 0 auto; padding: 0 32px; }
+
 .m-v2-root .eyebrow {
   font-size: var(--fs-xs);
   letter-spacing: var(--track-eyebrow);
   text-transform: uppercase;
   color: var(--accent-mint-deep);
   font-weight: 600;
+  font-family: var(--font-mono), ui-monospace, Consolas, monospace;
 }
+
 .m-v2-root .eyebrow.on-ink { color: var(--accent-mint); }
 
 .m-v2-root .btn {
@@ -97,34 +113,46 @@
   cursor: pointer;
   transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
   white-space: nowrap;
+  font-family: inherit;
 }
+
 .m-v2-root .btn-mint { background: var(--accent-mint); color: #052E1C; box-shadow: var(--shadow-mint); }
-.m-v2-root .btn-mint:hover { transform: scale(1.02); box-shadow: 0 24px 55px -18px rgba(52, 211, 153, 0.65); background: #2CC48A; }
+
+.m-v2-root .btn-mint:hover { transform: translateY(-1px) scale(1.02); box-shadow: 0 24px 55px -18px rgba(52,211,153,0.65); background: #2CC48A; }
+
 .m-v2-root .btn-ghost { background: transparent; color: var(--text-primary); border: 1px solid var(--divider); }
-.m-v2-root .btn-ghost:hover { transform: scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+
+.m-v2-root .btn-ghost:hover { transform: translateY(-1px) scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+
 .m-v2-root .btn-ghost.on-ink { color: var(--text-on-ink); border-color: var(--divider-ink); background: transparent; }
+
 .m-v2-root .btn-ghost.on-ink:hover { background: rgba(255,255,255,0.04); }
 
 .m-v2-root .divider-rule { height: 1px; background: var(--divider); }
 
-/* Reveal animation */
-.m-v2-root .reveal { opacity: 0; transform: translateY(12px); transition: opacity 400ms ease, transform 400ms ease; }
+/* Reveal animation — drives src/components/site/Reveal.tsx */
+
+.m-v2-root .reveal { opacity: 0; transform: translateY(14px); transition: opacity 600ms cubic-bezier(0.22,1,0.36,1), transform 600ms cubic-bezier(0.22,1,0.36,1); }
+
 .m-v2-root .reveal.in { opacity: 1; transform: translateY(0); }
 
-/* Sections */
 .m-v2-root section { position: relative; }
-.m-v2-root .section-light { background: var(--surface-base); }
-.m-v2-root .section-white { background: var(--surface-elevated); }
-.m-v2-root .section-mint { background: var(--accent-mint-wash); }
-.m-v2-root .section-ink { background: var(--surface-ink); color: var(--text-on-ink); }
-.m-v2-root .section-ink h1,
-.m-v2-root .section-ink h2,
-.m-v2-root .section-ink h3 { color: var(--text-on-ink); }
 
-/* Ambient glow (hero / final CTA) */
+.m-v2-root .section-light { background: var(--surface-base); }
+
+.m-v2-root .section-white { background: var(--surface-elevated); }
+
+.m-v2-root .section-mint { background: var(--accent-mint-wash); }
+
+.m-v2-root .section-ink { background: var(--surface-ink); color: var(--text-on-ink); }
+
+.m-v2-root .section-ink h1, .m-v2-root .section-ink h2, .m-v2-root .section-ink h3 { color: var(--text-on-ink); }
+
+/* Ambient glow */
+
 .m-v2-root .glow-wrap { position: relative; }
-.m-v2-root .glow-wrap::before,
-.m-v2-root .glow-wrap::after {
+
+.m-v2-root .glow-wrap::before, .m-v2-root .glow-wrap::after {
   content: '';
   position: absolute;
   pointer-events: none;
@@ -134,18 +162,24 @@
   filter: blur(80px);
   opacity: var(--glow-opacity, 0.18);
 }
+
 .m-v2-root .glow-wrap::before {
   top: -250px; right: -200px;
   background: radial-gradient(circle, var(--accent-orange) 0%, transparent 60%);
 }
+
 .m-v2-root .glow-wrap::after {
   bottom: -350px; left: -250px;
   background: radial-gradient(circle, var(--accent-mint) 0%, transparent 60%);
   opacity: calc(var(--glow-opacity, 0.18) * 0.6);
 }
+
 .m-v2-root .glow-wrap > * { position: relative; z-index: 1; }
 
-/* Nav ------------------------------------------------------------- */
+/* =========================================================================
+ * Nav
+ * ========================================================================= */
+
 .m-v2-root .nav-shell {
   position: fixed; top: 18px; left: 0; right: 0;
   display: flex; justify-content: center;
@@ -153,7 +187,9 @@
   transition: top 200ms ease;
   pointer-events: none;
 }
+
 .m-v2-root .nav-shell.scrolled { top: 10px; }
+
 .m-v2-root .nav-pill {
   pointer-events: auto;
   display: flex; align-items: center; gap: 10px;
@@ -166,11 +202,17 @@
   box-shadow: var(--shadow-md);
   transition: padding 200ms ease, transform 200ms ease;
 }
+
 .m-v2-root .nav-shell.scrolled .nav-pill { padding: 8px 8px 8px 16px; transform: scale(0.97); }
+
 .m-v2-root .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; text-decoration: none; }
+
 .m-v2-root .nav-logo .pay { color: var(--text-primary); }
+
 .m-v2-root .nav-logo .backer { color: var(--accent-mint-deep); }
+
 .m-v2-root .nav-links { display: flex; gap: 6px; margin: 0 14px; }
+
 .m-v2-root .nav-links a {
   font-size: 14px; font-weight: 500;
   color: var(--text-secondary);
@@ -179,16 +221,31 @@
   border-radius: var(--r-pill);
   transition: background 150ms, color 150ms;
 }
+
 .m-v2-root .nav-links a:hover { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+
 .m-v2-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
+
 .m-v2-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+
 .m-v2-root .nav-start {
   background: var(--accent-mint); color: #052E1C;
   padding: 10px 18px; border-radius: var(--r-pill);
   font-weight: 600; font-size: 14px; text-decoration: none;
   transition: transform 150ms, box-shadow 150ms;
 }
+
 .m-v2-root .nav-start:hover { transform: scale(1.03); box-shadow: var(--shadow-mint); }
+
+/* Scroll-progress bar — pure CSS extra */
+
+.m-v2-root .nav-progress {
+  position: fixed; top: 0; left: 0; right: 0; height: 2px; z-index: 101; pointer-events: none;
+  background: linear-gradient(90deg, var(--accent-mint) 0%, var(--accent-orange) 100%);
+  transform-origin: left center;
+  transform: scaleX(var(--progress, 0));
+  transition: transform 80ms linear;
+}
 
 .m-v2-root .trust-bar {
   text-align: center;
@@ -197,10 +254,15 @@
   color: var(--text-tertiary);
   letter-spacing: 0.02em;
 }
+
 .m-v2-root .trust-bar .dot { margin: 0 10px; opacity: 0.5; }
 
-/* Hero ------------------------------------------------------------ */
+/* =========================================================================
+ * Hero
+ * ========================================================================= */
+
 .m-v2-root .hero { padding: 32px 0 120px; }
+
 .m-v2-root .hero-grid {
   display: grid;
   grid-template-columns: 1.1fr 1fr;
@@ -208,6 +270,7 @@
   align-items: center;
   padding-top: 40px;
 }
+
 .m-v2-root .hero h1 {
   font-size: var(--fs-display);
   line-height: 0.94;
@@ -215,9 +278,13 @@
   font-weight: 700;
   margin: 18px 0 24px;
 }
+
 .m-v2-root .hero h1 .l1 { color: var(--text-primary); display: block; }
+
 .m-v2-root .hero h1 .l2 { color: var(--accent-mint-deep); display: block; }
+
 .m-v2-root .hero h1 .l3 { color: var(--accent-orange-deep); display: block; }
+
 .m-v2-root .hero-sub {
   font-size: 19px;
   color: var(--text-secondary);
@@ -225,7 +292,9 @@
   margin-bottom: 28px;
   text-wrap: pretty;
 }
+
 .m-v2-root .hero-cta-row { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+
 .m-v2-root .hero-ticker {
   margin-top: 22px;
   font-size: 14px;
@@ -233,29 +302,38 @@
   font-weight: 500;
   display: inline-flex; align-items: center; gap: 10px;
 }
+
 .m-v2-root .hero-ticker .pulse {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--accent-orange);
   box-shadow: 0 0 0 0 rgba(245,158,11,0.6);
-  animation: m-v2-pulse 2.4s infinite;
+  animation: pulse 2.4s infinite;
 }
-@keyframes m-v2-pulse {
+
+@keyframes pulse {
   0% { box-shadow: 0 0 0 0 rgba(245,158,11,0.5); }
   70% { box-shadow: 0 0 0 12px rgba(245,158,11,0); }
   100% { box-shadow: 0 0 0 0 rgba(245,158,11,0); }
 }
 
-/* Hero visual ----------------------------------------------------- */
+/* Hero visual */
+
 .m-v2-root .hero-visual {
   position: relative;
   height: 600px;
   perspective: 1400px;
 }
-.m-v2-root .hero-visual .float { animation: m-v2-float 6s ease-in-out infinite; }
-@keyframes m-v2-float {
+
+.m-v2-root .hero-visual .float { animation: float 6s ease-in-out infinite; }
+
+@keyframes float {
   0%, 100% { transform: translateY(0) rotate(var(--r, 0deg)); }
   50% { transform: translateY(-4px) rotate(var(--r, 0deg)); }
 }
+
+/* 3D tilt host — mouse-driven */
+
+.m-v2-root .tilt-host { transition: transform 220ms cubic-bezier(0.22,1,0.36,1); will-change: transform; }
 
 .m-v2-root .dash-card {
   position: absolute;
@@ -270,19 +348,26 @@
   --r: -4deg;
   z-index: 2;
 }
+
 .m-v2-root .dash-header {
   display: flex; justify-content: space-between; align-items: center;
   padding: 18px 22px;
   border-bottom: 1px solid var(--divider);
   font-size: 13px; color: var(--text-secondary);
 }
+
 .m-v2-root .dash-header .title { font-weight: 600; color: var(--text-primary); font-size: 15px; }
+
 .m-v2-root .dash-body { padding: 22px; }
+
 .m-v2-root .dash-body .label { font-size: 11px; color: var(--text-tertiary); letter-spacing: 0.08em; text-transform: uppercase; font-weight: 600; }
+
 .m-v2-root .dash-body .big-num { font-size: 38px; font-weight: 700; letter-spacing: -0.02em; margin: 4px 0 2px; }
+
 .m-v2-root .dash-body .delta { color: var(--accent-mint-deep); font-size: 13px; font-weight: 500; }
 
 .m-v2-root .donut-row { display: flex; gap: 18px; align-items: center; margin: 24px 0; }
+
 .m-v2-root .donut {
   width: 120px; height: 120px; flex-shrink: 0;
   border-radius: 50%;
@@ -295,37 +380,44 @@
   );
   position: relative;
 }
-.m-v2-root .donut::after {
-  content: '';
-  position: absolute; inset: 18px;
-  border-radius: 50%;
-  background: #fff;
-}
+
+.m-v2-root .donut::after { content: ''; position: absolute; inset: 18px; border-radius: 50%; background: #fff; }
+
 .m-v2-root .donut-center {
   position: absolute; inset: 0;
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   font-size: 11px; color: var(--text-tertiary); z-index: 1;
 }
+
 .m-v2-root .donut-center strong { font-size: 18px; color: var(--text-primary); font-weight: 700; }
+
 .m-v2-root .donut-legend { flex: 1; display: flex; flex-direction: column; gap: 8px; font-size: 12px; }
+
 .m-v2-root .donut-legend .row { display: flex; justify-content: space-between; align-items: center; }
+
 .m-v2-root .donut-legend .swatch { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 8px; vertical-align: middle; }
+
 .m-v2-root .donut-legend .name { color: var(--text-secondary); }
+
 .m-v2-root .donut-legend .amt { font-weight: 600; color: var(--text-primary); }
 
 .m-v2-root .sub-list { border-top: 1px solid var(--divider); padding-top: 16px; }
+
 .m-v2-root .sub-list .row {
   display: flex; justify-content: space-between; align-items: center;
   padding: 8px 0;
   font-size: 13px;
 }
+
 .m-v2-root .sub-list .name { color: var(--text-primary); font-weight: 500; }
+
 .m-v2-root .sub-list .tag {
   background: #FEF3C7; color: var(--accent-orange-deep);
   font-size: 10px; font-weight: 600; letter-spacing: 0.04em;
   padding: 2px 8px; border-radius: 999px; margin-left: 8px;
   text-transform: uppercase;
 }
+
 .m-v2-root .sub-list .amt { color: var(--text-secondary); font-variant-numeric: tabular-nums; }
 
 .m-v2-root .mini-card {
@@ -342,12 +434,19 @@
   overflow: hidden;
   z-index: 1;
 }
+
 .m-v2-root .mini-card .label { color: var(--text-on-ink-dim); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; }
+
 .m-v2-root .mini-card .big { font-size: 36px; font-weight: 700; letter-spacing: -0.02em; margin: 6px 0 2px; color: var(--accent-mint); }
+
 .m-v2-root .mini-card .desc { color: var(--text-on-ink-dim); font-size: 13px; margin-bottom: 24px; }
+
 .m-v2-root .mini-bar { display: flex; flex-direction: column; gap: 10px; }
+
 .m-v2-root .mini-bar .bar { height: 34px; background: rgba(255,255,255,0.06); border-radius: 10px; display: flex; align-items: center; padding: 0 12px; justify-content: space-between; font-size: 12px; }
+
 .m-v2-root .mini-bar .bar .n { color: var(--text-on-ink-dim); }
+
 .m-v2-root .mini-bar .bar .v { color: var(--accent-orange); font-weight: 600; }
 
 .m-v2-root .agent-bubble {
@@ -362,30 +461,36 @@
   transform: rotate(2deg);
   --r: 2deg;
   border: 1px solid rgba(11,18,32,0.05);
+  z-index: 3;
 }
+
 .m-v2-root .agent-bubble .who {
   display: flex; align-items: center; gap: 8px; margin-bottom: 8px;
   font-size: 11px; color: var(--text-tertiary); font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase;
 }
+
 .m-v2-root .agent-bubble .who .dot-mint { width: 18px; height: 18px; border-radius: 50%; background: linear-gradient(135deg, var(--accent-mint), var(--accent-orange)); }
+
 .m-v2-root .agent-bubble .msg { color: var(--text-primary); }
+
 .m-v2-root .agent-bubble .msg strong { color: var(--accent-orange-deep); }
 
-/* Trust strip ----------------------------------------------------- */
+/* Trust strip */
+
 .m-v2-root .trust-strip { padding: 48px 0; border-top: 1px solid var(--divider); border-bottom: 1px solid var(--divider); }
-.m-v2-root .trust-row {
-  display: grid; grid-template-columns: repeat(5, 1fr);
-  gap: 24px; align-items: center;
-}
+
+.m-v2-root .trust-row { display: grid; grid-template-columns: repeat(5, 1fr); gap: 24px; align-items: center; }
+
 .m-v2-root .trust-item {
   text-align: center;
   color: #9CA3AF;
-  font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace;
+  font-family: var(--font-mono), ui-monospace, Consolas, monospace;
   font-size: 13px;
   letter-spacing: 0.04em;
   font-weight: 500;
   display: flex; flex-direction: column; align-items: center; gap: 6px;
 }
+
 .m-v2-root .trust-item .ring {
   width: 28px; height: 28px; border-radius: 8px;
   border: 1.5px solid #D1D5DB;
@@ -393,9 +498,12 @@
   font-size: 12px; color: #9CA3AF; font-weight: 700;
 }
 
-/* Stats ----------------------------------------------------------- */
+/* Stats */
+
 .m-v2-root .stats-section { padding: 120px 0; }
+
 .m-v2-root .section-head { text-align: left; max-width: 720px; margin-bottom: 56px; }
+
 .m-v2-root .section-head h2 {
   font-size: var(--fs-h2);
   letter-spacing: var(--track-tight);
@@ -403,9 +511,11 @@
   line-height: 1.05;
   margin: 12px 0 18px;
 }
+
 .m-v2-root .section-head p { font-size: 19px; color: var(--text-secondary); text-wrap: pretty; max-width: 620px; }
 
 .m-v2-root .stats-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+
 .m-v2-root .stat-card {
   background: #fff;
   border-radius: var(--r-card);
@@ -414,23 +524,35 @@
   border: 1px solid rgba(11,18,32,0.04);
   position: relative;
   overflow: hidden;
+  transition: transform 200ms ease, box-shadow 200ms ease;
 }
+
+.m-v2-root .stat-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); }
+
 .m-v2-root .stat-card .label { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-tertiary); font-weight: 600; }
+
 .m-v2-root .stat-card .num {
   font-size: 64px; line-height: 1; font-weight: 700; letter-spacing: -0.03em;
   margin: 16px 0 6px;
   position: relative; display: inline-block;
+  font-variant-numeric: tabular-nums;
 }
+
 .m-v2-root .stat-card .num .unit { color: var(--text-tertiary); font-size: 0.5em; font-weight: 600; }
+
 .m-v2-root .stat-card .underline {
   height: 4px; width: 56px; background: var(--accent-orange); border-radius: 2px;
   margin-top: 4px; margin-bottom: 18px;
 }
+
 .m-v2-root .stat-card .blurb { color: var(--text-secondary); font-size: 15px; line-height: 1.5; text-wrap: pretty; }
 
-/* Pillars --------------------------------------------------------- */
+/* Pillars */
+
 .m-v2-root .pillars-section { padding: 120px 0; }
+
 .m-v2-root .pillar-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+
 .m-v2-root .pillar-card {
   background: #fff;
   border: 1px solid rgba(11,18,32,0.06);
@@ -438,9 +560,11 @@
   padding: 32px;
   display: flex; flex-direction: column;
   min-height: 480px;
-  transition: transform 200ms ease, box-shadow 200ms ease;
+  transition: transform 240ms cubic-bezier(0.22,1,0.36,1), box-shadow 240ms ease;
 }
-.m-v2-root .pillar-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-lg); }
+
+.m-v2-root .pillar-card:hover { transform: translateY(-6px); box-shadow: var(--shadow-lg); }
+
 .m-v2-root .pillar-icon {
   width: 48px; height: 48px; border-radius: 14px;
   display: grid; place-items: center;
@@ -448,11 +572,17 @@
   color: #fff;
   font-size: 22px;
 }
+
 .m-v2-root .pillar-icon.orange { background: var(--accent-orange); }
+
 .m-v2-root .pillar-icon.mint { background: var(--accent-mint-deep); }
+
 .m-v2-root .pillar-icon.gradient { background: linear-gradient(135deg, var(--accent-mint), var(--accent-orange)); }
+
 .m-v2-root .pillar-card h3 { font-size: 22px; font-weight: 700; letter-spacing: -0.01em; margin: 0 0 10px; }
+
 .m-v2-root .pillar-card .copy { color: var(--text-secondary); font-size: 15px; margin-bottom: 20px; }
+
 .m-v2-root .pillar-preview {
   margin-top: auto;
   border-radius: 14px;
@@ -464,33 +594,52 @@
   color: var(--text-secondary);
   min-height: 150px;
 }
+
 .m-v2-root .pillar-preview .head {
   font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-tertiary);
   margin-bottom: 8px; font-weight: 600;
 }
+
 .m-v2-root .letter-para { font-family: 'Georgia', serif; color: var(--text-primary); font-size: 12.5px; line-height: 1.5; }
+
 .m-v2-root .letter-para .hl { background: #FEF3C7; padding: 0 2px; border-radius: 2px; }
+
 .m-v2-root .donut-mini { display: flex; gap: 12px; align-items: center; }
+
 .m-v2-root .donut-mini .d {
   width: 64px; height: 64px; border-radius: 50%;
   background: conic-gradient(var(--accent-mint) 0 40%, var(--accent-orange) 40% 65%, #93C5FD 65% 80%, #E5E7EB 80% 100%);
   position: relative;
 }
+
 .m-v2-root .donut-mini .d::after { content: ''; position: absolute; inset: 10px; background: var(--surface-base); border-radius: 50%; }
+
 .m-v2-root .donut-mini .nums { display: flex; flex-direction: column; gap: 4px; }
+
 .m-v2-root .donut-mini .nums .row { display: flex; gap: 8px; font-size: 11px; }
+
 .m-v2-root .donut-mini .nums .row .sw { width: 8px; height: 8px; border-radius: 50%; }
+
 .m-v2-root .chat-preview { display: flex; flex-direction: column; gap: 8px; }
+
 .m-v2-root .chat-bubble { padding: 8px 12px; border-radius: 14px; max-width: 85%; font-size: 12px; }
+
 .m-v2-root .chat-bubble.user { background: var(--accent-mint-wash); align-self: flex-end; color: var(--text-primary); border-bottom-right-radius: 4px; }
+
 .m-v2-root .chat-bubble.agent { background: var(--surface-ink); color: var(--text-on-ink); align-self: flex-start; border-bottom-left-radius: 4px; }
 
-/* How it works ---------------------------------------------------- */
+/* How it works — dark */
+
 .m-v2-root .how-section { padding: 140px 0; }
+
 .m-v2-root .how-section .eyebrow { color: var(--accent-mint); }
+
 .m-v2-root .how-section h2 { color: var(--text-on-ink); font-size: var(--fs-h2); font-weight: 700; letter-spacing: var(--track-tight); line-height: 1.05; margin: 12px 0 18px; }
+
 .m-v2-root .how-section .sub { color: var(--text-on-ink-dim); font-size: 19px; max-width: 620px; }
+
 .m-v2-root .how-steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; margin-top: 64px; }
+
 .m-v2-root .how-step {
   background: var(--surface-ink-2);
   border: 1px solid var(--divider-ink);
@@ -499,87 +648,72 @@
   min-height: 380px;
   display: flex; flex-direction: column;
 }
-.m-v2-root .how-step .num { font-size: 80px; font-weight: 700; color: var(--accent-mint); line-height: 1; letter-spacing: -0.04em; margin-bottom: 14px; }
+
+.m-v2-root .how-step .num { font-size: 80px; font-weight: 700; color: var(--accent-mint); line-height: 1; letter-spacing: -0.04em; margin-bottom: 14px; font-variant-numeric: tabular-nums; }
+
 .m-v2-root .how-step h3 { color: var(--text-on-ink); font-size: 22px; font-weight: 700; letter-spacing: -0.01em; margin: 0 0 8px; text-wrap: balance; }
+
 .m-v2-root .how-step p { color: var(--text-on-ink-dim); font-size: 14px; margin: 0 0 18px; }
+
 .m-v2-root .mini-form { margin-top: auto; background: #0B1220; border: 1px solid var(--divider-ink); border-radius: 14px; padding: 16px; }
+
 .m-v2-root .mini-form label { font-size: 10px; color: var(--text-on-ink-dim); letter-spacing: 0.1em; text-transform: uppercase; font-weight: 600; }
-.m-v2-root .mini-form select,
-.m-v2-root .mini-form input {
+
+.m-v2-root .mini-form select, .m-v2-root .mini-form input {
   width: 100%; background: rgba(255,255,255,0.04); color: var(--text-on-ink);
   border: 1px solid var(--divider-ink); border-radius: 10px;
   padding: 10px 12px; font-size: 13px; margin-top: 6px; margin-bottom: 10px;
   font-family: inherit; outline: none;
 }
-.m-v2-root .mini-form select:focus,
-.m-v2-root .mini-form input:focus { border-color: var(--accent-mint); }
+
+.m-v2-root .mini-form select:focus, .m-v2-root .mini-form input:focus { border-color: var(--accent-mint); }
+
 .m-v2-root .mini-form button {
   width: 100%; padding: 10px;
   background: var(--accent-mint); color: #052E1C;
   border: none; border-radius: 10px;
   font-weight: 600; font-size: 13px; cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease;
 }
-.m-v2-root .mini-form button:disabled { opacity: 0.7; cursor: progress; }
-.m-v2-root .mini-letter-out {
-  margin-top: 14px;
-  padding: 12px 14px;
-  background: rgba(52,211,153,0.08);
-  border: 1px solid rgba(52,211,153,0.25);
-  border-radius: 10px;
-  font-size: 12.5px;
-  color: var(--text-on-ink);
-  line-height: 1.5;
-  max-height: 220px;
-  overflow-y: auto;
-}
-.m-v2-root .mini-letter-head {
-  font-size: 10px;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--accent-mint);
-  font-weight: 700;
-  margin-bottom: 6px;
-}
-.m-v2-root .mini-letter-out p {
-  margin: 0 0 10px;
-  font-family: 'Georgia', serif;
-  color: var(--text-on-ink);
-  text-wrap: pretty;
-  white-space: pre-wrap;
-}
-.m-v2-root .mini-letter-cta {
-  display: inline-block;
-  margin-top: 4px;
-  color: var(--accent-mint);
-  font-size: 12px;
-  font-weight: 600;
-  text-decoration: none;
-  letter-spacing: 0.02em;
-}
-.m-v2-root .mini-letter-cta:hover { text-decoration: underline; }
+
+.m-v2-root .mini-form button:hover:not(:disabled) { background: #2CC48A; }
+
+.m-v2-root .mini-form button:disabled { opacity: 0.85; cursor: progress; }
+
 .m-v2-root .bank-list { display: flex; flex-direction: column; gap: 8px; margin-top: auto; }
+
 .m-v2-root .bank-row {
   display: flex; justify-content: space-between; align-items: center;
   background: rgba(255,255,255,0.04); border: 1px solid var(--divider-ink);
   border-radius: 10px; padding: 10px 14px; font-size: 13px;
 }
+
 .m-v2-root .bank-row .n { color: var(--text-on-ink); }
+
 .m-v2-root .bank-row .v { color: var(--accent-mint); font-weight: 600; }
+
 .m-v2-root .bank-row .v.orange { color: var(--accent-orange); }
+
 .m-v2-root .deal-row {
   display: flex; justify-content: space-between; align-items: center;
   background: rgba(255,255,255,0.04); border: 1px solid var(--divider-ink);
   border-radius: 10px; padding: 12px 14px; font-size: 13px;
 }
+
 .m-v2-root .deal-row + .deal-row { margin-top: 8px; }
+
 .m-v2-root .deal-row .cat { color: var(--text-on-ink-dim); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; }
+
 .m-v2-root .deal-row .name { color: var(--text-on-ink); font-weight: 500; }
+
 .m-v2-root .deal-row .save { color: var(--accent-mint); font-weight: 600; }
 
 .m-v2-root .how-cta-row { text-align: center; margin-top: 56px; }
 
-/* Deals ----------------------------------------------------------- */
+/* Deals */
+
 .m-v2-root .deals-section { padding: 120px 0; }
+
 .m-v2-root .logo-cloud {
   display: flex; flex-wrap: wrap; gap: 12px 28px;
   justify-content: center;
@@ -587,15 +721,18 @@
   border-bottom: 1px dashed rgba(11,18,32,0.08);
   margin-bottom: 48px;
 }
+
 .m-v2-root .logo-chip {
-  font-family: 'JetBrains Mono', ui-monospace, Consolas, monospace;
+  font-family: var(--font-mono), ui-monospace, Consolas, monospace;
   font-size: 14px; color: #6B7280; font-weight: 600; letter-spacing: 0.02em;
   padding: 6px 10px;
   border: 1px solid var(--divider);
   border-radius: 8px;
   background: rgba(255,255,255,0.6);
 }
+
 .m-v2-root .category-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+
 .m-v2-root .cat-tile {
   background: #fff;
   border: 1px solid var(--divider);
@@ -603,12 +740,16 @@
   padding: 28px;
   display: flex; flex-direction: column; gap: 12px;
   min-height: 160px;
-  transition: transform 200ms ease, box-shadow 200ms ease;
+  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
   cursor: pointer;
 }
+
 .m-v2-root .cat-tile:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); border-color: var(--accent-mint); }
+
 .m-v2-root .cat-tile .cat-name { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; }
+
 .m-v2-root .cat-tile .cat-count { color: var(--text-tertiary); font-size: 13px; }
+
 .m-v2-root .save-badge {
   align-self: flex-start;
   background: var(--accent-mint);
@@ -618,11 +759,15 @@
   font-size: 12px; font-weight: 600;
   margin-top: auto;
 }
+
 .m-v2-root .commission-note { text-align: center; margin-top: 32px; color: var(--accent-orange-deep); font-size: 13px; }
 
-/* Pricing --------------------------------------------------------- */
+/* Pricing */
+
 .m-v2-root .pricing-section { padding: 120px 0; }
+
 .m-v2-root .pricing-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+
 .m-v2-root .price-card {
   background: #fff;
   border: 1px solid var(--divider);
@@ -630,24 +775,39 @@
   padding: 32px;
   position: relative;
   display: flex; flex-direction: column;
+  transition: transform 200ms ease, box-shadow 200ms ease;
 }
+
+.m-v2-root .price-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
+
 .m-v2-root .price-card.featured { border-color: var(--accent-mint); box-shadow: 0 30px 60px -30px rgba(52,211,153,0.35); }
+
+.m-v2-root .price-card.featured:hover { box-shadow: 0 40px 70px -30px rgba(52,211,153,0.45); }
+
 .m-v2-root .ribbon {
   position: absolute; top: -12px; left: 32px;
   background: var(--accent-mint); color: #052E1C;
   font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700;
   padding: 6px 12px; border-radius: 999px;
 }
+
 .m-v2-root .price-card .tier { font-size: 14px; color: var(--text-tertiary); font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; }
-.m-v2-root .price-card .price { font-size: 48px; font-weight: 700; letter-spacing: -0.02em; margin: 12px 0 4px; }
+
+.m-v2-root .price-card .price { font-size: 48px; font-weight: 700; letter-spacing: -0.02em; margin: 12px 0 4px; font-variant-numeric: tabular-nums; }
+
 .m-v2-root .price-card .price .per { font-size: 16px; color: var(--text-tertiary); font-weight: 500; }
+
 .m-v2-root .price-card .founding { color: var(--accent-orange-deep); font-size: 12px; font-weight: 600; margin-bottom: 18px; letter-spacing: 0.04em; text-transform: uppercase; }
-.m-v2-root .price-card .founding.hidden { visibility: hidden; }
+
+.m-v2-root .price-card .free-note { color: var(--text-tertiary); font-size: 12px; font-weight: 500; margin-bottom: 18px; letter-spacing: 0.04em; text-transform: uppercase; }
+
 .m-v2-root .price-card ul { list-style: none; padding: 0; margin: 0 0 24px; display: flex; flex-direction: column; gap: 10px; }
+
 .m-v2-root .price-card li {
   font-size: 14px; color: var(--text-secondary);
   padding-left: 26px; position: relative;
 }
+
 .m-v2-root .price-card li::before {
   content: ''; position: absolute; left: 0; top: 6px;
   width: 16px; height: 16px; border-radius: 50%;
@@ -655,25 +815,35 @@
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.2l3 2.8 6-6.5' stroke='%23059669' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   background-repeat: no-repeat; background-position: center;
 }
+
 .m-v2-root .price-card .cta { margin-top: auto; }
 
 .m-v2-root .compare-link { text-align: center; margin-top: 36px; font-size: 14px; color: var(--text-secondary); }
+
 .m-v2-root .compare-link a { color: var(--accent-mint-deep); text-decoration: none; font-weight: 600; }
+
 .m-v2-root .compare-link a:hover { text-decoration: underline; }
 
-/* Testimonials ---------------------------------------------------- */
+/* Testimonials */
+
 .m-v2-root .testimonials-section { padding: 120px 0; overflow: hidden; }
+
 .m-v2-root .testimonials-head { text-align: center; margin-bottom: 56px; }
+
 .m-v2-root .testimonials-head h2 { font-size: var(--fs-h2); letter-spacing: var(--track-tight); font-weight: 700; margin: 12px 0; }
+
 .m-v2-root .t-track {
   display: flex; gap: 22px; width: max-content;
-  animation: m-v2-tscroll 60s linear infinite;
+  animation: tscroll 60s linear infinite;
 }
+
 .m-v2-root .testimonials-section:hover .t-track { animation-play-state: paused; }
-@keyframes m-v2-tscroll {
+
+@keyframes tscroll {
   from { transform: translateX(0); }
   to { transform: translateX(-50%); }
 }
+
 .m-v2-root .t-card {
   width: 380px; flex-shrink: 0;
   background: #fff;
@@ -682,20 +852,28 @@
   padding: 26px;
   display: flex; flex-direction: column; gap: 14px;
 }
+
 .m-v2-root .t-card .who { display: flex; align-items: center; gap: 12px; }
+
 .m-v2-root .t-card .avatar {
   width: 40px; height: 40px; border-radius: 50%;
   display: grid; place-items: center;
   font-weight: 700; color: #fff;
   font-size: 15px;
 }
+
 .m-v2-root .t-card .name { font-weight: 600; font-size: 14px; }
+
 .m-v2-root .t-card .meta { font-size: 12px; color: var(--text-tertiary); }
+
 .m-v2-root .t-card .quote { font-size: 15px; color: var(--text-primary); line-height: 1.45; text-wrap: pretty; }
+
 .m-v2-root .t-card .saved { color: var(--accent-orange-deep); font-weight: 600; font-size: 13px; }
 
-/* Final CTA ------------------------------------------------------- */
+/* Final CTA */
+
 .m-v2-root .final-cta { padding: 140px 0; position: relative; overflow: hidden; }
+
 .m-v2-root .final-cta h2 {
   font-size: clamp(56px, 7vw, 88px);
   font-weight: 700;
@@ -705,685 +883,101 @@
   color: var(--text-on-ink);
   margin: 0;
 }
+
 .m-v2-root .final-cta h2 .mint { color: var(--accent-mint); }
+
 .m-v2-root .final-cta .fc-sub { text-align: center; color: var(--text-on-ink-dim); margin-top: 24px; font-size: 17px; }
+
 .m-v2-root .final-cta .fc-btn-row { text-align: center; margin-top: 36px; }
+
 .m-v2-root .final-cta .fine { text-align: center; margin-top: 20px; color: var(--text-on-ink-dim); font-size: 13px; }
 
-/* Footer ---------------------------------------------------------- */
+/* Footer */
+
 .m-v2-root footer { padding: 80px 0 40px; background: var(--surface-ink); color: var(--text-on-ink); border-top: 1px solid var(--divider-ink); }
+
 .m-v2-root .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr; gap: 32px; }
+
 .m-v2-root .footer-brand .logo { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 10px; }
+
 .m-v2-root .footer-brand .logo .backer { color: var(--accent-mint); }
+
 .m-v2-root .footer-brand p { color: var(--text-on-ink-dim); font-size: 14px; max-width: 280px; }
+
 .m-v2-root .footer-col h5 { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-on-ink-dim); font-weight: 600; margin: 0 0 16px; }
-.m-v2-root .footer-col a { display: block; color: var(--text-on-ink); text-decoration: none; font-size: 14px; margin-bottom: 10px; opacity: 0.85; }
+
+.m-v2-root .footer-col a { display: block; color: var(--text-on-ink); text-decoration: none; font-size: 14px; margin-bottom: 10px; opacity: 0.85; transition: opacity 150ms, color 150ms; }
+
 .m-v2-root .footer-col a:hover { opacity: 1; color: var(--accent-mint); }
+
 .m-v2-root .footer-bottom {
   border-top: 1px solid var(--divider-ink);
   margin-top: 56px; padding-top: 24px;
   display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px;
   font-size: 12px; color: var(--text-on-ink-dim);
 }
+
 .m-v2-root .footer-socials { display: flex; gap: 10px; }
+
 .m-v2-root .footer-socials a {
   width: 32px; height: 32px; border-radius: 8px;
   border: 1px solid var(--divider-ink);
   display: grid; place-items: center; font-size: 13px;
-  transition: background 150ms ease;
-}
-.m-v2-root .footer-socials a:hover { background: rgba(255,255,255,0.06); }
-
-/* Live chat ------------------------------------------------------- */
-.m-v2-root .live-chat {
-  position: fixed; bottom: 20px; right: 20px; z-index: 90;
-  width: 56px; height: 56px; border-radius: 50%;
-  background: var(--accent-mint); color: #052E1C;
-  display: grid; place-items: center;
-  box-shadow: var(--shadow-mint);
-  cursor: pointer;
-  opacity: 0; transform: translateY(10px);
-  transition: opacity 400ms ease, transform 400ms ease;
-  font-size: 22px;
-  border: none;
-}
-.m-v2-root .live-chat.shown { opacity: 1; transform: translateY(0); }
-
-/* Preview badge --------------------------------------------------- */
-.m-v2-root .preview-badge {
-  position: fixed; top: 8px; left: 8px; z-index: 120;
-  background: #0B1220; color: #F3F4F6;
-  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase;
-  font-weight: 700;
-  padding: 6px 10px; border-radius: 999px;
-  box-shadow: var(--shadow-md);
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  margin: 0; opacity: 0.85;
+  transition: background 150ms ease, opacity 150ms ease;
 }
 
-/* Placeholder note ------------------------------------------------ */
-.m-v2-root .placeholder-note {
-  display: inline-block;
-  margin-top: 14px;
-  font-size: 12px;
-  letter-spacing: 0.04em;
-  color: var(--accent-orange-deep);
-  background: #FEF3C7;
-  border: 1px solid rgba(245,158,11,0.25);
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-weight: 600;
-}
+.m-v2-root .footer-socials a:hover { background: rgba(255,255,255,0.06); opacity: 1; }
 
-/* Why We Exist (narrative band) ----------------------------------- */
-.m-v2-root .why-we-exist { padding: 120px 0; }
-.m-v2-root .why-grid {
-  display: grid;
-  grid-template-columns: 1.1fr 1fr;
-  gap: 72px;
-  align-items: center;
-}
-.m-v2-root .why-copy h2 {
-  font-size: var(--fs-h2);
-  letter-spacing: var(--track-tight);
-  font-weight: 700;
-  line-height: 1.05;
-  margin: 14px 0 24px;
-  font-family: 'Plus Jakarta Sans', 'Inter', sans-serif;
-}
-.m-v2-root .why-copy h2 .accent { color: var(--accent-orange-deep); }
-.m-v2-root .why-copy .lead {
-  font-size: 19px;
-  color: var(--text-primary);
-  margin: 0 0 18px;
-  text-wrap: pretty;
-}
-.m-v2-root .why-copy p {
-  font-size: 17px;
-  color: var(--text-secondary);
-  margin: 0 0 16px;
-  text-wrap: pretty;
-}
-.m-v2-root .why-copy .closing {
-  color: var(--accent-mint-deep);
-  font-weight: 600;
-  font-size: 17px;
-  margin-top: 10px;
-}
-.m-v2-root .why-stats {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
-}
-.m-v2-root .why-stat {
-  background: #fff;
-  border-radius: var(--r-card);
-  padding: 28px 22px;
-  border: 1px solid rgba(11,18,32,0.05);
-  box-shadow: var(--shadow-sm);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-height: 170px;
-}
-.m-v2-root .why-stat .n {
-  font-size: 38px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--accent-orange-deep);
-  line-height: 1;
-}
-.m-v2-root .why-stat:nth-child(2n) .n { color: var(--accent-mint-deep); }
-.m-v2-root .why-stat .l {
-  font-size: 13px;
-  color: var(--text-secondary);
-  line-height: 1.45;
-  text-wrap: pretty;
-}
+/* Sticky "find my overcharges" floating CTA — appears after hero */
 
-/* Pocket Agent Showcase (dark) ------------------------------------ */
-.m-v2-root .agent-showcase { padding: 140px 0; }
-.m-v2-root .agent-showcase .section-head h2 .mint { color: var(--accent-mint); }
-.m-v2-root .agent-showcase .section-head .sub {
-  color: var(--text-on-ink-dim);
-  font-size: 19px;
-  max-width: 640px;
-}
-.m-v2-root .agent-showcase-grid {
-  display: grid;
-  grid-template-columns: 0.9fr 1.1fr;
-  gap: 64px;
-  margin-top: 64px;
-  align-items: start;
-}
-.m-v2-root .agent-phone {
-  background: var(--surface-ink-2);
-  border: 1px solid var(--divider-ink);
-  border-radius: 28px;
+.m-v2-root .sticky-cta {
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(20px);
+  z-index: 90;
+  background: var(--surface-ink);
+  color: var(--text-on-ink);
+  padding: 12px 20px;
+  border-radius: var(--r-pill);
   box-shadow: var(--shadow-xl);
-  overflow: hidden;
-  max-width: 420px;
-  justify-self: center;
-  width: 100%;
-}
-.m-v2-root .agent-phone-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 16px 18px;
-  background: rgba(255,255,255,0.04);
-  border-bottom: 1px solid var(--divider-ink);
-  color: var(--text-on-ink-dim);
-  font-size: 12px;
-  letter-spacing: 0.04em;
-  font-weight: 600;
-}
-.m-v2-root .agent-phone-header .dot-mint {
-  width: 22px; height: 22px; border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent-mint), var(--accent-orange));
-}
-.m-v2-root .agent-phone-time { margin-left: auto; font-size: 11px; opacity: 0.7; letter-spacing: 0.02em; text-transform: none; }
-.m-v2-root .agent-phone-body {
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  max-height: 560px;
-  overflow: hidden;
-}
-.m-v2-root .ap-bubble {
-  font-size: 13.5px;
-  line-height: 1.5;
-  padding: 10px 14px;
-  border-radius: 16px;
-  max-width: 88%;
-  text-wrap: pretty;
-}
-.m-v2-root .ap-bubble.agent {
-  background: rgba(255,255,255,0.06);
-  color: var(--text-on-ink);
-  border-bottom-left-radius: 4px;
-  align-self: flex-start;
-}
-.m-v2-root .ap-bubble.agent strong { color: var(--accent-orange); }
-.m-v2-root .ap-bubble.user {
-  background: var(--accent-mint);
-  color: #052E1C;
-  border-bottom-right-radius: 4px;
-  align-self: flex-end;
-  font-weight: 500;
-}
-.m-v2-root .ap-link {
-  display: inline-block;
-  margin-top: 8px;
-  color: var(--accent-mint);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-.m-v2-root .ap-chips {
-  display: flex;
-  gap: 8px;
-  margin-top: 10px;
-  flex-wrap: wrap;
-}
-.m-v2-root .ap-chip {
-  display: inline-flex;
-  align-items: center;
-  font-size: 12px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(255,255,255,0.08);
-  color: var(--text-on-ink);
-  border: 1px solid var(--divider-ink);
-  font-weight: 500;
-}
-.m-v2-root .ap-chip-mint {
-  background: var(--accent-mint);
-  color: #052E1C;
-  border-color: transparent;
-  font-weight: 600;
-}
-.m-v2-root .agent-features {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 18px;
-}
-.m-v2-root .agent-feature {
-  display: flex;
-  gap: 14px;
-  background: var(--surface-ink-2);
-  border: 1px solid var(--divider-ink);
-  border-radius: var(--r-card);
-  padding: 22px;
-}
-.m-v2-root .agent-feature .af-icon {
-  width: 40px; height: 40px;
-  border-radius: 12px;
-  display: grid; place-items: center;
-  background: rgba(52,211,153,0.12);
-  font-size: 20px;
-  flex-shrink: 0;
-}
-.m-v2-root .agent-feature h4 {
-  color: var(--text-on-ink);
-  font-size: 16px;
-  font-weight: 700;
-  margin: 0 0 6px;
-  letter-spacing: -0.005em;
-}
-.m-v2-root .agent-feature p {
-  color: var(--text-on-ink-dim);
-  font-size: 13.5px;
-  line-height: 1.5;
-  margin: 0;
-  text-wrap: pretty;
+  font-size: 14px; font-weight: 600;
+  display: flex; align-items: center; gap: 10px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 240ms ease, transform 240ms ease;
 }
 
-/* AI Financial Assistant (light) ---------------------------------- */
-.m-v2-root .assistant-section { padding: 120px 0; }
-.m-v2-root .assistant-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 64px;
-  align-items: center;
-}
-.m-v2-root .assistant-copy h2 {
-  font-size: var(--fs-h2);
-  font-weight: 700;
-  letter-spacing: var(--track-tight);
-  line-height: 1.05;
-  margin: 14px 0 20px;
-  font-family: 'Plus Jakarta Sans', 'Inter', sans-serif;
-}
-.m-v2-root .assistant-copy p {
-  font-size: 17px;
-  color: var(--text-secondary);
-  margin: 0 0 22px;
-  text-wrap: pretty;
-}
-.m-v2-root .assistant-copy em { font-style: italic; color: var(--accent-mint-deep); }
-.m-v2-root .assistant-bullets {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-.m-v2-root .assistant-bullets li {
-  font-size: 15px;
-  color: var(--text-secondary);
-  line-height: 1.5;
-  padding-left: 28px;
-  position: relative;
-  text-wrap: pretty;
-}
-.m-v2-root .assistant-bullets li::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 5px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--accent-mint-wash);
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.2l3 2.8 6-6.5' stroke='%23059669' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-  background-repeat: no-repeat;
-  background-position: center;
-}
-.m-v2-root .assistant-bullets li strong { color: var(--text-primary); font-weight: 600; }
-.m-v2-root .assistant-chat {
-  background: #fff;
-  border: 1px solid rgba(11,18,32,0.06);
-  border-radius: var(--r-card);
-  box-shadow: var(--shadow-lg);
-  overflow: hidden;
-}
-.m-v2-root .ac-header {
-  padding: 16px 22px;
-  border-bottom: 1px solid var(--divider);
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  background: linear-gradient(to right, rgba(52,211,153,0.05), transparent);
-  letter-spacing: 0.02em;
-}
-.m-v2-root .ac-body {
-  padding: 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-.m-v2-root .ac-bubble {
-  font-size: 14px;
-  line-height: 1.55;
-  padding: 12px 16px;
-  border-radius: 16px;
-  max-width: 92%;
-  text-wrap: pretty;
-}
-.m-v2-root .ac-bubble.user {
-  background: var(--accent-mint-wash);
-  color: var(--text-primary);
-  align-self: flex-end;
-  border-bottom-right-radius: 4px;
-  font-weight: 500;
-}
-.m-v2-root .ac-bubble.assistant {
-  background: var(--surface-base);
-  border: 1px solid var(--divider);
-  color: var(--text-primary);
-  align-self: flex-start;
-  border-bottom-left-radius: 4px;
-}
-.m-v2-root .ac-bubble strong { color: var(--accent-mint-deep); font-weight: 700; }
-.m-v2-root .ac-chart {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  padding: 12px 0 14px;
-  margin-bottom: 8px;
-  border-bottom: 1px dashed var(--divider);
-}
-.m-v2-root .ac-pie {
-  width: 110px;
-  height: 110px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  background: conic-gradient(
-    var(--accent-mint) 0 34%,
-    var(--accent-orange) 34% 58%,
-    #60A5FA 58% 88%,
-    #A78BFA 88% 100%
-  );
-  position: relative;
-}
-.m-v2-root .ac-pie::after {
-  content: '';
-  position: absolute;
-  inset: 18px;
-  background: #fff;
-  border-radius: 50%;
-}
-.m-v2-root .ac-slice { display: none; }
-.m-v2-root .ac-legend {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 12px;
-  color: var(--text-secondary);
-  flex: 1;
-}
-.m-v2-root .ac-legend span {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.m-v2-root .ac-legend i {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  display: inline-block;
-  flex-shrink: 0;
+.m-v2-root .sticky-cta.shown { opacity: 1; transform: translateX(-50%) translateY(0); pointer-events: auto; }
+
+.m-v2-root .sticky-cta a {
+  color: #052E1C; background: var(--accent-mint);
+  padding: 6px 12px; border-radius: var(--r-pill);
+  text-decoration: none; font-size: 13px;
 }
 
-/* Smart Subscription Tracking (mint wash) ------------------------- */
-.m-v2-root .subs-section { padding: 120px 0; }
-.m-v2-root .subs-grid {
-  display: grid;
-  grid-template-columns: 1.1fr 1fr;
-  gap: 64px;
-  align-items: center;
-}
-.m-v2-root .subs-list {
-  background: #fff;
-  border-radius: var(--r-card);
-  border: 1px solid rgba(11,18,32,0.05);
-  box-shadow: var(--shadow-md);
-  padding: 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.m-v2-root .subs-list-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 4px 2px 14px;
-  border-bottom: 1px solid var(--divider);
-  font-size: 12px;
-  letter-spacing: 0.05em;
-  color: var(--text-tertiary);
-  text-transform: uppercase;
-  font-weight: 600;
-}
-.m-v2-root .subs-total {
-  color: var(--accent-orange-deep);
-  font-variant-numeric: tabular-nums;
-  font-size: 14px;
-  letter-spacing: 0;
-  text-transform: none;
-}
-.m-v2-root .subs-row {
-  display: grid;
-  grid-template-columns: 44px 1fr auto;
-  align-items: center;
-  gap: 14px;
-  padding: 10px 6px;
-  border-radius: 12px;
-  transition: background 150ms ease;
-}
-.m-v2-root .subs-row:hover { background: var(--surface-base); }
-.m-v2-root .subs-logo {
-  width: 40px;
-  height: 40px;
-  border-radius: 12px;
-  display: grid;
-  place-items: center;
-  color: #fff;
-  font-weight: 700;
-  font-size: 15px;
-  letter-spacing: -0.01em;
-}
-.m-v2-root .subs-logo.mint { background: linear-gradient(135deg, var(--accent-mint-deep), var(--accent-mint)); }
-.m-v2-root .subs-logo.orange { background: linear-gradient(135deg, var(--accent-orange-deep), var(--accent-orange)); }
-.m-v2-root .subs-meta { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
-.m-v2-root .subs-name {
-  font-weight: 600;
-  font-size: 14px;
-  color: var(--text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.m-v2-root .subs-tags { display: flex; flex-wrap: wrap; gap: 6px; }
-.m-v2-root .subs-tag {
-  font-size: 10.5px;
-  letter-spacing: 0.03em;
-  padding: 2px 8px;
-  border-radius: 999px;
-  background: #F3F4F6;
-  color: var(--text-secondary);
-  font-weight: 600;
-  text-transform: uppercase;
-}
-.m-v2-root .subs-tag.tag-orange { background: #FEF3C7; color: var(--accent-orange-deep); }
-.m-v2-root .subs-tag.tag-red { background: #FEE2E2; color: #B91C1C; }
-.m-v2-root .subs-tag.tag-mint { background: var(--accent-mint-wash); color: var(--accent-mint-deep); }
-.m-v2-root .subs-amt {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary);
-  font-variant-numeric: tabular-nums;
-}
-.m-v2-root .subs-copy h2 {
-  font-size: var(--fs-h2);
-  font-weight: 700;
-  letter-spacing: var(--track-tight);
-  line-height: 1.05;
-  margin: 14px 0 20px;
-  font-family: 'Plus Jakarta Sans', 'Inter', sans-serif;
-}
-.m-v2-root .subs-copy p {
-  font-size: 17px;
-  color: var(--text-secondary);
-  margin: 0 0 22px;
-  text-wrap: pretty;
-}
-.m-v2-root .subs-features {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.m-v2-root .subs-features li {
-  font-size: 15px;
-  color: var(--text-secondary);
-  line-height: 1.5;
-  padding-left: 28px;
-  position: relative;
-  text-wrap: pretty;
-}
-.m-v2-root .subs-features li::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 5px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: #fff;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.2l3 2.8 6-6.5' stroke='%23059669' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-  background-repeat: no-repeat;
-  background-position: center;
-  box-shadow: 0 0 0 1px rgba(52,211,153,0.4);
-}
-.m-v2-root .subs-features li strong { color: var(--text-primary); font-weight: 600; }
+/* Reduced motion */
 
-/* FAQ (light, accordion) ------------------------------------------ */
-.m-v2-root .faq-section { padding: 120px 0; }
-.m-v2-root .faq-list {
-  max-width: 880px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.m-v2-root .faq-item {
-  background: #fff;
-  border: 1px solid var(--divider);
-  border-radius: 18px;
-  padding: 0;
-  transition: border-color 150ms ease, box-shadow 150ms ease;
-  overflow: hidden;
-}
-.m-v2-root .faq-item[open] {
-  border-color: var(--accent-mint);
-  box-shadow: 0 12px 24px -14px rgba(52,211,153,0.35);
-}
-.m-v2-root .faq-item summary {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 24px;
-  padding: 22px 26px;
-  cursor: pointer;
-  list-style: none;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-  user-select: none;
-  transition: background 150ms ease;
-}
-.m-v2-root .faq-item summary::-webkit-details-marker { display: none; }
-.m-v2-root .faq-item summary:hover { background: var(--surface-base); }
-.m-v2-root .faq-item summary > span:first-child { flex: 1; text-wrap: pretty; }
-.m-v2-root .faq-chev {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  display: grid;
-  place-items: center;
-  background: var(--accent-mint-wash);
-  color: var(--accent-mint-deep);
-  font-size: 18px;
-  font-weight: 400;
-  flex-shrink: 0;
-  transition: transform 200ms ease, background 150ms ease;
-  line-height: 1;
-}
-.m-v2-root .faq-item[open] .faq-chev { transform: rotate(45deg); background: var(--accent-mint); color: #052E1C; }
-.m-v2-root .faq-body {
-  padding: 0 26px 24px;
-  border-top: 1px solid var(--divider);
-  padding-top: 20px;
-  color: var(--text-secondary);
-  font-size: 15px;
-  line-height: 1.6;
-}
-.m-v2-root .faq-body p { margin: 0 0 14px; text-wrap: pretty; }
-.m-v2-root .faq-body p:last-child { margin-bottom: 0; }
-.m-v2-root .faq-body ul {
-  padding-left: 20px;
-  margin: 0 0 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.m-v2-root .faq-body li { text-wrap: pretty; }
-.m-v2-root .faq-body a { color: var(--accent-mint-deep); text-decoration: none; font-weight: 600; }
-.m-v2-root .faq-body a:hover { text-decoration: underline; }
-.m-v2-root .faq-body strong { color: var(--text-primary); font-weight: 600; }
-.m-v2-root .faq-disclaimer {
-  font-size: 13px;
-  color: var(--text-tertiary);
-  background: var(--surface-base);
-  border-left: 3px solid var(--accent-orange);
-  padding: 12px 14px;
-  border-radius: 6px;
-  margin-top: 8px;
+@media (prefers-reduced-motion: reduce) {
+  .m-v2-root .reveal, .m-v2-root .reveal.in { opacity: 1; transform: none; transition: none; }
+  .m-v2-root .float, .m-v2-root .pulse, .m-v2-root .t-track, .m-v2-root .nav-progress { animation: none !important; transition: none !important; }
 }
 
-/* Responsive ------------------------------------------------------ */
+/* Responsive */
+
 @media (max-width: 980px) {
   .m-v2-root .hero-grid { grid-template-columns: 1fr; gap: 40px; }
   .m-v2-root .hero-visual { height: 520px; }
-  .m-v2-root .stats-grid,
-  .m-v2-root .pillar-grid,
-  .m-v2-root .how-steps,
-  .m-v2-root .category-grid,
-  .m-v2-root .pricing-grid { grid-template-columns: 1fr; }
+  .m-v2-root .stats-grid, .m-v2-root .pillar-grid, .m-v2-root .how-steps, .m-v2-root .category-grid, .m-v2-root .pricing-grid { grid-template-columns: 1fr; }
   .m-v2-root .trust-row { grid-template-columns: repeat(2, 1fr); gap: 16px; }
   .m-v2-root .footer-grid { grid-template-columns: 1fr 1fr; }
   .m-v2-root .nav-links { display: none; }
-  .m-v2-root .why-grid,
-  .m-v2-root .agent-showcase-grid,
-  .m-v2-root .assistant-grid,
-  .m-v2-root .subs-grid { grid-template-columns: 1fr; gap: 48px; }
-  .m-v2-root .agent-features { grid-template-columns: 1fr; }
-  .m-v2-root .why-stats { grid-template-columns: 1fr 1fr; }
 }
+
 @media (max-width: 480px) {
   .m-v2-root .wrap { padding: 0 20px; }
   .m-v2-root .hero-visual { height: 440px; }
   .m-v2-root .dash-card { width: 300px; height: 420px; right: 0; top: 10px; }
   .m-v2-root .mini-card { width: 200px; height: 280px; left: 0; top: 120px; }
   .m-v2-root .agent-bubble { width: 240px; right: 0; bottom: 0; }
-  .m-v2-root .stats-section,
-  .m-v2-root .pillars-section,
-  .m-v2-root .deals-section,
-  .m-v2-root .pricing-section,
-  .m-v2-root .testimonials-section,
-  .m-v2-root .why-we-exist,
-  .m-v2-root .assistant-section,
-  .m-v2-root .subs-section,
-  .m-v2-root .faq-section { padding: 80px 0; }
-  .m-v2-root .how-section,
-  .m-v2-root .agent-showcase,
-  .m-v2-root .final-cta { padding: 100px 0; }
-  .m-v2-root .why-stats { grid-template-columns: 1fr; }
-  .m-v2-root .faq-item summary { padding: 18px 20px; font-size: 15px; }
-  .m-v2-root .faq-body { padding: 16px 20px 20px; }
+  .m-v2-root .stats-section, .m-v2-root .pillars-section, .m-v2-root .deals-section, .m-v2-root .pricing-section, .m-v2-root .testimonials-section { padding: 80px 0; }
+  .m-v2-root .how-section, .m-v2-root .final-cta { padding: 100px 0; }
 }

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -264,12 +264,29 @@
 .m-v2-root .hero { padding: 32px 0 120px; }
 
 .m-v2-root .hero-grid {
-  display: grid;
-  grid-template-columns: 1.1fr 1fr;
-  gap: 64px;
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  gap: 56px;
   padding-top: 40px;
+  max-width: 1080px;
+  margin: 0 auto;
 }
+.m-v2-root .hero-copy {
+  text-align: center;
+  align-items: center;
+  max-width: 760px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+.m-v2-root .hero-copy .eyebrow { align-self: center; }
+.m-v2-root .hero-copy h1 { text-align: center; }
+.m-v2-root .hero-sub { text-align: center; margin-left: auto; margin-right: auto; }
+.m-v2-root .hero-cta-row { justify-content: center; }
+.m-v2-root .hero-ticker { justify-content: center; align-self: center; }
+.m-v2-root .hero-visual--live { width: 100%; max-width: 960px; }
+.m-v2-root .hero-visual--live .hero-demo-frame { max-width: 960px; }
 
 .m-v2-root .hero h1 {
   font-size: var(--fs-display);
@@ -964,7 +981,7 @@
 /* Responsive */
 
 @media (max-width: 980px) {
-  .m-v2-root .hero-grid { grid-template-columns: 1fr; gap: 40px; }
+  .m-v2-root .hero-grid { gap: 40px; }
   .m-v2-root .hero-visual { height: 520px; }
   .m-v2-root .stats-grid, .m-v2-root .pillar-grid, .m-v2-root .how-steps, .m-v2-root .category-grid, .m-v2-root .pricing-grid { grid-template-columns: 1fr; }
   .m-v2-root .trust-row { grid-template-columns: repeat(2, 1fr); gap: 16px; }
@@ -1267,6 +1284,28 @@
   width: 100%;
 }
 .m-v2-root .feature-copy .eyebrow { font-size: 12px; align-self: center; }
+
+/* NEW: big bold section title (e.g. "AI Disputes Centre") */
+.m-v2-root .feature-title {
+  font-size: clamp(36px, 5vw, 56px);
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  margin: 0;
+  color: var(--text-primary, #0A0F1C);
+}
+.m-v2-root .feature-section--ink .feature-title { color: #fff; }
+
+/* NEW: tagline sits under the big title */
+.m-v2-root .feature-tagline {
+  font-size: clamp(18px, 2vw, 22px);
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
+  color: var(--accent-mint-deep, #059669);
+}
+.m-v2-root .feature-section--ink .feature-tagline { color: var(--accent-mint, #34D399); }
+
 .m-v2-root .feature-copy h3 {
   font-size: clamp(28px, 3.4vw, 42px);
   font-weight: 700;
@@ -1339,112 +1378,186 @@
   justify-content: center;
 }
 
-/* Comparison matrix */
-.m-v2-root .compare-section {
-  padding: 96px 0;
-  background: #FFFFFF;
+/* ============================================================
+   Architecture diagram + competitor comparison matrix (DARK)
+   ============================================================ */
+
+.m-v2-root .compare-section.section-ink {
+  padding: 104px 0;
+  background: var(--ink-base, #0B1220);
+  color: #fff;
 }
-.m-v2-root .compare-table-wrap {
-  overflow-x: auto;
-  max-width: 1080px;
-  margin: 40px auto 0;
+.m-v2-root .compare-section .section-head--center h2 { color: #fff; }
+.m-v2-root .compare-section .section-head--center p { color: rgba(255,255,255,.7); }
+
+/* 3-panel architecture: Inputs · Core · Outputs */
+.m-v2-root .arch-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.05fr 1fr;
+  gap: 40px;
+  align-items: start;
+  max-width: 1180px;
+  margin: 56px auto 72px;
+}
+.m-v2-root .arch-col { padding: 8px 0; }
+.m-v2-root .arch-label {
+  text-transform: uppercase;
+  letter-spacing: .14em;
+  font-size: 12px;
+  font-weight: 800;
+  margin-bottom: 18px;
+}
+.m-v2-root .arch-label--orange { color: var(--accent-orange, #FB923C); }
+.m-v2-root .arch-label--mint { color: var(--accent-mint, #34D399); }
+.m-v2-root .arch-label--center { text-align: center; margin-bottom: 22px; }
+
+.m-v2-root .arch-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.m-v2-root .arch-list li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: rgba(255,255,255,.82);
+}
+.m-v2-root .arch-list li::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 8px;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--accent-mint, #34D399);
+  box-shadow: 0 0 0 3px rgba(52,211,153,.18);
+}
+.m-v2-root .arch-col--inputs .arch-list li::before { background: var(--accent-orange, #FB923C); box-shadow: 0 0 0 3px rgba(251,146,60,.18); }
+
+/* Bold + sub format used by core list */
+.m-v2-root .arch-list--bold li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: 18px;
+}
+.m-v2-root .arch-list--bold li strong {
+  color: #fff;
+  font-weight: 700;
+  font-size: 15px;
+}
+.m-v2-root .arch-list--bold li span {
+  color: rgba(255,255,255,.6);
+  font-size: 13.5px;
+}
+
+.m-v2-root .arch-core-card {
+  border: 1.5px solid rgba(52,211,153,.45);
   border-radius: 16px;
-  box-shadow: 0 24px 48px -12px rgba(11,18,32,.1), 0 4px 12px -4px rgba(11,18,32,.04);
-  border: 1px solid #E5E7EB;
-  background: #fff;
+  padding: 28px 28px 24px;
+  background: linear-gradient(180deg, rgba(52,211,153,.04) 0%, rgba(52,211,153,0) 100%);
+  box-shadow: 0 0 0 6px rgba(52,211,153,.04), 0 24px 60px -20px rgba(52,211,153,.18);
 }
-.m-v2-root .compare-table {
+
+/* Dark comparison table — PAYBACKER column on the right */
+.m-v2-root .compare-table-wrap--dark {
+  overflow-x: auto;
+  max-width: 1180px;
+  margin: 0 auto;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+.m-v2-root .compare-table--dark {
   width: 100%;
   border-collapse: collapse;
   font-size: 14.5px;
-  min-width: 720px;
+  min-width: 820px;
+  color: rgba(255,255,255,.85);
 }
-.m-v2-root .compare-table thead th {
-  background: #F9FAFB;
+.m-v2-root .compare-table--dark thead th {
+  background: transparent;
   padding: 18px 14px;
   text-align: center;
   font-weight: 700;
-  font-size: 12.5px;
+  font-size: 12px;
   text-transform: uppercase;
-  letter-spacing: .06em;
-  color: #6B7280;
-  border-bottom: 1px solid #E5E7EB;
+  letter-spacing: .12em;
+  color: rgba(255,255,255,.55);
+  border-bottom: 1px solid rgba(255,255,255,.12);
 }
-.m-v2-root .compare-table thead th.feature { text-align: left; padding-left: 24px; }
-.m-v2-root .compare-table thead th.us {
-  background: #ECFDF5;
-  color: #065F46;
-  font-size: 14px;
-  letter-spacing: .02em;
-}
-.m-v2-root .compare-table tbody td {
-  padding: 14px;
-  text-align: center;
-  border-bottom: 1px solid #F3F4F6;
-  color: #374151;
-  vertical-align: middle;
-}
-.m-v2-root .compare-table tbody td:first-child {
+.m-v2-root .compare-table--dark thead th.feature {
   text-align: left;
-  padding-left: 24px;
+  padding-left: 8px;
+}
+.m-v2-root .compare-table--dark thead th.us {
+  color: var(--accent-mint, #34D399);
+  letter-spacing: .14em;
+}
+.m-v2-root .compare-table--dark tbody td {
+  padding: 18px 14px;
+  text-align: center;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+  color: rgba(255,255,255,.78);
+  vertical-align: middle;
+  font-size: 14.5px;
+}
+.m-v2-root .compare-table--dark tbody td:first-child {
+  text-align: left;
+  padding-left: 8px;
   font-weight: 500;
-  color: #0A0F1C;
-  min-width: 220px;
+  color: #fff;
+  min-width: 260px;
 }
-.m-v2-root .compare-table tbody td.us {
-  background: #F0FDF4;
-  font-weight: 600;
-  color: #065F46;
+.m-v2-root .compare-table--dark tbody td.us {
+  color: var(--accent-mint, #34D399);
+  font-weight: 700;
 }
-.m-v2-root .compare-table tr:last-child td { border-bottom: none; }
-.m-v2-root .compare-table .chk {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px; height: 28px;
-  border-radius: 50%;
-  background: #D1FAE5;
-  color: #065F46;
+.m-v2-root .compare-table--dark tr:last-child td { border-bottom: none; }
+.m-v2-root .compare-table--dark .chk {
+  display: inline-block;
+  color: var(--accent-mint, #34D399);
   font-weight: 800;
-  font-size: 14px;
+  font-size: 18px;
   line-height: 1;
 }
-.m-v2-root .compare-table .x {
+.m-v2-root .compare-table--dark td.us .chk { color: var(--accent-mint, #34D399); }
+.m-v2-root .compare-table--dark .x {
   display: inline-block;
-  color: #9CA3AF;
-  font-size: 13.5px;
+  color: rgba(255,255,255,.32);
+  font-size: 16px;
 }
-.m-v2-root .compare-table .price-row td {
-  background: #FAFAF7;
-  font-weight: 700;
-  font-size: 15px;
-  color: #0A0F1C;
-}
-.m-v2-root .compare-table .price-row td.us {
-  background: #ECFDF5;
-  color: #065F46;
-}
-.m-v2-root .compare-footnote {
+
+.m-v2-root .compare-footnote.compare-footnote--ink {
   text-align: center;
   font-size: 13px;
-  color: var(--text-tertiary, #6B7280);
-  margin: 24px auto 0;
+  color: rgba(255,255,255,.5);
+  margin: 32px auto 0;
   max-width: 640px;
   line-height: 1.55;
 }
-.m-v2-root .compare-footnote a {
-  color: var(--accent-mint-deep, #059669);
+.m-v2-root .compare-footnote.compare-footnote--ink a {
+  color: var(--accent-mint, #34D399);
   text-decoration: none;
   font-weight: 600;
 }
-.m-v2-root .compare-footnote a:hover { text-decoration: underline; }
+.m-v2-root .compare-footnote.compare-footnote--ink a:hover { text-decoration: underline; }
 
 @media (max-width: 980px) {
   .m-v2-root .features-intro { padding: 72px 0 16px; }
   .m-v2-root .feature-section { padding: 48px 0 72px; }
   .m-v2-root .feature-grid { gap: 32px; }
   .m-v2-root .feature-stage .demo-stage { max-width: 100%; }
-  .m-v2-root .compare-section { padding: 64px 0; }
+  .m-v2-root .compare-section.section-ink { padding: 72px 0; }
+  .m-v2-root .arch-grid {
+    grid-template-columns: 1fr;
+    gap: 32px;
+    margin: 40px auto 56px;
+  }
+  .m-v2-root .arch-core-card { padding: 22px; }
 }
 
 @media (max-width: 480px) {

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1183,3 +1183,270 @@
   .m-v2-root .demo-block { margin-bottom: 32px; }
   .m-v2-root .demo-block--ink { padding: 32px 16px; margin-left: 0; margin-right: 0; }
 }
+
+/* ============================================================
+   Feature sections (merged copy + demo) + comparison matrix
+   ============================================================ */
+
+/* Hero: swap 3-card composition for a live Disputes demo frame */
+.m-v2-root .hero-visual--live { height: 620px; }
+.m-v2-root .hero-demo-frame {
+  position: absolute;
+  right: 0; top: 20px;
+  width: min(560px, 90%);
+  transform: rotate(-3deg);
+  --r: -3deg;
+  border-radius: 20px;
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
+  z-index: 2;
+  background: #fff;
+  transition: transform 220ms cubic-bezier(0.22,1,0.36,1);
+}
+.m-v2-root .hero-demo-frame .demo-stage {
+  max-width: none;
+  border-radius: 20px;
+  border: none;
+  box-shadow: none;
+}
+.m-v2-root .mini-card--hero {
+  width: 220px; height: auto; padding: 18px;
+  left: -12px; top: 180px;
+  z-index: 3;
+}
+.m-v2-root .mini-card--hero .big { margin-bottom: 4px; }
+.m-v2-root .agent-bubble--hero {
+  right: auto; left: 10%; bottom: 30px;
+  width: 260px;
+  z-index: 3;
+}
+
+/* Shared: centred section head modifier */
+.m-v2-root .section-head--center {
+  text-align: center;
+  max-width: 760px;
+  margin: 0 auto;
+}
+.m-v2-root .section-head--center h2,
+.m-v2-root .section-head--center p {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Features intro block */
+.m-v2-root .features-intro {
+  padding: 96px 0 32px;
+  background: #FAFAF7;
+}
+
+/* Each feature = copy + live demo side by side */
+.m-v2-root .feature-section {
+  padding: 56px 0 88px;
+  background: #FAFAF7;
+}
+.m-v2-root .feature-section--alt { background: #FFFFFF; }
+.m-v2-root .feature-section--ink {
+  background: var(--ink-base, #0B1220);
+  color: #fff;
+}
+
+.m-v2-root .feature-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.95fr) minmax(440px, 1.2fr);
+  gap: 56px;
+  align-items: center;
+  max-width: 1180px;
+  margin: 0 auto;
+}
+.m-v2-root .feature-grid--reverse .feature-stage { order: -1; }
+
+.m-v2-root .feature-copy { display: flex; flex-direction: column; gap: 18px; }
+.m-v2-root .feature-copy .eyebrow { font-size: 12px; align-self: flex-start; }
+.m-v2-root .feature-copy h3 {
+  font-size: clamp(26px, 3.2vw, 40px);
+  font-weight: 700;
+  line-height: 1.12;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--text-primary, #0A0F1C);
+}
+.m-v2-root .feature-section--ink .feature-copy h3 { color: #fff; }
+.m-v2-root .feature-copy > p {
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--text-secondary, #4B5563);
+  margin: 0;
+}
+.m-v2-root .feature-section--ink .feature-copy > p { color: rgba(255,255,255,.72); }
+.m-v2-root .feature-section--ink .eyebrow,
+.m-v2-root .feature-section--ink .eyebrow.on-ink {
+  color: var(--accent-mint, #34D399);
+}
+
+.m-v2-root .feature-bullets {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.m-v2-root .feature-bullets li {
+  position: relative;
+  padding-left: 28px;
+  font-size: 14.5px;
+  color: var(--text-secondary, #4B5563);
+  line-height: 1.5;
+}
+.m-v2-root .feature-bullets li::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 3px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: #D1FAE5 url("data:image/svg+xml;utf8,<svg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><path d='M4 8.5L7 11.5L12 5.5' stroke='%23065F46' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>") center/70% no-repeat;
+}
+.m-v2-root .feature-section--ink .feature-bullets li { color: rgba(255,255,255,.82); }
+.m-v2-root .feature-section--ink .feature-bullets li::before {
+  background-color: rgba(52,211,153,.18);
+  background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><path d='M4 8.5L7 11.5L12 5.5' stroke='%2334D399' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+}
+
+.m-v2-root .feature-stage {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.m-v2-root .feature-stage .demo-stage {
+  width: 100%;
+  max-width: 640px;
+}
+
+.m-v2-root .feature-cta-row {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+/* Comparison matrix */
+.m-v2-root .compare-section {
+  padding: 96px 0;
+  background: #FFFFFF;
+}
+.m-v2-root .compare-table-wrap {
+  overflow-x: auto;
+  max-width: 1080px;
+  margin: 40px auto 0;
+  border-radius: 16px;
+  box-shadow: 0 24px 48px -12px rgba(11,18,32,.1), 0 4px 12px -4px rgba(11,18,32,.04);
+  border: 1px solid #E5E7EB;
+  background: #fff;
+}
+.m-v2-root .compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14.5px;
+  min-width: 720px;
+}
+.m-v2-root .compare-table thead th {
+  background: #F9FAFB;
+  padding: 18px 14px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 12.5px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: #6B7280;
+  border-bottom: 1px solid #E5E7EB;
+}
+.m-v2-root .compare-table thead th.feature { text-align: left; padding-left: 24px; }
+.m-v2-root .compare-table thead th.us {
+  background: #ECFDF5;
+  color: #065F46;
+  font-size: 14px;
+  letter-spacing: .02em;
+}
+.m-v2-root .compare-table tbody td {
+  padding: 14px;
+  text-align: center;
+  border-bottom: 1px solid #F3F4F6;
+  color: #374151;
+  vertical-align: middle;
+}
+.m-v2-root .compare-table tbody td:first-child {
+  text-align: left;
+  padding-left: 24px;
+  font-weight: 500;
+  color: #0A0F1C;
+  min-width: 220px;
+}
+.m-v2-root .compare-table tbody td.us {
+  background: #F0FDF4;
+  font-weight: 600;
+  color: #065F46;
+}
+.m-v2-root .compare-table tr:last-child td { border-bottom: none; }
+.m-v2-root .compare-table .chk {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  background: #D1FAE5;
+  color: #065F46;
+  font-weight: 800;
+  font-size: 14px;
+  line-height: 1;
+}
+.m-v2-root .compare-table .x {
+  display: inline-block;
+  color: #9CA3AF;
+  font-size: 13.5px;
+}
+.m-v2-root .compare-table .price-row td {
+  background: #FAFAF7;
+  font-weight: 700;
+  font-size: 15px;
+  color: #0A0F1C;
+}
+.m-v2-root .compare-table .price-row td.us {
+  background: #ECFDF5;
+  color: #065F46;
+}
+.m-v2-root .compare-footnote {
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-tertiary, #6B7280);
+  margin: 24px auto 0;
+  max-width: 640px;
+  line-height: 1.55;
+}
+.m-v2-root .compare-footnote a {
+  color: var(--accent-mint-deep, #059669);
+  text-decoration: none;
+  font-weight: 600;
+}
+.m-v2-root .compare-footnote a:hover { text-decoration: underline; }
+
+@media (max-width: 980px) {
+  .m-v2-root .features-intro { padding: 72px 0 16px; }
+  .m-v2-root .feature-section { padding: 40px 0 64px; }
+  .m-v2-root .feature-grid,
+  .m-v2-root .feature-grid--reverse {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+  .m-v2-root .feature-grid--reverse .feature-stage { order: 0; }
+  .m-v2-root .feature-stage .demo-stage { max-width: 100%; }
+  .m-v2-root .compare-section { padding: 64px 0; }
+}
+
+@media (max-width: 480px) {
+  .m-v2-root .hero-visual--live { height: auto; min-height: 520px; padding-bottom: 40px; }
+  .m-v2-root .hero-demo-frame { position: relative; right: auto; top: auto; transform: none; --r: 0deg; width: 100%; margin: 0 auto 24px; }
+  .m-v2-root .mini-card--hero { position: relative; left: auto; top: auto; width: 100%; margin-bottom: 14px; transform: none; --r: 0deg; }
+  .m-v2-root .agent-bubble--hero { position: relative; right: auto; left: auto; bottom: auto; width: 100%; transform: none; --r: 0deg; }
+}

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -285,8 +285,6 @@
 .m-v2-root .hero-sub { text-align: center; margin-left: auto; margin-right: auto; }
 .m-v2-root .hero-cta-row { justify-content: center; }
 .m-v2-root .hero-ticker { justify-content: center; align-self: center; }
-.m-v2-root .hero-visual--live { width: 100%; max-width: 960px; }
-.m-v2-root .hero-visual--live .hero-demo-frame { max-width: 960px; }
 
 .m-v2-root .hero h1 {
   font-size: var(--fs-display);
@@ -333,11 +331,17 @@
   100% { box-shadow: 0 0 0 0 rgba(245,158,11,0); }
 }
 
-/* Hero visual */
+/* Hero visual — static 3-card composition: mini-card (left), dash-card
+   (right, mouse-tilt), agent-bubble (bottom-right). Needs a fixed width
+   so absolutely-positioned children have a containing block to anchor
+   against now that .hero-grid is a centred column. */
 
 .m-v2-root .hero-visual {
   position: relative;
+  width: 100%;
+  max-width: 720px;
   height: 600px;
+  margin: 0 auto;
   perspective: 1400px;
 }
 
@@ -1204,32 +1208,6 @@
 /* ============================================================
    Feature sections (merged copy + demo) + comparison matrix
    ============================================================ */
-
-/* Hero: clean centred Disputes demo — no rotation, no overlays.
-   The demo IS the centrepiece. Let it breathe. */
-.m-v2-root .hero-visual--live {
-  height: auto;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  padding-top: 8px;
-}
-.m-v2-root .hero-demo-frame {
-  position: relative;
-  width: 100%;
-  max-width: 620px;
-  border-radius: 20px;
-  box-shadow: var(--shadow-xl);
-  overflow: hidden;
-  background: #fff;
-}
-.m-v2-root .hero-demo-frame .demo-stage {
-  max-width: none;
-  width: 100%;
-  border-radius: 20px;
-  border: none;
-  box-shadow: none;
-}
 
 /* Shared: centred section head modifier */
 .m-v2-root .section-head--center {

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -981,3 +981,205 @@
   .m-v2-root .stats-section, .m-v2-root .pillars-section, .m-v2-root .deals-section, .m-v2-root .pricing-section, .m-v2-root .testimonials-section { padding: 80px 0; }
   .m-v2-root .how-section, .m-v2-root .final-cta { padding: 100px 0; }
 }
+
+/* ============================================================
+   Product demo shell — scoped to .m-v2-root .demo-stage only.
+   Tokens/classes mirror demos-handoff/demos/demo-shell.css.
+   All keyframes prefixed `demo` to avoid leaking.
+   ============================================================ */
+
+.m-v2-root .demo-stage {
+  /* Demo token overrides — only active inside a demo container. */
+  --text: #0A0F1C;
+  --text-2: #4B5563;
+  --text-3: #6B7280;
+  --text-4: #9CA3AF;
+  --mint: #34D399;
+  --mint-deep: #059669;
+  --mint-wash: #D1FAE5;
+  --mint-dark: #065F46;
+  --orange: #F59E0B;
+  --orange-deep: #B45309;
+  --orange-wash: #FEF3C7;
+  --red: #EF4444;
+  --red-wash: #FEE2E2;
+  --paper: #FFFFFF;
+  --bg: #F3F4F6;
+  --ink: #0B1220;
+  --divider: #E5E7EB;
+  --shadow-sm: 0 1px 2px rgba(11,18,32,.06);
+  --shadow-md: 0 8px 24px -6px rgba(11,18,32,.12), 0 2px 6px -2px rgba(11,18,32,.08);
+  --shadow-lg: 0 24px 48px -12px rgba(11,18,32,.18), 0 4px 12px -4px rgba(11,18,32,.1);
+
+  width: 100%;
+  max-width: 980px;
+  aspect-ratio: 16 / 10;
+  background: var(--paper);
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid var(--divider);
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  margin: 0 auto;
+}
+.m-v2-root .demo-stage.dark { background: #0B1220; border-color: rgba(255,255,255,.08); }
+
+.m-v2-root .demo-stage *,
+.m-v2-root .demo-stage *::before,
+.m-v2-root .demo-stage *::after { box-sizing: border-box; }
+
+/* Fake cursor */
+.m-v2-root .demo-stage .cursor {
+  position: absolute; width: 22px; height: 22px; pointer-events: none;
+  z-index: 50; filter: drop-shadow(0 2px 4px rgba(0,0,0,.25));
+  transition: transform 600ms cubic-bezier(.4,.0,.2,1), opacity 240ms, left 600ms cubic-bezier(.4,.0,.2,1), top 600ms cubic-bezier(.4,.0,.2,1);
+}
+.m-v2-root .demo-stage .cursor svg { width: 100%; height: 100%; display: block; }
+
+/* Pulse ring on cursor click */
+.m-v2-root .demo-stage .click-ring {
+  position: absolute; width: 36px; height: 36px; border-radius: 50%;
+  border: 2px solid var(--mint-deep);
+  pointer-events: none; opacity: 0; z-index: 49;
+  transform: translate(-50%,-50%) scale(.6);
+  animation: demoClickPing 600ms ease-out forwards;
+}
+@keyframes demoClickPing {
+  0% { opacity: .9; transform: translate(-50%,-50%) scale(.6); }
+  100% { opacity: 0; transform: translate(-50%,-50%) scale(1.8); }
+}
+
+/* Typing caret */
+.m-v2-root .demo-stage .caret {
+  display: inline-block; width: 1.5px; height: 1em; background: currentColor;
+  vertical-align: -2px; margin-left: 1px; animation: demoCaretBlink 1s infinite;
+}
+@keyframes demoCaretBlink { 50% { opacity: 0; } }
+
+/* Toast */
+.m-v2-root .demo-stage .toast {
+  position: absolute; bottom: 18px; left: 50%; transform: translate(-50%,20px);
+  background: var(--ink); color: #fff; padding: 10px 16px; border-radius: 10px;
+  font-size: 13px; font-weight: 500; display: flex; align-items: center; gap: 8px;
+  opacity: 0; transition: opacity 300ms, transform 300ms;
+  box-shadow: var(--shadow-md); z-index: 40;
+}
+.m-v2-root .demo-stage .toast.show { opacity: 1; transform: translate(-50%,0); }
+.m-v2-root .demo-stage .toast .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--mint); }
+
+/* Utility */
+.m-v2-root .demo-stage .mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+.m-v2-root .demo-stage .eyebrow {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--mint-deep);
+}
+.m-v2-root .demo-stage .pill {
+  display: inline-flex; align-items: center; gap: 5px; padding: 3px 8px;
+  border-radius: 999px; font-size: 11px; font-weight: 600;
+}
+.m-v2-root .demo-stage .pill.mint { background: var(--mint-wash); color: var(--mint-dark); }
+.m-v2-root .demo-stage .pill.orange { background: var(--orange-wash); color: var(--orange-deep); }
+.m-v2-root .demo-stage .pill.red { background: var(--red-wash); color: #991B1B; }
+.m-v2-root .demo-stage .pill.grey { background: #F3F4F6; color: var(--text-3); }
+.m-v2-root .demo-stage .pill.ink { background: var(--ink); color: #fff; }
+
+/* Demo meta caption — hidden in production, shown only when .demo-stage has data-dev attr. */
+.m-v2-root .demo-stage .demo-label { display: none; }
+
+/* Shared keyframes used by demos (all demo*-prefixed) */
+@keyframes demoFadeInUp {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes demoFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes demoPulse { 0%,100% { opacity: 1; } 50% { opacity: .3; } }
+@keyframes demoSpin { to { transform: rotate(360deg); } }
+@keyframes demoSlideInRight {
+  from { opacity: 0; transform: translateX(30px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes demoPingRing {
+  0% { opacity: .9; transform: translate(-50%,-50%) scale(.6); }
+  100% { opacity: 0; transform: translate(-50%,-50%) scale(1.8); }
+}
+@keyframes demoDropdownIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes demoMsgIn {
+  from { opacity: 0; transform: translateY(6px) scale(.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes demoDotPulse {
+  0%, 80%, 100% { opacity: .3; transform: scale(.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+@keyframes demoBudgetPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(239,68,68,.45); }
+  50% { box-shadow: 0 0 0 6px rgba(239,68,68,0); }
+}
+
+/* Wrapping block around each homepage-mounted demo */
+.m-v2-root .demo-slot {
+  display: flex; justify-content: center;
+  padding: 24px 0 8px;
+}
+.m-v2-root .demo-slot--dark { padding: 24px 0 8px; }
+
+/* ============================================================
+   Demo showcase blocks (containers around mounted demos)
+   ============================================================ */
+.m-v2-root .demos-section { padding: 96px 0 56px; background: #FAFAF7; }
+.m-v2-root .mcp-section { padding: 120px 0 72px; }
+
+.m-v2-root .demo-block {
+  margin: 0 auto 48px;
+  max-width: 1080px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.m-v2-root .demo-block:last-child { margin-bottom: 0; }
+
+.m-v2-root .demo-block-head {
+  text-align: center; max-width: 720px; margin: 0 auto 4px;
+}
+.m-v2-root .demo-block-head .eyebrow {
+  display: inline-block; margin-bottom: 8px;
+}
+.m-v2-root .demo-block-head h3 {
+  font-size: clamp(20px, 2.4vw, 28px);
+  font-weight: 700; letter-spacing: -.015em; margin: 0;
+  color: var(--text-primary, #0A0F1C);
+  line-height: 1.25;
+}
+.m-v2-root .demo-block-head h3.on-ink { color: #fff; }
+.m-v2-root .eyebrow.on-ink { color: rgba(255,255,255,.7); }
+
+.m-v2-root .demo-block--ink {
+  background: var(--ink-base, #0B1220);
+  border-radius: 24px;
+  padding: 56px 32px;
+  margin-left: -16px; margin-right: -16px;
+}
+
+/* Pill-pro for MCP section */
+.m-v2-root .pill-pro {
+  display: inline-flex; align-items: center;
+  padding: 4px 11px; border-radius: 999px;
+  background: linear-gradient(120deg, #34D399, #059669);
+  color: #fff; font-size: 11px; font-weight: 700;
+  letter-spacing: .08em; text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+/* Responsive */
+@media (max-width: 980px) {
+  .m-v2-root .demos-section { padding: 64px 0 32px; }
+  .m-v2-root .mcp-section { padding: 80px 0 48px; }
+  .m-v2-root .demo-block { margin-bottom: 32px; }
+  .m-v2-root .demo-block--ink { padding: 32px 16px; margin-left: 0; margin-right: 0; }
+}


### PR DESCRIPTION
Cuts the dynamic homepage redesign over to `/`.

## What's in it
- 7 ported product demos (Disputes, Pocket Agent, Money Hub, Subscriptions, Export, Deals, MCP)
- Each feature section: big bold header → tagline → copy → demo, stacked at full ~960px width
- Hero: original 3-card mock (savings snapshot + Money Hub tilt + Pocket Agent bubble) — Disputes demo lives in its own section, no duplication
- Comparison: dark navy 3-panel architecture (Inputs / Core / Outputs) above competitor matrix vs Emma, Snoop, Lunchflow, Resolver, Which?
- Deals + Pricing section heads centred via `section-head--center`
- Belt-and-braces flex `order` on `.feature-grid` so copy is *always* painted above the demo
- All styles scoped under `.m-v2-root` — no leakage to dashboard / docs / auth

## Risk
Low. `src/app/page.tsx` already re-exports from `preview/homepage/page` — only the 3 files inside `preview/homepage/` change. Master pages, API routes, dashboard, auth and dynamic agents are untouched.

## Test plan
- [ ] paybacker.co.uk renders new design after master deploy READY
- [ ] Demos auto-play on scroll (IntersectionObserver)
- [ ] Hero static mock renders without overlap on 1280/1440/1920
- [ ] CTA hrefs `/join`, `/login`, `/pricing` all resolve
