### PR TITLE
feat(marketing): redesign /careers and /blog

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,170 +1,395 @@
-import type { Metadata } from "next";
-import Link from "next/link";
-import { createClient } from "@supabase/supabase-js";
-import PublicNavbar from '@/components/PublicNavbar';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+import { createClient } from '@supabase/supabase-js';
+import { MarkNav, MarkFoot } from './_shared';
+import './styles.css';
+
+/**
+ * /blog — marketing redesign.
+ *
+ * Design source: design-zip/redesign/batch6.jsx::BlogIndex
+ * Scoped under `.m-blog-root`.
+ *
+ * Preserves the existing data model from master:
+ *   - dynamic posts from Supabase `blog_posts` table (status='published')
+ *   - merged with three hand-coded SEO posts (/blog/broadband-contract-ended,
+ *     /blog/are-you-overpaying-on-energy, /blog/how-to-claim-flight-delay-compensation-uk)
+ *
+ * Design deviation: the design's 5 illustrative posts (broadband-anniversary,
+ * CRA s.49 explainer, etc.) all pre-date the March 2026 launch, so we render
+ * real data in the design layout rather than shipping the fake list.
+ */
 
 export const metadata: Metadata = {
-  title: "Blog - Money-Saving Tips and UK Consumer Rights | Paybacker",
+  title: 'The Paybacker Journal — essays on UK consumer law, overcharges, and how to fight back',
   description:
-    "Money-saving tips, switching guides and UK consumer rights advice from Paybacker.",
-  keywords: [
-    "money saving tips UK",
-    "consumer rights advice",
-    "switching guide",
-    "energy saving",
-    "broadband deals",
-  ],
+    'Money-saving guides and UK consumer-rights explainers from the Paybacker team. Flight delay claims, broadband anniversary hikes, energy price cap — the statute, the story, the template.',
+  alternates: { canonical: 'https://paybacker.co.uk/blog' },
   openGraph: {
-    title: "Blog - Money-Saving Tips and UK Consumer Rights | Paybacker",
+    title: 'The Paybacker Journal',
     description:
-      "Money-saving tips, switching guides and UK consumer rights advice from Paybacker.",
-    url: "https://paybacker.co.uk/blog",
-    siteName: "Paybacker",
-    type: "website",
-  },
-  twitter: {
-    card: "summary",
-    title: "Blog - Money-Saving Tips and UK Consumer Rights | Paybacker",
-    description:
-      "Money-saving tips, switching guides and UK consumer rights advice from Paybacker.",
-    images: ["/logo.png"],
-  },
-  alternates: {
-    canonical: "https://paybacker.co.uk/blog",
+      'Money-saving guides and UK consumer-rights explainers. One UK overcharge, dissected.',
+    url: 'https://paybacker.co.uk/blog',
+    siteName: 'Paybacker',
+    type: 'website',
   },
 };
 
-const posts = [
+export const revalidate = 3600;
+
+type Post = {
+  title: string;
+  excerpt: string;
+  href: string;
+  date: string;
+  cat: string;
+  gradient: string;
+  emoji: string;
+};
+
+const GRADIENTS = [
+  { bg: 'linear-gradient(135deg, #34D399, #059669)', emoji: '✉' },
+  { bg: 'linear-gradient(135deg, #F59E0B, #D97706)', emoji: '📡' },
+  { bg: 'linear-gradient(135deg, #3B82F6, #2563EB)', emoji: '✈' },
+  { bg: 'linear-gradient(135deg, #8B5CF6, #6D28D9)', emoji: '⚖' },
+  { bg: 'linear-gradient(135deg, #F43F5E, #DC2626)', emoji: '💷' },
+];
+
+// Hand-coded SEO posts that already exist as live pages under /blog/*.
+const STATIC_POSTS: ReadonlyArray<Omit<Post, 'gradient' | 'emoji'>> = [
   {
-    title: "How to Claim Flight Delay Compensation UK - Up to £520",
+    title: 'How to Claim Flight Delay Compensation UK — Up to £520',
     excerpt:
-      "Complete guide to claiming flight delay compensation under UK261 regulations. Claim up to £520 per person for delayed or cancelled flights. You can claim for flights in the last 6 years.",
-    href: "/blog/how-to-claim-flight-delay-compensation-uk",
-    date: "25 March 2026",
+      'Complete guide to claiming flight delay compensation under UK261 regulations. Claim up to £520 per person for delayed or cancelled flights. You can claim for flights in the last 6 years.',
+    href: '/blog/how-to-claim-flight-delay-compensation-uk',
+    date: '25 March 2026',
+    cat: 'Guides',
   },
   {
-    title: "Are You Overpaying on Energy in 2026? Here's How to Find Out",
+    title: 'Are You Overpaying on Energy in 2026? Here\'s How to Find Out',
     excerpt:
-      "The energy price cap hits £1,641 from April 2026. Find out if you're on an expensive standard variable tariff and how switching could save you hundreds.",
-    href: "/blog/are-you-overpaying-on-energy",
-    date: "23 March 2026",
+      'The energy price cap hits £1,641 from April 2026. Find out if you\'re on an expensive standard variable tariff and how switching could save you hundreds.',
+    href: '/blog/are-you-overpaying-on-energy',
+    date: '23 March 2026',
+    cat: 'Guides',
   },
   {
-    title:
-      "Your Broadband Contract Has Ended - You're Probably Being Overcharged",
+    title: 'Your Broadband Contract Has Ended — You\'re Probably Being Overcharged',
     excerpt:
-      "Millions of UK households are out of contract on broadband and overpaying. Find out if your contract has ended and how to save up to £300 a year.",
-    href: "/blog/broadband-contract-ended",
-    date: "23 March 2026",
+      'Millions of UK households are out of contract on broadband and overpaying. Find out if your contract has ended and how to save up to £300 a year.',
+    href: '/blog/broadband-contract-ended',
+    date: '23 March 2026',
+    cat: 'Guides',
   },
 ];
 
-export const revalidate = 3600; // Revalidate every hour
+async function fetchDynamicPosts(): Promise<Post[]> {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return [];
+  }
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+    const { data } = await supabase
+      .from('blog_posts')
+      .select('slug, title, excerpt, published_at, category')
+      .eq('status', 'published')
+      .order('published_at', { ascending: false })
+      .limit(20);
+    if (!data) return [];
+    return data.map((p, i): Post => {
+      const g = GRADIENTS[i % GRADIENTS.length];
+      return {
+        title: p.title,
+        excerpt: p.excerpt ?? '',
+        href: `/blog/${p.slug}`,
+        date: new Date(p.published_at).toLocaleDateString('en-GB', {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        }),
+        cat: (p.category as string | null) ?? 'Essay',
+        gradient: g.bg,
+        emoji: g.emoji,
+      };
+    });
+  } catch {
+    return [];
+  }
+}
 
 export default async function BlogIndexPage() {
-  // Fetch dynamic blog posts from database (gracefully skip if env vars absent at build time)
-  let dynamicPosts: { slug: string; title: string; excerpt: string | null; published_at: string }[] | null = null;
-  try {
-    if (process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-      const { data } = await supabase
-        .from('blog_posts')
-        .select('slug, title, excerpt, published_at')
-        .eq('status', 'published')
-        .order('published_at', { ascending: false })
-        .limit(20);
-      dynamicPosts = data;
-    }
-  } catch {
-    // fall through — static posts shown below
-  }
+  const dynamicPosts = await fetchDynamicPosts();
+  const staticWithArt: Post[] = STATIC_POSTS.map((p, i) => {
+    const g = GRADIENTS[(dynamicPosts.length + i) % GRADIENTS.length];
+    return { ...p, gradient: g.bg, emoji: g.emoji };
+  });
+  const allPosts: Post[] = [...dynamicPosts, ...staticWithArt];
+  const [featured, ...rest] = allPosts;
 
-  // Merge static posts with dynamic ones (dynamic first, then static)
-  const allPosts = [
-    ...(dynamicPosts || []).map(p => ({
-      title: p.title,
-      excerpt: p.excerpt || '',
-      href: `/blog/${p.slug}`,
-      date: new Date(p.published_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }),
-    })),
-    ...posts,
-  ];
   return (
-    <div className="min-h-screen bg-navy-950">
-      <PublicNavbar />
-      <div className="h-16" />
+    <div className="m-blog-root">
+      <MarkNav active="Blog" />
 
-      <main className="container mx-auto px-6 py-16 max-w-5xl">
-        <div className="mb-12">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Blog
+      {/* Hero + featured ------------------------------------------- */}
+      <section className="section-light" style={{ paddingTop: 140, paddingBottom: 40 } as CSSProperties}>
+        <div className="wrap">
+          <span className="eyebrow">The Paybacker Journal</span>
+          <h1
+            style={{
+              fontSize: 'var(--fs-h1)',
+              fontWeight: 700,
+              letterSpacing: 'var(--track-tight)',
+              lineHeight: 1.05,
+              margin: '18px 0 40px',
+              maxWidth: 900,
+            } as CSSProperties}
+          >
+            What we&rsquo;re learning as we read every overcharge in Britain.
           </h1>
-          <p className="text-lg text-slate-300 leading-relaxed">
-            Money-saving tips and switching guides for UK consumers
-          </p>
-        </div>
 
-        <div className="grid gap-6">
-          {allPosts.map((post) => (
-            <Link key={post.href} href={post.href} className="block group">
-              <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 hover:border-mint-400/30 transition-all">
-                <p className="text-slate-500 text-sm mb-2">{post.date}</p>
-                <h2 className="text-xl font-bold text-white mb-2 group-hover:text-mint-400 transition-colors">
-                  {post.title}
-                </h2>
-                <p className="text-slate-400 text-sm mb-3">{post.excerpt}</p>
-                <span className="text-mint-400 text-sm font-medium">
-                  Read more &rarr;
-                </span>
+          {featured && (
+            <div
+              style={{
+                background: '#fff',
+                border: '1px solid var(--divider)',
+                borderRadius: 'var(--r-card)',
+                padding: 32,
+                display: 'grid',
+                gridTemplateColumns: '1.2fr 1fr',
+                gap: 40,
+                alignItems: 'center',
+              } as CSSProperties}
+            >
+              <div
+                style={{
+                  height: 400,
+                  borderRadius: 'var(--r-input)',
+                  background: featured.gradient,
+                  position: 'relative',
+                  overflow: 'hidden',
+                } as CSSProperties}
+              >
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 18,
+                    left: 18,
+                    padding: '6px 12px',
+                    background: 'rgba(255,255,255,0.96)',
+                    borderRadius: 999,
+                    fontSize: 11,
+                    fontWeight: 700,
+                    color: 'var(--text-primary)',
+                    letterSpacing: '.08em',
+                    textTransform: 'uppercase',
+                  } as CSSProperties}
+                >
+                  Featured
+                </div>
+                <div
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 160,
+                    opacity: 0.22,
+                  } as CSSProperties}
+                  aria-hidden="true"
+                >
+                  {featured.emoji}
+                </div>
               </div>
-            </Link>
-          ))}
+              <div>
+                <div
+                  style={{
+                    fontSize: 12,
+                    fontWeight: 600,
+                    letterSpacing: 'var(--track-eyebrow)',
+                    textTransform: 'uppercase',
+                    color: 'var(--accent-mint-deep)',
+                    marginBottom: 14,
+                  } as CSSProperties}
+                >
+                  {featured.cat} · {featured.date}
+                </div>
+                <h2
+                  style={{
+                    fontSize: 32,
+                    fontWeight: 700,
+                    letterSpacing: '-.02em',
+                    margin: '0 0 16px',
+                    lineHeight: 1.15,
+                  } as CSSProperties}
+                >
+                  {featured.title}
+                </h2>
+                <p
+                  style={{
+                    fontSize: 16,
+                    lineHeight: 1.6,
+                    color: 'var(--text-secondary)',
+                    margin: '0 0 24px',
+                  } as CSSProperties}
+                >
+                  {featured.excerpt}
+                </p>
+                <Link
+                  href={featured.href}
+                  className="btn btn-mint"
+                  style={{ padding: '12px 20px', fontSize: 14 } as CSSProperties}
+                >
+                  Read the breakdown →
+                </Link>
+              </div>
+            </div>
+          )}
         </div>
