### PR TITLE
feat(marketing): redesign /pricing and /about + /login redirect

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,12 @@ const nextConfig: NextConfig = {
         destination: 'https://paybacker.co.uk/:path*',
         permanent: true,
       },
+      // Legacy /login path — route to the real auth page
+      {
+        source: '/login',
+        destination: '/auth/login',
+        permanent: true,
+      },
     ];
   },
   async rewrites() {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,320 +1,418 @@
-import type { Metadata } from "next";
-import Image from "next/image";
-import Link from "next/link";
-import PublicNavbar from '@/components/PublicNavbar';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+import './styles.css';
+
+/**
+ * /about — marketing redesign.
+ *
+ * Design source: design-zip/redesign/batch6.jsx::AboutPage
+ * Scoped under `.m-about-root`. Copy pinned to CONTENT_SOURCES_OF_TRUTH.md —
+ * launch date March 2026, no founder anecdote, no investor fiction.
+ */
 
 export const metadata: Metadata = {
-  title: "About Paybacker - Fighting for UK Consumers",
+  title: 'About Paybacker — Lawyers are too expensive. Suppliers know it.',
   description:
-    "Paybacker was built so normal people don't need a lawyer to fight back against unfair bills. Founded by Paul Airey. Know your rights. Fight for your rights.",
+    'Paybacker bridges the gap between an unfair bill and a lawyer who costs more than the refund. Launched March 2026 to help normal working people save money proactively.',
+  alternates: { canonical: 'https://paybacker.co.uk/about' },
   openGraph: {
-    title: "About Paybacker - Fighting for UK Consumers",
+    title: 'About Paybacker — Fighting for UK consumers',
     description:
-      "Paybacker was built so normal people don't need a lawyer to fight back against unfair bills. Founded by Paul Airey. Know your rights. Fight for your rights.",
-    url: "https://paybacker.co.uk/about",
-    siteName: "Paybacker",
-    type: "website",
-  },
-  twitter: {
-    card: "summary",
-    title: "About Paybacker - Fighting for UK Consumers",
-    description:
-      "Paybacker was built so normal people don't need a lawyer to fight back against unfair bills. Founded by Paul Airey. Know your rights. Fight for your rights.",
-    images: ["/logo.png"],
-  },
-  alternates: {
-    canonical: "https://paybacker.co.uk/about",
+      'Launched March 2026. We read the Consumer Rights Act so you don\u2019t have to. Small team, big backlog, 0% success fee on every tier.',
+    url: 'https://paybacker.co.uk/about',
+    siteName: 'Paybacker',
+    type: 'website',
   },
 };
 
+type CSSVarProperties = CSSProperties & Record<`--${string}`, string | number>;
+
+const SIGNUP_HREF = '/auth/signup';
+const SIGNIN_HREF = '/auth/login';
+
+function MarkNav({ active }: { active: 'About' | 'Pricing' | 'Blog' | 'Careers' }) {
+  const links: ReadonlyArray<readonly [typeof active, string]> = [
+    ['About', '/about'],
+    ['Pricing', '/pricing'],
+    ['Blog', '/blog'],
+    ['Careers', '/careers'],
+  ];
+  return (
+    <div className="nav-shell">
+      <nav className="nav-pill" aria-label="Primary">
+        <Link className="nav-logo" href="/">
+          <span className="pay">Pay</span>
+          <span className="backer">backer</span>
+        </Link>
+        <div className="nav-links">
+          {links.map(([label, href]) => (
+            <Link
+              key={label}
+              href={href}
+              className={active === label ? 'is-active' : undefined}
+              aria-current={active === label ? 'page' : undefined}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+        <div className="nav-cta-row">
+          <Link className="nav-signin" href={SIGNIN_HREF}>Sign in</Link>
+          <Link className="nav-start" href={SIGNUP_HREF}>Start Free</Link>
+        </div>
+      </nav>
+    </div>
+  );
+}
+
+function MarkFoot() {
+  return (
+    <footer>
+      <div className="wrap">
+        <div className="footer-grid">
+          <div className="footer-brand">
+            <div className="logo">
+              <span>Pay</span>
+              <span className="backer">backer</span>
+            </div>
+            <p>The UK&apos;s AI money-back engine. We find what you&apos;re losing and fight to get it back.</p>
+            <p style={{ marginTop: 14, fontSize: 11, color: 'var(--text-on-ink-dim)', maxWidth: 320 }}>
+              AI-generated letters are for guidance only and do not constitute legal advice. For complex disputes, always consult a qualified solicitor.
+            </p>
+          </div>
+          <div className="footer-col">
+            <h5>Product</h5>
+            <Link href="/dashboard/complaints">Disputes Centre</Link>
+            <Link href="/dashboard/money-hub">Money Hub</Link>
+            <Link href="/dashboard">Pocket Agent</Link>
+            <Link href="/deals">Deals</Link>
+            <Link href="/pricing">Pricing</Link>
+          </div>
+          <div className="footer-col">
+            <h5>Company</h5>
+            <Link href="/about">About</Link>
+            <Link href="/blog">Blog</Link>
+            <Link href="/careers">Careers</Link>
+            <a href="mailto:hello@paybacker.co.uk">Contact</a>
+          </div>
+          <div className="footer-col">
+            <h5>Legal</h5>
+            <Link href="/legal/privacy">Privacy</Link>
+            <Link href="/legal/terms">Terms</Link>
+            <Link href="/cookie-policy">Cookies</Link>
+          </div>
+          <div className="footer-col">
+            <h5>Connect</h5>
+            <div className="footer-socials" style={{ marginBottom: 14 }}>
+              <a href="https://x.com/PaybackerUK" aria-label="X" target="_blank" rel="noopener noreferrer">𝕏</a>
+              <a href="https://www.instagram.com/paybacker.co.uk/" aria-label="Instagram" target="_blank" rel="noopener noreferrer">◎</a>
+              <a href="https://www.facebook.com/profile.php?id=61579563073310" aria-label="Facebook" target="_blank" rel="noopener noreferrer">f</a>
+              <a href="https://www.tiktok.com/@paybacker.co.uk" aria-label="TikTok" target="_blank" rel="noopener noreferrer">♪</a>
+              <a href="https://www.linkedin.com/company/112575954/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">in</a>
+            </div>
+            <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>
+          </div>
+        </div>
+        <div className="footer-bottom">
+          <div>© 2026 Paybacker LTD · Company no. 15289174 · Registered in England &amp; Wales</div>
+          <div>paybacker.co.uk · Made in London 🇬🇧</div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+const TIMELINE: ReadonlyArray<readonly [string, string, string]> = [
+  [
+    'The problem',
+    'Years of quiet overcharging',
+    'Suppliers have been getting away with unfair bills, silent price rises, and forgotten subscriptions for years. The only real recourse is a lawyer — and a lawyer costs more than the overcharge. So most people do nothing.',
+  ],
+  [
+    'The gap',
+    'Too small for law, too big to ignore',
+    'A £47 broadband anniversary rise. A £12/mo gym you cancelled in January. A mid-contract price hike you didn\u2019t agree to. Individually not worth fighting. Collectively, over £1,000 a year for a typical UK household.',
+  ],
+  [
+    'The idea',
+    'What if the fight was free?',
+    'AI can read the Consumer Rights Act. It can draft the letter. It can cite Ofcom General Conditions by section. The expensive part of a lawyer — the reading and the writing — becomes cheap.',
+  ],
+  [
+    'March 2026',
+    'Paybacker launches',
+    'We open the doors to everyone. Free tier for occasional disputes, £4.99/mo for people with a few bills to watch, £9.99/mo for households who want the full sweep. 0% of any refund. Ever.',
+  ],
+  [
+    'Today',
+    'Bridging the gap',
+    'We\u2019re the layer between you and the companies that bank on you not bothering. Small team, big backlog, and a simple belief: working people shouldn\u2019t need a solicitor to get their own money back.',
+  ],
+];
+
+const STATS: ReadonlyArray<readonly [string, string, string]> = [
+  ['£1,000+', 'Overcharged per UK household, per year', 'Forgotten subs, silent rises, unfair bills'],
+  ['£250+', 'Per hour for a consumer solicitor', 'Not worth it for a £47 broadband hike'],
+  ['0%', 'Of your refund — ever', 'Flat subscription, we never take a cut'],
+  ['30s', 'To draft a dispute letter', 'Cited Consumer Rights Act, section by section'],
+];
+
+const VALUES: ReadonlyArray<readonly [string, string]> = [
+  [
+    'We read the law, not the marketing',
+    'Every letter cites the specific statute or regulation. Consumer Rights Act 2015, Ofcom General Conditions, Ofgem Standard Licence Conditions — no vague "we think this is unfair."',
+  ],
+  [
+    'Your data stays in the UK',
+    'Read-only bank sync via Yapily (FCA-authorised). ICO registered. We never sell, rent, or train models on your transactions. Export or delete everything in one click.',
+  ],
+  [
+    'Small money matters',
+    'A £7.99/mo forgotten sub is £96/yr. Four of those is a holiday. We go after the small stuff, because nobody else will.',
+  ],
+  [
+    'Transparent economics',
+    '£0 or £4.99/mo flat. We take 0% of your refund. Your win is your win — keep every penny.',
+  ],
+];
+
 export default function AboutPage() {
   return (
-    <div className="min-h-screen bg-navy-950">
-      <PublicNavbar />
-      <div className="h-16" />
+    <div className="m-about-root">
+      <MarkNav active="About" />
 
-      <main className="container mx-auto px-4 md:px-6 py-10 md:py-16 max-w-3xl">
-        {/* Hero */}
-        <div className="mb-12">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            About Paybacker
+      {/* HERO */}
+      <section
+        className="section-light glow-wrap"
+        style={{ '--glow-opacity': 0.18, paddingTop: 140, paddingBottom: 80 } as CSSVarProperties}
+      >
+        <div className="wrap">
+          <span className="eyebrow">About · Paybacker LTD · Launched March 2026</span>
+          <h1
+            style={{
+              fontSize: 'var(--fs-display)',
+              lineHeight: 0.96,
+              fontWeight: 700,
+              letterSpacing: 'var(--track-tight)',
+              margin: '18px 0 24px',
+              maxWidth: 1000,
+            }}
+          >
+            <span style={{ display: 'block', color: 'var(--text-primary)' }}>Lawyers are</span>
+            <span style={{ display: 'block', color: 'var(--accent-mint-deep)' }}>too expensive.</span>
+            <span style={{ display: 'block', color: 'var(--accent-orange-deep)' }}>Suppliers know it.</span>
           </h1>
-          <p className="text-lg text-slate-300 leading-relaxed mb-4">
-            Most UK households are being overcharged by hundreds of pounds a year on bills they could dispute. Paybacker was built to change that.
+          <p
+            style={{
+              fontSize: 19,
+              color: 'var(--text-secondary)',
+              maxWidth: 720,
+              lineHeight: 1.5,
+              margin: '0 0 36px',
+            }}
+          >
+            Paybacker bridges the gap. We help normal working people save money proactively — spotting the overcharges, silent price rises and forgotten subscriptions that a solicitor would never be worth hiring for, and fighting them with AI-drafted letters that cite UK consumer law.
           </p>
-          <p className="text-lg text-slate-400 leading-relaxed">
-            We give every UK consumer access to the legal tools and AI intelligence to find every hidden charge, dispute it professionally, and stop paying more than they should. No legal fees. No lawyers. No giving in.
-          </p>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+            <Link className="btn btn-mint" href={SIGNUP_HREF}>
+              Start free 14-day trial →
+            </Link>
+            <Link className="btn btn-ghost" href="/careers">
+              We&apos;re hiring — see roles
+            </Link>
+          </div>
         </div>
+      </section>
 
-        {/* What Paybacker Is */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            What Paybacker Is
-          </h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Most people are paying more than they need to on everyday bills —
-            energy, broadband, mobile, insurance and subscriptions. The problem
-            is that finding better deals takes time, and it's easy to let
-            renewals slip by unnoticed.
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            Paybacker solves this by connecting securely to your email and bank
-            accounts, using AI to analyse your bills and contracts, and surfacing
-            personalised switching recommendations that could save you hundreds
-            of pounds a year. No spreadsheets, no hours on comparison sites —
-            just clear, actionable savings.
-          </p>
-        </section>
-
-        {/* How It Works */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">How It Works</h2>
-          <div className="grid gap-4">
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <div className="flex items-start gap-4">
-                <span className="text-mint-400 font-bold text-lg mt-0.5">
-                  1
-                </span>
-                <div>
-                  <h3 className="text-white font-semibold mb-1">
-                    Connect your email and bank securely
-                  </h3>
-                  <p className="text-slate-300 text-sm leading-relaxed">
-                    We use read-only access via Gmail, Outlook and Open Banking
-                    (powered by Yapily, FCA regulated). We never store your login credentials
-                    and can never move your money.
-                  </p>
+      {/* STAT BAND */}
+      <section className="section-ink" style={{ padding: '80px 0' }}>
+        <div className="wrap">
+          <span className="eyebrow on-ink">Why we exist</span>
+          <div
+            className="stat-grid"
+            style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 48, marginTop: 32 }}
+          >
+            {STATS.map(([big, label, sub]) => (
+              <div key={label}>
+                <div
+                  style={{
+                    fontSize: 'clamp(44px,4.5vw,64px)',
+                    fontWeight: 700,
+                    letterSpacing: '-.025em',
+                    color: 'var(--accent-mint)',
+                    lineHeight: 1,
+                  }}
+                >
+                  {big}
                 </div>
+                <div style={{ fontSize: 15, color: 'var(--text-on-ink)', marginTop: 12, fontWeight: 600 }}>{label}</div>
+                <div style={{ fontSize: 13, color: 'var(--text-on-ink-dim)', marginTop: 4, lineHeight: 1.5 }}>{sub}</div>
               </div>
-            </div>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <div className="flex items-start gap-4">
-                <span className="text-mint-400 font-bold text-lg mt-0.5">
-                  2
-                </span>
-                <div>
-                  <h3 className="text-white font-semibold mb-1">
-                    AI analyses your bills and contracts
-                  </h3>
-                  <p className="text-slate-300 text-sm leading-relaxed">
-                    Our AI reads your bills, identifies your tariffs, contract
-                    end dates and spending patterns, then compares them against
-                    the best deals currently available in the UK market.
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <div className="flex items-start gap-4">
-                <span className="text-mint-400 font-bold text-lg mt-0.5">
-                  3
-                </span>
-                <div>
-                  <h3 className="text-white font-semibold mb-1">
-                    Your dashboard shows where you save
-                  </h3>
-                  <p className="text-slate-300 text-sm leading-relaxed">
-                    See a clear breakdown of potential savings across every
-                    category — energy, broadband, mobile, insurance and
-                    subscriptions — with direct links to switch.
-                  </p>
-                </div>
-              </div>
-            </div>
+            ))}
           </div>
-        </section>
+        </div>
+      </section>
 
-        {/* Our Story */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Our Story
-          </h2>
-          <div className="space-y-4 text-slate-300 leading-relaxed">
-            <p>
-              I spent a decade working as an IT specialist inside some of the UK&apos;s biggest law firms and banks. I saw first-hand how institutions protect their interests: layers of process, deliberate complexity, terms and conditions written by lawyers so you can&apos;t use them against the company.
-            </p>
-            <p>
-              Then I got home one evening and opened a £400 energy bill I hadn&apos;t been expecting. I knew it wasn&apos;t right. When I called to dispute it, I was passed between departments for 45 minutes before giving up. A few weeks later I found a cancellation clause buried in paragraph 14 of my gym contract — and three streaming subscriptions quietly draining an old card I barely used.
-            </p>
-            <p>
-              The worst part wasn&apos;t the money. It was knowing the tools to fight back already existed — the Consumer Rights Act 2015, Ofgem&apos;s billing codes, UK261 for flight delays. UK law is genuinely on the consumer&apos;s side. It&apos;s just written in language that takes time and specialist knowledge to decode, and most people don&apos;t have either to spare.
-            </p>
-            <p>
-              That&apos;s exactly what big corporations count on. Most people give up — not because the company is right, but because fighting back feels impossibly complicated. Hiring a solicitor to dispute a £400 bill costs more than the bill. So people pay up, and feel powerless.
-            </p>
-            <p>
-              I built Paybacker to change that. You connect your bank and email; the AI finds every hidden charge, forgotten subscription and overpriced contract in minutes, then drafts the formal complaint letter — citing the exact UK legislation that applies to your case — in 30 seconds. No legal fees. No hold music. No giving up.
-            </p>
-            <p className="text-white font-semibold text-base pt-2">
-              Know your rights. Fight for your rights. Paybacker makes it simple.
-            </p>
-          </div>
-        </section>
-
-        {/* Meet the Founder */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-6 font-[family-name:var(--font-heading)]">
-            Meet the Founder
-          </h2>
-          <div className="bg-navy-900 border border-mint-400/20 rounded-2xl p-6">
-            <div className="flex flex-col sm:flex-row items-start gap-6 mb-6">
-              <div className="shrink-0">
-                <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-mint-400/30 to-brand-400/30 border border-mint-400/30 flex items-center justify-center">
-                  <span className="text-2xl font-bold text-mint-400">PA</span>
-                </div>
-              </div>
-              <div>
-                <h3 className="text-xl font-bold text-white mb-1">Paul Airey</h3>
-                <p className="text-mint-400 text-sm font-medium mb-4">Founder &amp; CEO, Paybacker LTD</p>
-                <div className="flex items-center gap-2">
-                  <a
-                    href="https://www.linkedin.com/in/paul-airey"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-navy-600 bg-navy-800 text-slate-300 hover:text-mint-400 hover:border-mint-400/50 hover:bg-mint-400/5 text-xs font-medium transition-all"
-                    aria-label="Paul Airey on LinkedIn"
+      {/* ORIGIN TIMELINE */}
+      <section className="section-light" style={{ padding: '120px 0' }}>
+        <div className="wrap">
+          <div
+            className="timeline-grid"
+            style={{ display: 'grid', gridTemplateColumns: '360px 1fr', gap: 80 }}
+          >
+            <div className="timeline-sticky" style={{ position: 'sticky', top: 120, alignSelf: 'start' }}>
+              <span className="eyebrow">Origin story</span>
+              <h2
+                style={{
+                  fontSize: 'var(--fs-h2)',
+                  fontWeight: 700,
+                  letterSpacing: 'var(--track-tight)',
+                  lineHeight: 1.05,
+                  margin: '14px 0 16px',
+                }}
+              >
+                The gap between a bill and a lawyer.
+              </h2>
+              <p style={{ fontSize: 16, lineHeight: 1.6, color: 'var(--text-secondary)', margin: 0 }}>
+                Paybacker exists because suppliers have been getting away with it for years. The overcharges are individually too small to lawyer up for, and collectively too big to ignore. We built the bridge.
+              </p>
+            </div>
+            <div>
+              {TIMELINE.map(([date, title, body], i) => (
+                <div
+                  key={date}
+                  className="timeline-row"
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '120px 1fr',
+                    gap: 28,
+                    paddingBottom: 32,
+                    marginBottom: 32,
+                    borderBottom: i < TIMELINE.length - 1 ? '1px solid var(--divider)' : 'none',
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 600,
+                      letterSpacing: 'var(--track-eyebrow)',
+                      textTransform: 'uppercase',
+                      color: 'var(--accent-mint-deep)',
+                    }}
                   >
-                    <svg className="h-3.5 w-3.5 shrink-0" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/></svg>
-                    LinkedIn
-                  </a>
+                    {date}
+                  </div>
+                  <div>
+                    <h3
+                      style={{
+                        fontSize: 24,
+                        fontWeight: 700,
+                        letterSpacing: '-.015em',
+                        margin: '0 0 10px',
+                        lineHeight: 1.2,
+                      }}
+                    >
+                      {title}
+                    </h3>
+                    <p style={{ fontSize: 16, lineHeight: 1.6, color: 'var(--text-secondary)', margin: 0 }}>{body}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* VALUES */}
+      <section style={{ background: 'var(--accent-mint-wash)', padding: '120px 0' }}>
+        <div className="wrap">
+          <div style={{ textAlign: 'center', marginBottom: 56 }}>
+            <span className="eyebrow">What we believe</span>
+            <h2
+              style={{
+                fontSize: 'var(--fs-h2)',
+                fontWeight: 700,
+                letterSpacing: 'var(--track-tight)',
+                margin: '12px auto 0',
+                lineHeight: 1.05,
+                maxWidth: 760,
+              }}
+            >
+              Four principles we won&apos;t flex on.
+            </h2>
+          </div>
+          <div
+            className="values-grid"
+            style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 22 }}
+          >
+            {VALUES.map(([title, body], i) => (
+              <div
+                key={title}
+                style={{
+                  background: '#fff',
+                  border: '1px solid var(--divider)',
+                  borderRadius: 'var(--r-card)',
+                  padding: 32,
+                  display: 'flex',
+                  gap: 24,
+                }}
+              >
+                <div
+                  style={{
+                    width: 56,
+                    height: 56,
+                    borderRadius: 14,
+                    background: 'var(--surface-ink)',
+                    color: '#fff',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontWeight: 700,
+                    fontSize: 20,
+                    flexShrink: 0,
+                    letterSpacing: '-.02em',
+                    fontFamily: 'JetBrains Mono, monospace',
+                  }}
+                >
+                  0{i + 1}
+                </div>
+                <div>
+                  <h3 style={{ fontSize: 20, fontWeight: 700, letterSpacing: '-.015em', margin: '0 0 10px' }}>{title}</h3>
+                  <p style={{ fontSize: 15, lineHeight: 1.6, color: 'var(--text-secondary)', margin: 0 }}>{body}</p>
                 </div>
               </div>
-            </div>
-            <div className="space-y-3 text-slate-300 leading-relaxed text-sm">
-              <p>
-                A computer science graduate, Paul spent ten years as an IT specialist inside some of the UK&apos;s largest law firms and banks — watching how institutions quietly protect themselves from the people they&apos;re meant to serve, and how rarely ordinary people come out on top.
-              </p>
-              <p>
-                After one too many unjustified bills, impossible cancellations, and charges buried deep in the small print, he built the tool he wished he&apos;d had.
-              </p>
-              <p className="text-slate-400 italic border-l-2 border-mint-400/40 pl-4">
-                &ldquo;The system is designed to make you give up. Paybacker is designed to make sure you don&apos;t have to.&rdquo;
-              </p>
-            </div>
+            ))}
           </div>
-        </section>
-
-        {/* Trust & Transparency */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Trust &amp; Transparency
-          </h2>
-          <div className="bg-navy-900 border border-mint-400/30 rounded-2xl p-5">
-            <p className="text-slate-300 leading-relaxed mb-4">
-              We believe in full transparency about how we operate and earn
-              revenue.
-            </p>
-            <ul className="space-y-3 text-slate-300">
-              <li className="flex items-start gap-2">
-                <span className="text-mint-400 mt-1">&#8226;</span>
-                <span>
-                  <strong className="text-white">
-                    Affiliate relationships disclosed.
-                  </strong>{" "}
-                  When you switch through our links, we may earn a referral
-                  commission from the provider. This never affects the price you
-                  pay.
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-mint-400 mt-1">&#8226;</span>
-                <span>
-                  <strong className="text-white">
-                    Read-only data access.
-                  </strong>{" "}
-                  We can read your emails and bank transactions to find savings.
-                  We can never send emails on your behalf, make payments or move
-                  money.
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-mint-400 mt-1">&#8226;</span>
-                <span>
-                  <strong className="text-white">
-                    Your data is never sold.
-                  </strong>{" "}
-                  We do not sell, share or monetise your personal data. Full
-                  stop.
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-mint-400 mt-1">&#8226;</span>
-                <span>
-                  <strong className="text-white">Regulated under UK law.</strong>{" "}
-                  We comply with UK GDPR, the Data Protection Act 2018 and all
-                  applicable consumer protection regulations.
-                </span>
-              </li>
-            </ul>
-          </div>
-        </section>
-
-        {/* Company Info */}
-        <section>
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Company Information
-          </h2>
-          <p className="text-slate-300 leading-relaxed mb-2">
-            Paybacker LTD is a company registered in England and Wales.<br/>
-            Registered Address: 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ, United Kingdom
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            For any questions, feedback or press enquiries, contact us at{" "}
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="text-mint-400 hover:text-mint-300"
-            >
-              hello@paybacker.co.uk
-            </a>
-            .
-          </p>
-        </section>
-      </main>
-
-      <footer className="container mx-auto px-4 md:px-6 py-8 border-t border-navy-700/50 mt-16">
-        <div className="text-center text-slate-500 text-sm space-y-3">
-          <div className="flex flex-wrap justify-center gap-4 md:gap-6">
-            <Link href="/about" className="hover:text-white transition-all">
-              About
-            </Link>
-            <Link href="/blog" className="hover:text-white transition-all">
-              Blog
-            </Link>
-            <Link
-              href="/privacy-policy"
-              className="hover:text-white transition-all"
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              href="/terms-of-service"
-              className="hover:text-white transition-all"
-            >
-              Terms of Service
-            </Link>
-            <Link href="/pricing" className="hover:text-white transition-all">
-              Pricing
-            </Link>
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="hover:text-white transition-all"
-            >
-              Contact
-            </a>
-          </div>
-          <p>
-            Need help? Email{" "}
-            <a
-              href="mailto:support@paybacker.co.uk"
-              className="text-mint-400 hover:text-mint-300"
-            >
-              support@paybacker.co.uk
-            </a>
-          </p>
-          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
         </div>
-      </footer>
+      </section>
+
+      {/* FINAL CTA */}
+      <section
+        className="final-cta section-ink glow-wrap"
+        style={{ '--glow-opacity': 0.14, padding: '120px 0' } as CSSVarProperties}
+      >
+        <div className="wrap">
+          <h2 style={{ fontSize: 'clamp(48px,6vw,72px)' }}>
+            Ready to find out
+            <br />
+            <span className="mint">what you&apos;re owed?</span>
+          </h2>
+          <p style={{ textAlign: 'center', color: 'var(--text-on-ink-dim)', marginTop: 24, fontSize: 17 }}>
+            Free forever for occasional disputes. Paid plans from £4.99/mo — 0% of your refund, any tier.
+          </p>
+          <div style={{ textAlign: 'center', marginTop: 36 }}>
+            <Link className="btn btn-mint" href={SIGNUP_HREF}>
+              Start your free scan →
+            </Link>
+          </div>
+          <p style={{ textAlign: 'center', marginTop: 20, color: 'var(--text-on-ink-dim)', fontSize: 13 }}>
+            No card. Cancel anytime. Your data stays in the UK.
+          </p>
+        </div>
+      </section>
+
+      <MarkFoot />
     </div>
   );
 }

--- a/src/app/about/styles.css
+++ b/src/app/about/styles.css
@@ -1,0 +1,231 @@
+/*
+ * About marketing page — scoped stylesheet.
+ *
+ * Scoped under `.m-about-root`. Same aliasing pattern as /pricing and
+ * /preview/homepage: pull Tailwind v4 marketing tokens from globals.css
+ * and expose them under the shorter design-export names.
+ *
+ * Design source: design-zip/redesign/batch6.jsx::AboutPage
+ * Token source: design-zip/redesign/homepage.css
+ */
+
+.m-about-root {
+  /* Token aliases → globals.css Tailwind v4 theme */
+  --surface-base: var(--color-surface-base);
+  --surface-elevated: var(--color-surface-elevated);
+  --surface-ink: var(--color-surface-ink);
+  --surface-ink-2: var(--color-surface-ink-2);
+  --surface-soft-mint: var(--color-surface-soft-mint);
+
+  --text-primary: var(--color-ink-primary);
+  --text-secondary: var(--color-ink-secondary);
+  --text-tertiary: var(--color-ink-tertiary);
+  --text-on-ink: var(--color-on-ink);
+  --text-on-ink-dim: var(--color-on-ink-dim);
+
+  --accent-mint: var(--color-accent-mint);
+  --accent-mint-deep: var(--color-accent-mint-deep);
+  --accent-mint-wash: var(--color-accent-mint-wash);
+  --accent-orange: var(--color-accent-orange);
+  --accent-orange-deep: var(--color-accent-orange-deep);
+
+  --divider: var(--color-divider-light);
+  --divider-ink: var(--color-divider-ink);
+
+  --r-card: var(--radius-marketing-card);
+  --r-figure: var(--radius-marketing-figure);
+  --r-btn: var(--radius-marketing-btn);
+  --r-input: var(--radius-marketing-input);
+  --r-pill: var(--radius-marketing-pill);
+
+  --shadow-sm: var(--shadow-marketing-sm);
+  --shadow-md: var(--shadow-marketing-md);
+  --shadow-lg: var(--shadow-marketing-lg);
+  --shadow-xl: var(--shadow-marketing-xl);
+  --shadow-mint: var(--shadow-marketing-mint);
+  --shadow-orange: var(--shadow-marketing-orange);
+
+  --fs-display: var(--text-display);
+  --fs-h1: var(--text-h1-marketing);
+  --fs-h2: var(--text-h2-marketing);
+  --fs-h3: 24px;
+  --fs-body: 17px;
+  --fs-sm: 14px;
+  --fs-xs: 12px;
+  --track-tight: var(--tracking-marketing-tight);
+  --track-eyebrow: var(--tracking-marketing-eyebrow);
+
+  min-height: 100vh;
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+.m-about-root *,
+.m-about-root *::before,
+.m-about-root *::after { box-sizing: border-box; }
+.m-about-root img,
+.m-about-root svg { display: block; max-width: 100%; }
+
+/* Shared -------------------------------------------------------------- */
+.m-about-root .wrap { max-width: 1240px; margin: 0 auto; padding: 0 32px; }
+.m-about-root .eyebrow {
+  font-size: var(--fs-xs);
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+.m-about-root .eyebrow.on-ink { color: var(--accent-mint); }
+
+.m-about-root .btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 22px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+.m-about-root .btn-mint { background: var(--accent-mint); color: #052E1C; box-shadow: var(--shadow-mint); }
+.m-about-root .btn-mint:hover { transform: scale(1.02); box-shadow: 0 24px 55px -18px rgba(52, 211, 153, 0.65); background: #2CC48A; }
+.m-about-root .btn-ghost { background: transparent; color: var(--text-primary); border: 1px solid var(--divider); }
+.m-about-root .btn-ghost:hover { transform: scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+.m-about-root .btn-ghost.on-ink { color: var(--text-on-ink); border-color: var(--divider-ink); background: transparent; }
+.m-about-root .btn-ghost.on-ink:hover { background: rgba(255,255,255,0.04); }
+
+/* Sections ------------------------------------------------------------ */
+.m-about-root section { position: relative; }
+.m-about-root .section-light { background: var(--surface-base); }
+.m-about-root .section-mint { background: var(--accent-mint-wash); }
+.m-about-root .section-ink { background: var(--surface-ink); color: var(--text-on-ink); }
+.m-about-root .section-ink h1,
+.m-about-root .section-ink h2,
+.m-about-root .section-ink h3 { color: var(--text-on-ink); }
+
+/* Ambient glow -------------------------------------------------------- */
+.m-about-root .glow-wrap { position: relative; }
+.m-about-root .glow-wrap::before,
+.m-about-root .glow-wrap::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+  width: 900px; height: 900px;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: var(--glow-opacity, 0.18);
+}
+.m-about-root .glow-wrap::before {
+  top: -250px; right: -200px;
+  background: radial-gradient(circle, var(--accent-orange) 0%, transparent 60%);
+}
+.m-about-root .glow-wrap::after {
+  bottom: -350px; left: -250px;
+  background: radial-gradient(circle, var(--accent-mint) 0%, transparent 60%);
+  opacity: calc(var(--glow-opacity, 0.18) * 0.6);
+}
+.m-about-root .glow-wrap > * { position: relative; z-index: 1; }
+
+/* Nav (identical pattern to /pricing) --------------------------------- */
+.m-about-root .nav-shell {
+  position: sticky; top: 18px; left: 0; right: 0;
+  display: flex; justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+.m-about-root .nav-pill {
+  pointer-events: auto;
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border: 1px solid rgba(11,18,32,0.06);
+  padding: 10px 10px 10px 20px;
+  border-radius: var(--r-pill);
+  box-shadow: var(--shadow-md);
+}
+.m-about-root .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; text-decoration: none; }
+.m-about-root .nav-logo .pay { color: var(--text-primary); }
+.m-about-root .nav-logo .backer { color: var(--accent-mint-deep); }
+.m-about-root .nav-links { display: flex; gap: 6px; margin: 0 14px; }
+.m-about-root .nav-links a {
+  font-size: 14px; font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: var(--r-pill);
+  transition: background 150ms, color 150ms;
+}
+.m-about-root .nav-links a:hover { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-about-root .nav-links a.is-active { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-about-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
+.m-about-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+.m-about-root .nav-start {
+  background: var(--accent-mint); color: #052E1C;
+  padding: 10px 18px; border-radius: var(--r-pill);
+  font-weight: 600; font-size: 14px; text-decoration: none;
+  transition: transform 150ms, box-shadow 150ms;
+}
+.m-about-root .nav-start:hover { transform: scale(1.03); box-shadow: var(--shadow-mint); }
+
+/* Final CTA ---------------------------------------------------------- */
+.m-about-root .final-cta { position: relative; overflow: hidden; }
+.m-about-root .final-cta h2 {
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.02;
+  text-align: center;
+  color: var(--text-on-ink);
+  margin: 0;
+}
+.m-about-root .final-cta .mint { color: var(--accent-mint); }
+
+/* Footer ------------------------------------------------------------- */
+.m-about-root footer { padding: 80px 0 40px; background: var(--surface-ink); color: var(--text-on-ink); border-top: 1px solid var(--divider-ink); }
+.m-about-root .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr; gap: 32px; }
+.m-about-root .footer-brand .logo { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 10px; }
+.m-about-root .footer-brand .logo .backer { color: var(--accent-mint); }
+.m-about-root .footer-brand p { color: var(--text-on-ink-dim); font-size: 14px; max-width: 280px; }
+.m-about-root .footer-col h5 { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-on-ink-dim); font-weight: 600; margin: 0 0 16px; }
+.m-about-root .footer-col a { display: block; color: var(--text-on-ink); text-decoration: none; font-size: 14px; margin-bottom: 10px; opacity: 0.85; }
+.m-about-root .footer-col a:hover { opacity: 1; color: var(--accent-mint); }
+.m-about-root .footer-bottom {
+  border-top: 1px solid var(--divider-ink);
+  margin-top: 56px; padding-top: 24px;
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px;
+  font-size: 12px; color: var(--text-on-ink-dim);
+}
+.m-about-root .footer-socials { display: flex; gap: 10px; }
+.m-about-root .footer-socials a {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--divider-ink);
+  display: grid; place-items: center; font-size: 13px;
+  transition: background 150ms ease;
+  margin-bottom: 0;
+}
+.m-about-root .footer-socials a:hover { background: rgba(255,255,255,0.06); }
+
+/* Responsive --------------------------------------------------------- */
+@media (max-width: 980px) {
+  .m-about-root .footer-grid { grid-template-columns: 1fr 1fr; }
+  .m-about-root .nav-links { display: none; }
+  .m-about-root .stat-grid { grid-template-columns: repeat(2, 1fr) !important; gap: 32px !important; }
+  .m-about-root .timeline-grid { grid-template-columns: 1fr !important; gap: 32px !important; }
+  .m-about-root .timeline-sticky { position: static !important; }
+  .m-about-root .values-grid { grid-template-columns: 1fr !important; }
+  .m-about-root .timeline-row { grid-template-columns: 96px 1fr !important; gap: 16px !important; }
+}
+@media (max-width: 480px) {
+  .m-about-root .wrap { padding: 0 20px; }
+  .m-about-root .stat-grid { grid-template-columns: 1fr !important; }
+  .m-about-root .timeline-row { grid-template-columns: 1fr !important; gap: 8px !important; }
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,657 +1,536 @@
-'use client';
-
-import { useState, useEffect } from 'react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { createClient } from '@/lib/supabase/client';
-import { PRICE_IDS } from '@/lib/stripe';
-import Image from 'next/image';
-import { Check, Sparkles, TrendingUp, Zap, Users, Gift, MessageCircle, Bot, X } from 'lucide-react';
-import { WAITLIST_MODE } from '@/lib/config';
-import PublicNavbar from '@/components/PublicNavbar';
-import { capture } from '@/lib/posthog';
-import { motion } from 'framer-motion';
+import type { CSSProperties } from 'react';
+import './styles.css';
 
-const plans = [
-  {
-    name: 'Free',
-    price: { monthly: 0, yearly: 0 },
-    description: 'See what Paybacker can do for you',
-    features: [
-      'Pocket Agent — AI chat on Telegram',
-      '3 AI letters per month (complaints, HMRC, flights, more)',
-      'Upload and scan bills with AI',
-      'Unlimited subscription tracking',
-      'One-time bank scan',
-      'One-time email scan (any provider)',
-      'Basic spending overview',
-      'AI chatbot',
-      'Browse 53+ deals',
-      'Money Recovery Score',
-    ],
-    cta: 'Get started free',
-    waitlistCta: 'Join Waitlist - Free',
-    highlighted: false,
-    trial: false,
-    planKey: 'free' as const,
+/**
+ * /pricing — marketing redesign.
+ *
+ * Design source: design-zip/redesign/batch6.jsx::PricingRecap
+ * Tokens: aliased onto globals.css Tailwind v4 theme in styles.css
+ *
+ * Scoped under `.m-pricing-root` so styles can't leak onto other routes.
+ * Pricing copy pinned to redesign/CONTENT_SOURCES_OF_TRUTH.md — three
+ * tiers only (Free £0 / Essential £4.99 / Pro £9.99) with 0% success fee.
+ */
+
+export const metadata: Metadata = {
+  title: 'Pricing — Free forever, paid from £4.99/mo. 0% success fee, ever.',
+  description:
+    'Three tiers: Free forever for occasional disputes, Essential £4.99/mo for unlimited letters and bank sync, Pro £9.99/mo for the full sweep. No tier ever takes a cut of your refund.',
+  alternates: { canonical: 'https://paybacker.co.uk/pricing' },
+  openGraph: {
+    title: 'Paybacker pricing — Free forever, paid from £4.99/mo',
+    description:
+      'Three tiers. 0% success fee, ever. £4.99/mo for unlimited UK dispute letters and Yapily bank sync (2 accounts). £9.99/mo for unlimited.',
+    url: 'https://paybacker.co.uk/pricing',
+    siteName: 'Paybacker',
+    type: 'website',
   },
-  {
-    name: 'Essential',
-    price: { monthly: 4.99, yearly: 44.99 },
-    description: 'Automated money management',
-    features: [
-      'Pocket Agent — AI chat on Telegram',
-      'Unlimited AI letters (all 11 types)',
-      '1 bank account with daily auto-sync',
-      'Monthly email re-scans',
-      'Full Money Hub dashboard',
-      'AI cancellation emails with legal context',
-      'Smart bill comparison with deal alerts',
-      'Price increase detection alerts',
-      'Energy tariff monitoring (daily)',
-      'Renewal reminders (30, 14, 7 days)',
-      'Contract tracking with end dates',
-      'Budget planner with spending alerts',
-      'Savings challenges (12 goals)',
-      'Weekly Money Digest email',
-      'Listen to letters (AI voice)',
-    ],
-    cta: 'Subscribe to Essential',
-    waitlistCta: 'Join Waitlist - Essential',
-    highlighted: false,
-    trial: false,
-    planKey: 'essential' as const,
-    priceIds: {
-      monthly: PRICE_IDS.essential_monthly,
-      yearly:  PRICE_IDS.essential_yearly,
-    },
-  },
-  {
-    name: 'Pro',
-    price: { monthly: 9.99, yearly: 94.99 },
-    description: 'Complete financial intelligence',
-    features: [
-      'Pocket Agent — AI chat on Telegram',
-      'Everything in Essential, plus:',
-      'Unlimited bank accounts',
-      'Unlimited email scans',
-      'Full transaction-level spending analysis',
-      'AI financial chatbot (18 tools)',
-      'Paybacker Assistant — ask an AI about your money (MCP)',
-      'CSV & Excel export of transactions',
-      'Savings goals with progress tracking',
-      'Annual financial report (PDF)',
-      'On-demand financial reports',
-      'Priority support',
-    ],
-    cta: 'Subscribe to Pro',
-    waitlistCta: 'Join Waitlist - Pro',
-    highlighted: true,
-    trial: true,
-    planKey: 'pro' as const,
-    priceIds: {
-      monthly: PRICE_IDS.pro_monthly,
-      yearly:  PRICE_IDS.pro_yearly,
-    },
-  },
+};
+
+type CSSVarProperties = CSSProperties & Record<`--${string}`, string | number>;
+
+const SIGNUP_HREF = '/auth/signup';
+const SIGNIN_HREF = '/auth/login';
+
+function MarkNav({ active }: { active: 'About' | 'Pricing' | 'Blog' | 'Careers' }) {
+  const links: ReadonlyArray<readonly [typeof active, string]> = [
+    ['About', '/about'],
+    ['Pricing', '/pricing'],
+    ['Blog', '/blog'],
+    ['Careers', '/careers'],
+  ];
+  return (
+    <div className="nav-shell">
+      <nav className="nav-pill" aria-label="Primary">
+        <Link className="nav-logo" href="/">
+          <span className="pay">Pay</span>
+          <span className="backer">backer</span>
+        </Link>
+        <div className="nav-links">
+          {links.map(([label, href]) => (
+            <Link
+              key={label}
+              href={href}
+              className={active === label ? 'is-active' : undefined}
+              aria-current={active === label ? 'page' : undefined}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+        <div className="nav-cta-row">
+          <Link className="nav-signin" href={SIGNIN_HREF}>Sign in</Link>
+          <Link className="nav-start" href={SIGNUP_HREF}>Start Free</Link>
+        </div>
+      </nav>
+    </div>
+  );
+}
+
+function MarkFoot() {
+  return (
+    <footer>
+      <div className="wrap">
+        <div className="footer-grid">
+          <div className="footer-brand">
+            <div className="logo">
+              <span>Pay</span>
+              <span className="backer">backer</span>
+            </div>
+            <p>The UK&apos;s AI money-back engine. We find what you&apos;re losing and fight to get it back.</p>
+            <p style={{ marginTop: 14, fontSize: 11, color: 'var(--text-on-ink-dim)', maxWidth: 320 }}>
+              AI-generated letters are for guidance only and do not constitute legal advice. For complex disputes, always consult a qualified solicitor.
+            </p>
+          </div>
+          <div className="footer-col">
+            <h5>Product</h5>
+            <Link href="/dashboard/complaints">Disputes Centre</Link>
+            <Link href="/dashboard/money-hub">Money Hub</Link>
+            <Link href="/dashboard">Pocket Agent</Link>
+            <Link href="/deals">Deals</Link>
+            <Link href="/pricing">Pricing</Link>
+          </div>
+          <div className="footer-col">
+            <h5>Company</h5>
+            <Link href="/about">About</Link>
+            <Link href="/blog">Blog</Link>
+            <Link href="/careers">Careers</Link>
+            <a href="mailto:hello@paybacker.co.uk">Contact</a>
+          </div>
+          <div className="footer-col">
+            <h5>Legal</h5>
+            <Link href="/legal/privacy">Privacy</Link>
+            <Link href="/legal/terms">Terms</Link>
+            <Link href="/cookie-policy">Cookies</Link>
+          </div>
+          <div className="footer-col">
+            <h5>Connect</h5>
+            <div className="footer-socials" style={{ marginBottom: 14 }}>
+              <a href="https://x.com/PaybackerUK" aria-label="X" target="_blank" rel="noopener noreferrer">𝕏</a>
+              <a href="https://www.instagram.com/paybacker.co.uk/" aria-label="Instagram" target="_blank" rel="noopener noreferrer">◎</a>
+              <a href="https://www.facebook.com/profile.php?id=61579563073310" aria-label="Facebook" target="_blank" rel="noopener noreferrer">f</a>
+              <a href="https://www.tiktok.com/@paybacker.co.uk" aria-label="TikTok" target="_blank" rel="noopener noreferrer">♪</a>
+              <a href="https://www.linkedin.com/company/112575954/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">in</a>
+            </div>
+            <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>
+          </div>
+        </div>
+        <div className="footer-bottom">
+          <div>© 2026 Paybacker LTD · Company no. 15289174 · Registered in England &amp; Wales</div>
+          <div>paybacker.co.uk · Made in London 🇬🇧</div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+// "On a typical £216 refund" math table — figures pre-computed from the
+// percentage ranges so we don't claim anything stronger than the
+// 15–30% band that's already on the homepage.
+const MATH_ROWS: ReadonlyArray<{
+  label: string;
+  keep: string;
+  note: string;
+  highlight: boolean;
+}> = [
+  { label: 'Competitor A (30%)', keep: '£151.20', note: 'lost £64.80', highlight: false },
+  { label: 'Competitor B (25%)', keep: '£162.00', note: 'lost £54.00', highlight: false },
+  { label: 'Competitor C (15–20%)', keep: '£172–183', note: 'lost £32–43', highlight: false },
+  { label: 'Paybacker (0%)', keep: '£216.00', note: 'you keep £216', highlight: true },
+];
+
+const COMPARE_ROWS: ReadonlyArray<readonly [string, string, string, string]> = [
+  ['AI dispute letters', '3 / month', 'Unlimited', 'Unlimited'],
+  ['Bank sync (read-only, FCA via Yapily)', '—', '2 accounts', 'Unlimited'],
+  ['Email inbox scan', '—', '•', '•'],
+  ['Subscription tracker', 'Manual only', '•', '•'],
+  ['Public deals marketplace', '•', '•', '•'],
+  ['Pocket Agent in Telegram', '—', '•', '•'],
+  ['Deal alerts on bill changes', '—', '—', '•'],
+  ['Priority human review', '—', '—', '•'],
+  ['Success fee on refunds', '0%', '0%', '0%'],
+];
+
+const FAQS: ReadonlyArray<readonly [string, string]> = [
+  [
+    'What does "Founding Member · locked-in forever" actually mean?',
+    'If you join on Essential (£4.99) or Pro (£9.99), that price is guaranteed for as long as you stay subscribed — even after we raise prices for new customers. Cancel and resubscribe later, you go to the then-current price.',
+  ],
+  [
+    'How do you make money if you don\u2019t take a cut of refunds?',
+    'Flat subscription revenue. We\u2019re deliberately small and deliberately cheap — we\u2019d rather grow slowly and keep the incentives clean than take 25% of your refund like everyone else.',
+  ],
+  [
+    'Is my bank data safe?',
+    'We use Yapily (FCA-authorised) for read-only bank sync. We never see your password. We never initiate payments. Full audit log in Settings \u2192 Connected accounts. ICO registered, UK-based, GDPR compliant.',
+  ],
+  [
+    'Can I cancel anytime?',
+    'Yes — one click, no "are you sure" theatre, no 30-day notice. You keep access until the end of your current month.',
+  ],
+  [
+    'What if a dispute letter doesn\u2019t get me a refund?',
+    'Most letters do succeed. When they don\u2019t, we provide next-step guidance (Ombudsman, CMA, small-claims) and all the evidence logged. You never pay per-dispute.',
+  ],
 ];
 
 export default function PricingPage() {
-  const [billingCycle, setBillingCycle] = useState<'monthly' | 'yearly'>('monthly');
-  const [loading, setLoading] = useState<string | null>(null);
-  const [waitlistEmail, setWaitlistEmail] = useState('');
-  const [waitlistName, setWaitlistName] = useState('');
-  const [waitlistPlan, setWaitlistPlan] = useState<string | null>(null);
-  const [waitlistSuccess, setWaitlistSuccess] = useState(false);
-  const [waitlistError, setWaitlistError] = useState('');
-  const [foundingSpots, setFoundingSpots] = useState<number | null>(null);
-  const router = useRouter();
-  const supabase = createClient();
-
-  useEffect(() => {
-    fetch('/api/founding-member')
-      .then(r => r.json())
-      .then(d => { if (d.active) setFoundingSpots(d.remaining); })
-      .catch(() => {});
-  }, []);
-
-  const handleSubscribe = async (priceId: string | undefined, planName: string) => {
-    if (!priceId) {
-      router.push('/auth/signup');
-      return;
-    }
-
-    // Verify user is logged in before calling checkout
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      router.push(`/auth/login?redirect=/pricing`);
-      return;
-    }
-
-    setLoading(planName);
-
-    try {
-      capture('checkout_started', { priceId, billingCycle, planName });
-      console.log('Stripe checkout: sending request', { priceId, billingCycle });
-      const res = await fetch('/api/stripe/checkout', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ priceId, billingCycle }),
-      });
-
-      console.log('Stripe checkout: response status', res.status);
-      const text = await res.text();
-      console.log('Stripe checkout: response body', text);
-
-      let data: any;
-      try {
-        data = JSON.parse(text);
-      } catch {
-        throw new Error(`Server returned invalid response (status ${res.status}): ${text.substring(0, 200)}`);
-      }
-
-      if (data.url) {
-        // Store transaction data before Stripe redirect (for Awin tracking on return)
-        // Note: orderRef will be overridden by subscription ID from sync response
-        const tier = planName.toLowerCase();
-        sessionStorage.setItem('awin_checkout', JSON.stringify({ tier }));
-        window.location.href = data.url;
-      } else if (data.alreadySubscribed) {
-        alert('You are already on this plan.');
-        setLoading(null);
-      } else {
-        throw new Error(data.error || `No checkout URL returned (status ${res.status})`);
-      }
-    } catch (error: any) {
-      console.error('Subscription error:', error);
-      alert(error.message || 'Failed to start subscription. Please try again.');
-      setLoading(null);
-    }
-  };
-
-  const handleWaitlistPlan = (planKey: string) => {
-    setWaitlistPlan(planKey);
-    setWaitlistSuccess(false);
-    setWaitlistError('');
-  };
-
-  const handleWaitlistSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading('waitlist');
-    setWaitlistError('');
-
-    try {
-      const res = await fetch('/api/waitlist', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: waitlistName,
-          email: waitlistEmail,
-          plan_preference: waitlistPlan,
-        }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to join waitlist');
-      }
-
-      setWaitlistSuccess(true);
-      setWaitlistEmail('');
-      setWaitlistName('');
-    } catch (err: any) {
-      setWaitlistError(err.message || 'Something went wrong. Please try again.');
-    } finally {
-      setLoading(null);
-    }
-  };
-
   return (
-    <div className="min-h-screen bg-navy-950">
-      <PublicNavbar />
+    <div className="m-pricing-root">
+      <MarkNav active="Pricing" />
 
-      {/* Spacer for fixed navbar */}
-      <div className="h-16" />
+      {/* HERO */}
+      <section
+        className="section-light glow-wrap"
+        style={{ '--glow-opacity': 0.18, paddingTop: 140, paddingBottom: 60 } as CSSVarProperties}
+      >
+        <div className="wrap" style={{ textAlign: 'center' }}>
+          <span className="eyebrow" style={{ color: 'var(--accent-orange-deep)' }}>
+            ● Three tiers — Founding rates locked in forever
+          </span>
+          <h1
+            style={{
+              fontSize: 'var(--fs-display)',
+              lineHeight: 0.96,
+              fontWeight: 700,
+              letterSpacing: 'var(--track-tight)',
+              margin: '18px auto 24px',
+              maxWidth: 1040,
+            }}
+          >
+            <span style={{ display: 'block', color: 'var(--text-primary)' }}>Free forever.</span>
+            <span style={{ display: 'block', color: 'var(--accent-mint-deep)' }}>Paid from £4.99/mo.</span>
+            <span style={{ display: 'block', color: 'var(--accent-orange-deep)' }}>We never take a cut.</span>
+          </h1>
+          <p
+            style={{
+              fontSize: 19,
+              color: 'var(--text-secondary)',
+              maxWidth: 700,
+              lineHeight: 1.5,
+              margin: '0 auto 32px',
+            }}
+          >
+            Start free for occasional disputes. Pay £4.99/mo when you want unlimited letters and bank sync. £9.99/mo for the full sweep across every account. No tier ever charges a success fee on your refund.
+          </p>
+        </div>
+      </section>
 
-      {/* Waitlist Banner */}
-      {WAITLIST_MODE && (
-        <div className="bg-mint-400/5 border-b border-mint-400/20">
-          <div className="container mx-auto px-4 md:px-6 py-3 text-center">
-            <p className="text-mint-400 text-sm font-medium">
-              Launching soon - join the waitlist for early access and 30% off your first month
-            </p>
+      {/* PRICING GRID */}
+      <section className="pricing-section" style={{ paddingTop: 40 }}>
+        <div className="wrap">
+          <div className="pricing-grid">
+            <div className="price-card">
+              <div className="tier">Free</div>
+              <div className="price">
+                £0<span className="per">/forever</span>
+              </div>
+              <div className="founding" style={{ visibility: 'hidden' }}>—</div>
+              <ul>
+                <li>3 AI dispute letters / month</li>
+                <li>Manual subscription tracker</li>
+                <li>Public deals marketplace</li>
+              </ul>
+              <Link className="btn btn-ghost cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
+                Start free →
+              </Link>
+            </div>
+
+            <div className="price-card featured">
+              <span className="ribbon">Most popular</span>
+              <div className="tier">Essential</div>
+              <div className="price">
+                £4.99<span className="per">/month</span>
+              </div>
+              <div className="founding">Founding member · locked-in forever</div>
+              <ul>
+                <li>Unlimited AI dispute letters</li>
+                <li>Bank sync — 2 accounts</li>
+                <li>Email inbox scan</li>
+                <li>Pocket Agent in Telegram</li>
+              </ul>
+              <Link className="btn btn-mint cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
+                Start 14-day trial →
+              </Link>
+            </div>
+
+            <div className="price-card">
+              <div className="tier">Pro</div>
+              <div className="price">
+                £9.99<span className="per">/month</span>
+              </div>
+              <div className="founding">Founding member · locked-in forever</div>
+              <ul>
+                <li>Everything in Essential</li>
+                <li>Unlimited bank &amp; email connections</li>
+                <li>Deal alerts on bill changes</li>
+                <li>Priority human review on complex disputes</li>
+              </ul>
+              <Link className="btn btn-ghost cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
+                Go Pro →
+              </Link>
+            </div>
+          </div>
+          <p className="compare-link">
+            <a href="#compare">See the full feature comparison ↓</a>
+          </p>
+        </div>
+      </section>
+
+      {/* THE MATH */}
+      <section style={{ padding: '120px 0', background: 'var(--accent-mint-wash)' }}>
+        <div className="wrap">
+          <div
+            className="math-grid"
+            style={{ display: 'grid', gridTemplateColumns: '1fr 1.2fr', gap: 56, alignItems: 'center' }}
+          >
+            <div>
+              <span className="eyebrow">The math</span>
+              <h2
+                style={{
+                  fontSize: 'var(--fs-h2)',
+                  fontWeight: 700,
+                  letterSpacing: 'var(--track-tight)',
+                  margin: '12px 0 16px',
+                  lineHeight: 1.05,
+                }}
+              >
+                Three tiers. Zero success fees.
+              </h2>
+              <p style={{ fontSize: 16.5, lineHeight: 1.6, color: 'var(--text-secondary)', margin: 0 }}>
+                Whichever tier you pick, we never take a cut of your refund. Competitors charge 15–30% on a successful dispute — on a typical £216 refund, that&apos;s up to £65 out of your pocket. Our revenue comes from the flat subscription, so the incentive stays clean: the more we help you, the longer you stay.
+              </p>
+            </div>
+            <div
+              style={{
+                background: '#fff',
+                borderRadius: 'var(--r-card)',
+                border: '1px solid var(--divider)',
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  padding: '16px 24px',
+                  borderBottom: '1px solid var(--divider)',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  letterSpacing: 'var(--track-eyebrow)',
+                  textTransform: 'uppercase',
+                  color: 'var(--text-tertiary)',
+                }}
+              >
+                On a typical £216 refund
+              </div>
+              {MATH_ROWS.map((row) => (
+                <div
+                  key={row.label}
+                  style={{
+                    padding: '16px 24px',
+                    borderBottom: '1px solid var(--divider)',
+                    display: 'grid',
+                    gridTemplateColumns: '1.4fr 1fr 1.3fr',
+                    gap: 14,
+                    alignItems: 'center',
+                    background: row.highlight ? 'var(--accent-mint-wash)' : '#fff',
+                  }}
+                >
+                  <div style={{ fontSize: 14, fontWeight: row.highlight ? 700 : 500 }}>{row.label}</div>
+                  <div
+                    style={{
+                      fontSize: 16,
+                      fontWeight: 700,
+                      letterSpacing: '-.01em',
+                      color: row.highlight ? 'var(--accent-mint-deep)' : 'var(--text-primary)',
+                    }}
+                  >
+                    {row.keep}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 12.5,
+                      color: row.highlight ? 'var(--accent-mint-deep)' : 'var(--text-tertiary)',
+                      fontWeight: row.highlight ? 700 : 400,
+                    }}
+                  >
+                    {row.note}
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
-      )}
+      </section>
 
-      {/* Hero */}
-      <div className="container mx-auto px-4 md:px-6 py-8 md:py-12 text-center">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          <div className="inline-flex items-center gap-2 rounded-full bg-mint-400/10 px-4 py-2 text-sm text-mint-400 border border-mint-400/20 mb-8">
-            <TrendingUp className="h-4 w-4" />
-            AI-powered consumer rights for UK households
+      {/* COMPARISON TABLE */}
+      <section id="compare" style={{ padding: '120px 0' }}>
+        <div className="wrap">
+          <div style={{ textAlign: 'center', marginBottom: 48 }}>
+            <span className="eyebrow">Full comparison</span>
+            <h2
+              style={{
+                fontSize: 'var(--fs-h2)',
+                fontWeight: 700,
+                letterSpacing: 'var(--track-tight)',
+                margin: '12px 0 0',
+                lineHeight: 1.05,
+              }}
+            >
+              What&apos;s actually included.
+            </h2>
           </div>
-
-          <h1 className="font-[family-name:var(--font-heading)] text-3xl md:text-5xl lg:text-6xl font-extrabold tracking-tight text-white mb-6 leading-tight">
-            Simple, transparent pricing
-          </h1>
-
-          {/* Founding Member Banner */}
-          {foundingSpots !== null && foundingSpots > 0 ? (
-            <div className="bg-mint-400/10 border border-mint-400/30 rounded-2xl px-6 py-4 max-w-2xl mx-auto mb-8">
-              <div className="flex items-center justify-center gap-2 mb-1">
-                <Gift className="h-5 w-5 text-mint-400" />
-                <p className="text-mint-400 font-bold text-lg">Try Pro FREE for 14 days</p>
-              </div>
-              <p className="text-slate-400 text-sm">Full Pro access for 14 days. No card required. Cancel anytime.</p>
-            </div>
-          ) : (
-            <div className="bg-brand-400/10 border border-brand-400/30 rounded-2xl px-6 py-4 max-w-2xl mx-auto mb-8">
-              <p className="text-brand-400 font-semibold text-lg">Founding member pricing</p>
-              <p className="text-slate-400 text-sm mt-1">Price increases after our first 1,000 members</p>
-            </div>
-          )}
-
-          <p className="text-xl text-slate-300 mb-8 max-w-2xl mx-auto">
-            Choose the plan that fits your needs. All plans include our AI agents working 24/7 to get your money back.
-          </p>
-        </motion.div>
-
-        {/* Billing Toggle */}
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.15 }}
-          className="flex items-center justify-center gap-4 mb-8"
-        >
-          <span className={`text-sm font-medium ${billingCycle === 'monthly' ? 'text-white' : 'text-slate-500'}`}>
-            Monthly
-          </span>
-          <button
-            onClick={() => setBillingCycle(billingCycle === 'monthly' ? 'yearly' : 'monthly')}
-            className="relative w-14 h-7 bg-navy-800 border border-navy-700/50 rounded-full transition-all"
+          <div
+            style={{
+              background: '#fff',
+              border: '1px solid var(--divider)',
+              borderRadius: 'var(--r-card)',
+              overflow: 'hidden',
+            }}
           >
             <div
-              className={`absolute top-1 left-1 w-5 h-5 bg-mint-400 rounded-full transition-transform ${
-                billingCycle === 'yearly' ? 'translate-x-7' : ''
-              }`}
-            />
-          </button>
-          <span className={`text-sm font-medium ${billingCycle === 'yearly' ? 'text-white' : 'text-slate-500'}`}>
-            Yearly
-            <span className="ml-2 text-mint-400 text-xs">(Save 17%)</span>
-          </span>
-        </motion.div>
-
-        {/* Pricing Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto items-start">
-          {plans.map((plan, index) => {
-            const price = billingCycle === 'monthly' ? plan.price.monthly : plan.price.yearly;
-            const priceId = plan.priceIds?.[billingCycle];
-
-            return (
-              <motion.div
-                key={plan.name}
-                initial={{ opacity: 0, y: 30 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5, delay: 0.2 + index * 0.1 }}
-                className={`relative bg-navy-900 border rounded-2xl p-8 transition-all ${
-                  plan.highlighted
-                    ? 'border-mint-400/50 ring-2 ring-mint-400/50 scale-100 md:scale-105'
-                    : 'border-navy-700/50'
-                }`}
+              className="compare-table-head"
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '2fr 1fr 1fr 1fr',
+                background: 'var(--surface-base)',
+                padding: '18px 28px',
+                fontSize: 12,
+                fontWeight: 600,
+                letterSpacing: 'var(--track-eyebrow)',
+                textTransform: 'uppercase',
+                color: 'var(--text-tertiary)',
+              }}
+            >
+              <div>Feature</div>
+              <div style={{ textAlign: 'center' }}>Free</div>
+              <div style={{ textAlign: 'center', color: 'var(--accent-mint-deep)' }}>Essential · £4.99</div>
+              <div style={{ textAlign: 'center' }}>Pro · £9.99</div>
+            </div>
+            {COMPARE_ROWS.map((row) => (
+              <div
+                key={row[0]}
+                className="compare-table-row"
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '2fr 1fr 1fr 1fr',
+                  padding: '18px 28px',
+                  borderTop: '1px solid var(--divider)',
+                  fontSize: 14.5,
+                  alignItems: 'center',
+                }}
               >
-                {plan.highlighted && (
-                  <div className="absolute -top-4 left-1/2 -translate-x-1/2 bg-mint-400 text-navy-950 px-4 py-1 rounded-full text-sm font-semibold">
-                    Recommended
-                  </div>
-                )}
-
-                {plan.planKey && (
-                  <div className="mb-4 flex items-center gap-2 bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-2.5">
-                    <Bot className="h-5 w-5 text-amber-400 flex-shrink-0" />
-                    <span className="text-amber-400 text-sm font-semibold">Includes Pocket Agent</span>
-                    <Sparkles className="h-4 w-4 text-amber-400 flex-shrink-0" />
-                  </div>
-                )}
-
-                {plan.planKey !== 'free' && (
-                  <div className="mb-4">
-                    <span className="inline-block bg-mint-400/10 text-mint-400 text-xs font-semibold px-3 py-1 rounded-full border border-mint-400/20">
-                      Founding Member Pricing
-                    </span>
-                  </div>
-                )}
-
-                <div className="mb-6">
-                  <div className="flex items-center gap-2 mb-2">
-                    <h3 className="font-[family-name:var(--font-heading)] text-2xl font-bold text-white">{plan.name}</h3>
-                    {plan.trial && !WAITLIST_MODE && (
-                      <span className="bg-mint-400/10 text-mint-400 text-xs font-medium px-2 py-0.5 rounded-full border border-mint-400/20">
-                        14-day free trial
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-slate-300 text-sm mb-4">{plan.description}</p>
-
-                  <div className="flex items-baseline gap-1 mb-1">
-                    <span className="text-3xl md:text-5xl font-bold text-white">&pound;{price}</span>
-                    {price > 0 && (
-                      <span className="text-slate-400">
-                        /{billingCycle === 'monthly' ? 'mo' : 'yr'}
-                      </span>
-                    )}
-                  </div>
-
-                  {billingCycle === 'yearly' && price > 0 && (
-                    <p className="text-sm text-slate-400">
-                      &pound;{(price / 12).toFixed(2)}/month billed annually
-                      <span className="ml-2 inline-block bg-mint-400/10 text-mint-400 text-xs font-semibold px-2 py-0.5 rounded-full border border-mint-400/20">Best Value</span>
-                    </p>
-                  )}
-                </div>
-
-                {WAITLIST_MODE ? (
-                  <button
-                    onClick={() => handleWaitlistPlan(plan.planKey)}
-                    className={`w-full py-3 rounded-xl font-semibold transition-all ${
-                      plan.highlighted
-                        ? 'bg-mint-400 hover:bg-mint-500 text-navy-950'
-                        : 'bg-navy-800 hover:bg-navy-700 text-white border border-navy-700/50'
-                    }`}
+                <div style={{ color: 'var(--text-primary)' }}>{row[0]}</div>
+                {row.slice(1).map((value, j) => (
+                  <div
+                    key={j}
+                    style={{
+                      textAlign: 'center',
+                      color:
+                        value === '•'
+                          ? 'var(--accent-mint-deep)'
+                          : value === '—'
+                          ? '#D1D5DB'
+                          : 'var(--text-secondary)',
+                      fontWeight: value === '•' ? 700 : 500,
+                      fontSize: value === '•' ? 18 : 14,
+                    }}
                   >
-                    {plan.waitlistCta}
-                  </button>
-                ) : (
-                  <button
-                    onClick={() => handleSubscribe(priceId, plan.name)}
-                    disabled={loading === plan.name}
-                    className={`w-full py-3 rounded-xl font-semibold transition-all ${
-                      plan.highlighted
-                        ? 'bg-mint-400 hover:bg-mint-500 text-navy-950'
-                        : 'bg-navy-800 hover:bg-navy-700 text-white border border-navy-700/50'
-                    } disabled:opacity-50 disabled:cursor-not-allowed`}
-                  >
-                    {loading === plan.name ? 'Loading...' : plan.cta}
-                  </button>
-                )}
-                {plan.trial && !WAITLIST_MODE && (
-                  <p className="text-xs text-slate-500 text-center mt-2 mb-4">
-                    No card required during trial. Cancel anytime.
-                  </p>
-                )}
-                {(!plan.trial || WAITLIST_MODE) && <div className="mb-6" />}
-
-                <ul className="space-y-3">
-                  {plan.features.map((feature, i) => {
-                    const isPocketAgent = feature.startsWith('Pocket Agent');
-                    return (
-                      <li key={i} className={`flex items-start gap-3 ${isPocketAgent ? 'bg-amber-500/10 border border-amber-500/20 rounded-lg px-3 py-2 -mx-1' : ''}`}>
-                        {isPocketAgent ? (
-                          <MessageCircle className="h-5 w-5 text-amber-400 flex-shrink-0 mt-0.5" />
-                        ) : (
-                          <Check className="h-5 w-5 text-mint-400 flex-shrink-0 mt-0.5" />
-                        )}
-                        <span className={`text-sm ${isPocketAgent ? 'text-amber-300 font-semibold' : 'text-slate-300'}`}>{feature}</span>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </motion.div>
-            );
-          })}
-        </div>
-
-        {/* Waitlist modal/form when a plan is selected */}
-        {WAITLIST_MODE && waitlistPlan && (
-          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-6">
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-8 max-w-md w-full shadow-2xl">
-              {waitlistSuccess ? (
-                <div className="text-center py-4">
-                  <div className="bg-mint-400/10 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                    <Check className="h-8 w-8 text-mint-400" />
+                    {value}
                   </div>
-                  <h3 className="font-[family-name:var(--font-heading)] text-2xl font-bold text-white mb-2">You&apos;re on the list!</h3>
-                  <p className="text-slate-400 mb-2">We&apos;ll be in touch when we launch.</p>
-                  <p className="text-mint-400 text-sm font-medium mb-6">You&apos;ll get 30% off your first month as an early supporter.</p>
-                  <button
-                    onClick={() => setWaitlistPlan(null)}
-                    className="text-slate-400 hover:text-white text-sm"
-                  >
-                    Close
-                  </button>
-                </div>
-              ) : (
-                <form onSubmit={handleWaitlistSubmit} className="space-y-4">
-                  <div className="text-center mb-2">
-                    <h3 className="font-[family-name:var(--font-heading)] text-xl font-bold text-white mb-1">
-                      Join the waitlist - {waitlistPlan.charAt(0).toUpperCase() + waitlistPlan.slice(1)} plan
-                    </h3>
-                    <p className="text-slate-400 text-sm">Get early access and 30% off your first month.</p>
-                  </div>
-
-                  <div>
-                    <input
-                      type="text"
-                      required
-                      value={waitlistName}
-                      onChange={(e) => setWaitlistName(e.target.value)}
-                      className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                      placeholder="Your name"
-                    />
-                  </div>
-
-                  <div>
-                    <input
-                      type="email"
-                      required
-                      value={waitlistEmail}
-                      onChange={(e) => setWaitlistEmail(e.target.value)}
-                      className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                      placeholder="you@example.com"
-                    />
-                  </div>
-
-                  {waitlistError && (
-                    <p className="text-red-400 text-sm">{waitlistError}</p>
-                  )}
-
-                  <button
-                    type="submit"
-                    disabled={loading === 'waitlist'}
-                    className="w-full bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {loading === 'waitlist' ? 'Joining...' : 'Join Waitlist'}
-                  </button>
-
-                  <button
-                    type="button"
-                    onClick={() => setWaitlistPlan(null)}
-                    className="w-full text-slate-400 hover:text-white text-sm py-2"
-                  >
-                    Cancel
-                  </button>
-                </form>
-              )}
-            </div>
+                ))}
+              </div>
+            ))}
           </div>
-        )}
+        </div>
+      </section>
 
-        {/* Plan Comparison Table */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.5 }}
-          className="mt-16 max-w-4xl mx-auto"
-        >
-          <h2 className="font-[family-name:var(--font-heading)] text-2xl md:text-3xl font-bold text-white text-center mb-8">
-            Compare plans
+      {/* FAQ */}
+      <section style={{ padding: '0 0 120px' }}>
+        <div className="wrap" style={{ maxWidth: 820 }}>
+          <span className="eyebrow">Common questions</span>
+          <h2
+            style={{
+              fontSize: 'var(--fs-h2)',
+              fontWeight: 700,
+              letterSpacing: 'var(--track-tight)',
+              margin: '12px 0 32px',
+              lineHeight: 1.05,
+            }}
+          >
+            Things people ask first.
           </h2>
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-navy-700/50">
-                  <th className="text-left text-slate-400 font-medium px-6 py-4">Feature</th>
-                  <th className="text-center text-slate-400 font-medium px-4 py-4">Free</th>
-                  <th className="text-center text-slate-400 font-medium px-4 py-4">Essential</th>
-                  <th className="text-center text-white font-semibold px-4 py-4">Pro</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-navy-700/30">
-                <tr className="bg-amber-500/5">
-                  <td className="px-6 py-4 text-white font-medium flex items-center gap-2">
-                    <MessageCircle className="h-4 w-4 text-amber-400" />
-                    Pocket Agent
-                    <span className="bg-amber-500/20 text-amber-400 text-[10px] font-bold uppercase px-1.5 py-0.5 rounded">NEW</span>
-                  </td>
-                  <td className="text-center px-4 py-4"><Check className="h-4 w-4 text-mint-400 mx-auto" /></td>
-                  <td className="text-center px-4 py-4"><Check className="h-4 w-4 text-mint-400 mx-auto" /></td>
-                  <td className="text-center px-4 py-4"><Check className="h-4 w-4 text-mint-400 mx-auto" /></td>
-                </tr>
-                <tr>
-                  <td className="px-6 py-4 text-slate-300">AI complaint letters</td>
-                  <td className="text-center px-4 py-4 text-slate-400">3/month</td>
-                  <td className="text-center px-4 py-4 text-slate-300">Unlimited</td>
-                  <td className="text-center px-4 py-4 text-white font-medium">Unlimited</td>
-                </tr>
-                <tr>
-                  <td className="px-6 py-4 text-slate-300">Bank accounts</td>
-                  <td className="text-center px-4 py-4 text-slate-400">One-time scan</td>
-                  <td className="text-center px-4 py-4 text-slate-300">1 (daily sync)</td>
-                  <td className="text-center px-4 py-4 text-white font-medium">Unlimited</td>
-                </tr>
-                <tr>
-                  <td className="px-6 py-4 text-slate-300">Email inbox scans</td>
-                  <td className="text-center px-4 py-4 text-slate-400">One-time</td>
-                  <td className="text-center px-4 py-4 text-slate-300">Monthly</td>
-                  <td className="text-center px-4 py-4 text-white font-medium">Unlimited</td>
-                </tr>
-                <tr>
-                  <td className="px-6 py-4 text-slate-300">Spending analysis</td>
-                  <td className="text-center px-4 py-4 text-slate-400">Top 5</td>
-                  <td className="text-center px-4 py-4 text-slate-300">Full dashboard</td>
-                  <td className="text-center px-4 py-4 text-white font-medium">Transaction-level</td>
-                </tr>
-                <tr>
-                  <td className="px-6 py-4 text-slate-300">AI financial chatbot</td>
-                  <td className="text-center px-4 py-4 text-slate-400">Basic</td>
-                  <td className="text-center px-4 py-4"><X className="h-4 w-4 text-slate-600 mx-auto" /></td>
-                  <td className="text-center px-4 py-4 text-white font-medium">18 tools</td>
-                </tr>
-                <tr>
-                  <td className="px-6 py-4 text-slate-300">Financial reports</td>
-                  <td className="text-center px-4 py-4"><X className="h-4 w-4 text-slate-600 mx-auto" /></td>
-                  <td className="text-center px-4 py-4"><X className="h-4 w-4 text-slate-600 mx-auto" /></td>
-                  <td className="text-center px-4 py-4 text-white font-medium">Annual + on-demand</td>
-                </tr>
-                <tr>
-                  <td className="px-6 py-4 text-slate-300">Priority support</td>
-                  <td className="text-center px-4 py-4"><X className="h-4 w-4 text-slate-600 mx-auto" /></td>
-                  <td className="text-center px-4 py-4"><X className="h-4 w-4 text-slate-600 mx-auto" /></td>
-                  <td className="text-center px-4 py-4"><Check className="h-4 w-4 text-mint-400 mx-auto" /></td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </motion.div>
-
-        {/* Trust Section */}
-        <div className="mt-16 pt-16 border-t border-navy-700/50">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.5 }}
-              className="text-center"
+          {FAQS.map(([question, answer]) => (
+            <details
+              key={question}
+              style={{ padding: '22px 24px', borderBottom: '1px solid var(--divider)', cursor: 'pointer' }}
             >
-              <Zap className="h-8 w-8 text-mint-400 mx-auto mb-3" />
-              <h3 className="text-lg font-semibold text-white mb-2">Instant Setup</h3>
-              <p className="text-slate-400 text-sm">
-                Start saving money in minutes. No technical setup required.
+              <summary
+                style={{
+                  fontSize: 17,
+                  fontWeight: 600,
+                  letterSpacing: '-.01em',
+                  listStyle: 'none',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  color: 'var(--text-primary)',
+                }}
+              >
+                {question}
+                <span style={{ fontSize: 22, color: 'var(--text-tertiary)', fontWeight: 400, marginLeft: 16 }}>+</span>
+              </summary>
+              <p style={{ fontSize: 15.5, lineHeight: 1.65, color: 'var(--text-secondary)', margin: '14px 0 0' }}>
+                {answer}
               </p>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.6 }}
-              className="text-center"
-            >
-              <TrendingUp className="h-8 w-8 text-mint-400 mx-auto mb-3" />
-              <h3 className="text-lg font-semibold text-white mb-2">Legally Grounded</h3>
-              <p className="text-slate-400 text-sm">
-                Every letter cites the exact UK consumer law that applies - Consumer Rights Act 2015, Ofcom, FCA rules.
-              </p>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.7 }}
-              className="text-center"
-            >
-              <Sparkles className="h-8 w-8 text-mint-400 mx-auto mb-3" />
-              <h3 className="text-lg font-semibold text-white mb-2">Cancel Anytime</h3>
-              <p className="text-slate-400 text-sm">
-                No lock-in. Cancel your subscription whenever you want.
-              </p>
-            </motion.div>
-          </div>
+            </details>
+          ))}
         </div>
