### PR TITLE
feat(marketing): redesign /how-it-works

### DIFF
--- a/src/app/blog/_shared.tsx
+++ b/src/app/blog/_shared.tsx
@@ -1,0 +1,215 @@
+/**
+ * Shared chrome for /blog and /blog/[slug].
+ *
+ * Both routes scope their styles under `.m-blog-root` so the nav + footer
+ * components live in a single module to keep per-route page.tsx files small.
+ */
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+export const SIGNUP_HREF = '/auth/signup';
+export const SIGNIN_HREF = '/auth/login';
+
+type NavLabel = 'About' | 'Pricing' | 'Blog' | 'Careers';
+
+export function MarkNav({ active }: { active?: NavLabel }) {
+  const links: ReadonlyArray<readonly [NavLabel, string]> = [
+    ['About', '/about'],
+    ['Pricing', '/pricing'],
+    ['Blog', '/blog'],
+    ['Careers', '/careers'],
+  ];
+  return (
+    <div className="nav-shell">
+      <nav className="nav-pill" aria-label="Primary">
+        <Link className="nav-logo" href="/">
+          <span className="pay">Pay</span>
+          <span className="backer">backer</span>
+        </Link>
+        <div className="nav-links">
+          {links.map(([label, href]) => (
+            <Link key={label} href={href} className={label === active ? 'is-active' : undefined}>
+              {label}
+            </Link>
+          ))}
+        </div>
+        <div className="nav-cta-row">
+          <Link className="nav-signin" href={SIGNIN_HREF}>Sign in</Link>
+          <Link className="nav-start" href={SIGNUP_HREF}>Start free</Link>
+        </div>
+      </nav>
+    </div>
+  );
+}
+
+export function MarkFoot() {
+  return (
+    <footer>
+      <div className="wrap">
+        <div className="footer-grid">
+          <div className="footer-brand">
+            <div className="logo">Pay<span className="backer">backer</span></div>
+            <p>Find hidden overcharges. Fight unfair bills. Get your money back. Paybacker LTD, registered in England &amp; Wales (company no. 15289174).</p>
+          </div>
+          <div className="footer-col">
+            <h5>Product</h5>
+            <Link href="/how-it-works">How it works</Link>
+            <Link href="/pricing">Pricing</Link>
+            <Link href="/deals">Deals</Link>
+            <Link href="/templates">Letter templates</Link>
+          </div>
+          <div className="footer-col">
+            <h5>Company</h5>
+            <Link href="/about">About</Link>
+            <Link href="/careers">Careers</Link>
+            <Link href="/blog">Blog</Link>
+            <a href="mailto:hello@paybacker.co.uk">Contact</a>
+          </div>
+          <div className="footer-col">
+            <h5>Legal</h5>
+            <Link href="/privacy">Privacy</Link>
+            <Link href="/terms">Terms</Link>
+            <Link href="/cookies">Cookies</Link>
+            <Link href="/ico-notice">ICO notice</Link>
+          </div>
+          <div className="footer-col">
+            <h5>Connect</h5>
+            <div className="footer-socials" aria-label="Social links">
+              <a href="https://x.com/PaybackerUK" aria-label="X (Twitter)">𝕏</a>
+              <a href="https://www.linkedin.com/company/112575954/" aria-label="LinkedIn">in</a>
+              <a href="https://www.instagram.com/paybacker.co.uk/" aria-label="Instagram">ig</a>
+            </div>
+          </div>
+        </div>
+        <div className="footer-bottom">
+          <div>© 2026 Paybacker LTD · Launched March 2026</div>
+          <div>Paybacker helps you exercise your rights under UK consumer law (Consumer Rights Act 2015, Ofcom General Conditions, Ofgem Standard Licence Conditions). We are not a law firm.</div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Post-level shell reused by /blog/[slug] + the three static SEO post pages.
+// Scopes content under `.m-blog-root` and assembles the
+// breadcrumb/headline/meta + three-column post-body-grid (TOC/body/aside).
+// ---------------------------------------------------------------------------
+
+export type TocItem = { id: string; label: string };
+
+export type PostAsideCTAProps = {
+  eyebrow?: string;
+  title: string;
+  description: string;
+  ctaLabel: string;
+  ctaHref: string;
+};
+
+export function PostAsideCTA({ eyebrow, title, description, ctaLabel, ctaHref }: PostAsideCTAProps) {
+  return (
+    <div className="post-aside-cta">
+      {eyebrow ? <div className="eyebrow on-ink">{eyebrow}</div> : null}
+      <h3>{title}</h3>
+      <p>{description}</p>
+      <Link className="btn btn-mint" href={ctaHref}>{ctaLabel}</Link>
+    </div>
+  );
+}
+
+export type PostShellProps = {
+  category?: string;
+  title: string;
+  dek?: string;
+  dateLabel: string;
+  readTime?: string;
+  toc?: TocItem[];
+  aside?: PostAsideCTAProps;
+  children: ReactNode;
+  /** Optional JSON-LD block to place at the top of the root. */
+  jsonLd?: Record<string, unknown>;
+};
+
+export function PostShell({
+  category,
+  title,
+  dek,
+  dateLabel,
+  readTime,
+  toc,
+  aside,
+  children,
+  jsonLd,
+}: PostShellProps) {
+  const defaultAside: PostAsideCTAProps = {
+    eyebrow: 'Try Paybacker',
+    title: 'Generate a formal letter in 30 seconds',
+    description: 'Our AI writes complaint letters citing exact UK law. Free to try — 3 letters per month.',
+    ctaLabel: 'Start free',
+    ctaHref: SIGNUP_HREF,
+  };
+  const asideProps = aside ?? defaultAside;
+
+  return (
+    <div className="m-blog-root">
+      {jsonLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      ) : null}
+      <MarkNav active="Blog" />
+      <main>
+        <section className="section-light" style={{ paddingTop: 64 }}>
+          <div className="wrap">
+            <div className="post-breadcrumb">
+              <Link href="/blog">Blog</Link>
+              <span>/</span>
+              {category ? <span className="cat">{category}</span> : <span>{title.length > 48 ? title.slice(0, 48) + '…' : title}</span>}
+            </div>
+            <h1 className="post-headline">{title}</h1>
+            {dek ? <p className="post-dek">{dek}</p> : null}
+            <div className="post-meta">
+              <div className="author-dot" aria-hidden>PB</div>
+              <div>
+                <div style={{ fontSize: 14, fontWeight: 600 }}>Paybacker</div>
+                <div style={{ fontSize: 13, color: 'var(--text-tertiary)' }}>
+                  {dateLabel}{readTime ? ` · ${readTime}` : ''}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="section-light" style={{ paddingTop: 56, paddingBottom: 96 }}>
+          <div className="wrap">
+            <div className="post-body-grid">
+              {/* TOC */}
+              <aside className="post-toc" aria-label="On this page">
+                {toc && toc.length > 0 ? (
+                  <>
+                    <div className="post-toc-title">On this page</div>
+                    {toc.map((item) => (
+                      <a key={item.id} href={`#${item.id}`} className="post-toc-link">
+                        {item.label}
+                      </a>
+                    ))}
+                  </>
+                ) : null}
+              </aside>
+
+              {/* Body */}
+              <div className="post-body">{children}</div>
+
+              {/* Aside CTA */}
+              <aside className="post-aside">
+                <PostAsideCTA {...asideProps} />
+              </aside>
+            </div>
+          </div>
+        </section>
+      </main>
+      <MarkFoot />
+    </div>
+  );
+}

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -1,0 +1,871 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+import { MarkNav, MarkFoot, SIGNUP_HREF } from '../blog/_shared';
+import './styles.css';
+
+/**
+ * /how-it-works — marketing redesign.
+ *
+ * Design source: design-zip/design_handoff_paybacker_homepage/Paybacker How It Works.html
+ * Scoped under `.m-how-root`.
+ *
+ * Six numbered demo sections walk through the product surface by surface:
+ *   01 Disputes Centre     — LIVE
+ *   02 Subscriptions       — LIVE
+ *   03 Money Hub           — LIVE
+ *   04 Telegram agent      — COMING SOON (per CLAUDE.md roadmap)
+ *   05 Google Sheets sync  — COMING SOON
+ *   06 Stacked             — comparison with Emma / Snoop / Resolver / Which? / Lunchflow
+ *
+ * The design's JS-driven filter tagbar is replaced with anchor-link
+ * jump nav — every section is rendered and links scroll to it.
+ *
+ * Content-accuracy deviations vs the design file:
+ * - Telegram + Sheets marked "Coming soon" (CLAUDE.md: both on roadmap, not live).
+ * - "53+ UK partners" replaced with "UK partner network" (no specific count to commit to).
+ * - Bank connection copy references Yapily (current provider) rather than TrueLayer.
+ */
+
+export const metadata: Metadata = {
+  title: 'How Paybacker works — the five tools in one app',
+  description:
+    'AI-drafted legal dispute letters, subscription tracking, a bank-connected Money Hub, a Telegram pocket agent and a live Google Sheets export. All from one app, citing real UK consumer law.',
+  alternates: { canonical: 'https://paybacker.co.uk/how-it-works' },
+  openGraph: {
+    title: 'How Paybacker works',
+    description:
+      'The five tools, side by side. Disputes, subscriptions, Money Hub, Telegram agent, Sheets sync.',
+    url: 'https://paybacker.co.uk/how-it-works',
+    siteName: 'Paybacker',
+    type: 'website',
+  },
+};
+
+export default function HowItWorksPage() {
+  return (
+    <div className="m-how-root">
+      <MarkNav />
+
+      <header className="hero">
+        <nav className="jump" aria-label="Jump to section">
+          <Link href="#disputes">Disputes</Link>
+          <Link href="#subs">Subscriptions</Link>
+          <Link href="#hub">Money Hub</Link>
+          <Link href="#agent">Telegram agent</Link>
+          <Link href="#sheets">Sheets export</Link>
+          <Link href="#stacked">Stacked</Link>
+        </nav>
+        <h1>
+          One app. Everything{' '}
+          <span style={{ color: 'var(--accent-mint-deep)' } as CSSProperties}>Emma</span>,{' '}
+          <span style={{ color: 'var(--accent-orange-deep)' } as CSSProperties}>Lunchflow</span>{' '}
+          and a letter-writing lawyer can do.
+        </h1>
+        <p>
+          Paybacker&rsquo;s five tools work brilliantly on their own &mdash; and become
+          unstoppable stacked together. Here&rsquo;s how each one fits into your day.
+        </p>
+      </header>
+
+      {/* 01 — DISPUTES */}
+      <Section1Disputes />
+
+      {/* 02 — SUBSCRIPTIONS */}
+      <Section2Subscriptions />
+
+      {/* 03 — MONEY HUB */}
+      <Section3MoneyHub />
+
+      {/* 04 — TELEGRAM */}
+      <Section4Telegram />
+
+      {/* 05 — SHEETS */}
+      <Section5Sheets />
+
+      {/* 06 — STACKED */}
+      <Section6Stacked />
+
+      <section style={{ padding: '40px 0 0' } as CSSProperties}>
+        <div className="wrap" style={{ textAlign: 'center', padding: '60px 0' } as CSSProperties}>
+          <h2
+            style={{
+              fontSize: 36,
+              fontWeight: 800,
+              letterSpacing: 'var(--track-tight)',
+              margin: '0 0 14px',
+            } as CSSProperties}
+          >
+            Ready to see it in your own numbers?
+          </h2>
+          <p
+            style={{
+              fontSize: 17,
+              color: 'var(--text-secondary)',
+              maxWidth: 560,
+              margin: '0 auto 28px',
+            } as CSSProperties}
+          >
+            Connect a UK bank account in under a minute. Free forever on the starter plan.
+          </p>
+          <Link href={SIGNUP_HREF} className="btn btn-mint">
+            Start free &rarr;
+          </Link>
+        </div>
+      </section>
+
+      <MarkFoot />
+    </div>
+  );
+}
+
+/* ==================================================================== */
+/* 01 — AI Disputes Centre                                              */
+/* ==================================================================== */
+
+function Section1Disputes() {
+  return (
+    <section className="demo" id="disputes">
+      <div className="demo-head">
+        <div>
+          <div className="demo-num">01 &middot; AI DISPUTES CENTRE</div>
+          <h2 className="demo-title">
+            Formal complaint letters citing exact UK law, in 30 seconds.{' '}
+            <span style={{ color: 'var(--accent-orange-deep)' } as CSSProperties}>
+              You send them. We track the replies.
+            </span>
+          </h2>
+          <p className="demo-sub">
+            We write the letter, you send it from your own inbox &mdash; then Paybacker&rsquo;s
+            AI watches the email thread for you. When the provider replies, we analyse it,
+            draft your rebuttal, and alert you in-app when action is needed.
+          </p>
+        </div>
+        <span className="vs-badge">vs. Which? / Resolver</span>
+      </div>
+
+      <div className="stage plain">
+        <div className="dispute-flow">
+          <div className="dispute-card">
+            <h4>Letter preview</h4>
+            <div className="letter-preview">
+              <div className="letter-meta">
+                &#x2728; Generated in 0:28 &middot; CRA 2015 s.49 &middot; Ofcom Fairness Framework
+              </div>
+              <p style={{ margin: '0 0 10px' } as CSSProperties}>
+                <strong>To:</strong> complaints@virginmedia.co.uk<br />
+                <strong>Subject:</strong> Formal dispute &mdash; mid-contract price increase of
+                £12 applied 1 October
+              </p>
+              <p style={{ margin: '0 0 10px' } as CSSProperties}>Dear Virgin Media Customer Relations,</p>
+              <p style={{ margin: '0 0 10px' } as CSSProperties}>
+                I am writing to formally dispute the{' '}
+                <span className="hl">£12 CPI+3.9% increase</span> applied to my broadband
+                contract on 1 October, reference <span className="hl">VM-774-2245</span>.
+              </p>
+              <p style={{ margin: '0 0 10px' } as CSSProperties}>
+                Under <span className="hl">Ofcom&rsquo;s Fairness Framework (2021)</span> and
+                the <span className="hl">Consumer Rights Act 2015, s.49</span>, you are obliged
+                to provide clear and reasonable notice of price increases and a penalty-free
+                right to exit where material terms change mid-contract&hellip;
+              </p>
+            </div>
+            <div className="copy-actions">
+              <span className="copy-btn primary">Copy letter to clipboard</span>
+              <span className="copy-btn">Download .pdf</span>
+              <span className="copy-btn">Open in your email app</span>
+            </div>
+          </div>
+
+          <div className="dispute-card">
+            <h4>What you filled in (30 seconds)</h4>
+            <div className="form-field">
+              <label>Category</label>
+              <div className="v">Mid-contract price rise &middot; Broadband</div>
+            </div>
+            <div className="form-field">
+              <label>Provider</label>
+              <div className="v">Virgin Media</div>
+            </div>
+            <div className="form-field">
+              <label>What happened</label>
+              <div className="v">My bill jumped £12 without my agreement. Contract was fixed.</div>
+            </div>
+            <div className="form-field">
+              <label>Paybacker picked for you</label>
+              <div className="v picked">✓ CRA 2015 s.49 &middot; ✓ Ofcom Fairness Framework</div>
+            </div>
+          </div>
+
+          <div className="clarity-banner">
+            <div className="icon">i</div>
+            <div>
+              <strong>You send it &mdash; we watch the reply.</strong> Paybacker never emails
+              providers on your behalf. You send from your own inbox, then our AI monitors that
+              email thread: when a reply lands, we analyse the provider&rsquo;s response, draft
+              your counter-reply, and alert you in-app when action is needed.
+            </div>
+          </div>
+
+          <div className="thread-monitor">
+            <div className="live">
+              <div className="dot" />
+              <div className="live-label">Live &middot; Monitoring 1 thread</div>
+              <div className="inbox">Gmail &middot; connected</div>
+            </div>
+            <div className="thread-row">
+              <span>&#x1F4E4;</span>
+              <div>
+                <strong>You &rarr; Virgin Media</strong> &middot; Formal dispute &mdash;
+                mid-contract price increase
+              </div>
+              <span className="dt">Mon 14:22</span>
+            </div>
+            <div className="thread-row">
+              <span>&#x1F4E5;</span>
+              <div>
+                <strong>Virgin Media &rarr; You</strong> &middot; &ldquo;We&rsquo;ve received
+                your complaint&hellip;&rdquo;
+              </div>
+              <span className="dt">Tue 09:04</span>
+            </div>
+            <div className="thread-row alert">
+              <span>&#x1F916;</span>
+              <div>
+                <strong style={{ color: 'var(--accent-orange-deep)' } as CSSProperties}>
+                  Paybacker AI flagged this reply.
+                </strong>{' '}
+                Virgin is offering £6/mo credit but not dropping the hike. Draft rebuttal ready
+                citing Ofcom para 4.2.
+              </div>
+              <span className="dt">ACT NOW</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="caption-row">
+        <div className="caption-col">
+          <h3>How to use it</h3>
+          <p>
+            Pick a category (bill hike, flight delay, bad service, etc.), tell us what happened
+            in a sentence or two, and the AI drafts a legally-grounded letter. Copy it, download
+            as PDF, or open in your email app pre-filled. Then just connect your Gmail or
+            Outlook &mdash; Paybacker reads incoming replies in that thread, flags them by
+            urgency, drafts your counter-reply, and pings you the moment action is needed.
+          </p>
+        </div>
+        <div className="caption-col">
+          <h3>Why it&rsquo;s different</h3>
+          <ul>
+            <li>Cites specific UK statutes &mdash; not generic &ldquo;I&rsquo;m unhappy&rdquo; prose</li>
+            <li>Monitors email threads end-to-end &mdash; knows when a reply lands</li>
+            <li>Drafts rebuttals automatically when providers push back</li>
+            <li>In-app alerts the moment you need to act</li>
+            <li>Works across Ofcom / Ofgem / FCA / UK261 / CRA 2015</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ==================================================================== */
+/* 02 — Subscriptions                                                   */
+/* ==================================================================== */
+
+function Section2Subscriptions() {
+  return (
+    <section className="demo" id="subs">
+      <div className="demo-head">
+        <div>
+          <div className="demo-num">02 &middot; SUBSCRIPTIONS TRACKER</div>
+          <h2 className="demo-title">Every recurring charge. Flagged, categorised, cancellable.</h2>
+          <p className="demo-sub">
+            Read-only sync with your bank via Open Banking. Each subscription is auto-tagged
+            &mdash; hikes, duplicates, trials, inactive &mdash; and one tap takes you to the
+            provider&rsquo;s cancel page.
+          </p>
+        </div>
+        <span className="vs-badge">vs. Emma &middot; Snoop</span>
+      </div>
+
+      <div className="stage">
+        <div className="iphone tilt">
+          <div className="iphone-inner">
+            <div className="iphone-screen">
+              <div className="island" />
+              <div className="status-bar dark-text">
+                <span>9:41</span>
+                <span>●●● 100%</span>
+              </div>
+              <div className="tracker-screen">
+                <div className="tracker-head">
+                  <div className="t">Subscriptions</div>
+                  <div className="tot">18 active</div>
+                </div>
+                <div className="tracker-total">
+                  <div className="lbl">Monthly spend</div>
+                  <div className="big">£284.16</div>
+                  <div className="delta">
+                    &uarr; £38 vs. last month &middot;{' '}
+                    <strong style={{ color: 'var(--accent-orange)' } as CSSProperties}>
+                      4 need review
+                    </strong>
+                  </div>
+                </div>
+                <SubRow logo="N" color="#E50914" name="Netflix Premium" tag="hike" tagLabel="+£3 hike" meta="Monthly · Next: 14 Nov" amt="£17.99" />
+                <SubRow logo="V" color="#D9232A" name="Virgin Media" tag="hike" tagLabel="+£12 hike" meta="Monthly · Next: 1 Nov" amt="£49.00" />
+                <SubRow logo="A" color="#00A693" name="Audible" meta="Monthly · Next: 18 Nov" amt="£7.99" />
+                <SubRow logo="T" color="#9146FF" name="Twitch Turbo" tag="dup" tagLabel="Duplicate" meta="You also have Prime" amt="£8.99" />
+                <SubRow logo="C" color="#FF6A00" name="Canva Pro" tag="trial" tagLabel="Trial ends 3d" meta="Charges £12.99 on 15 Nov" amt="£0.00" />
+                <SubRow logo="S" color="#1DB954" name="Spotify Family" meta="Monthly · Next: 22 Nov" amt="£17.99" />
+                <SubRow logo="P" color="#0F9D58" name="PureGym" tag="renewal" tagLabel="Renews in 5d" meta="Monthly · Next: 5 Nov" amt="£34.99" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, maxWidth: 420, display: 'flex', flexDirection: 'column', gap: 14 } as CSSProperties}>
+          <div className="dispute-card" style={{ padding: '18px 22px' } as CSSProperties}>
+            <h4 style={{ marginBottom: 8, color: 'var(--accent-orange-deep)' } as CSSProperties}>
+              4 flagged this month
+            </h4>
+            <div style={{ fontSize: 13, lineHeight: 1.5, color: 'var(--text-secondary)' } as CSSProperties}>
+              <div style={{ marginBottom: 10 } as CSSProperties}>
+                <strong>Netflix Premium</strong> &mdash; silently raised £3 this month. Fight or cancel?
+              </div>
+              <div style={{ marginBottom: 10 } as CSSProperties}>
+                <strong>Virgin Media</strong> &mdash; mid-contract hike. Ofcom allows exit.
+              </div>
+              <div style={{ marginBottom: 10 } as CSSProperties}>
+                <strong>Twitch Turbo</strong> &mdash; duplicate with Prime benefits.
+              </div>
+              <div>
+                <strong>Canva trial</strong> &mdash; auto-renews in 3 days unless you act.
+              </div>
+            </div>
+          </div>
+          <div className="dispute-card" style={{ padding: '18px 22px' } as CSSProperties}>
+            <h4 style={{ marginBottom: 8 } as CSSProperties}>One tap &middot; three outcomes</h4>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, fontSize: 13 } as CSSProperties}>
+              <div style={{ display: 'flex', justifyContent: 'space-between' } as CSSProperties}>
+                <span>&rarr; Cancel</span>
+                <span style={{ color: 'var(--accent-mint-deep)', fontWeight: 700 } as CSSProperties}>
+                  Deep-link to provider
+                </span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' } as CSSProperties}>
+                <span>&rarr; Dispute</span>
+                <span style={{ color: 'var(--accent-mint-deep)', fontWeight: 700 } as CSSProperties}>
+                  Hand-off to Disputes
+                </span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' } as CSSProperties}>
+                <span>&rarr; Switch</span>
+                <span style={{ color: 'var(--accent-mint-deep)', fontWeight: 700 } as CSSProperties}>
+                  Show cheaper deal
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="caption-row">
+        <div className="caption-col">
+          <h3>How to use it</h3>
+          <p>
+            Connect your bank once (read-only, Open Banking via Yapily). Paybacker auto-detects
+            every recurring charge and tags them: price hikes (amber), duplicates (red),
+            expiring trials (blue), upcoming renewals (grey). Tap any row to cancel, dispute,
+            or switch &mdash; we deep-link you straight to the provider&rsquo;s cancel page.
+          </p>
+        </div>
+        <div className="caption-col">
+          <h3>Why it beats Emma / Snoop</h3>
+          <ul>
+            <li>Emma shows subs. We flag <em>why</em> you should act on each one.</li>
+            <li>Every row has a next-step action, not just a line item.</li>
+            <li>Direct hand-off to the AI Disputes Centre on hikes.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type SubRowProps = {
+  logo: string;
+  color: string;
+  name: string;
+  meta: string;
+  amt: string;
+  tag?: 'hike' | 'dup' | 'trial' | 'unused' | 'renewal';
+  tagLabel?: string;
+};
+
+function SubRow({ logo, color, name, meta, amt, tag, tagLabel }: SubRowProps) {
+  return (
+    <div className="sub-item">
+      <div className="sub-logo" style={{ background: color } as CSSProperties}>{logo}</div>
+      <div className="sub-info">
+        <div className="sub-name">
+          {name}
+          {tag && tagLabel && <span className={`sub-tag ${tag}`}>{tagLabel}</span>}
+        </div>
+        <div className="sub-meta">{meta}</div>
+      </div>
+      <div className="sub-amt">{amt}</div>
+    </div>
+  );
+}
+
+/* ==================================================================== */
+/* 03 — Money Hub                                                       */
+/* ==================================================================== */
+
+function Section3MoneyHub() {
+  return (
+    <section className="demo" id="hub">
+      <div className="demo-head">
+        <div>
+          <div className="demo-num">03 &middot; MONEY HUB</div>
+          <h2 className="demo-title">All your accounts, in one place. With a fighter built in.</h2>
+          <p className="demo-sub">
+            Connects to every UK bank via Open Banking (FCA-authorised via Yapily). Net
+            position, breakdown, live transactions. Everything Emma does &mdash; plus a dispute
+            engine, a deals engine, and an AI agent, all reading from the same ledger.
+          </p>
+        </div>
+        <span className="vs-badge">vs. Emma &middot; Monzo Trends</span>
+      </div>
+
+      <div className="stage">
+        <div className="iphone">
+          <div className="iphone-inner">
+            <div className="iphone-screen">
+              <div className="island" />
+              <div className="status-bar dark-text">
+                <span>9:41</span>
+                <span>●●● 100%</span>
+              </div>
+              <div className="hub-screen">
+                <div className="hub-header">
+                  <div className="t">Money Hub</div>
+                  <div className="month">October</div>
+                </div>
+                <div className="net-card">
+                  <div className="lbl">Net this month</div>
+                  <div className="big">£2,847.12</div>
+                  <div className="delta">&uarr; £312 vs. Sep &middot; on track</div>
+                </div>
+                <div className="hub-donut-row">
+                  <div className="hub-donut">
+                    <div className="hub-donut-center">
+                      <span>Tracked</span>
+                      <strong>£4,892</strong>
+                    </div>
+                  </div>
+                  <div className="hub-legend">
+                    <div className="r"><span><span className="sw" style={{ background: 'var(--accent-mint)' } as CSSProperties} />Essentials</span><span className="amt">£1,859</span></div>
+                    <div className="r"><span><span className="sw" style={{ background: 'var(--accent-orange)' } as CSSProperties} />Subs</span><span className="amt">£1,174</span></div>
+                    <div className="r"><span><span className="sw" style={{ background: '#60A5FA' } as CSSProperties} />Transport</span><span className="amt">£782</span></div>
+                    <div className="r"><span><span className="sw" style={{ background: '#A78BFA' } as CSSProperties} />Dining</span><span className="amt">£588</span></div>
+                    <div className="r"><span><span className="sw" style={{ background: '#E5E7EB' } as CSSProperties} />Other</span><span className="amt">£489</span></div>
+                  </div>
+                </div>
+                <div className="hub-list">
+                  <div className="hdr">Today &middot; 3 transactions</div>
+                  <div className="tx"><div className="dot" style={{ background: '#FB923C' } as CSSProperties}>T</div><div className="nm">Tesco Express</div><div className="amt">-£23.40</div></div>
+                  <div className="tx"><div className="dot" style={{ background: 'var(--accent-mint-deep)' } as CSSProperties}>£</div><div className="nm">Salary &middot; Acme Ltd</div><div className="amt in">+£3,284</div></div>
+                  <div className="tx"><div className="dot" style={{ background: '#A78BFA' } as CSSProperties}>D</div><div className="nm">Deliveroo</div><div className="amt">-£18.50</div></div>
+                  <div className="hdr">Yesterday</div>
+                  <div className="tx">
+                    <div className="dot" style={{ background: '#D9232A' } as CSSProperties}>V</div>
+                    <div className="nm">
+                      Virgin Media{' '}
+                      <span style={{ fontSize: 9, color: 'var(--accent-orange-deep)', fontWeight: 800, marginLeft: 4 } as CSSProperties}>
+                        HIKE
+                      </span>
+                    </div>
+                    <div className="amt">-£49.00</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="compare-pane">
+          <h4>Money Hub vs. Emma</h4>
+          <div className="vs-head">
+            <span>Feature</span>
+            <span>Emma</span>
+            <span>Paybacker</span>
+          </div>
+          <CompareRow feat="Account sync" them="✓" us="✓" />
+          <CompareRow feat="Subscriptions" them="List only" us="+ action flags" />
+          <CompareRow feat="Dispute engine" them="—" us="✓ Built-in" />
+          <CompareRow feat="Bill-hike alerts" them="Basic" us="With law cited" />
+          <CompareRow feat="Telegram agent" them="—" us="Coming soon" />
+          <CompareRow feat="Sheets export" them="CSV" us="Coming soon" />
+          <CompareRow feat="Switch deals" them="Generic" us="Coming soon" />
+        </div>
+      </div>
+
+      <div className="caption-row">
+        <div className="caption-col">
+          <h3>How to use it</h3>
+          <p>
+            Open the app to your daily snapshot &mdash; net position for the month, spending
+            breakdown by category, and today&rsquo;s transactions in a live feed. Any row with
+            a flag is actionable: tap it to dispute, cancel, or switch. Same visual grammar as
+            Emma or Monzo Trends &mdash; but every flagged row has a next step beyond
+            &ldquo;look at it.&rdquo;
+          </p>
+        </div>
+        <div className="caption-col">
+          <h3>What makes it different</h3>
+          <ul>
+            <li>Hikes are actionable in-app, not just labelled.</li>
+            <li>Categorisation uses your actual contract terms, not generic MCC codes.</li>
+            <li>Everything else reads from this same ledger.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CompareRow({ feat, them, us }: { feat: string; them: string; us: string }) {
+  return (
+    <div className="compare-row">
+      <span className="feat">{feat}</span>
+      <span className="them">{them}</span>
+      <span className="us">{us}</span>
+    </div>
+  );
+}
+
+/* ==================================================================== */
+/* 04 — Telegram Pocket Agent (coming soon)                             */
+/* ==================================================================== */
+
+function Section4Telegram() {
+  return (
+    <section className="demo dark" id="agent">
+      <div className="demo-head">
+        <div>
+          <div className="demo-num">04 &middot; POCKET AGENT</div>
+          <h2 className="demo-title">Ask anything about your money, in Telegram.</h2>
+          <p className="demo-sub">
+            Your bank data and dispute tools, wrapped in a chat interface. Push alerts when
+            bills hike. Natural language for every action. No app to open.
+          </p>
+        </div>
+        <span className="vs-badge soon">Coming soon</span>
+      </div>
+
+      <div className="stage" style={{ minHeight: 620 } as CSSProperties}>
+        <div className="iphone">
+          <div className="iphone-inner">
+            <div className="iphone-screen">
+              <div className="island" />
+              <div className="status-bar light-text">
+                <span>9:41</span>
+                <span>●●● 100%</span>
+              </div>
+              <div className="tg-app">
+                <div className="tg-header">
+                  <div className="av">PB</div>
+                  <div className="info">
+                    <div className="nm">Paybacker &middot; Pocket Agent</div>
+                    <div className="st">bot &middot; last seen just now</div>
+                  </div>
+                </div>
+                <div className="tg-body">
+                  <div className="tg-msg in">
+                    Virgin Media just charged you £49 &mdash; that&rsquo;s{' '}
+                    <strong>£12 more</strong> than last month. Want to fight it?
+                    <div className="buttons">
+                      <span className="ibtn">Fight it</span>
+                      <span className="ibtn">Details</span>
+                      <span className="ibtn">Dismiss</span>
+                    </div>
+                    <div className="time">09:14</div>
+                  </div>
+                  <div className="tg-msg out">
+                    Fight it<div className="time">09:14 ✓✓</div>
+                  </div>
+                  <div className="tg-msg in">
+                    Letter drafted &mdash; Ofcom Fairness Framework + CRA 2015 s.49
+                    <div className="buttons">
+                      <span className="ibtn">Copy text</span>
+                      <span className="ibtn">Open in email</span>
+                    </div>
+                    <div className="time">09:14</div>
+                  </div>
+                  <div className="tg-msg out">
+                    Is my energy bill fair?<div className="time">09:22 ✓✓</div>
+                  </div>
+                  <div className="tg-msg in">
+                    British Gas &middot; £128/mo. UK median for your postcode is{' '}
+                    <strong>£94</strong>. Octopus Tracker would save you{' '}
+                    <strong>£287/yr</strong> on current usage.
+                    <div className="buttons">
+                      <span className="ibtn">See deal</span>
+                      <span className="ibtn">Switch me</span>
+                    </div>
+                    <div className="time">09:22</div>
+                  </div>
+                </div>
+                <div className="tg-input">
+                  <div className="field">Ask anything…</div>
+                  <div className="send">▶</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="tg-scenarios">
+          <div className="tg-scenario"><div className="q">&ldquo;Cancel my gym&rdquo;</div><div className="a">&rarr; Finds PureGym DD, opens cancel link</div></div>
+          <div className="tg-scenario"><div className="q">&ldquo;Is £68 fair for 100Mb broadband?&rdquo;</div><div className="a">&rarr; Compares to postcode median, shows cheaper option</div></div>
+          <div className="tg-scenario"><div className="q">&ldquo;What subscriptions renew this week?&rdquo;</div><div className="a">&rarr; Lists upcoming charges + any trial expiries</div></div>
+          <div className="tg-scenario"><div className="q">&ldquo;Draft a letter for my delayed flight&rdquo;</div><div className="a">&rarr; UK261 complaint in 30s</div></div>
+          <div className="tg-scenario"><div className="q">&ldquo;How am I doing vs. my budget?&rdquo;</div><div className="a">&rarr; Live status pulled from Money Hub</div></div>
+        </div>
+      </div>
+
+      <div className="caption-row">
+        <div className="caption-col">
+          <h3>How it will work</h3>
+          <p>
+            Once the Telegram agent ships, you&rsquo;ll connect it to your Paybacker account in
+            30 seconds. From then on, just ask: &ldquo;cancel my gym,&rdquo; &ldquo;is my
+            energy bill fair?&rdquo;, &ldquo;what renews this week?&rdquo; &mdash; and it
+            answers from your own data. The agent also pushes proactive alerts the moment it
+            spots a bill hike, with a one-tap &ldquo;Fight it&rdquo; button.
+          </p>
+        </div>
+        <div className="caption-col">
+          <h3>Why Telegram</h3>
+          <ul>
+            <li>Users don&rsquo;t need to open an app &mdash; it comes to them.</li>
+            <li>Zero-friction approval for automated actions.</li>
+            <li>Works cross-device, notification-first.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ==================================================================== */
+/* 05 — Google Sheets export (coming soon)                              */
+/* ==================================================================== */
+
+function Section5Sheets() {
+  return (
+    <section className="demo" id="sheets">
+      <div className="demo-head">
+        <div>
+          <div className="demo-num">05 &middot; GOOGLE SHEETS EXPORT</div>
+          <h2 className="demo-title">Live-sync to your own spreadsheet. Own your data, forever.</h2>
+          <p className="demo-sub">
+            Everything Lunchflow does &mdash; transaction export, monthly roll-up, custom
+            categories &mdash; piped into a Google Sheet that updates hourly. Your formulas,
+            your charts, your AI agents can read from it.
+          </p>
+        </div>
+        <span className="vs-badge soon">Coming soon</span>
+      </div>
+
+      <div className="stage plain">
+        <div className="sheet-frame">
+          <div className="sheet-head">
+            <div className="doc-icon">▤</div>
+            <div>
+              <div className="title">Paybacker &middot; October</div>
+              <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 1 } as CSSProperties}>
+                paybacker-oct.gsheet
+              </div>
+            </div>
+            <div className="save">Synced &middot; 2 min ago</div>
+          </div>
+          <div className="sheet-toolbar">
+            <span>File</span><span>Edit</span><span>View</span><span>Insert</span>
+            <span>Format</span><span>Data</span><span>Tools</span>
+            <span style={{ marginLeft: 'auto', color: 'var(--accent-mint-deep)', fontWeight: 600 } as CSSProperties}>
+              ● Paybacker live sync
+            </span>
+          </div>
+          <div className="formula-bar">
+            <span className="cell">B4</span>
+            <span>=SUMIFS(Transactions!D:D,Transactions!E:E,&quot;Subscriptions&quot;)</span>
+          </div>
+          <table className="sheet-grid">
+            <thead>
+              <tr>
+                <th className="rowhdr" />
+                <th>A &mdash; Date</th>
+                <th>B &mdash; Merchant</th>
+                <th>C &mdash; Category</th>
+                <th>D &mdash; Amount</th>
+                <th>E &mdash; Flag</th>
+                <th>F &mdash; Paybacker tag</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td className="rowhdr">1</td><td>14-10</td><td>Tesco Express</td><td>Groceries</td><td className="num">-£23.40</td><td></td><td></td></tr>
+              <tr><td className="rowhdr">2</td><td>14-10</td><td>Acme Ltd &middot; Payroll</td><td>Income</td><td className="num" style={{ color: 'var(--accent-mint-deep)', fontWeight: 700 } as CSSProperties}>+£3,284.00</td><td></td><td></td></tr>
+              <tr className="hike"><td className="rowhdr">3</td><td>14-10</td><td>Virgin Media</td><td>Broadband</td><td className="num">-£49.00</td><td>HIKE +£12</td><td>dispute-ready</td></tr>
+              <tr><td className="rowhdr">4</td><td>13-10</td><td>Deliveroo</td><td>Dining</td><td className="num">-£18.50</td><td></td><td></td></tr>
+              <tr className="new"><td className="rowhdr">5</td><td>13-10</td><td>Octopus Energy</td><td>Energy</td><td className="num">-£94.12</td><td>SWITCHED</td><td>saves £287/yr</td></tr>
+              <tr><td className="rowhdr">6</td><td>12-10</td><td>Spotify</td><td>Subscriptions</td><td className="num">-£17.99</td><td></td><td></td></tr>
+              <tr className="dup"><td className="rowhdr">7</td><td>12-10</td><td>Twitch Turbo</td><td>Subscriptions</td><td className="num">-£8.99</td><td>DUPLICATE</td><td>cancel-ready</td></tr>
+              <tr><td className="rowhdr">8</td><td>11-10</td><td>TfL &middot; Oyster</td><td>Transport</td><td className="num">-£12.80</td><td></td><td></td></tr>
+              <tr><td className="rowhdr">9</td><td>11-10</td><td>Netflix Premium</td><td>Subscriptions</td><td className="num">-£17.99</td><td>UNUSED 62d</td><td>cancel-ready</td></tr>
+              <tr><td className="rowhdr">10</td><td>10-10</td><td>Waterstones</td><td>Shopping</td><td className="num">-£14.99</td><td></td><td></td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="export-flow">
+        <div className="export-node">
+          <div className="logo">&#x1F3E6;</div>
+          <div className="nm">UK banks</div>
+          <div className="sub">via Yapily (Open Banking)</div>
+        </div>
+        <div className="export-arrow">&rarr;</div>
+        <div className="export-node" style={{ borderColor: 'var(--accent-mint)' } as CSSProperties}>
+          <div className="logo">&#x1F527;</div>
+          <div className="nm">Paybacker</div>
+          <div className="sub">categorise &middot; flag &middot; enrich</div>
+        </div>
+        <div className="export-arrow">&rarr;</div>
+        <div className="export-node">
+          <div className="logo" style={{ color: 'var(--sheets-green)' } as CSSProperties}>▤</div>
+          <div className="nm">Google Sheets</div>
+          <div className="sub">live sync every hour</div>
+        </div>
+      </div>
+
+      <div className="caption-row">
+        <div className="caption-col">
+          <h3>How it will work</h3>
+          <p>
+            From settings, click &ldquo;Sync to Google Sheets&rdquo; and authorise once.
+            Paybacker creates a live sheet in your Drive and updates it every hour with every
+            transaction, plus two extra columns: <strong>Flag</strong> (hike, duplicate,
+            unused, switched) and <strong>Paybacker tag</strong> (dispute-ready, cancel-ready,
+            saves £X/yr). Use it with your own formulas, charts, or AI agents.
+          </p>
+        </div>
+        <div className="caption-col">
+          <h3>Why it beats Lunchflow</h3>
+          <ul>
+            <li>Sync columns include Paybacker&rsquo;s enrichment, not just raw txns.</li>
+            <li>Two-way: write &ldquo;cancelled&rdquo; in the sheet, it updates the app.</li>
+            <li>Works with any AI agent that can read a Google Sheet.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ==================================================================== */
+/* 06 — Stacked                                                         */
+/* ==================================================================== */
+
+function Section6Stacked() {
+  return (
+    <section className="demo dark" id="stacked">
+      <div className="demo-head">
+        <div>
+          <div className="demo-num">06 &middot; STACKED</div>
+          <h2 className="demo-title">Individually good. Stacked, unmatched.</h2>
+          <p className="demo-sub">
+            No single competitor combines bank sync, subscription tracking, AI-drafted legal
+            disputes, a conversational agent, and a live spreadsheet export. Paybacker does.
+          </p>
+        </div>
+      </div>
+
+      <div className="stage" style={{ padding: 32 } as CSSProperties}>
+        <div className="arch">
+          <div className="arch-col">
+            <h5 style={{ color: 'var(--accent-orange)' } as CSSProperties}>INPUTS</h5>
+            <div className="arch-item"><span className="d" />UK banks via Yapily</div>
+            <div className="arch-item"><span className="d" />Gmail / Outlook inbox scan</div>
+            <div className="arch-item"><span className="d" />Manual subscription add</div>
+            <div className="arch-item"><span className="d" />Telegram commands (coming soon)</div>
+            <div className="arch-item"><span className="d" />Dispute form (web or chat)</div>
+          </div>
+          <div className="arch-col hub">
+            <h5>PAYBACKER CORE</h5>
+            <div className="arch-item"><span className="d" /><strong>Unified ledger</strong> &mdash; every txn, contract, hike</div>
+            <div className="arch-item"><span className="d" /><strong>Classifier</strong> &mdash; Money Hub categorisation</div>
+            <div className="arch-item"><span className="d" /><strong>Flag engine</strong> &mdash; hikes, duplicates, trials</div>
+            <div className="arch-item"><span className="d" /><strong>Law library</strong> &mdash; CRA, Ofcom, Ofgem, UK261, FCA</div>
+            <div className="arch-item"><span className="d" /><strong>Deals graph</strong> &mdash; UK partner network</div>
+          </div>
+          <div className="arch-col">
+            <h5 style={{ color: 'var(--accent-mint)' } as CSSProperties}>OUTPUTS</h5>
+            <div className="arch-item"><span className="d" />Web app &mdash; Money Hub + Disputes</div>
+            <div className="arch-item"><span className="d" />Telegram Pocket Agent (coming soon)</div>
+            <div className="arch-item"><span className="d" />Complaint letters (copy/email/PDF)</div>
+            <div className="arch-item"><span className="d" />Google Sheets live sync (coming soon)</div>
+            <div className="arch-item"><span className="d" />Deep-links to cancel / switch</div>
+          </div>
+        </div>
+      </div>
+
+      <table className="power-table">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th>Emma</th>
+            <th>Snoop</th>
+            <th>Lunchflow</th>
+            <th>Resolver</th>
+            <th>Which?</th>
+            <th style={{ color: 'var(--accent-mint)' } as CSSProperties}>Paybacker</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td className="feat">Bank sync (Open Banking)</td><td className="us">✓</td><td className="us">✓</td><td className="us">✓</td><td className="them">—</td><td className="them">—</td><td className="us">✓</td></tr>
+          <tr><td className="feat">Subscription flagging (hike/dup/unused)</td><td className="them">Basic</td><td className="them">Basic</td><td className="them">—</td><td className="them">—</td><td className="them">—</td><td className="us">Full</td></tr>
+          <tr><td className="feat">Legal-grade dispute letters</td><td className="them">—</td><td className="them">—</td><td className="them">—</td><td className="them">Templates</td><td className="them">Guide</td><td className="us">AI + law</td></tr>
+          <tr><td className="feat">UK consumer law library cited</td><td className="them">—</td><td className="them">—</td><td className="them">—</td><td className="them">Partial</td><td className="them">Partial</td><td className="us">5+ statutes</td></tr>
+          <tr><td className="feat">Telegram / chat agent</td><td className="them">—</td><td className="them">—</td><td className="them">—</td><td className="them">—</td><td className="them">—</td><td className="us">Coming soon</td></tr>
+          <tr><td className="feat">Live Google Sheets export</td><td className="them">CSV only</td><td className="them">—</td><td className="us">✓</td><td className="them">—</td><td className="them">—</td><td className="us">Coming soon</td></tr>
+          <tr><td className="feat">User in control (no auto-sent emails)</td><td className="us">✓</td><td className="us">✓</td><td className="us">✓</td><td className="them">Semi</td><td className="us">✓</td><td className="us">✓</td></tr>
+        </tbody>
+      </table>
+
+      <div className="caption-row">
+        <div className="caption-col">
+          <h3>The unfair advantage</h3>
+          <p>
+            The Paybacker core is one unified ledger &mdash; every feature reads from it. When
+            you dispute a charge, the Money Hub reflects it. When you cancel from the
+            subscriptions screen, the ledger updates. No other UK product stacks the same five
+            surfaces.
+          </p>
+        </div>
+        <div className="caption-col">
+          <h3>What this means for users</h3>
+          <ul>
+            <li>One subscription replaces Emma + Resolver + (eventually) Lunchflow.</li>
+            <li>Actions flow: flag &rarr; dispute &rarr; cancel &rarr; switch &rarr; log.</li>
+            <li>You stay in control &mdash; we never email on your behalf.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/how-it-works/styles.css
+++ b/src/app/how-it-works/styles.css
@@ -1,0 +1,974 @@
+/*
+ * /how-it-works — scoped stylesheet.
+ *
+ * Scoped under `.m-how-root`.
+ *
+ * Design source: design-zip/design_handoff_paybacker_homepage/Paybacker How It Works.html
+ * Port preserves the 6-section structure (Disputes, Subs, Money Hub, Telegram,
+ * Sheets, Stacked) but drops the JS tagbar filter — anchor links jump between
+ * sections and every section is visible on load.
+ *
+ * Content deviations documented inline in page.tsx (Telegram + Sheets marked
+ * "Coming soon" per CLAUDE.md roadmap; partner count made vague).
+ */
+
+.m-how-root {
+  /* Token aliases → globals.css */
+  --surface-base: var(--color-surface-base);
+  --surface-elevated: var(--color-surface-elevated);
+  --surface-ink: var(--color-surface-ink);
+  --surface-ink-2: var(--color-surface-ink-2);
+  --surface-paper: #FAFAF7;
+
+  --text-primary: var(--color-ink-primary);
+  --text-secondary: var(--color-ink-secondary);
+  --text-tertiary: var(--color-ink-tertiary);
+  --text-on-ink: var(--color-on-ink);
+  --text-on-ink-dim: var(--color-on-ink-dim);
+
+  --accent-mint: var(--color-accent-mint);
+  --accent-mint-deep: var(--color-accent-mint-deep);
+  --accent-mint-wash: var(--color-accent-mint-wash);
+  --accent-orange: var(--color-accent-orange);
+  --accent-orange-deep: var(--color-accent-orange-deep);
+  --amber-wash: #FEF3C7;
+  --sheets-green: #0F9D58;
+
+  --divider: var(--color-divider-light);
+  --divider-ink: var(--color-divider-ink);
+
+  --r-card: var(--radius-marketing-card);
+  --r-figure: var(--radius-marketing-figure);
+  --r-btn: var(--radius-marketing-btn);
+  --r-input: var(--radius-marketing-input);
+  --r-pill: var(--radius-marketing-pill);
+
+  --shadow-sm: var(--shadow-marketing-sm);
+  --shadow-md: var(--shadow-marketing-md);
+  --shadow-lg: var(--shadow-marketing-lg);
+  --shadow-xl: var(--shadow-marketing-xl);
+  --shadow-mint: var(--shadow-marketing-mint);
+
+  --fs-h1: var(--text-h1-marketing);
+  --fs-h2: var(--text-h2-marketing);
+  --fs-body: 17px;
+  --fs-sm: 14px;
+  --fs-xs: 12px;
+  --track-tight: var(--tracking-marketing-tight);
+  --track-eyebrow: var(--tracking-marketing-eyebrow);
+
+  min-height: 100vh;
+  background: var(--surface-paper);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+.m-how-root *,
+.m-how-root *::before,
+.m-how-root *::after { box-sizing: border-box; }
+.m-how-root img,
+.m-how-root svg { display: block; max-width: 100%; }
+
+.m-how-root .wrap { max-width: 1240px; margin: 0 auto; padding: 0 32px; }
+.m-how-root .eyebrow {
+  font-size: var(--fs-xs);
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+.m-how-root .eyebrow.on-ink { color: var(--accent-mint); }
+
+.m-how-root .btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 22px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+.m-how-root .btn-mint { background: var(--accent-mint); color: #052E1C; box-shadow: var(--shadow-mint); }
+.m-how-root .btn-mint:hover { transform: scale(1.02); background: #2CC48A; }
+.m-how-root .btn-ghost { background: transparent; color: var(--text-primary); border: 1px solid var(--divider); }
+.m-how-root .btn-ghost:hover { transform: scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+
+/* Nav (shared with blog/careers) ------------------------------------ */
+.m-how-root .nav-shell {
+  position: sticky; top: 18px; left: 0; right: 0;
+  display: flex; justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+.m-how-root .nav-pill {
+  pointer-events: auto;
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border: 1px solid rgba(11,18,32,0.06);
+  padding: 10px 10px 10px 20px;
+  border-radius: var(--r-pill);
+  box-shadow: var(--shadow-md);
+}
+.m-how-root .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; text-decoration: none; }
+.m-how-root .nav-logo .pay { color: var(--text-primary); }
+.m-how-root .nav-logo .backer { color: var(--accent-mint-deep); }
+.m-how-root .nav-links { display: flex; gap: 6px; margin: 0 14px; }
+.m-how-root .nav-links a {
+  font-size: 14px; font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: var(--r-pill);
+  transition: background 150ms, color 150ms;
+}
+.m-how-root .nav-links a:hover { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-how-root .nav-links a.is-active { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-how-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
+.m-how-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+.m-how-root .nav-start {
+  background: var(--accent-mint); color: #052E1C;
+  padding: 10px 18px; border-radius: var(--r-pill);
+  font-weight: 600; font-size: 14px; text-decoration: none;
+  transition: transform 150ms, box-shadow 150ms;
+}
+.m-how-root .nav-start:hover { transform: scale(1.03); box-shadow: var(--shadow-mint); }
+
+/* Section chrome ----------------------------------------------------- */
+.m-how-root header.hero {
+  text-align: center;
+  padding: 120px 24px 56px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.m-how-root header.hero .jump {
+  display: inline-flex; gap: 8px;
+  padding: 8px;
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: 999px;
+  margin-bottom: 32px;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 100%;
+}
+.m-how-root header.hero .jump a {
+  border: none;
+  background: transparent;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: background 120ms, color 120ms;
+}
+.m-how-root header.hero .jump a:hover { background: var(--accent-mint-wash); color: var(--accent-mint-deep); }
+.m-how-root header.hero h1 {
+  font-size: clamp(36px, 5vw, 52px);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 0 0 14px;
+  line-height: 1.05;
+}
+.m-how-root header.hero p {
+  font-size: 20px; color: var(--text-secondary);
+  max-width: 760px; margin: 0 auto;
+}
+
+.m-how-root .demo {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: 28px;
+  padding: 48px;
+  margin: 0 auto 40px;
+  max-width: 1240px;
+  position: relative;
+  overflow: hidden;
+  scroll-margin-top: 100px;
+}
+.m-how-root .demo.dark { background: var(--surface-ink); color: var(--text-on-ink); border-color: var(--divider-ink); }
+.m-how-root .demo.dark h2,
+.m-how-root .demo.dark h3 { color: #fff; }
+
+.m-how-root .demo-head {
+  display: flex; gap: 24px; align-items: flex-start;
+  margin-bottom: 32px;
+}
+.m-how-root .demo-num {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px; font-weight: 700;
+  color: var(--accent-mint-deep);
+  letter-spacing: 0.1em;
+  margin-bottom: 8px;
+}
+.m-how-root .demo.dark .demo-num { color: var(--accent-mint); }
+.m-how-root .demo-title {
+  font-size: clamp(26px, 3vw, 34px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  margin: 0 0 10px;
+  max-width: 720px;
+}
+.m-how-root .demo-sub {
+  font-size: 17px;
+  color: var(--text-secondary);
+  max-width: 720px;
+  margin: 0;
+}
+.m-how-root .demo.dark .demo-sub { color: var(--text-on-ink-dim); }
+
+.m-how-root .vs-badge {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--amber-wash);
+  color: var(--accent-orange-deep);
+  white-space: nowrap;
+  align-self: flex-start;
+}
+.m-how-root .vs-badge.soon {
+  background: rgba(52, 211, 153, 0.15);
+  color: var(--accent-mint);
+}
+
+/* Stage - the main visual area of each demo ------------------------- */
+.m-how-root .stage {
+  background: linear-gradient(135deg, #F3F4F6, #E5E7EB);
+  border-radius: 20px;
+  padding: 40px;
+  display: flex;
+  gap: 32px;
+  align-items: center;
+  justify-content: center;
+  min-height: 520px;
+  position: relative;
+  overflow: hidden;
+  flex-wrap: wrap;
+}
+.m-how-root .stage.plain { background: #fff; border: 1px solid var(--divider); padding: 28px; }
+.m-how-root .demo.dark .stage { background: linear-gradient(135deg, #0F1826, #1A2540); border: 1px solid var(--divider-ink); }
+
+.m-how-root .caption-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  margin-top: 32px;
+}
+.m-how-root .caption-col h3 {
+  font-size: 19px; font-weight: 700;
+  margin: 0 0 10px; letter-spacing: -0.01em;
+}
+.m-how-root .caption-col p {
+  margin: 0 0 14px; color: var(--text-secondary);
+  font-size: 15px; line-height: 1.6;
+}
+.m-how-root .demo.dark .caption-col p { color: var(--text-on-ink-dim); }
+.m-how-root .caption-col ul {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.m-how-root .caption-col li {
+  font-size: 14px; color: var(--text-secondary);
+  padding-left: 26px; position: relative;
+  line-height: 1.5;
+}
+.m-how-root .demo.dark .caption-col li { color: #D1D5DB; }
+.m-how-root .caption-col li::before {
+  content: '✓'; position: absolute; left: 0; top: 0;
+  color: var(--accent-mint-deep); font-weight: 800;
+}
+.m-how-root .demo.dark .caption-col li::before { color: var(--accent-mint); }
+
+/* iPhone frame ------------------------------------------------------- */
+.m-how-root .iphone {
+  width: 340px; height: 700px;
+  flex-shrink: 0;
+  background: linear-gradient(140deg, #4a4a4a 0%, #6b6b6b 25%, #2a2a2a 70%, #4a4a4a 100%);
+  border-radius: 52px;
+  padding: 11px;
+  box-shadow: 0 50px 100px -30px rgba(0,0,0,0.4), 0 0 0 1px rgba(0,0,0,0.1);
+  position: relative;
+}
+.m-how-root .iphone.tilt { transform: rotate(-4deg); }
+.m-how-root .iphone-inner {
+  width: 100%; height: 100%;
+  background: #000; border-radius: 42px;
+  padding: 3px; overflow: hidden; position: relative;
+}
+.m-how-root .iphone-screen {
+  width: 100%; height: 100%;
+  border-radius: 39px;
+  overflow: hidden; position: relative;
+  background: #fff;
+}
+.m-how-root .island {
+  position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+  width: 108px; height: 30px;
+  background: #000; border-radius: 18px; z-index: 20;
+}
+.m-how-root .status-bar {
+  position: absolute; top: 0; left: 0; right: 0;
+  height: 52px;
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 14px 28px 0;
+  font-size: 13px; font-weight: 600;
+  z-index: 15;
+}
+.m-how-root .status-bar.dark-text { color: #000; }
+.m-how-root .status-bar.light-text { color: #fff; }
+
+/* Dispute demo ------------------------------------------------------- */
+.m-how-root .dispute-flow {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 24px;
+  align-items: stretch;
+  width: 100%;
+}
+.m-how-root .dispute-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: 16px;
+  padding: 24px;
+}
+.m-how-root .demo.dark .dispute-card { background: var(--surface-ink-2); border-color: var(--divider-ink); color: #fff; }
+.m-how-root .dispute-card h4 {
+  margin: 0 0 16px;
+  font-size: 13px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  font-weight: 700;
+}
+.m-how-root .form-field { margin-bottom: 14px; }
+.m-how-root .form-field label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+}
+.m-how-root .form-field .v {
+  padding: 12px 14px;
+  background: var(--surface-paper);
+  border: 1px solid var(--divider);
+  border-radius: 10px;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+.m-how-root .form-field .v.picked {
+  background: var(--accent-mint-wash);
+  border-color: var(--accent-mint);
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+.m-how-root .letter-preview {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 14px; line-height: 1.55;
+  color: var(--text-primary);
+  background: #FDFDF7;
+  padding: 22px;
+  border-radius: 12px;
+  border: 1px solid var(--divider);
+  max-height: 340px;
+  overflow: hidden;
+  position: relative;
+}
+.m-how-root .letter-preview::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0; right: 0; height: 60px;
+  background: linear-gradient(to bottom, transparent, #FDFDF7);
+}
+.m-how-root .letter-preview .hl {
+  background: var(--amber-wash);
+  padding: 0 3px; border-radius: 2px;
+}
+.m-how-root .letter-meta {
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+.m-how-root .copy-actions {
+  display: flex; gap: 10px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+.m-how-root .copy-btn {
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 13px; font-weight: 600;
+  border: 1px solid var(--divider);
+  background: #fff;
+  cursor: default;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+}
+.m-how-root .copy-btn.primary { background: var(--text-primary); color: #fff; border-color: var(--text-primary); }
+.m-how-root .clarity-banner {
+  grid-column: 1 / -1;
+  margin-top: 16px;
+  padding: 14px 18px;
+  background: var(--amber-wash);
+  border: 1px solid var(--accent-orange);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+.m-how-root .clarity-banner .icon {
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: var(--accent-orange);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  flex-shrink: 0;
+}
+.m-how-root .thread-monitor {
+  grid-column: 1 / -1;
+  margin-top: 14px;
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: 14px;
+  padding: 18px 20px;
+}
+.m-how-root .thread-monitor .live {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 14px;
+}
+.m-how-root .thread-monitor .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent-mint);
+  box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.18);
+}
+.m-how-root .thread-monitor .live-label {
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--accent-mint-deep);
+}
+.m-how-root .thread-monitor .inbox {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+.m-how-root .thread-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: var(--surface-paper);
+  border-radius: 10px;
+  font-size: 13px;
+  margin-top: 8px;
+  line-height: 1.4;
+}
+.m-how-root .thread-row.alert {
+  background: var(--amber-wash);
+  border: 1px solid var(--accent-orange);
+  padding: 12px;
+}
+.m-how-root .thread-row .dt {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  margin-left: auto;
+}
+.m-how-root .thread-row.alert .dt {
+  font-weight: 700;
+  color: var(--accent-orange-deep);
+}
+
+/* Subscription tracker demo ------------------------------------------ */
+.m-how-root .tracker-screen {
+  width: 100%; height: 100%;
+  background: #fff;
+  padding: 60px 16px 16px;
+  overflow: hidden;
+}
+.m-how-root .tracker-head {
+  padding: 8px 8px 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.m-how-root .tracker-head .t { font-size: 20px; font-weight: 800; letter-spacing: -0.01em; color: #0B1220; }
+.m-how-root .tracker-head .tot { font-size: 12px; color: var(--text-tertiary); }
+.m-how-root .tracker-total {
+  margin: 4px 8px 18px;
+  padding: 14px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--surface-ink), var(--surface-ink-2));
+  color: #fff;
+}
+.m-how-root .tracker-total .lbl { font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; opacity: 0.6; font-weight: 700; }
+.m-how-root .tracker-total .big { font-size: 30px; font-weight: 800; letter-spacing: -0.02em; line-height: 1.05; margin: 4px 0 2px; }
+.m-how-root .tracker-total .delta { font-size: 11px; color: var(--accent-mint); }
+.m-how-root .sub-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--divider);
+}
+.m-how-root .sub-item:last-child { border-bottom: none; }
+.m-how-root .sub-logo {
+  width: 34px; height: 34px; border-radius: 10px;
+  display: grid; place-items: center;
+  color: #fff; font-weight: 800; font-size: 12px;
+  flex-shrink: 0;
+}
+.m-how-root .sub-info { flex: 1; min-width: 0; }
+.m-how-root .sub-name { font-size: 12.5px; font-weight: 600; margin-bottom: 2px; color: #0B1220; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; line-height: 1.3; }
+.m-how-root .sub-meta { font-size: 11px; color: var(--text-tertiary); }
+.m-how-root .sub-amt { font-size: 13px; font-weight: 700; text-align: right; font-variant-numeric: tabular-nums; color: #0B1220; }
+.m-how-root .sub-tag {
+  font-size: 9px; font-weight: 800;
+  letter-spacing: 0.06em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.m-how-root .sub-tag.hike { background: var(--amber-wash); color: var(--accent-orange-deep); }
+.m-how-root .sub-tag.dup { background: #FEE2E2; color: #B91C1C; }
+.m-how-root .sub-tag.unused { background: #E5E7EB; color: var(--text-tertiary); }
+.m-how-root .sub-tag.renewal { background: #E5E7EB; color: var(--text-secondary); }
+.m-how-root .sub-tag.trial { background: #DBEAFE; color: #1E40AF; }
+
+/* Money Hub demo ----------------------------------------------------- */
+.m-how-root .hub-screen {
+  width: 100%; height: 100%;
+  background: #fff;
+  padding: 60px 0 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.m-how-root .hub-header {
+  padding: 8px 16px 12px;
+  display: flex; justify-content: space-between; align-items: baseline;
+}
+.m-how-root .hub-header .t { font-size: 19px; font-weight: 800; letter-spacing: -0.01em; color: #0B1220; }
+.m-how-root .hub-header .month { font-size: 11px; color: var(--text-tertiary); font-weight: 600; }
+.m-how-root .net-card {
+  margin: 0 16px 14px;
+  padding: 16px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--accent-mint-wash), #D1FAE5);
+  border: 1px solid #A7F3D0;
+  position: relative;
+  overflow: hidden;
+}
+.m-how-root .net-card .lbl { font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; font-weight: 700; color: var(--accent-mint-deep); }
+.m-how-root .net-card .big { font-size: 32px; font-weight: 800; letter-spacing: -0.02em; line-height: 1; margin: 6px 0 2px; color: var(--text-primary); }
+.m-how-root .net-card .delta { font-size: 12px; color: var(--accent-mint-deep); font-weight: 600; }
+.m-how-root .hub-donut-row { display: flex; gap: 10px; margin: 0 16px 12px; align-items: center; }
+.m-how-root .hub-donut {
+  width: 82px; height: 82px; border-radius: 50%; flex-shrink: 0;
+  background: conic-gradient(var(--accent-mint) 0 38%, var(--accent-orange) 38% 62%, #60A5FA 62% 78%, #A78BFA 78% 90%, #E5E7EB 90% 100%);
+  position: relative;
+}
+.m-how-root .hub-donut::after { content: ''; position: absolute; inset: 14px; background: #fff; border-radius: 50%; }
+.m-how-root .hub-donut-center {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  z-index: 1; font-size: 9px; color: var(--text-tertiary);
+}
+.m-how-root .hub-donut-center strong { font-size: 13px; color: var(--text-primary); font-weight: 800; }
+.m-how-root .hub-legend { flex: 1; display: flex; flex-direction: column; gap: 4px; font-size: 10px; color: #0B1220; }
+.m-how-root .hub-legend .r { display: flex; justify-content: space-between; align-items: center; }
+.m-how-root .hub-legend .sw { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 6px; }
+.m-how-root .hub-legend .amt { font-weight: 700; }
+.m-how-root .hub-list { flex: 1; overflow: hidden; }
+.m-how-root .hub-list .hdr { padding: 10px 16px 6px; font-size: 10px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-tertiary); }
+.m-how-root .tx { display: flex; align-items: center; gap: 10px; padding: 7px 16px; }
+.m-how-root .tx .dot { width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center; font-size: 11px; color: #fff; font-weight: 700; flex-shrink: 0; }
+.m-how-root .tx .nm { flex: 1; font-size: 12px; font-weight: 500; color: #0B1220; }
+.m-how-root .tx .amt { font-size: 12px; font-weight: 700; font-variant-numeric: tabular-nums; color: #0B1220; }
+.m-how-root .tx .amt.in { color: var(--accent-mint-deep); }
+
+.m-how-root .compare-pane {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 340px;
+  flex: 1;
+}
+.m-how-root .compare-pane h4 { margin: 0 0 16px; font-size: 14px; font-weight: 700; letter-spacing: -0.01em; color: var(--text-primary); }
+.m-how-root .compare-row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--divider);
+  font-size: 12px;
+}
+.m-how-root .compare-row:last-child { border-bottom: none; }
+.m-how-root .compare-row .feat { color: var(--text-secondary); font-weight: 500; }
+.m-how-root .compare-row .them { color: var(--text-tertiary); font-size: 11px; text-align: right; }
+.m-how-root .compare-row .us { color: var(--accent-mint-deep); font-weight: 700; font-size: 11px; text-align: right; }
+.m-how-root .vs-head {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--divider);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-tertiary);
+}
+.m-how-root .vs-head span:nth-child(2),
+.m-how-root .vs-head span:nth-child(3) { text-align: right; }
+
+/* Telegram demo ------------------------------------------------------ */
+.m-how-root .tg-app {
+  width: 100%; height: 100%;
+  background: linear-gradient(180deg, #EFEEF4, #E4E3EA);
+  display: flex; flex-direction: column;
+  padding-top: 52px;
+}
+.m-how-root .tg-header {
+  background: #517DA2; color: #fff;
+  padding: 12px 16px;
+  display: flex; align-items: center; gap: 10px;
+}
+.m-how-root .tg-header .av {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-mint), var(--accent-orange));
+  display: grid; place-items: center;
+  color: #052E1C; font-weight: 800; font-size: 11px;
+}
+.m-how-root .tg-header .info { flex: 1; min-width: 0; }
+.m-how-root .tg-header .nm { font-size: 13px; font-weight: 700; }
+.m-how-root .tg-header .st { font-size: 10px; opacity: 0.8; }
+.m-how-root .tg-body {
+  flex: 1; padding: 14px;
+  display: flex; flex-direction: column; gap: 8px;
+  overflow-y: auto;
+  background: #E4E3EA;
+  min-height: 0;
+}
+.m-how-root .tg-msg {
+  max-width: 82%;
+  padding: 9px 13px;
+  border-radius: 14px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.05);
+  position: relative;
+  word-wrap: break-word;
+}
+.m-how-root .tg-msg.in { background: #fff; align-self: flex-start; border-bottom-left-radius: 4px; color: #111; }
+.m-how-root .tg-msg.out { background: #DCF8C6; align-self: flex-end; border-bottom-right-radius: 4px; color: #111; }
+.m-how-root .tg-msg .time { font-size: 9px; color: #999; margin-top: 2px; text-align: right; }
+.m-how-root .tg-msg .buttons { display: flex; gap: 4px; margin-top: 8px; flex-wrap: wrap; }
+.m-how-root .tg-msg .ibtn {
+  font-size: 10.5px;
+  color: #517DA2;
+  background: #F0F7FD;
+  padding: 4px 9px;
+  border-radius: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+  display: inline-block;
+}
+.m-how-root .tg-input {
+  background: #fff;
+  padding: 10px 14px;
+  display: flex; align-items: center; gap: 8px;
+  border-top: 1px solid #D1D5DB;
+}
+.m-how-root .tg-input .field {
+  flex: 1;
+  background: #F0F0F0;
+  border-radius: 16px;
+  padding: 7px 12px;
+  font-size: 12px;
+  color: #999;
+}
+.m-how-root .tg-input .send {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: #517DA2; color: #fff;
+  display: grid; place-items: center;
+  font-size: 11px;
+}
+.m-how-root .tg-scenarios { display: flex; flex-direction: column; gap: 12px; flex: 1; max-width: 420px; }
+.m-how-root .tg-scenario {
+  background: var(--surface-ink-2);
+  border: 1px solid var(--divider-ink);
+  border-radius: 12px;
+  padding: 14px 18px;
+  font-size: 14px;
+  color: #fff;
+}
+.m-how-root .tg-scenario .q { color: var(--text-on-ink-dim); font-style: italic; margin-bottom: 4px; }
+.m-how-root .tg-scenario .a { font-weight: 600; }
+
+/* Sheets demo -------------------------------------------------------- */
+.m-how-root .sheet-frame {
+  width: 100%;
+  max-width: 960px;
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--divider);
+  box-shadow: 0 30px 60px -25px rgba(0,0,0,0.2);
+}
+.m-how-root .sheet-head {
+  background: #F8F9FA;
+  padding: 10px 16px;
+  display: flex; align-items: center; gap: 12px;
+  border-bottom: 1px solid var(--divider);
+}
+.m-how-root .sheet-head .doc-icon {
+  width: 22px; height: 30px;
+  background: var(--sheets-green);
+  border-radius: 3px;
+  display: grid; place-items: center;
+  color: #fff; font-size: 10px; font-weight: 800;
+}
+.m-how-root .sheet-head .title { font-size: 14px; font-weight: 500; color: var(--text-primary); }
+.m-how-root .sheet-head .save {
+  margin-left: auto; font-size: 11px; color: var(--text-tertiary);
+  display: flex; align-items: center; gap: 6px;
+}
+.m-how-root .sheet-head .save::before {
+  content: ''; width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--sheets-green);
+}
+.m-how-root .sheet-toolbar {
+  padding: 6px 16px;
+  background: #fff;
+  border-bottom: 1px solid var(--divider);
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex; gap: 14px; flex-wrap: wrap;
+}
+.m-how-root .sheet-grid { width: 100%; border-collapse: collapse; font-size: 12px; }
+.m-how-root .sheet-grid th,
+.m-how-root .sheet-grid td {
+  padding: 7px 10px;
+  border: 1px solid #E5E7EB;
+  text-align: left;
+  font-weight: 400;
+}
+.m-how-root .sheet-grid th { background: #F8F9FA; font-size: 11px; font-weight: 600; color: var(--text-secondary); }
+.m-how-root .sheet-grid td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.m-how-root .sheet-grid .rowhdr { background: #F8F9FA; color: var(--text-tertiary); width: 28px; text-align: center; font-weight: 500; }
+.m-how-root .sheet-grid tr.hike td { background: #FEF3C7; }
+.m-how-root .sheet-grid tr.dup td { background: #FEE2E2; }
+.m-how-root .sheet-grid tr.new td { background: #D1FAE5; }
+.m-how-root .formula-bar {
+  padding: 6px 16px;
+  background: #fff;
+  border-bottom: 1px solid var(--divider);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+  display: flex; align-items: center; gap: 8px;
+}
+.m-how-root .formula-bar .cell {
+  background: #F3F4F6;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-weight: 600;
+}
+
+.m-how-root .export-flow {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-top: 24px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.m-how-root .export-node {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: 14px;
+  padding: 16px 20px;
+  min-width: 170px;
+  text-align: center;
+}
+.m-how-root .export-node .logo { font-size: 26px; margin-bottom: 4px; }
+.m-how-root .export-node .nm { font-size: 14px; font-weight: 700; color: var(--text-primary); }
+.m-how-root .export-node .sub { font-size: 11px; color: var(--text-tertiary); margin-top: 2px; }
+.m-how-root .export-arrow { font-size: 24px; color: var(--accent-mint); font-weight: 300; }
+
+/* Stacked / combined demo ------------------------------------------- */
+.m-how-root .arch {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr 1fr;
+  gap: 20px;
+  align-items: stretch;
+  width: 100%;
+}
+.m-how-root .arch-col {
+  background: var(--surface-ink-2);
+  border: 1px solid var(--divider-ink);
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.m-how-root .arch-col h5 {
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: #fff;
+}
+.m-how-root .arch-item {
+  padding: 10px 12px;
+  background: var(--surface-ink);
+  border-radius: 10px;
+  font-size: 12px;
+  color: #D1D5DB;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.m-how-root .arch-item .d {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent-mint);
+  flex-shrink: 0;
+}
+.m-how-root .arch-col.hub {
+  border-color: var(--accent-mint);
+  box-shadow: 0 20px 40px -20px rgba(52,211,153,0.4);
+}
+.m-how-root .arch-col.hub h5 { color: var(--accent-mint); }
+.m-how-root .arch-col.hub .arch-item { background: rgba(52,211,153,0.1); color: #E5E7EB; }
+
+.m-how-root .power-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 24px;
+}
+.m-how-root .power-table th,
+.m-how-root .power-table td {
+  padding: 12px 14px;
+  text-align: left;
+  font-size: 13.5px;
+  border-bottom: 1px solid var(--divider-ink);
+}
+.m-how-root .power-table th {
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-on-ink-dim);
+  font-weight: 700;
+}
+.m-how-root .power-table td.us { color: var(--accent-mint); font-weight: 700; }
+.m-how-root .power-table td.them { color: var(--text-on-ink-dim); }
+.m-how-root .power-table td.feat { font-weight: 600; color: #fff; }
+
+/* Footer reuse ------------------------------------------------------- */
+.m-how-root footer {
+  background: var(--surface-ink);
+  color: var(--text-on-ink);
+  padding: 80px 0 40px;
+  margin-top: 60px;
+}
+.m-how-root footer .footer-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
+  gap: 48px;
+  padding-bottom: 48px;
+  border-bottom: 1px solid var(--divider-ink);
+}
+.m-how-root footer .footer-brand p {
+  font-size: 13.5px; color: var(--text-on-ink-dim);
+  line-height: 1.5; margin: 16px 0 0; max-width: 320px;
+}
+.m-how-root footer .footer-brand .logo {
+  font-size: 20px; font-weight: 700; letter-spacing: -0.02em;
+}
+.m-how-root footer .footer-brand .logo .backer { color: var(--accent-mint); }
+.m-how-root footer .footer-col h5 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-on-ink-dim);
+  margin: 0 0 16px;
+  font-weight: 700;
+}
+.m-how-root footer .footer-col a {
+  display: block;
+  font-size: 14px; color: var(--text-on-ink);
+  text-decoration: none;
+  margin-bottom: 10px;
+  transition: color 120ms;
+}
+.m-how-root footer .footer-col a:hover { color: var(--accent-mint); }
+.m-how-root footer .footer-socials { display: flex; gap: 10px; }
+.m-how-root footer .footer-socials a {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: rgba(255,255,255,0.06);
+  display: grid; place-items: center;
+  font-size: 13px;
+  margin-bottom: 0;
+}
+.m-how-root footer .footer-bottom {
+  padding-top: 32px;
+  display: flex; justify-content: space-between; align-items: flex-start;
+  gap: 32px;
+  font-size: 12px;
+  color: var(--text-on-ink-dim);
+}
+
+/* Responsive --------------------------------------------------------- */
+@media (max-width: 980px) {
+  .m-how-root .demo { padding: 28px; }
+  .m-how-root .stage { padding: 24px; flex-direction: column; }
+  .m-how-root .caption-row { grid-template-columns: 1fr; gap: 24px; }
+  .m-how-root .dispute-flow,
+  .m-how-root .arch { grid-template-columns: 1fr; }
+  .m-how-root .demo-head { flex-direction: column; }
+  .m-how-root .vs-badge { margin-left: 0; }
+  .m-how-root .iphone { width: 300px; height: 620px; }
+  .m-how-root footer .footer-grid { grid-template-columns: 1fr 1fr; gap: 32px; }
+  .m-how-root footer .footer-bottom { flex-direction: column; }
+}
+@media (max-width: 480px) {
+  .m-how-root .demo { padding: 20px; border-radius: 20px; }
+  .m-how-root .demo-title { font-size: 24px; }
+  .m-how-root header.hero { padding: 100px 20px 40px; }
+  .m-how-root header.hero h1 { font-size: 32px; }
+  .m-how-root header.hero p { font-size: 16px; }
+  .m-how-root .iphone { width: 280px; height: 580px; }
+  .m-how-root footer .footer-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
Marketing redesign batch 3 — `/how-it-works`. The page linked from both the
homepage CTAs and the footer "Product" column finally matches the rest of the
refreshed marketing surface.

### What's in here

| Route | Source | Shipping |
|---|---|---|
| `/how-it-works` (new) | `design_handoff_paybacker_homepage/Paybacker How It Works.html` | Six-section walkthrough of the product |

### Structure

Six numbered demo sections, each with a title, a visual "stage" (iPhone mockup or browser/sheet frame), and a How-to-use / Why-it's-different caption row:

1. **AI Disputes Centre** — LIVE. Letter preview + filled-in form + thread-monitor mockup showing how inbound replies get flagged.
2. **Subscriptions Tracker** — LIVE. iPhone mockup listing subs with hike/dup/trial/renewal tags + side cards for flagged items and one-tap actions.
3. **Money Hub** — LIVE. iPhone mockup with net card, donut breakdown, live transaction feed + side-by-side compare pane against Emma.
4. **Telegram Pocket Agent** — COMING SOON (badge + "How it will work" copy). iPhone mockup showing example chat exchanges.
5. **Google Sheets Export** — COMING SOON. Spreadsheet mockup with formula bar + 3-node data-flow diagram.
6. **Stacked** — 3-column architecture diagram (inputs → core → outputs) plus the competitor comparison table.

Final CTA block with a "Start free" button to `/auth/signup`.

### Content accuracy

The raw design file over-promises a few things. Per `CONTENT_SOURCES_OF_TRUTH.md` we only ship truthful copy:

- **Telegram Pocket Agent** — CLAUDE.md lists Telegram under "COMING SOON" alongside WhatsApp/SMS. Section retained with a visible "Coming soon" badge and forward-tense copy ("How it will work"). The compare-pane row and Stacked table entries both say "Coming soon" rather than ✓.
- **Google Sheets export** — not in the live feature list. Same treatment as Telegram.
- **"53+ UK partners"** — not a count we've confirmed. Replaced with "UK partner network" in the architecture diagram.
- **Bank sync** — all mentions say Yapily (our current open-banking provider), not TrueLayer.

### Architecture

- Server Component (no `'use client'`). The design's tagbar filter was client-side JS; we replace it with anchor links that scroll to each `id="..."` section.
- Route-scoped CSS in `src/app/how-it-works/styles.css` (one stylesheet, all visual primitives: iphone frame, dispute cards, sheet grid, telegram chat, architecture grid, power table).
- Reuses `MarkNav` / `MarkFoot` from `src/app/blog/_shared.tsx` to keep chrome consistent with the other marketing pages.
- `MarkNav`'s `active` prop is now optional — /how-it-works isn't in the nav pill, so nothing should highlight.

### Checks

- `npx tsc --noEmit`: clean for the three files in this PR. Pre-existing errors elsewhere in the repo (dashboard/money-hub, cron/trial-expiry, the known CareersInterestForm false positive from batch 2) are unchanged by this PR.
- No new API keys, no client-side secrets, no database changes, no new env vars.
- Page loads data statically (no fetching) — safe on Vercel ISR / build-time rendering.

### Next

After this lands, the main remaining design-debt is the dark-theme `/blog/[slug]` template plus the 3 hand-coded SEO post pages (`broadband-contract-ended`, `are-you-overpaying-on-energy`, `how-to-claim-flight-delay-compensation-uk`) — they still use the legacy PublicNavbar.