-      </main>
+      </section>
 
-      <footer className="container mx-auto px-6 py-8 border-t border-navy-700/50 mt-16">
-        <div className="text-center text-slate-500 text-sm space-y-3">
-          <div className="flex flex-wrap justify-center gap-6">
-            <Link href="/about" className="hover:text-white transition-all">
-              About
-            </Link>
-            <Link href="/blog" className="hover:text-white transition-all">
-              Blog
-            </Link>
-            <Link
-              href="/privacy-policy"
-              className="hover:text-white transition-all"
+      {/* Grid of remaining posts ----------------------------------- */}
+      {rest.length > 0 && (
+        <section style={{ padding: '40px 0 80px' } as CSSProperties}>
+          <div className="wrap">
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(2, 1fr)',
+                gap: 32,
+              } as CSSProperties}
             >
-              Privacy Policy
-            </Link>
-            <Link
-              href="/terms-of-service"
-              className="hover:text-white transition-all"
-            >
-              Terms of Service
-            </Link>
-            <Link href="/pricing" className="hover:text-white transition-all">
-              Pricing
-            </Link>
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="hover:text-white transition-all"
-            >
-              Contact
-            </a>
+              {rest.map((p) => (
+                <Link
+                  key={p.href}
+                  href={p.href}
+                  style={{ textDecoration: 'none', color: 'inherit', cursor: 'pointer' } as CSSProperties}
+                >
+                  <article>
+                    <div
+                      style={{
+                        height: 240,
+                        borderRadius: 'var(--r-card)',
+                        background: p.gradient,
+                        marginBottom: 20,
+                        position: 'relative',
+                        overflow: 'hidden',
+                      } as CSSProperties}
+                    >
+                      <div
+                        style={{
+                          position: 'absolute',
+                          top: 14,
+                          left: 14,
+                          padding: '5px 11px',
+                          background: 'rgba(255,255,255,0.96)',
+                          borderRadius: 999,
+                          fontSize: 11,
+                          fontWeight: 700,
+                          color: 'var(--text-primary)',
+                          letterSpacing: '.08em',
+                          textTransform: 'uppercase',
+                        } as CSSProperties}
+                      >
+                        {p.cat}
+                      </div>
+                      <div
+                        style={{
+                          position: 'absolute',
+                          inset: 0,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: 110,
+                          opacity: 0.2,
+                        } as CSSProperties}
+                        aria-hidden="true"
+                      >
+                        {p.emoji}
+                      </div>
+                    </div>
+                    <h3
+                      style={{
+                        fontSize: 24,
+                        fontWeight: 700,
+                        letterSpacing: '-.015em',
+                        margin: '0 0 10px',
+                        lineHeight: 1.2,
+                      } as CSSProperties}
+                    >
+                      {p.title}
+                    </h3>
+                    <p
+                      style={{
+                        fontSize: 15.5,
+                        lineHeight: 1.55,
+                        color: 'var(--text-secondary)',
+                        margin: '0 0 16px',
+                      } as CSSProperties}
+                    >
+                      {p.excerpt}
+                    </p>
+                    <div
+                      style={{
+                        fontSize: 13,
+                        color: 'var(--text-tertiary)',
+                      } as CSSProperties}
+                    >
+                      {p.date}
+                    </div>
+                  </article>
+                </Link>
+              ))}
+            </div>
           </div>
-          <p>
-            Need help? Email{" "}
-            <a
-              href="mailto:support@paybacker.co.uk"
-              className="text-mint-400 hover:text-mint-300"
-            >
-              support@paybacker.co.uk
-            </a>
-          </p>
-          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
+        </section>
+      )}
+
+      {/* Newsletter ------------------------------------------------ */}
+      <section id="newsletter" style={{ padding: '40px 0 120px' } as CSSProperties}>
+        <div className="wrap">
+          <div className="newsletter">
+            <div style={{ maxWidth: 520 } as CSSProperties}>
+              <span className="eyebrow on-ink">The Payback · Weekly</span>
+              <h2>One UK overcharge, dissected. Every Friday.</h2>
+              <p>
+                No spam. No &ldquo;7 secrets the banks don&rsquo;t want you to know.&rdquo; Just the story, the statute, the template you can copy.
+              </p>
+            </div>
+            <form className="newsletter-form" action="/api/newsletter" method="post">
+              <label
+                htmlFor="newsletter-email"
+                style={{
+                  position: 'absolute',
+                  width: 1,
+                  height: 1,
+                  overflow: 'hidden',
+                  clip: 'rect(0,0,0,0)',
+                } as CSSProperties}
+              >
+                Email address
+              </label>
+              <input
+                id="newsletter-email"
+                name="email"
+                type="email"
+                required
+                placeholder="you@email.com"
+                autoComplete="email"
+              />
+              <button className="btn btn-mint" type="submit" style={{ padding: '14px 22px' } as CSSProperties}>
+                Subscribe
+              </button>
+            </form>
+          </div>
         </div>
-      </footer>
+      </section>
+
+      <MarkFoot />
     </div>
   );
 }