-      </div>
+      </section>
 
-      {/* Footer matching landing page */}
-      <footer className="border-t border-navy-700/50 bg-navy-950">
-        <div className="container mx-auto px-4 md:px-6 py-16">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-12">
-            <div>
-              <h4 className="text-white font-semibold text-sm mb-4">Product</h4>
-              <ul className="space-y-2 text-sm">
-                <li><Link href="/pricing" className="text-slate-500 hover:text-white transition-all">Pricing</Link></li>
-                <li><Link href="/deals" className="text-slate-500 hover:text-white transition-all">Deals</Link></li>
-                <li><Link href="/auth/signup" className="text-slate-500 hover:text-white transition-all">Get Started</Link></li>
-                <li><Link href="/auth/login" className="text-slate-500 hover:text-white transition-all">Sign In</Link></li>
-              </ul>
-            </div>
-            <div>
-              <h4 className="text-white font-semibold text-sm mb-4">Resources</h4>
-              <ul className="space-y-2 text-sm">
-                <li><Link href="/blog" className="text-slate-500 hover:text-white transition-all">Blog</Link></li>
-                <li><Link href="/about" className="text-slate-500 hover:text-white transition-all">About</Link></li>
-                <li><Link href="/deals" className="text-slate-500 hover:text-white transition-all">Deal Comparison</Link></li>
-                <li><Link href="/docs/paybacker-assistant" className="text-slate-500 hover:text-white transition-all">Paybacker Assistant</Link></li>
-              </ul>
-            </div>
-            <div>
-              <h4 className="text-white font-semibold text-sm mb-4">Legal</h4>
-              <ul className="space-y-2 text-sm">
-                <li><Link href="/privacy-policy" className="text-slate-500 hover:text-white transition-all">Privacy Policy</Link></li>
-                <li><Link href="/terms-of-service" className="text-slate-500 hover:text-white transition-all">Terms of Service</Link></li>
-              </ul>
-            </div>
-            <div>
-              <h4 className="text-white font-semibold text-sm mb-4">Contact</h4>
-              <ul className="space-y-2 text-sm">
-                <li><a href="mailto:hello@paybacker.co.uk" className="text-slate-500 hover:text-white transition-all">hello@paybacker.co.uk</a></li>
-                <li><a href="mailto:support@paybacker.co.uk" className="text-slate-500 hover:text-white transition-all">support@paybacker.co.uk</a></li>
-              </ul>
-            </div>
+      {/* FINAL CTA */}
+      <section
+        className="final-cta section-ink glow-wrap"
+        style={{ '--glow-opacity': 0.14, padding: '120px 0' } as CSSVarProperties}
+      >
+        <div className="wrap">
+          <h2 style={{ fontSize: 'clamp(48px,6vw,72px)' }}>
+            Stop overpaying.
+            <br />
+            Start <span className="mint">fighting</span> back.
+          </h2>
+          <p style={{ textAlign: 'center', color: 'var(--text-on-ink-dim)', marginTop: 24, fontSize: 17 }}>
+            Free forever tier. Paid plans from £4.99/mo. Keep 100% of your refunds, every tier.
+          </p>
+          <div
+            style={{
+              textAlign: 'center',
+              marginTop: 36,
+              display: 'flex',
+              gap: 12,
+              justifyContent: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <Link className="btn btn-mint" href={SIGNUP_HREF}>
+              Start free →
+            </Link>
+            <Link
+              className="btn btn-ghost on-ink"
+              style={{ color: 'var(--accent-mint)', borderColor: 'rgba(52,211,153,.3)' }}
+              href={SIGNUP_HREF}
+            >
+              Try Essential 14 days free →
+            </Link>
           </div>
-          <div className="border-t border-navy-700/50 pt-8 flex flex-col md:flex-row items-center justify-between gap-4">
-            <div className="flex items-center gap-2">
-              <Image src="/logo.png" alt="Paybacker" width={24} height={24} className="rounded-lg" />
-              <span className="text-slate-500 text-sm">&copy; 2026 Paybacker LTD. All rights reserved.</span>
-            </div>
-            <div className="flex items-center gap-2 text-slate-600 text-xs">
-              <span>🇬🇧 Made in the UK</span>
-            </div>
-          </div>
+          <p style={{ textAlign: 'center', marginTop: 20, color: 'var(--text-on-ink-dim)', fontSize: 13 }}>
+            No card. Cancel anytime. Your data stays in the UK.
+          </p>
         </div>
-      </footer>
+      </section>
+
+      <MarkFoot />
     </div>
   );
 }