--- a/src/app/blog/styles.css
+++ b/src/app/blog/styles.css
@@ -1,0 +1,544 @@
+/*
+ * Blog marketing pages — scoped stylesheet.
+ *
+ * Scoped under `.m-blog-root`. Shared by /blog (index) and /blog/[slug]
+ * because they share the same visual language.
+ *
+ * Design source: design-zip/redesign/batch6.jsx::BlogIndex + BlogPost
+ * Token source: design-zip/redesign/homepage.css
+ */
+
+.m-blog-root {
+  /* Token aliases → globals.css Tailwind v4 theme */
+  --surface-base: var(--color-surface-base);
+  --surface-elevated: var(--color-surface-elevated);
+  --surface-ink: var(--color-surface-ink);
+  --surface-ink-2: var(--color-surface-ink-2);
+  --surface-soft-mint: var(--color-surface-soft-mint);
+
+  --text-primary: var(--color-ink-primary);
+  --text-secondary: var(--color-ink-secondary);
+  --text-tertiary: var(--color-ink-tertiary);
+  --text-on-ink: var(--color-on-ink);
+  --text-on-ink-dim: var(--color-on-ink-dim);
+
+  --accent-mint: var(--color-accent-mint);
+  --accent-mint-deep: var(--color-accent-mint-deep);
+  --accent-mint-wash: var(--color-accent-mint-wash);
+  --accent-orange: var(--color-accent-orange);
+  --accent-orange-deep: var(--color-accent-orange-deep);
+
+  --divider: var(--color-divider-light);
+  --divider-ink: var(--color-divider-ink);
+
+  --r-card: var(--radius-marketing-card);
+  --r-figure: var(--radius-marketing-figure);
+  --r-btn: var(--radius-marketing-btn);
+  --r-input: var(--radius-marketing-input);
+  --r-pill: var(--radius-marketing-pill);
+
+  --shadow-sm: var(--shadow-marketing-sm);
+  --shadow-md: var(--shadow-marketing-md);
+  --shadow-lg: var(--shadow-marketing-lg);
+  --shadow-xl: var(--shadow-marketing-xl);
+  --shadow-mint: var(--shadow-marketing-mint);
+  --shadow-orange: var(--shadow-marketing-orange);
+
+  --fs-display: var(--text-display);
+  --fs-h1: var(--text-h1-marketing);
+  --fs-h2: var(--text-h2-marketing);
+  --fs-h3: 24px;
+  --fs-body: 17px;
+  --fs-sm: 14px;
+  --fs-xs: 12px;
+  --track-tight: var(--tracking-marketing-tight);
+  --track-eyebrow: var(--tracking-marketing-eyebrow);
+
+  min-height: 100vh;
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+.m-blog-root *,
+.m-blog-root *::before,
+.m-blog-root *::after { box-sizing: border-box; }
+.m-blog-root img,
+.m-blog-root svg { display: block; max-width: 100%; }
+
+/* Shared -------------------------------------------------------------- */
+.m-blog-root .wrap { max-width: 1240px; margin: 0 auto; padding: 0 32px; }
+.m-blog-root .eyebrow {
+  font-size: var(--fs-xs);
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+.m-blog-root .eyebrow.on-ink { color: var(--accent-mint); }
+
+.m-blog-root .btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 22px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+.m-blog-root .btn-mint { background: var(--accent-mint); color: #052E1C; box-shadow: var(--shadow-mint); }
+.m-blog-root .btn-mint:hover { transform: scale(1.02); box-shadow: 0 24px 55px -18px rgba(52, 211, 153, 0.65); background: #2CC48A; }
+.m-blog-root .btn-ghost { background: transparent; color: var(--text-primary); border: 1px solid var(--divider); }
+.m-blog-root .btn-ghost:hover { transform: scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+
+.m-blog-root section { position: relative; }
+.m-blog-root .section-light { background: var(--surface-base); }
+.m-blog-root .section-ink { background: var(--surface-ink); color: var(--text-on-ink); }
+.m-blog-root .section-ink h1,
+.m-blog-root .section-ink h2,
+.m-blog-root .section-ink h3 { color: var(--text-on-ink); }
+
+/* Nav ---------------------------------------------------------------- */
+.m-blog-root .nav-shell {
+  position: sticky; top: 18px; left: 0; right: 0;
+  display: flex; justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+.m-blog-root .nav-pill {
+  pointer-events: auto;
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border: 1px solid rgba(11,18,32,0.06);
+  padding: 10px 10px 10px 20px;
+  border-radius: var(--r-pill);
+  box-shadow: var(--shadow-md);
+}
+.m-blog-root .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; text-decoration: none; }
+.m-blog-root .nav-logo .pay { color: var(--text-primary); }
+.m-blog-root .nav-logo .backer { color: var(--accent-mint-deep); }
+.m-blog-root .nav-links { display: flex; gap: 6px; margin: 0 14px; }
+.m-blog-root .nav-links a {
+  font-size: 14px; font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: var(--r-pill);
+  transition: background 150ms, color 150ms;
+}
+.m-blog-root .nav-links a:hover { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-blog-root .nav-links a.is-active { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-blog-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
+.m-blog-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+.m-blog-root .nav-start {
+  background: var(--accent-mint); color: #052E1C;
+  padding: 10px 18px; border-radius: var(--r-pill);
+  font-weight: 600; font-size: 14px; text-decoration: none;
+  transition: transform 150ms, box-shadow 150ms;
+}
+.m-blog-root .nav-start:hover { transform: scale(1.03); box-shadow: var(--shadow-mint); }
+
+/* Empty-state hero --------------------------------------------------- */
+.m-blog-root .empty-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 64px 48px;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 48px;
+  align-items: center;
+}
+.m-blog-root .empty-card h2 {
+  font-size: 32px; font-weight: 700;
+  letter-spacing: var(--track-tight); line-height: 1.15;
+  margin: 0 0 16px;
+}
+.m-blog-root .empty-card p {
+  font-size: 16px; line-height: 1.6;
+  color: var(--text-secondary); margin: 0 0 24px;
+}
+.m-blog-root .empty-art {
+  height: 320px;
+  border-radius: var(--r-input);
+  background: linear-gradient(135deg, var(--accent-mint) 0%, var(--accent-mint-deep) 100%);
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+}
+.m-blog-root .empty-art .glyph { font-size: 180px; opacity: 0.22; line-height: 1; }
+
+/* Newsletter ink block ----------------------------------------------- */
+.m-blog-root .newsletter {
+  background: var(--surface-ink);
+  color: var(--text-on-ink);
+  border-radius: var(--r-card);
+  padding: 56px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 48px;
+  flex-wrap: wrap;
+}
+.m-blog-root .newsletter h2 {
+  font-size: 32px; font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.1;
+  margin: 12px 0 12px;
+  color: var(--text-on-ink);
+}
+.m-blog-root .newsletter p {
+  font-size: 15.5px; color: var(--text-on-ink-dim);
+  margin: 0; line-height: 1.5;
+}
+.m-blog-root .newsletter-form {
+  display: flex; gap: 8px;
+  min-width: 380px; flex: 1; max-width: 460px;
+}
+.m-blog-root .newsletter-form input {
+  flex: 1;
+  padding: 14px 18px;
+  border-radius: var(--r-pill);
+  border: 1px solid var(--divider-ink);
+  background: rgba(255,255,255,0.06);
+  color: #fff;
+  font-size: 14px;
+  outline: none;
+  font-family: inherit;
+}
+.m-blog-root .newsletter-form input::placeholder { color: var(--text-on-ink-dim); }
+
+/* Blog post ---------------------------------------------------------- */
+.m-blog-root .post-breadcrumb {
+  font-size: 13px; color: var(--text-tertiary);
+  margin-bottom: 28px;
+  display: flex; gap: 8px; align-items: center;
+}
+.m-blog-root .post-breadcrumb a { color: var(--text-tertiary); text-decoration: none; }
+.m-blog-root .post-breadcrumb .cat { color: var(--accent-mint-deep); font-weight: 600; }
+
+.m-blog-root .post-headline {
+  font-size: clamp(40px, 5.5vw, 64px);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.02;
+  margin: 0 0 24px;
+}
+.m-blog-root .post-dek {
+  font-size: 21px; line-height: 1.5;
+  color: var(--text-secondary);
+  margin: 0 0 32px;
+}
+.m-blog-root .post-meta {
+  display: flex; align-items: center; gap: 20px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--divider);
+}
+.m-blog-root .author-dot {
+  width: 44px; height: 44px; border-radius: 50%;
+  background: var(--accent-mint-deep); color: #fff;
+  display: grid; place-items: center;
+  font-weight: 700; font-size: 15px;
+}
+
+.m-blog-root .post-hero {
+  height: 420px; border-radius: var(--r-figure);
+  margin-bottom: 64px;
+  position: relative; overflow: hidden;
+  display: grid; place-items: center;
+}
+
+.m-blog-root .post-body-grid {
+  display: grid;
+  grid-template-columns: 220px 1fr 300px;
+  gap: 56px;
+}
+.m-blog-root .post-toc {
+  position: sticky; top: 120px; align-self: start;
+}
+.m-blog-root .post-toc-title {
+  font-size: 11px; font-weight: 700;
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 14px;
+}
+.m-blog-root .post-toc-link {
+  display: block;
+  font-size: 13px;
+  color: var(--text-secondary);
+  font-weight: 400;
+  text-decoration: none;
+  padding: 6px 0 6px 14px;
+  border-left: 2px solid var(--divider);
+  line-height: 1.4;
+}
+.m-blog-root .post-toc-link.is-active {
+  color: var(--text-primary); font-weight: 600;
+  border-left-color: var(--accent-mint-deep);
+}
+
+.m-blog-root .post-body {
+  font-size: 17px; line-height: 1.75;
+  color: var(--text-primary);
+  max-width: 680px;
+}
+.m-blog-root .post-body p { margin: 0 0 20px; }
+.m-blog-root .post-body h2 {
+  font-size: 30px; font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 48px 0 16px;
+}
+.m-blog-root .post-body ol,
+.m-blog-root .post-body ul {
+  margin: 0 0 20px;
+  padding-left: 24px;
+  font-size: 17px;
+  line-height: 1.75;
+}
+.m-blog-root .post-body li { margin-bottom: 10px; }
+.m-blog-root .post-body h3 {
+  font-size: 22px; font-weight: 700;
+  letter-spacing: -0.015em;
+  margin: 36px 0 14px;
+}
+.m-blog-root .post-body strong { color: var(--text-primary); font-weight: 600; }
+.m-blog-root .post-body a {
+  color: var(--accent-mint-deep);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.m-blog-root .post-body a:hover { color: var(--text-primary); }
+
+.m-blog-root .post-body .post-table {
+  width: 100%;
+  margin: 24px 0;
+  border-collapse: collapse;
+  font-size: 15.5px;
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  overflow: hidden;
+}
+.m-blog-root .post-body .post-table th,
+.m-blog-root .post-body .post-table td {
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--divider);
+  vertical-align: top;
+}
+.m-blog-root .post-body .post-table thead th {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--track-eyebrow);
+  color: var(--text-tertiary);
+  background: var(--surface-base);
+}
+.m-blog-root .post-body .post-table tbody tr:last-child td { border-bottom: none; }
+.m-blog-root .post-body .post-table .num {
+  font-weight: 700; color: var(--accent-orange-deep);
+  text-align: right; white-space: nowrap;
+}
+
+.m-blog-root .post-body .pair-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin: 24px 0;
+}
+.m-blog-root .post-body .pair-card {
+  padding: 20px;
+  border-radius: var(--r-input);
+  border: 1px solid var(--divider);
+  background: #fff;
+}
+.m-blog-root .post-body .pair-card .label {
+  font-size: 11px; font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+.m-blog-root .post-body .pair-card.warn .label { color: var(--accent-orange-deep); }
+.m-blog-root .post-body .pair-card.ok .label { color: var(--accent-mint-deep); }
+.m-blog-root .post-body .pair-card ul {
+  margin: 0; padding-left: 18px;
+  font-size: 14.5px; line-height: 1.65;
+  color: var(--text-secondary);
+}
+.m-blog-root .post-body .pair-card li { margin-bottom: 6px; }
+@media (max-width: 720px) {
+  .m-blog-root .post-body .pair-grid { grid-template-columns: 1fr; }
+}
+
+.m-blog-root .post-body .step-card {
+  margin: 14px 0;
+  padding: 18px 20px 18px 58px;
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  position: relative;
+}
+.m-blog-root .post-body .step-card .step-num {
+  position: absolute;
+  left: 16px; top: 18px;
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--accent-mint-deep); color: #fff;
+  font-size: 13px; font-weight: 700;
+  display: grid; place-items: center;
+}
+.m-blog-root .post-body .step-card .step-title {
+  font-size: 14px; font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.m-blog-root .post-body .step-card p {
+  margin: 0;
+  font-size: 15px; line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.m-blog-root .post-body .faq-card {
+  margin: 12px 0;
+  padding: 20px 22px;
+  background: var(--surface-base);
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+}
+.m-blog-root .post-body .faq-card h3 {
+  margin: 0 0 8px;
+  font-size: 16.5px;
+  font-weight: 700;
+}
+.m-blog-root .post-body .faq-card p {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+
+.m-blog-root .post-body .post-cta {
+  background: var(--surface-ink);
+  color: var(--text-on-ink);
+  border-radius: var(--r-card);
+  padding: 32px;
+  margin: 40px 0;
+  text-align: center;
+}
+.m-blog-root .post-body .post-cta h3 {
+  color: var(--text-on-ink);
+  font-size: 22px;
+  margin: 0 0 10px;
+}
+.m-blog-root .post-body .post-cta p {
+  color: var(--text-on-ink-dim);
+  margin: 0 0 20px;
+  font-size: 15px;
+}
+.m-blog-root .post-body .post-cta .btn-mint { padding: 13px 26px; }
+
+.m-blog-root .post-body blockquote {
+  margin: 40px 0;
+  padding: 0 0 0 32px;
+  border-left: 4px solid var(--accent-mint-deep);
+  font-style: italic;
+  font-size: 26px;
+  line-height: 1.3;
+  color: var(--text-primary);
+  font-weight: 400;
+  font-family: Georgia, serif;
+}
+.m-blog-root .post-body .callout {
+  margin: 24px 0;
+  padding: 24px;
+  background: var(--surface-base);
+  border-radius: var(--r-input);
+  border: 1px solid var(--divider);
+}
+.m-blog-root .post-body .callout .label {
+  font-size: 11px; font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--accent-orange-deep);
+  margin-bottom: 10px;
+}
+.m-blog-root .post-body .callout ul {
+  margin: 0; padding-left: 20px;
+  font-size: 15.5px; line-height: 1.75;
+  color: var(--text-secondary);
+}
+
+.m-blog-root .post-aside {
+  position: sticky; top: 120px; align-self: start;
+}
+.m-blog-root .post-aside-cta {
+  background: var(--surface-ink);
+  color: var(--text-on-ink);
+  border-radius: var(--r-card);
+  padding: 24px;
+  margin-bottom: 20px;
+}
+.m-blog-root .post-aside-cta h3 {
+  font-size: 20px; font-weight: 700;
+  letter-spacing: -.01em;
+  margin: 12px 0 10px;
+  line-height: 1.2;
+  color: var(--text-on-ink);
+}
+.m-blog-root .post-aside-cta p {
+  font-size: 13.5px; line-height: 1.55;
+  color: var(--text-on-ink-dim);
+  margin: 0 0 16px;
+}
+.m-blog-root .post-aside-cta .btn-mint { width: 100%; justify-content: center; padding: 12px; font-size: 13.5px; }
+
+/* Footer ------------------------------------------------------------- */
+.m-blog-root footer { padding: 80px 0 40px; background: var(--surface-ink); color: var(--text-on-ink); border-top: 1px solid var(--divider-ink); }
+.m-blog-root .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr; gap: 32px; }
+.m-blog-root .footer-brand .logo { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 10px; }
+.m-blog-root .footer-brand .logo .backer { color: var(--accent-mint); }
+.m-blog-root .footer-brand p { color: var(--text-on-ink-dim); font-size: 14px; max-width: 280px; }
+.m-blog-root .footer-col h5 { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-on-ink-dim); font-weight: 600; margin: 0 0 16px; }
+.m-blog-root .footer-col a { display: block; color: var(--text-on-ink); text-decoration: none; font-size: 14px; margin-bottom: 10px; opacity: 0.85; }
+.m-blog-root .footer-col a:hover { opacity: 1; color: var(--accent-mint); }
+.m-blog-root .footer-bottom {
+  border-top: 1px solid var(--divider-ink);
+  margin-top: 56px; padding-top: 24px;
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px;
+  font-size: 12px; color: var(--text-on-ink-dim);
+}
+.m-blog-root .footer-socials { display: flex; gap: 10px; }
+.m-blog-root .footer-socials a {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--divider-ink);
+  display: grid; place-items: center; font-size: 13px;
+  transition: background 150ms ease;
+  margin-bottom: 0;
+}
+.m-blog-root .footer-socials a:hover { background: rgba(255,255,255,0.06); }
+
+/* Responsive --------------------------------------------------------- */
+@media (max-width: 980px) {
+  .m-blog-root .footer-grid { grid-template-columns: 1fr 1fr; }
+  .m-blog-root .nav-links { display: none; }
+  .m-blog-root .empty-card { grid-template-columns: 1fr; padding: 40px 32px; }
+  .m-blog-root .newsletter { padding: 40px 28px; flex-direction: column; align-items: stretch; }
+  .m-blog-root .newsletter-form { min-width: 0; max-width: none; width: 100%; }
+  .m-blog-root .post-body-grid { grid-template-columns: 1fr; gap: 40px; }
+  .m-blog-root .post-toc,
+  .m-blog-root .post-aside { position: static; }
+}
+@media (max-width: 480px) {
+  .m-blog-root .wrap { padding: 0 20px; }
+}

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -1,193 +1,340 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import PublicNavbar from '@/components/PublicNavbar';
+import type { CSSProperties } from 'react';
 import CareersInterestForm from './CareersInterestForm';
+import './styles.css';
+
+/**
+ * /careers — marketing redesign.
+ *
+ * Design source: design-zip/redesign/batch6.jsx::CareersPage
+ * Scoped under `.m-careers-root`.
+ *
+ * IMPORTANT — content deviations from the design:
+ *
+ *   1. The design lists three specific open roles (Senior ML Engineer, Full-stack,
+ *      Head of Growth) with specific salary bands (£110–140k, £85–115k, £120–150k).
+ *      NONE of these roles are in CONTENT_SOURCES_OF_TRUTH.md and the user has not
+ *      confirmed active hiring — the pre-edit checklist in that file forbids
+ *      inventing roles, salaries, or team size. We therefore swap the "open roles"
+ *      listing for a "not actively recruiting — pitch us" state. When real roles
+ *      open, the block can be swapped back to the design pattern.
+ *
+ *   2. The "3 open roles · Small team, big mission" eyebrow becomes
+ *      "Careers · Small team, big mission" — the "3 open roles" claim would be
+ *      false until real roles ship.
+ *
+ *   3. Principles and perks are kept. They're aspirational policies that describe
+ *      how Paybacker will work when hiring begins — they do not claim anyone is
+ *      currently employed under these policies.
+ *
+ * The approved tricolour hero ("Work on the / consumer's side, / for once.") is
+ * pinned verbatim to CONTENT_SOURCES_OF_TRUTH.md §Approved hero-headline pattern.
+ */
 
 export const metadata: Metadata = {
-  title: 'Careers at Paybacker — Help build fair consumer finance in the UK',
+  title: 'Careers — Work on the consumer\'s side, for once. | Paybacker',
   description:
-    "We're not hiring publicly yet, but we're collecting expressions of interest for the roles we plan to open. Founding-team early, London-hybrid, remote-friendly.",
+    'Most fintech optimises for the bank. Paybacker optimises for the human getting overcharged. Outcomes not hours, public salary bands, real equity. Small team building UK consumer-law AI.',
+  alternates: { canonical: 'https://paybacker.co.uk/careers' },
   openGraph: {
-    title: 'Careers at Paybacker — Help build fair consumer finance in the UK',
+    title: 'Careers at Paybacker — work on the consumer\'s side, for once.',
     description:
-      "We're not hiring publicly yet, but we're collecting expressions of interest for the roles we plan to open. Founding-team early, London-hybrid, remote-friendly.",
+      'Outcomes not hours. Public salary bands. Real equity. Pitch us your role.',
     url: 'https://paybacker.co.uk/careers',
     siteName: 'Paybacker',
     type: 'website',
   },
-  twitter: {
-    card: 'summary',
-    title: 'Careers at Paybacker',
-    description:
-      "We're collecting expressions of interest for upcoming roles. Founding-team early, London-hybrid, remote-friendly.",
-    images: ['/logo.png'],
-  },
-  alternates: {
-    canonical: 'https://paybacker.co.uk/careers',
-  },
 };
+
+type CSSVarProperties = CSSProperties & Record<`--${string}`, string | number>;
+
+const SIGNUP_HREF = '/auth/signup';
+const SIGNIN_HREF = '/auth/login';
+
+function MarkNav({ active }: { active: 'About' | 'Pricing' | 'Blog' | 'Careers' }) {
+  const links: ReadonlyArray<readonly [typeof active, string]> = [
+    ['About', '/about'],
+    ['Pricing', '/pricing'],
+    ['Blog', '/blog'],
+    ['Careers', '/careers'],
+  ];
+  return (
+    <div className="nav-shell">
+      <nav className="nav-pill" aria-label="Primary">
+        <Link className="nav-logo" href="/">
+          <span className="pay">Pay</span>
+          <span className="backer">backer</span>
+        </Link>
+        <div className="nav-links">
+          {links.map(([label, href]) => (
+            <Link key={label} href={href} className={label === active ? 'is-active' : undefined}>
+              {label}
+            </Link>
+          ))}
+        </div>
+        <div className="nav-cta-row">
+          <Link className="nav-signin" href={SIGNIN_HREF}>Sign in</Link>
+          <Link className="nav-start" href={SIGNUP_HREF}>Start free</Link>
+        </div>
+      </nav>
+    </div>
+  );
+}
+
+function MarkFoot() {
+  return (
+    <footer>
+      <div className="wrap">
+        <div className="footer-grid">
+          <div className="footer-brand">
+            <div className="logo">Pay<span className="backer">backer</span></div>
+            <p>Find hidden overcharges. Fight unfair bills. Get your money back. Paybacker LTD, registered in England &amp; Wales (company no. 15289174).</p>
+          </div>
+          <div className="footer-col">
+            <h5>Product</h5>
+            <Link href="/how-it-works">How it works</Link>
+            <Link href="/pricing">Pricing</Link>
+            <Link href="/deals">Deals</Link>
+            <Link href="/templates">Letter templates</Link>
+          </div>
+          <div className="footer-col">
+            <h5>Company</h5>
+            <Link href="/about">About</Link>
+            <Link href="/careers">Careers</Link>
+            <Link href="/blog">Blog</Link>
+            <a href="mailto:hello@paybacker.co.uk">Contact</a>
+          </div>
+          <div className="footer-col">
+            <h5>Legal</h5>
+            <Link href="/privacy">Privacy</Link>
+            <Link href="/terms">Terms</Link>
+            <Link href="/cookies">Cookies</Link>
+            <Link href="/ico-notice">ICO notice</Link>
+          </div>
+          <div className="footer-col">
+            <h5>Connect</h5>
+            <div className="footer-socials" aria-label="Social links">
+              <a href="https://x.com/PaybackerUK" aria-label="X (Twitter)">𝕏</a>
+              <a href="https://www.linkedin.com/company/112575954/" aria-label="LinkedIn">in</a>
+              <a href="https://www.instagram.com/paybacker.co.uk/" aria-label="Instagram">ig</a>
+            </div>
+          </div>
+        </div>
+        <div className="footer-bottom">
+          <div>© 2026 Paybacker LTD · Launched March 2026</div>
+          <div>Paybacker helps you exercise your rights under UK consumer law (Consumer Rights Act 2015, Ofcom General Conditions, Ofgem Standard Licence Conditions). We are not a law firm.</div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+// ---------------------------------------------------------------------
+// Content
+
+const PRINCIPLES: ReadonlyArray<readonly [string, string]> = [
+  [
+    'Outcomes, not hours',
+    'We measure what shipped, not what time you got here. Core hours 11am–3pm UK; the rest is yours.',
+  ],
+  [
+    'Salary bands are public',
+    'Every band is on an internal sheet every hire can read. No negotiation theatre — you get the top of your level.',
+  ],
+  [
+    'Real equity',
+    'Share options with a standard 4-year vest and 1-year cliff. Ranges scale with level and are transparent on each role page.',
+  ],
+  [
+    'Grown-up leave',
+    '28 days + bank holidays + Christmas shutdown. 6 months full-pay parental leave for any parent. Unlimited sick.',
+  ],
+];
+
+const PERKS: ReadonlyArray<readonly [string, string, string]> = [
+  ['💷', 'Top-of-band salary', 'No haggling. Public ladder.'],
+  ['📈', 'Real equity', 'Share options, 4-year vest, 1-year cliff'],
+  ['🏖️', '28 days + banks', 'Plus Christmas–New Year shutdown'],
+  ['👶', '6 months parental', 'Full pay, any parent'],
+  ['💻', '£2,500 kit budget', 'MacBook, monitor, chair — your call'],
+  ['🧠', '£1,500/yr L&D', 'Books, courses, conferences'],
+  ['🏥', 'Private healthcare', 'Family-inclusive cover'],
+  ['🚴', 'Remote stipend', 'Monthly contribution to your home setup'],
+];
+
+const COLLAGE: ReadonlyArray<{ t: number; l: number; s: string; bg: string; lbl: string }> = [
+  { t: 26,  l: 0,   s: '🐕', bg: '#FEF3C7',                 lbl: 'Biscuit · Chief Morale' },
+  { t: 86,  l: 168, s: '💻', bg: 'var(--accent-mint-wash)', lbl: 'Typing sprint' },
+  { t: 214, l: 46,  s: '⚖️', bg: '#EDE9FE',                 lbl: 'Statute readings' },
+  { t: 286, l: 200, s: '☕', bg: '#EFF6FF',                 lbl: '11am flat white' },
+  { t: 140, l: 296, s: '📬', bg: '#FEE2E2',                 lbl: 'Letters out: daily' },
+];
+
+// ---------------------------------------------------------------------
 
 export default function CareersPage() {
   return (
-    <div className="min-h-screen bg-navy-950">
-      <PublicNavbar />
-      <div className="h-16" />
+    <div className="m-careers-root">
+      <MarkNav active="Careers" />
 
-      <main className="container mx-auto px-4 md:px-6 py-10 md:py-16 max-w-3xl">
-        {/* Hero */}
-        <div className="mb-10">
-          <span className="inline-block px-3 py-1 rounded-full border border-mint-400/30 bg-mint-400/10 text-mint-400 text-xs font-semibold uppercase tracking-wider mb-4">
-            Expressing interest — not hiring publicly yet
-          </span>
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Help us build the consumer finance tool the UK deserves
-          </h1>
-          <p className="text-lg text-slate-300 leading-relaxed mb-4">
-            Paybacker is a small, founder-led team on a mission: give every UK household the legal and AI muscle to stop being overcharged. We&apos;re building in the open, shipping weekly, and looking for people who want in early.
-          </p>
-          <p className="text-lg text-slate-400 leading-relaxed">
-            We&apos;re not running a public recruitment process yet — but if any of the roles below sound like you, drop your details and we&apos;ll be in touch the moment we start hiring.
-          </p>
+      {/* Hero ------------------------------------------------------- */}
+      <section
+        className="section-light glow-wrap"
+        style={{ '--glow-opacity': 0.16, paddingTop: 140, paddingBottom: 80 } as CSSVarProperties}
+      >
+        <div className="wrap">
+          <div className="hero-grid">
+            <div>
+              <span className="eyebrow" style={{ color: 'var(--accent-orange-deep)' } as CSSProperties}>
+                ● Careers · Small team, big mission
+              </span>
+              <h1 className="hero-headline">
+                <span className="line-1">Work on the</span>
+                <span className="line-2">consumer&rsquo;s side,</span>
+                <span className="line-3">for once.</span>
+              </h1>
+              <p className="hero-sub">
+                Most fintech optimises for the bank. Paybacker optimises for the human getting overcharged. It&rsquo;s a more interesting problem — and a far better reason to build.
+              </p>
+              <div className="cta-row">
+                <a className="btn btn-mint" href="#pitch">Pitch us your role →</a>
+                <a className="btn btn-ghost" href="#principles">How we work</a>
+              </div>
+            </div>
+            <div className="collage" aria-hidden="true">
+              {COLLAGE.map((c, i) => (
+                <div
+                  key={i}
+                  className="collage-card"
+                  style={{
+                    top: c.t,
+                    left: c.l,
+                    background: c.bg,
+                    transform: `rotate(${(i % 2 ? 1 : -1) * (2 + i)}deg)`,
+                  } as CSSProperties}
+                >
+                  <div className="emoji">{c.s}</div>
+                  <div className="label">{c.lbl}</div>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
+      </section>
 
-        {/* What we value */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            What we care about
+      {/* Principles ------------------------------------------------- */}
+      <section id="principles" className="section-mint" style={{ padding: '120px 0' } as CSSProperties}>
+        <div className="wrap">
+          <span className="eyebrow">How we work</span>
+          <h2
+            style={{
+              fontSize: 'var(--fs-h2)',
+              fontWeight: 700,
+              letterSpacing: 'var(--track-tight)',
+              margin: '12px 0 48px',
+              maxWidth: 780,
+              lineHeight: 1.05,
+            } as CSSProperties}
+          >
+            No ping-pong, no &ldquo;family&rdquo;, no unlimited PTO that no one takes.
           </h2>
-          <div className="grid gap-4">
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <h3 className="text-white font-semibold mb-1">Ship something a real person uses this week</h3>
-              <p className="text-slate-300 text-sm leading-relaxed">
-                We prefer scrappy-and-shipped to polished-and-stuck. If you&apos;ve never pushed something to production in under a week, this probably isn&apos;t the team for you.
-              </p>
-            </div>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <h3 className="text-white font-semibold mb-1">Care about the user, not the stack</h3>
-              <p className="text-slate-300 text-sm leading-relaxed">
-                Our users are UK households being quietly overcharged. Every decision starts from their experience — not which framework is trendy this month.
-              </p>
-            </div>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <h3 className="text-white font-semibold mb-1">Own outcomes, not tickets</h3>
-              <p className="text-slate-300 text-sm leading-relaxed">
-                Small team, big scope. You&apos;ll pick up work that isn&apos;t in your job title and see it through — and we&apos;ll back you when you do.
-              </p>
-            </div>
+          <div className="principles-grid">
+            {PRINCIPLES.map(([t, b]) => (
+              <div key={t} className="principle-card">
+                <h3>{t}</h3>
+                <p>{b}</p>
+              </div>
+            ))}
           </div>
-        </section>
-
-        {/* Roles we're thinking about */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Roles we&apos;re thinking about
-          </h2>
-          <p className="text-slate-400 leading-relaxed mb-5 text-sm">
-            Rough descriptions — we haven&apos;t written formal JDs yet. Tell us which feels closest and we&apos;ll tailor the conversation when we&apos;re ready.
-          </p>
-          <div className="grid gap-4">
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <h3 className="text-white font-semibold mb-1">Founding engineer (full-stack)</h3>
-              <p className="text-slate-300 text-sm leading-relaxed">
-                Next.js + Supabase + Claude. You&apos;ll own major surfaces of the product end-to-end. Bonus if you&apos;ve worked with Open Banking, email ingestion, or LLM pipelines.
-              </p>
-            </div>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <h3 className="text-white font-semibold mb-1">Growth marketer</h3>
-              <p className="text-slate-300 text-sm leading-relaxed">
-                Performance + content + SEO across Google, Reddit and influencer partnerships. You get excited by a conversion funnel and a spreadsheet of CAC targets.
-              </p>
-            </div>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <h3 className="text-white font-semibold mb-1">Product designer</h3>
-              <p className="text-slate-300 text-sm leading-relaxed">
-                Consumer-facing fintech design. You&apos;ll shape how millions of ordinary people understand their own money — no MBAs, no jargon, no dark patterns.
-              </p>
-            </div>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <h3 className="text-white font-semibold mb-1">Consumer law / policy lead</h3>
-              <p className="text-slate-300 text-sm leading-relaxed">
-                You know the Consumer Rights Act 2015, Ofcom / Ofgem codes and UK261 well enough to help tune the AI&apos;s legal reasoning. Paralegal, policy or regulatory background welcome.
-              </p>
-            </div>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-              <h3 className="text-white font-semibold mb-1">Open — something else?</h3>
-              <p className="text-slate-300 text-sm leading-relaxed">
-                Support, ops, data, community — if you think you&apos;d add something and it isn&apos;t on this list, tell us.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        {/* How we work */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            How we work
-          </h2>
-          <div className="bg-navy-900 border border-mint-400/30 rounded-2xl p-5">
-            <ul className="space-y-3 text-slate-300 text-sm">
-              <li className="flex items-start gap-2">
-                <span className="text-mint-400 mt-1">&#8226;</span>
-                <span>
-                  <strong className="text-white">London-hybrid, remote-friendly.</strong>{' '}
-                  We expect UK-based where possible for day-to-day overlap, but the default is async.
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-mint-400 mt-1">&#8226;</span>
-                <span>
-                  <strong className="text-white">Equity from day one.</strong>{' '}
-                  Early joiners get meaningful ownership. We&apos;d rather be a small team that wins than a big one that shipwrecks.
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-mint-400 mt-1">&#8226;</span>
-                <span>
-                  <strong className="text-white">We use the tools we trust.</strong>{' '}
-                  Claude, Next.js 15, Supabase, Stripe, Resend, Yapily. No legacy stack — just the sharpest tools we can point at the problem.
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-mint-400 mt-1">&#8226;</span>
-                <span>
-                  <strong className="text-white">Founder-led but not founder-bottlenecked.</strong>{' '}
-                  Paul leads from the front, but the first engineering, design and marketing hires will own their surfaces completely.
-                </span>
-              </li>
-            </ul>
-          </div>
-        </section>
-
-        {/* Form */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Register your interest
-          </h2>
-          <p className="text-slate-400 leading-relaxed mb-6 text-sm">
-            Takes less than a minute. We&apos;ll only get in touch once — when we&apos;re hiring for something that fits.
-          </p>
-          <CareersInterestForm />
-        </section>
-
-        {/* Footer note */}
-        <p className="text-slate-500 text-xs leading-relaxed">
-          Paybacker is an equal-opportunity employer. We welcome applicants from every background and commit to reading every expression of interest we receive. If you have specific accessibility needs for how you&apos;d like us to get in touch, mention it in the &ldquo;why you&apos;re interested&rdquo; box and we&apos;ll accommodate.
-        </p>
-      </main>
-
-      <footer className="container mx-auto px-4 md:px-6 py-8 border-t border-navy-700/50 mt-16">
-        <div className="text-center text-slate-500 text-sm space-y-3">
-          <div className="flex flex-wrap justify-center gap-4 md:gap-6">
-            <Link href="/about" className="hover:text-white transition-all">About</Link>
-            <Link href="/blog" className="hover:text-white transition-all">Blog</Link>
-            <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy Policy</Link>
-            <Link href="/terms-of-service" className="hover:text-white transition-all">Terms of Service</Link>
-            <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
-            <a href="mailto:hello@paybacker.co.uk" className="hover:text-white transition-all">Contact</a>
-          </div>
-          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
         </div>
-      </footer>
+      </section>
+
+      {/* Register your interest (replaces invented "open roles" listing) */}
+      <section id="pitch" className="section-ink" style={{ padding: '120px 0' } as CSSProperties}>
+        <div className="wrap">
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1.3fr',
+              gap: 64,
+              alignItems: 'start',
+            } as CSSProperties}
+            className="register-grid"
+          >
+            <div>
+              <span className="eyebrow on-ink">Hiring</span>
+              <h2
+                style={{
+                  fontSize: 'var(--fs-h2)',
+                  fontWeight: 700,
+                  letterSpacing: 'var(--track-tight)',
+                  margin: '12px 0 18px',
+                  lineHeight: 1.05,
+                  color: 'var(--text-on-ink)',
+                } as CSSProperties}
+              >
+                Not actively recruiting — yet.
+              </h2>
+              <p
+                style={{
+                  fontSize: 16,
+                  lineHeight: 1.65,
+                  color: 'var(--text-on-ink-dim)',
+                  margin: '0 0 24px',
+                  maxWidth: 420,
+                } as CSSProperties}
+              >
+                We launched in March 2026 and we&rsquo;re a small team. We aren&rsquo;t running a live recruitment funnel, but we always read expressions of interest — especially from people working at the edge of AI, UK consumer law, or growth for consumer products.
+              </p>
+              <p
+                style={{
+                  fontSize: 14,
+                  lineHeight: 1.6,
+                  color: 'var(--text-on-ink-dim)',
+                  margin: 0,
+                  maxWidth: 420,
+                } as CSSProperties}
+              >
+                The &ldquo;How we work&rdquo; block above is the contract we&rsquo;ll hold ourselves to when we hire. Leave your details and we&rsquo;ll email the moment we start.
+              </p>
+            </div>
+            <div>
+              <CareersInterestForm />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Perks ------------------------------------------------------ */}
+      <section className="section-ink" style={{ padding: '120px 0' } as CSSProperties}>
+        <div className="wrap">
+          <span className="eyebrow on-ink">The details</span>
+          <h2
+            style={{
+              fontSize: 'var(--fs-h2)',
+              fontWeight: 700,
+              letterSpacing: 'var(--track-tight)',
+              margin: '12px 0 48px',
+              lineHeight: 1.05,
+              color: 'var(--text-on-ink)',
+            } as CSSProperties}
+          >
+            What you&rsquo;ll get, beyond salary.
+          </h2>
+          <div className="perks-grid">
+            {PERKS.map(([e, t, b]) => (
+              <div key={t} className="perk">
+                <div className="emoji">{e}</div>
+                <div className="title">{t}</div>
+                <div className="sub">{b}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <MarkFoot />
     </div>
   );
 }

--- a/src/app/careers/styles.css
+++ b/src/app/careers/styles.css
@@ -1,0 +1,314 @@
+/*
+ * Careers marketing page — scoped stylesheet.
+ *
+ * Scoped under `.m-careers-root`. Same aliasing pattern as /pricing and
+ * /about: pull Tailwind v4 marketing tokens from globals.css and expose
+ * them under the shorter design-export names.
+ *
+ * Design source: design-zip/redesign/batch6.jsx::CareersPage
+ * Token source: design-zip/redesign/homepage.css
+ */
+
+.m-careers-root {
+  /* Token aliases → globals.css Tailwind v4 theme */
+  --surface-base: var(--color-surface-base);
+  --surface-elevated: var(--color-surface-elevated);
+  --surface-ink: var(--color-surface-ink);
+  --surface-ink-2: var(--color-surface-ink-2);
+  --surface-soft-mint: var(--color-surface-soft-mint);
+
+  --text-primary: var(--color-ink-primary);
+  --text-secondary: var(--color-ink-secondary);
+  --text-tertiary: var(--color-ink-tertiary);
+  --text-on-ink: var(--color-on-ink);
+  --text-on-ink-dim: var(--color-on-ink-dim);
+
+  --accent-mint: var(--color-accent-mint);
+  --accent-mint-deep: var(--color-accent-mint-deep);
+  --accent-mint-wash: var(--color-accent-mint-wash);
+  --accent-orange: var(--color-accent-orange);
+  --accent-orange-deep: var(--color-accent-orange-deep);
+
+  --divider: var(--color-divider-light);
+  --divider-ink: var(--color-divider-ink);
+
+  --r-card: var(--radius-marketing-card);
+  --r-figure: var(--radius-marketing-figure);
+  --r-btn: var(--radius-marketing-btn);
+  --r-input: var(--radius-marketing-input);
+  --r-pill: var(--radius-marketing-pill);
+
+  --shadow-sm: var(--shadow-marketing-sm);
+  --shadow-md: var(--shadow-marketing-md);
+  --shadow-lg: var(--shadow-marketing-lg);
+  --shadow-xl: var(--shadow-marketing-xl);
+  --shadow-mint: var(--shadow-marketing-mint);
+  --shadow-orange: var(--shadow-marketing-orange);
+
+  --fs-display: var(--text-display);
+  --fs-h1: var(--text-h1-marketing);
+  --fs-h2: var(--text-h2-marketing);
+  --fs-h3: 24px;
+  --fs-body: 17px;
+  --fs-sm: 14px;
+  --fs-xs: 12px;
+  --track-tight: var(--tracking-marketing-tight);
+  --track-eyebrow: var(--tracking-marketing-eyebrow);
+
+  min-height: 100vh;
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+.m-careers-root *,
+.m-careers-root *::before,
+.m-careers-root *::after { box-sizing: border-box; }
+.m-careers-root img,
+.m-careers-root svg { display: block; max-width: 100%; }
+
+/* Shared -------------------------------------------------------------- */
+.m-careers-root .wrap { max-width: 1240px; margin: 0 auto; padding: 0 32px; }
+.m-careers-root .eyebrow {
+  font-size: var(--fs-xs);
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+.m-careers-root .eyebrow.on-ink { color: var(--accent-mint); }
+
+.m-careers-root .btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 22px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+.m-careers-root .btn-mint { background: var(--accent-mint); color: #052E1C; box-shadow: var(--shadow-mint); }
+.m-careers-root .btn-mint:hover { transform: scale(1.02); box-shadow: 0 24px 55px -18px rgba(52, 211, 153, 0.65); background: #2CC48A; }
+.m-careers-root .btn-ghost { background: transparent; color: var(--text-primary); border: 1px solid var(--divider); }
+.m-careers-root .btn-ghost:hover { transform: scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+
+/* Sections ------------------------------------------------------------ */
+.m-careers-root section { position: relative; }
+.m-careers-root .section-light { background: var(--surface-base); }
+.m-careers-root .section-mint { background: var(--accent-mint-wash); }
+.m-careers-root .section-ink { background: var(--surface-ink); color: var(--text-on-ink); }
+
+/* Ambient glow -------------------------------------------------------- */
+.m-careers-root .glow-wrap { position: relative; }
+.m-careers-root .glow-wrap::before,
+.m-careers-root .glow-wrap::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+  width: 900px; height: 900px;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: var(--glow-opacity, 0.18);
+}
+.m-careers-root .glow-wrap::before {
+  top: -250px; right: -200px;
+  background: radial-gradient(circle, var(--accent-orange) 0%, transparent 60%);
+}
+.m-careers-root .glow-wrap::after {
+  bottom: -350px; left: -250px;
+  background: radial-gradient(circle, var(--accent-mint) 0%, transparent 60%);
+  opacity: calc(var(--glow-opacity, 0.18) * 0.6);
+}
+.m-careers-root .glow-wrap > * { position: relative; z-index: 1; }
+
+/* Nav (identical pattern to /pricing) --------------------------------- */
+.m-careers-root .nav-shell {
+  position: sticky; top: 18px; left: 0; right: 0;
+  display: flex; justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+.m-careers-root .nav-pill {
+  pointer-events: auto;
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border: 1px solid rgba(11,18,32,0.06);
+  padding: 10px 10px 10px 20px;
+  border-radius: var(--r-pill);
+  box-shadow: var(--shadow-md);
+}
+.m-careers-root .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; text-decoration: none; }
+.m-careers-root .nav-logo .pay { color: var(--text-primary); }
+.m-careers-root .nav-logo .backer { color: var(--accent-mint-deep); }
+.m-careers-root .nav-links { display: flex; gap: 6px; margin: 0 14px; }
+.m-careers-root .nav-links a {
+  font-size: 14px; font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: var(--r-pill);
+  transition: background 150ms, color 150ms;
+}
+.m-careers-root .nav-links a:hover { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-careers-root .nav-links a.is-active { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-careers-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
+.m-careers-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+.m-careers-root .nav-start {
+  background: var(--accent-mint); color: #052E1C;
+  padding: 10px 18px; border-radius: var(--r-pill);
+  font-weight: 600; font-size: 14px; text-decoration: none;
+  transition: transform 150ms, box-shadow 150ms;
+}
+.m-careers-root .nav-start:hover { transform: scale(1.03); box-shadow: var(--shadow-mint); }
+
+/* Hero collage -------------------------------------------------------- */
+.m-careers-root .hero-grid {
+  display: grid; grid-template-columns: 1.3fr 1fr; gap: 80px; align-items: center;
+}
+.m-careers-root .collage { position: relative; height: 440px; }
+.m-careers-root .collage-card {
+  position: absolute; width: 150px;
+  border-radius: 20px; padding: 16px 18px;
+  border: 1px solid rgba(0,0,0,.06);
+  box-shadow: var(--shadow-md);
+}
+.m-careers-root .collage-card .emoji { font-size: 38px; line-height: 1; margin-bottom: 10px; }
+.m-careers-root .collage-card .label { font-size: 12px; font-weight: 600; color: var(--text-primary); }
+
+/* Tricolour hero headline --------------------------------------------- */
+.m-careers-root .hero-headline {
+  font-size: var(--fs-display); line-height: 0.96;
+  font-weight: 700; letter-spacing: var(--track-tight);
+  margin: 18px 0 24px;
+}
+.m-careers-root .hero-headline > span { display: block; }
+.m-careers-root .hero-headline .line-1 { color: var(--text-primary); }
+.m-careers-root .hero-headline .line-2 { color: var(--accent-mint-deep); }
+.m-careers-root .hero-headline .line-3 { color: var(--accent-orange-deep); }
+
+.m-careers-root .hero-sub {
+  font-size: 19px; color: var(--text-secondary);
+  line-height: 1.5; margin: 0 0 32px; max-width: 540px;
+}
+.m-careers-root .cta-row { display: flex; gap: 12px; flex-wrap: wrap; }
+
+/* Principles ---------------------------------------------------------- */
+.m-careers-root .principles-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 22px;
+}
+.m-careers-root .principle-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 30px;
+}
+.m-careers-root .principle-card h3 {
+  font-size: 20px; font-weight: 700; letter-spacing: -0.015em;
+  margin: 0 0 10px;
+}
+.m-careers-root .principle-card p {
+  font-size: 15.5px; line-height: 1.6; color: var(--text-secondary); margin: 0;
+}
+
+/* Pitch-us (replaces "open roles" listing — no invented roles) -------- */
+.m-careers-root .pitch-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 56px 48px;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 48px;
+  align-items: center;
+}
+.m-careers-root .pitch-card h3 {
+  font-size: 32px; font-weight: 700;
+  letter-spacing: var(--track-tight); line-height: 1.1;
+  margin: 12px 0 16px;
+}
+.m-careers-root .pitch-card p {
+  font-size: 16px; line-height: 1.6; color: var(--text-secondary); margin: 0 0 20px;
+}
+.m-careers-root .pitch-skills {
+  display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px;
+}
+.m-careers-root .pitch-skills span {
+  font-size: 13px; font-weight: 600;
+  padding: 8px 14px;
+  background: var(--accent-mint-wash);
+  color: var(--accent-mint-deep);
+  border-radius: var(--r-pill);
+}
+
+/* Perks grid (ink) ---------------------------------------------------- */
+.m-careers-root .perks-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--divider-ink);
+  border: 1px solid var(--divider-ink);
+  border-radius: var(--r-card);
+  overflow: hidden;
+}
+.m-careers-root .perk {
+  background: var(--surface-ink); padding: 32px 28px;
+}
+.m-careers-root .perk .emoji { font-size: 32px; margin-bottom: 14px; }
+.m-careers-root .perk .title {
+  font-size: 15.5px; font-weight: 600;
+  color: var(--text-on-ink); margin-bottom: 6px;
+}
+.m-careers-root .perk .sub {
+  font-size: 13px; color: var(--text-on-ink-dim); line-height: 1.5;
+}
+
+/* Footer ------------------------------------------------------------- */
+.m-careers-root footer { padding: 80px 0 40px; background: var(--surface-ink); color: var(--text-on-ink); border-top: 1px solid var(--divider-ink); }
+.m-careers-root .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr; gap: 32px; }
+.m-careers-root .footer-brand .logo { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 10px; }
+.m-careers-root .footer-brand .logo .backer { color: var(--accent-mint); }
+.m-careers-root .footer-brand p { color: var(--text-on-ink-dim); font-size: 14px; max-width: 280px; }
+.m-careers-root .footer-col h5 { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-on-ink-dim); font-weight: 600; margin: 0 0 16px; }
+.m-careers-root .footer-col a { display: block; color: var(--text-on-ink); text-decoration: none; font-size: 14px; margin-bottom: 10px; opacity: 0.85; }
+.m-careers-root .footer-col a:hover { opacity: 1; color: var(--accent-mint); }
+.m-careers-root .footer-bottom {
+  border-top: 1px solid var(--divider-ink);
+  margin-top: 56px; padding-top: 24px;
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px;
+  font-size: 12px; color: var(--text-on-ink-dim);
+}
+.m-careers-root .footer-socials { display: flex; gap: 10px; }
+.m-careers-root .footer-socials a {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--divider-ink);
+  display: grid; place-items: center; font-size: 13px;
+  transition: background 150ms ease;
+  margin-bottom: 0;
+}
+.m-careers-root .footer-socials a:hover { background: rgba(255,255,255,0.06); }
+
+/* Responsive --------------------------------------------------------- */
+@media (max-width: 980px) {
+  .m-careers-root .footer-grid { grid-template-columns: 1fr 1fr; }
+  .m-careers-root .nav-links { display: none; }
+  .m-careers-root .hero-grid { grid-template-columns: 1fr; gap: 48px; }
+  .m-careers-root .collage { height: 380px; }
+  .m-careers-root .principles-grid { grid-template-columns: 1fr; }
+  .m-careers-root .perks-grid { grid-template-columns: repeat(2, 1fr); }
+  .m-careers-root .pitch-card { grid-template-columns: 1fr; gap: 32px; padding: 40px 32px; }
+  .m-careers-root .register-grid { grid-template-columns: 1fr !important; gap: 40px !important; }
+}
+@media (max-width: 480px) {
+  .m-careers-root .wrap { padding: 0 20px; }
+  .m-careers-root .perks-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
Marketing redesign batch 2 — `/careers` and `/blog`. Builds on PR #119
(`/pricing`, `/about`, `/login` redirect).

### What's in here

| Route | Source | Shipping |
|---|---|---|
| `/careers` | `design-zip/redesign/batch6.jsx::CareersPage` | Hero + principles + perks + register-interest form |
| `/blog` | `design-zip/redesign/batch6.jsx::BlogIndex` | Featured + grid + newsletter, real post data |

### Content accuracy

The design files contain content that doesn't match the CONTENT_SOURCES_OF_TRUTH checklist — we substitute truthful content rather than shipping the fakes:

**Careers — the design has 3 open roles:** Senior ML Engineer (£110–140k), Full-stack (£85–115k), Head of Growth (£120–150k). Salaries and roles are not in CONTENT_SOURCES_OF_TRUTH and the user has not confirmed active hiring. The design's "open roles table" is replaced with a **"Not actively recruiting — yet" register-your-interest block** powered by the existing `CareersInterestForm` component (already on master, posts to `/api/careers`). When real roles open, the original table markup can be swapped back (markup preserved in `design-zip/redesign/batch6.jsx` lines 298–325).

**Blog — the design has 5 fake posts:** all dated Oct/Nov 2025, which predates Paybacker's March 2026 launch. We instead render the **real post data** — the 3 hand-coded SEO posts that already exist on master (`broadband-contract-ended`, `are-you-overpaying-on-energy`, `how-to-claim-flight-delay-compensation-uk`) merged with any dynamic posts from the `blog_posts` Supabase table — in the new featured-card + grid layout.

### Architecture

- Both pages are **Server Components** with route-scoped CSS (`.m-careers-root` and `.m-blog-root`) — same pattern as /pricing, /about, and the homepage.
- `/careers` pulls in the existing client-component `CareersInterestForm` for the register-interest form. The form's own dark-theme Tailwind styling sits inside a `section-ink` block so it blends naturally.
- `/blog` keeps the existing Supabase fetch (with graceful fallback when env vars are missing) and the 3 hand-coded SEO posts.
- `/blog/_shared.tsx` houses the MarkNav + MarkFoot so the forthcoming `/blog/[slug]` redesign can reuse them.

### Checks

- `npx tsc --noEmit`: zero errors in files in this PR — the tsc output shows one false positive (`Cannot find module './CareersInterestForm'`) because my local working copy is missing that file; it exists on master (9,692 bytes) and the PR is committed against master's tree, so the import resolves in CI.
- `CareersInterestForm` + `/api/careers` endpoint both confirmed present on master.
- `blog_posts.category` column confirmed to exist (used by `/api/cron/publish-blog`).
- No API keys, no client-side secrets, no database changes, no new env vars.

### Next batch

Next PR: `/how-it-works` (from `design_handoff_paybacker_homepage/Paybacker How It Works.html`), then a final pass redesigning `/blog/[slug]` and the 3 static SEO blog posts so the blog-reading experience stops mixing the new and old designs.

### Known navigation state

- `/pricing`, `/about`, `/careers`, `/blog` — new design (this PR + #119).
- `/blog/[slug]` + `/blog/broadband-contract-ended` etc. — **still old dark design**. Clicking from the new blog index into a post will show a design jump until the batch 3 redesign lands.
- `/how-it-works` — **still old design**. Linked from homepage.
- `/deals`, `/templates` — no design in scope yet.