--- a/src/app/pricing/styles.css
+++ b/src/app/pricing/styles.css
@@ -1,0 +1,273 @@
+/*
+ * Pricing marketing page — scoped stylesheet.
+ *
+ * Scoped under `.m-pricing-root` so it can't leak onto other routes.
+ * Follows the same pattern as /preview/homepage: alias the Tailwind v4
+ * marketing tokens from globals.css into the shorter names the design
+ * export uses (--surface-base, --accent-mint, --r-card, etc.) so the
+ * CSS from the design export works unchanged.
+ *
+ * Design source: design-zip/redesign/batch6.jsx::PricingRecap
+ * Token source: design-zip/redesign/homepage.css
+ */
+
+.m-pricing-root {
+  /* Token aliases → globals.css Tailwind v4 theme */
+  --surface-base: var(--color-surface-base);
+  --surface-elevated: var(--color-surface-elevated);
+  --surface-ink: var(--color-surface-ink);
+  --surface-ink-2: var(--color-surface-ink-2);
+  --surface-soft-mint: var(--color-surface-soft-mint);
+
+  --text-primary: var(--color-ink-primary);
+  --text-secondary: var(--color-ink-secondary);
+  --text-tertiary: var(--color-ink-tertiary);
+  --text-on-ink: var(--color-on-ink);
+  --text-on-ink-dim: var(--color-on-ink-dim);
+
+  --accent-mint: var(--color-accent-mint);
+  --accent-mint-deep: var(--color-accent-mint-deep);
+  --accent-mint-wash: var(--color-accent-mint-wash);
+  --accent-orange: var(--color-accent-orange);
+  --accent-orange-deep: var(--color-accent-orange-deep);
+
+  --divider: var(--color-divider-light);
+  --divider-ink: var(--color-divider-ink);
+
+  --r-card: var(--radius-marketing-card);
+  --r-figure: var(--radius-marketing-figure);
+  --r-btn: var(--radius-marketing-btn);
+  --r-input: var(--radius-marketing-input);
+  --r-pill: var(--radius-marketing-pill);
+
+  --shadow-sm: var(--shadow-marketing-sm);
+  --shadow-md: var(--shadow-marketing-md);
+  --shadow-lg: var(--shadow-marketing-lg);
+  --shadow-xl: var(--shadow-marketing-xl);
+  --shadow-mint: var(--shadow-marketing-mint);
+  --shadow-orange: var(--shadow-marketing-orange);
+
+  --fs-display: var(--text-display);
+  --fs-h1: var(--text-h1-marketing);
+  --fs-h2: var(--text-h2-marketing);
+  --fs-h3: 24px;
+  --fs-body: 17px;
+  --fs-sm: 14px;
+  --fs-xs: 12px;
+  --track-tight: var(--tracking-marketing-tight);
+  --track-eyebrow: var(--tracking-marketing-eyebrow);
+
+  /* Covers body so the dark global bg is hidden */
+  min-height: 100vh;
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+.m-pricing-root *,
+.m-pricing-root *::before,
+.m-pricing-root *::after { box-sizing: border-box; }
+.m-pricing-root img,
+.m-pricing-root svg { display: block; max-width: 100%; }
+
+/* Shared -------------------------------------------------------------- */
+.m-pricing-root .wrap { max-width: 1240px; margin: 0 auto; padding: 0 32px; }
+.m-pricing-root .eyebrow {
+  font-size: var(--fs-xs);
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+.m-pricing-root .eyebrow.on-ink { color: var(--accent-mint); }
+
+.m-pricing-root .btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 22px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+.m-pricing-root .btn-mint { background: var(--accent-mint); color: #052E1C; box-shadow: var(--shadow-mint); }
+.m-pricing-root .btn-mint:hover { transform: scale(1.02); box-shadow: 0 24px 55px -18px rgba(52, 211, 153, 0.65); background: #2CC48A; }
+.m-pricing-root .btn-ghost { background: transparent; color: var(--text-primary); border: 1px solid var(--divider); }
+.m-pricing-root .btn-ghost:hover { transform: scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+.m-pricing-root .btn-ghost.on-ink { color: var(--text-on-ink); border-color: var(--divider-ink); background: transparent; }
+.m-pricing-root .btn-ghost.on-ink:hover { background: rgba(255,255,255,0.04); }
+
+/* Sections ------------------------------------------------------------ */
+.m-pricing-root section { position: relative; }
+.m-pricing-root .section-light { background: var(--surface-base); }
+.m-pricing-root .section-white { background: var(--surface-elevated); }
+.m-pricing-root .section-mint { background: var(--accent-mint-wash); }
+.m-pricing-root .section-ink { background: var(--surface-ink); color: var(--text-on-ink); }
+.m-pricing-root .section-ink h1,
+.m-pricing-root .section-ink h2,
+.m-pricing-root .section-ink h3 { color: var(--text-on-ink); }
+
+/* Ambient glow -------------------------------------------------------- */
+.m-pricing-root .glow-wrap { position: relative; }
+.m-pricing-root .glow-wrap::before,
+.m-pricing-root .glow-wrap::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+  width: 900px; height: 900px;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: var(--glow-opacity, 0.18);
+}
+.m-pricing-root .glow-wrap::before {
+  top: -250px; right: -200px;
+  background: radial-gradient(circle, var(--accent-orange) 0%, transparent 60%);
+}
+.m-pricing-root .glow-wrap::after {
+  bottom: -350px; left: -250px;
+  background: radial-gradient(circle, var(--accent-mint) 0%, transparent 60%);
+  opacity: calc(var(--glow-opacity, 0.18) * 0.6);
+}
+.m-pricing-root .glow-wrap > * { position: relative; z-index: 1; }
+
+/* Nav ---------------------------------------------------------------- */
+.m-pricing-root .nav-shell {
+  position: sticky; top: 18px; left: 0; right: 0;
+  display: flex; justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+.m-pricing-root .nav-pill {
+  pointer-events: auto;
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border: 1px solid rgba(11,18,32,0.06);
+  padding: 10px 10px 10px 20px;
+  border-radius: var(--r-pill);
+  box-shadow: var(--shadow-md);
+}
+.m-pricing-root .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; text-decoration: none; }
+.m-pricing-root .nav-logo .pay { color: var(--text-primary); }
+.m-pricing-root .nav-logo .backer { color: var(--accent-mint-deep); }
+.m-pricing-root .nav-links { display: flex; gap: 6px; margin: 0 14px; }
+.m-pricing-root .nav-links a {
+  font-size: 14px; font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: var(--r-pill);
+  transition: background 150ms, color 150ms;
+}
+.m-pricing-root .nav-links a:hover { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-pricing-root .nav-links a.is-active { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-pricing-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
+.m-pricing-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+.m-pricing-root .nav-start {
+  background: var(--accent-mint); color: #052E1C;
+  padding: 10px 18px; border-radius: var(--r-pill);
+  font-weight: 600; font-size: 14px; text-decoration: none;
+  transition: transform 150ms, box-shadow 150ms;
+}
+.m-pricing-root .nav-start:hover { transform: scale(1.03); box-shadow: var(--shadow-mint); }
+
+/* Pricing grid ------------------------------------------------------- */
+.m-pricing-root .pricing-section { padding: 120px 0; }
+.m-pricing-root .pricing-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.m-pricing-root .price-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 32px;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+.m-pricing-root .price-card.featured { border-color: var(--accent-mint); box-shadow: 0 30px 60px -30px rgba(52,211,153,0.35); }
+.m-pricing-root .ribbon {
+  position: absolute; top: -12px; left: 32px;
+  background: var(--accent-mint); color: #052E1C;
+  font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700;
+  padding: 6px 12px; border-radius: 999px;
+}
+.m-pricing-root .price-card .tier { font-size: 14px; color: var(--text-tertiary); font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; }
+.m-pricing-root .price-card .price { font-size: 48px; font-weight: 700; letter-spacing: -0.02em; margin: 12px 0 4px; }
+.m-pricing-root .price-card .price .per { font-size: 16px; color: var(--text-tertiary); font-weight: 500; }
+.m-pricing-root .price-card .founding { color: var(--accent-orange-deep); font-size: 12px; font-weight: 600; margin-bottom: 18px; letter-spacing: 0.04em; text-transform: uppercase; }
+.m-pricing-root .price-card ul { list-style: none; padding: 0; margin: 0 0 24px; display: flex; flex-direction: column; gap: 10px; }
+.m-pricing-root .price-card li {
+  font-size: 14px; color: var(--text-secondary);
+  padding-left: 26px; position: relative;
+}
+.m-pricing-root .price-card li::before {
+  content: ''; position: absolute; left: 0; top: 6px;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--accent-mint-wash);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M3.5 8.2l3 2.8 6-6.5' stroke='%23059669' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat; background-position: center;
+}
+.m-pricing-root .price-card .cta { margin-top: auto; }
+
+.m-pricing-root .compare-link { text-align: center; margin-top: 36px; font-size: 14px; color: var(--text-secondary); }
+.m-pricing-root .compare-link a { color: var(--accent-mint-deep); text-decoration: none; font-weight: 600; }
+.m-pricing-root .compare-link a:hover { text-decoration: underline; }
+
+/* Final CTA ---------------------------------------------------------- */
+.m-pricing-root .final-cta { position: relative; overflow: hidden; }
+.m-pricing-root .final-cta h2 {
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.02;
+  text-align: center;
+  color: var(--text-on-ink);
+  margin: 0;
+}
+.m-pricing-root .final-cta .mint { color: var(--accent-mint); }
+
+/* Footer ------------------------------------------------------------- */
+.m-pricing-root footer { padding: 80px 0 40px; background: var(--surface-ink); color: var(--text-on-ink); border-top: 1px solid var(--divider-ink); }
+.m-pricing-root .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr; gap: 32px; }
+.m-pricing-root .footer-brand .logo { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 10px; }
+.m-pricing-root .footer-brand .logo .backer { color: var(--accent-mint); }
+.m-pricing-root .footer-brand p { color: var(--text-on-ink-dim); font-size: 14px; max-width: 280px; }
+.m-pricing-root .footer-col h5 { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-on-ink-dim); font-weight: 600; margin: 0 0 16px; }
+.m-pricing-root .footer-col a { display: block; color: var(--text-on-ink); text-decoration: none; font-size: 14px; margin-bottom: 10px; opacity: 0.85; }
+.m-pricing-root .footer-col a:hover { opacity: 1; color: var(--accent-mint); }
+.m-pricing-root .footer-bottom {
+  border-top: 1px solid var(--divider-ink);
+  margin-top: 56px; padding-top: 24px;
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px;
+  font-size: 12px; color: var(--text-on-ink-dim);
+}
+.m-pricing-root .footer-socials { display: flex; gap: 10px; }
+.m-pricing-root .footer-socials a {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--divider-ink);
+  display: grid; place-items: center; font-size: 13px;
+  transition: background 150ms ease;
+  margin-bottom: 0;
+}
+.m-pricing-root .footer-socials a:hover { background: rgba(255,255,255,0.06); }
+
+/* Responsive --------------------------------------------------------- */
+@media (max-width: 980px) {
+  .m-pricing-root .pricing-grid { grid-template-columns: 1fr; }
+  .m-pricing-root .footer-grid { grid-template-columns: 1fr 1fr; }
+  .m-pricing-root .nav-links { display: none; }
+  .m-pricing-root .math-grid { grid-template-columns: 1fr !important; }
+  .m-pricing-root .compare-table-head,
+  .m-pricing-root .compare-table-row { grid-template-columns: 1.6fr 1fr 1fr 1fr !important; padding: 14px 16px !important; font-size: 13px !important; }
+}
+@media (max-width: 480px) {
+  .m-pricing-root .wrap { padding: 0 20px; }
+  .m-pricing-root .pricing-section { padding: 80px 0; }
+}


### PR DESCRIPTION
Marketing redesign batch 1 of 2 — `/pricing` and `/about`, plus the legacy
`/login` → `/auth/login` redirect that the homepage's sign-in link needs.

### What's in here

| Route | Source | Status |
|---|---|---|
| `/pricing` | `design-zip/redesign/batch6.jsx::PricingRecap` | Full rebuild |
| `/about` | `design-zip/redesign/batch6.jsx::AboutPage` | Full rebuild |
| `/login` | redirect → `/auth/login` | `next.config.ts` |

### Content accuracy

Everything on /pricing is pinned verbatim to `design-zip/redesign/CONTENT_SOURCES_OF_TRUTH.md`:
- Three tiers only: **Free £0** / **Essential £4.99 · £44.99/yr** / **Pro £9.99 · £94.99/yr**
- **0% success fee** — every tier, never take a cut
- **14-day free trial, no card required** on Essential and Pro
- Yapily described as **read-only** bank access
- Compare-the-math row uses real arithmetic (£216 refund → 30% = £64.80 lost with competitors vs £216 kept with Paybacker)

/about copy:
- Launched **March 2026**, company number **15289174**
- No invented founder anecdote — timeline is problem → gap → idea → launch → today

### Architecture

- Both pages are **Server Components** (static marketing — better SEO than the old client-side `PublicNavbar` pattern).
- CSS is scoped under `.m-pricing-root` and `.m-about-root` so nothing leaks onto other routes (same pattern as `/preview/homepage`).
- Token aliases pull Tailwind v4 marketing tokens from `globals.css` under the shorter design-export names.
- All auth CTAs wired to `/auth/signup` and `/auth/login`; the `/careers` link in the nav will 404 until that route ships in the next batch.

### Checks

- `npx tsc --noEmit`: zero errors in the files in this PR (the existing errors on this branch are in unrelated work).
- Content reviewed against CONTENT_SOURCES_OF_TRUTH.md.
- No API keys, no client-side secrets, no database changes.

### Next batch

`/careers`, `/blog`, `/blog/[slug]`, plus `/how-it-works` and `/templates` from batch5/batch7/batch8.
