### PR TITLE
feat(marketing): redesign /blog/[slug] + 3 static SEO posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,7 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { Metadata } from 'next';
-import PublicNavbar from '@/components/PublicNavbar';
+import { PostShell, SIGNUP_HREF } from '../_shared';
+import '../styles.css';
 
 // Force dynamic rendering so new blog posts are available immediately
 export const dynamic = 'force-dynamic';
@@ -93,68 +94,42 @@ export default async function DynamicBlogPost({ params }: { params: Promise<{ sl
   };
 
   return (
-    <div className="min-h-screen bg-navy-950">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
-      <div className="relative">
-        <PublicNavbar />
-        <div className="h-16" />
+    <PostShell
+      category={post.category || undefined}
+      title={post.title}
+      dek={post.excerpt || undefined}
+      dateLabel={publishedDate}
+      readTime={post.read_time ? `${post.read_time} min read` : undefined}
+      aside={{
+        eyebrow: 'Try Paybacker',
+        title: 'Need a formal letter?',
+        description: 'Our AI writes complaint letters citing exact UK law in 30 seconds. Free to try — 3 letters per month.',
+        ctaLabel: 'Generate your letter free',
+        ctaHref: SIGNUP_HREF,
+      }}
+      jsonLd={jsonLd}
+    >
+      {/* Body — content is stored as HTML in Supabase. Post-body CSS in styles.css
+          styles the p / h2 / h3 / ul / ol / blockquote / a / strong / table inside. */}
+      <div dangerouslySetInnerHTML={{ __html: post.content }} />
 
-        <main className="container mx-auto px-6 py-12">
-          <article className="max-w-3xl mx-auto">
-            <div className="mb-8">
-              <div className="flex items-center gap-2 text-sm text-slate-500 mb-4">
-                <Link href="/blog" className="hover:text-white transition-all">Blog</Link>
-                <span>/</span>
-                <span className="text-slate-400">{post.title.substring(0, 40)}...</span>
-              </div>
-              <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 leading-tight font-[family-name:var(--font-heading)]">{post.title}</h1>
-              <div className="flex items-center gap-4 text-sm text-slate-500">
-                <span>{publishedDate}</span>
-                {post.target_keyword && <span className="bg-mint-400/10 text-mint-400 px-2 py-0.5 rounded-full text-xs">{post.category}</span>}
-              </div>
-            </div>
-
-            <div
-              className="prose prose-invert prose-slate max-w-none [&_h2]:text-2xl [&_h2]:font-bold [&_h2]:text-white [&_h2]:mt-10 [&_h2]:mb-4 [&_h3]:text-xl [&_h3]:font-semibold [&_h3]:text-white [&_h3]:mt-7 [&_h3]:mb-3 [&_p]:text-slate-300 [&_p]:leading-relaxed [&_p]:mb-4 [&_ul]:text-slate-300 [&_ul]:space-y-2 [&_ul]:mb-4 [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:text-slate-300 [&_ol]:space-y-2 [&_ol]:mb-4 [&_ol]:list-decimal [&_ol]:pl-6 [&_li]:text-slate-300 [&_strong]:text-white [&_a]:text-amber-400 [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-amber-300"
-              dangerouslySetInnerHTML={{ __html: post.content }}
-            />
-
-            {/* CTA */}
-            <div className="bg-mint-400/10 border border-mint-400/20 rounded-2xl p-8 my-10 text-center">
-              <h2 className="text-2xl font-bold text-white mb-3 font-[family-name:var(--font-heading)]">Need help with this? Paybacker can generate a formal letter in 30 seconds</h2>
-              <p className="text-slate-400 mb-6">Our AI writes complaint letters citing exact UK law. Free to try - 3 letters per month.</p>
-              <Link href="/auth/signup" className="inline-block bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-8 py-4 rounded-xl transition-all text-lg">
-                Generate Your Letter Free
-              </Link>
-            </div>
-
-            {/* Deal section if relevant */}
-            {post.deal_category && (
-              <div className="bg-green-500/10 border border-green-500/20 rounded-xl p-6 mb-8 text-center">
-                <p className="text-green-400 font-semibold mb-2">Looking for a better deal?</p>
-                <p className="text-slate-400 text-sm mb-4">Compare {post.deal_category} deals from top UK providers. Free to browse, no signup needed.</p>
-                <Link href="/dashboard/deals" className="inline-block bg-green-500 hover:bg-green-600 text-white font-semibold px-6 py-3 rounded-xl transition-all text-sm">
-                  Browse {post.deal_category} Deals
-                </Link>
-              </div>
-            )}
-          </article>
-        </main>
-
-        <footer className="border-t border-navy-700/50 py-8 mt-16">
-          <div className="container mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
-            <div className="text-slate-500 text-sm">Paybacker LTD - paybacker.co.uk</div>
-            <div className="flex gap-4 text-slate-500 text-sm">
-              <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
-              <Link href="/about" className="hover:text-white transition-all">About</Link>
-              <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy</Link>
-            </div>
-          </div>
-        </footer>
+      {/* Inline CTA ---------------------------------------------------- */}
+      <div className="post-cta">
+        <h3>Need help with this? Paybacker generates the letter in 30 seconds.</h3>
+        <p>Our AI writes complaint letters citing exact UK consumer law. Free to try — 3 letters per month.</p>
+        <Link className="btn btn-mint" href={SIGNUP_HREF}>Start free</Link>
       </div>
-    </div>
+
+      {/* Deal section if relevant */}
+      {post.deal_category ? (
+        <div className="post-cta" style={{ background: 'var(--surface-soft-mint)', color: 'var(--text-primary)' }}>
+          <h3 style={{ color: 'var(--text-primary)' }}>Looking for a better deal?</h3>
+          <p style={{ color: 'var(--text-secondary)' }}>
+            Compare {post.deal_category} deals from top UK providers. Free to browse, no signup needed.
+          </p>
+          <Link className="btn btn-mint" href="/dashboard/deals">Browse {post.deal_category} deals</Link>
+        </div>
+      ) : null}
+    </PostShell>
   );
 }

--- a/src/app/blog/are-you-overpaying-on-energy/page.tsx
+++ b/src/app/blog/are-you-overpaying-on-energy/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
+import { PostShell, SIGNUP_HREF } from "../_shared";
+import "../styles.css";
 
 export const metadata: Metadata = {
   title:
@@ -31,245 +32,134 @@ export const metadata: Metadata = {
   },
 };
 
+const TOC = [
+  { id: "svt-vs-fixed", label: "Standard variable vs fixed deals" },
+  { id: "signs", label: "Signs you're overpaying" },
+  { id: "how-to-check", label: "How to check what you're paying" },
+  { id: "switching", label: "Switching is easier than you think" },
+  { id: "paybacker", label: "Let Paybacker do the work" },
+];
+
 export default function EnergyBlogPost() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
-      <header className="container mx-auto px-6 py-6 border-b border-slate-800">
-        <div className="flex items-center justify-between">
-          <Link href="/" className="flex items-center gap-2">
-            <Image src="/logo.png" alt="Paybacker" width={32} height={32} className="rounded-lg" />
-            <span className="text-xl font-bold text-white">
-              Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-            </span>
-          </Link>
-          <nav className="flex items-center gap-1 md:gap-3 text-sm">
-            <Link
-              href="/about"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              About
-            </Link>
-            <Link
-              href="/blog"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Blog
-            </Link>
-            <Link
-              href="/pricing"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Pricing
-            </Link>
-            <Link
-              href="/auth/login"
-              className="text-slate-300 hover:text-white font-medium px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Sign In
-            </Link>
-          </nav>
-        </div>
-      </header>
+    <PostShell
+      category="Energy"
+      title="Are You Overpaying on Energy in 2026? Here's How to Find Out"
+      dek="The Ofgem price cap lands at £1,641 from April 2026 — but that's just a maximum unit rate, not a total. If you haven't switched in two years, you're almost certainly on the most expensive tariff your supplier offers."
+      dateLabel="23 March 2026"
+      readTime="4 min read"
+      toc={TOC}
+      aside={{
+        eyebrow: "Try Paybacker",
+        title: "Find out if you're overpaying",
+        description: "Sign up free and let our AI scan your energy bills. It takes two minutes and could save you hundreds.",
+        ctaLabel: "Generate your letter free",
+        ctaHref: "/dashboard/complaints?type=energy_dispute&new=1",
+      }}
+    >
+      <p>
+        Energy bills have been one of the biggest household expenses in the UK
+        for several years now, and 2026 is no different. With the Ofgem energy
+        price cap set at <strong>£1,641 per year</strong> for a typical dual-fuel
+        household from April 2026, millions of people are paying more than they
+        need to — without even realising it.
+      </p>
+      <p>
+        The price cap doesn&apos;t limit your total bill. It caps the maximum
+        unit rate and standing charge your supplier can charge if you&apos;re on
+        a standard variable tariff (SVT). If you use more energy than average,
+        you&apos;ll pay more than £1,641. And if you haven&apos;t switched in a
+        while, you&apos;re almost certainly on an SVT — the most expensive type
+        of tariff.
+      </p>
 
-      <main className="container mx-auto px-6 py-16 max-w-3xl">
+      <h2 id="svt-vs-fixed">Standard variable tariffs vs fixed deals</h2>
+      <p>
+        When your fixed energy deal ends, your supplier automatically moves you
+        onto their standard variable tariff. This is typically the most expensive
+        rate they offer. It&apos;s designed to be a default, not a good deal.
+      </p>
+      <p>
+        Fixed deals, on the other hand, lock in your unit rate for 12 or 24
+        months. Right now, some of the best fixed tariffs are priced{" "}
+        <strong>below the price cap</strong>, meaning you could save a
+        significant amount by switching away from your SVT. The difference can
+        be anywhere from £100 to £300 or more per year, depending on your usage.
+      </p>
+
+      <h2 id="signs">Signs you&apos;re overpaying</h2>
+      <p>You&apos;re likely overpaying on energy if any of the following apply to you:</p>
+      <ul>
+        <li>You haven&apos;t switched energy supplier or tariff in the last two years.</li>
+        <li>
+          You&apos;re not currently on a fixed-rate deal (check your latest bill —
+          it will say &quot;variable&quot; or &quot;standard&quot;).
+        </li>
+        <li>Your annual energy spend is above £1,641 for a typical three-bedroom house.</li>
+        <li>You&apos;ve never compared your unit rate against what&apos;s available on the market.</li>
+        <li>You moved into a new property and never changed the default energy supplier.</li>
+      </ul>
+
+      <h2 id="how-to-check">How to check what you&apos;re actually paying</h2>
+      <p>
+        The two numbers that matter most on your energy bill are your{" "}
+        <strong>unit rate</strong> (the cost per kilowatt-hour of gas and
+        electricity you use) and your <strong>standing charge</strong> (a daily
+        fixed fee just for having a supply connected).
+      </p>
+      <p>
+        Find these on your latest bill or your online account. Then compare them
+        against the best deals currently available. If your unit rate is higher
+        than the cheapest fixed deals on the market, you&apos;re leaving money
+        on the table.
+      </p>
+
+      <h2 id="switching">Switching is easier than you think</h2>
+      <p>
+        Many people put off switching because they assume it&apos;s complicated.
+        In reality, it takes about five minutes. You don&apos;t need to call
+        anyone, no engineer needs to visit, and your supply is never
+        interrupted. The switch typically completes within five working days,
+        and your new supplier handles everything — including contacting your old
+        one.
+      </p>
+      <p>
+        If you&apos;re on a standard variable tariff, there are no exit fees. If
+        you&apos;re on a fixed deal that hasn&apos;t ended yet, check whether the
+        savings from switching outweigh any early exit penalty (usually £30–£50
+        per fuel).
+      </p>
+
+      <h2 id="paybacker">Let Paybacker do the work for you</h2>
+      <p>
+        Comparing tariffs manually is doable, but it takes time — and you need to
+        remember to do it every year. Paybacker automates this entirely. Connect
+        your email or bank account, and our AI scans your energy bills, identifies
+        your current tariff, and surfaces the best deals available right now. No
+        forms to fill in, no comparison sites to trawl through.
+      </p>
+      <p>
+        We also alert you before your fixed deal ends, so you never accidentally
+        roll onto an expensive standard variable tariff again.
+      </p>
+
+      <div className="post-cta">
+        <h3>Find out if you&apos;re overpaying</h3>
+        <p>
+          Sign up to Paybacker and let our AI scan your bills. It takes two
+          minutes and could save you hundreds.
+        </p>
         <Link
-          href="/blog"
-          className="text-amber-400 hover:text-amber-300 text-sm mb-8 inline-block"
+          className="btn btn-mint"
+          href="/dashboard/complaints?type=energy_dispute&new=1"
         >
-          &larr; Back to Blog
+          Generate your energy dispute letter free
         </Link>
+      </div>
 
-        <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
-          Are You Overpaying on Energy in 2026? Here&apos;s How to Find Out
-        </h1>
-        <p className="text-slate-500 text-sm mb-8">23 March 2026 &middot; 4 min read</p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          Energy bills have been one of the biggest household expenses in the UK
-          for several years now, and 2026 is no different. With the Ofgem energy
-          price cap set at <strong className="text-white">£1,641 per year</strong> for a
-          typical dual-fuel household from April 2026, millions of people are
-          paying more than they need to — without even realising it.
-        </p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          The price cap doesn&apos;t limit your total bill. It caps the maximum
-          unit rate and standing charge your supplier can charge if you&apos;re
-          on a standard variable tariff (SVT). If you use more energy than
-          average, you&apos;ll pay more than £1,641. And if you haven&apos;t
-          switched in a while, you&apos;re almost certainly on an SVT — the most
-          expensive type of tariff.
-        </p>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          Standard Variable Tariffs vs Fixed Deals
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          When your fixed energy deal ends, your supplier automatically moves
-          you onto their standard variable tariff. This is typically the most
-          expensive rate they offer. It&apos;s designed to be a default, not a
-          good deal.
-        </p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          Fixed deals, on the other hand, lock in your unit rate for 12 or 24
-          months. Right now, some of the best fixed tariffs are priced{" "}
-          <strong className="text-white">below the price cap</strong>, meaning
-          you could save a significant amount by switching away from your SVT.
-          The difference can be anywhere from £100 to £300 or more per year,
-          depending on your usage.
-        </p>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          Signs You&apos;re Overpaying
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          You&apos;re likely overpaying on energy if any of the following apply
-          to you:
-        </p>
-
-        <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-6">
-          <li>
-            You haven&apos;t switched energy supplier or tariff in the last two
-            years
-          </li>
-          <li>
-            You&apos;re not currently on a fixed-rate deal (check your latest
-            bill — it will say &quot;variable&quot; or &quot;standard&quot;)
-          </li>
-          <li>
-            Your annual energy spend is above £1,641 for a typical three-bedroom
-            house
-          </li>
-          <li>
-            You&apos;ve never compared your unit rate against what&apos;s
-            available on the market
-          </li>
-          <li>
-            You moved into a new property and never changed the default energy
-            supplier
-          </li>
-        </ul>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          How to Check What You&apos;re Actually Paying
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          The two numbers that matter most on your energy bill are your{" "}
-          <strong className="text-white">unit rate</strong> (the cost per
-          kilowatt-hour of gas and electricity you use) and your{" "}
-          <strong className="text-white">standing charge</strong> (a daily fixed
-          fee just for having a supply connected).
-        </p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          Find these on your latest bill or your online account. Then compare
-          them against the best deals currently available. If your unit rate is
-          higher than the cheapest fixed deals on the market, you&apos;re leaving
-          money on the table.
-        </p>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          Switching Is Easier Than You Think
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          Many people put off switching because they assume it&apos;s
-          complicated. In reality, it takes about five minutes. You don&apos;t
-          need to call anyone, no engineer needs to visit, and your supply is
-          never interrupted. The switch typically completes within five working
-          days, and your new supplier handles everything — including contacting
-          your old one.
-        </p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          If you&apos;re on a standard variable tariff, there are no exit fees.
-          If you&apos;re on a fixed deal that hasn&apos;t ended yet, check
-          whether the savings from switching outweigh any early exit penalty
-          (usually £30-£50 per fuel).
-        </p>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          Let Paybacker Do the Work for You
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          Comparing tariffs manually is doable, but it takes time — and you need
-          to remember to do it every year. Paybacker automates this entirely. Connect
-          your email or bank account, and our AI scans your energy bills,
-          identifies your current tariff, and surfaces the best deals available
-          right now. No forms to fill in, no comparison sites to trawl through.
-        </p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          We also alert you before your fixed deal ends, so you never
-          accidentally roll onto an expensive standard variable tariff again.
-        </p>
-
-        {/* CTA */}
-        <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-6 mt-10">
-          <h3 className="text-xl font-bold text-white mb-2">
-            Find out if you&apos;re overpaying
-          </h3>
-          <p className="text-slate-300 mb-4">
-            Sign up to Paybacker and let our AI scan your bills. It takes two
-            minutes and could save you hundreds.
-          </p>
-          <Link
-            href="/dashboard/complaints?type=energy_dispute&new=1"
-            className="inline-block bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold px-6 py-3 rounded-lg transition-all"
-          >
-            Generate Your Energy Dispute Letter Free
-          </Link>
-        </div>
-      </main>
-
-      <footer className="container mx-auto px-6 py-8 border-t border-slate-800 mt-16">
-        <div className="text-center text-slate-500 text-sm space-y-3">
-          <div className="flex flex-wrap justify-center gap-6">
-            <Link href="/about" className="hover:text-white transition-all">
-              About
-            </Link>
-            <Link href="/blog" className="hover:text-white transition-all">
-              Blog
-            </Link>
-            <Link
-              href="/privacy-policy"
-              className="hover:text-white transition-all"
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              href="/terms-of-service"
-              className="hover:text-white transition-all"
-            >
-              Terms of Service
-            </Link>
-            <Link href="/pricing" className="hover:text-white transition-all">
-              Pricing
-            </Link>
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="hover:text-white transition-all"
-            >
-              Contact
-            </a>
-          </div>
-          <p>
-            Need help? Email{" "}
-            <a
-              href="mailto:support@paybacker.co.uk"
-              className="text-amber-500 hover:text-amber-400"
-            >
-              support@paybacker.co.uk
-            </a>
-          </p>
-          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
-        </div>
-      </footer>
-    </div>
+      <p style={{ fontSize: 14, color: "var(--text-tertiary)", marginTop: 24 }}>
+        Want to browse before signing up? <Link href={SIGNUP_HREF}>Create a free account</Link> and our AI will flag any expensive tariff the moment you connect your email or bank.
+      </p>
+    </PostShell>
   );
 }

--- a/src/app/blog/broadband-contract-ended/page.tsx
+++ b/src/app/blog/broadband-contract-ended/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
+import { PostShell, SIGNUP_HREF } from "../_shared";
+import "../styles.css";
 
 export const metadata: Metadata = {
   title:
@@ -31,261 +32,155 @@ export const metadata: Metadata = {
   },
 };
 
+const TOC = [
+  { id: "what-happens", label: "What happens when your contract ends" },
+  { id: "loyalty-penalty", label: "The loyalty penalty problem" },
+  { id: "how-to-check", label: "How to check if you're out of contract" },
+  { id: "what-to-do", label: "What to do about it" },
+  { id: "how-paybacker-helps", label: "How Paybacker helps" },
+];
+
 export default function BroadbandBlogPost() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
-      <header className="container mx-auto px-6 py-6 border-b border-slate-800">
-        <div className="flex items-center justify-between">
-          <Link href="/" className="flex items-center gap-2">
-            <Image src="/logo.png" alt="Paybacker" width={32} height={32} className="rounded-lg" />
-            <span className="text-xl font-bold text-white">
-              Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-            </span>
-          </Link>
-          <nav className="flex items-center gap-1 md:gap-3 text-sm">
-            <Link
-              href="/about"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              About
-            </Link>
-            <Link
-              href="/blog"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Blog
-            </Link>
-            <Link
-              href="/pricing"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Pricing
-            </Link>
-            <Link
-              href="/auth/login"
-              className="text-slate-300 hover:text-white font-medium px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Sign In
-            </Link>
-          </nav>
-        </div>
-      </header>
+    <PostShell
+      category="Broadband"
+      title="Your Broadband Contract Has Ended — You're Probably Being Overcharged"
+      dek="If your initial 18 or 24-month broadband contract has lapsed, you're almost certainly rolled onto a more expensive out-of-contract rate — for the exact same service."
+      dateLabel="23 March 2026"
+      readTime="4 min read"
+      toc={TOC}
+      aside={{
+        eyebrow: "Try Paybacker",
+        title: "Stop overpaying on broadband",
+        description: "Sign up free and we'll check your contract status and find you a better deal — in minutes, not hours.",
+        ctaLabel: "Generate your letter free",
+        ctaHref: "/dashboard/complaints?type=broadband_complaint&new=1",
+      }}
+    >
+      <p>
+        If you signed up for a broadband deal 18 or 24 months ago and haven&apos;t
+        thought about it since, there&apos;s a very good chance you&apos;re now
+        paying significantly more than you need to. In the UK, an estimated{" "}
+        <strong>8.8 million households</strong> are out of contract on their
+        broadband — and most of them are overpaying by hundreds of pounds a year.
+      </p>
 
-      <main className="container mx-auto px-6 py-16 max-w-3xl">
+      <h2 id="what-happens">What happens when your contract ends</h2>
+      <p>
+        When your initial broadband contract period ends (typically 18 or 24
+        months), you don&apos;t get cut off. Instead, your provider automatically
+        rolls you onto an out-of-contract rate — sometimes called a
+        &quot;rolling monthly&quot; plan. This rate is almost always{" "}
+        <strong>significantly higher than what you were paying</strong> during
+        your contract.
+      </p>
+      <p>
+        For example, a deal that was £25 a month during contract might jump to
+        £45 or even £50 once it ends. That&apos;s an extra £240–£300 a year for
+        the exact same service — same speed, same router, same everything. The
+        only thing that changes is the price.
+      </p>
+
+      <h2 id="loyalty-penalty">The loyalty penalty problem</h2>
+      <p>
+        This practice is known as the &quot;loyalty penalty&quot; — loyal
+        customers who stay with the same provider end up paying more than new
+        customers who sign up for introductory deals. Ofcom has taken steps to
+        address this, requiring providers to notify you when your contract is
+        ending and tell you about the best deals available. But many people miss
+        these notifications or simply don&apos;t act on them.
+      </p>
+      <p>
+        On top of that, most broadband providers now include annual mid-contract
+        price rises tied to inflation (often CPI + 3.9%). So even if you&apos;re
+        still in contract, you might be paying more than you expected when you
+        first signed up.
+      </p>
+
+      <h2 id="how-to-check">How to check if you&apos;re out of contract</h2>
+      <p>There are a few quick ways to find out:</p>
+      <ul>
+        <li>
+          <strong>Check your latest bill</strong> — it should state whether
+          you&apos;re in or out of contract.
+        </li>
+        <li>
+          <strong>Log into your provider&apos;s app or website</strong> — most
+          show your contract status and end date in your account settings.
+        </li>
+        <li>
+          <strong>Think back to when you signed up</strong> — if it was more
+          than two years ago and you haven&apos;t renewed, you&apos;re almost
+          certainly out of contract.
+        </li>
+        <li>
+          <strong>Check your email for end-of-contract notifications</strong> —
+          your provider is legally required to send one.
+        </li>
+      </ul>
+
+      <h2 id="what-to-do">What to do about it</h2>
+      <p>
+        If you&apos;re out of contract, you have several options — and all of
+        them are better than doing nothing:
+      </p>
+      <ul>
+        <li>
+          <strong>Switch to a new provider</strong> — new customer deals are
+          almost always the cheapest option. Switching is managed by the new
+          provider and typically takes around two weeks. You won&apos;t lose
+          your broadband during the switch.
+        </li>
+        <li>
+          <strong>Negotiate with your current provider</strong> — call their
+          retentions team and ask what deals they can offer you as an existing
+          customer. They will often match or come close to new customer prices
+          to keep you.
+        </li>
+        <li>
+          <strong>Re-contract at a lower rate</strong> — some providers let you
+          sign a new contract online at a better rate than your out-of-contract
+          price, without needing to call.
+        </li>
+      </ul>
+      <p>
+        Since you&apos;re out of contract, there are <strong>no exit fees</strong>{" "}
+        to worry about. You&apos;re free to leave at any time, usually with just
+        30 days&apos; notice.
+      </p>
+
+      <h2 id="how-paybacker-helps">How Paybacker helps</h2>
+      <p>
+        Keeping track of contract end dates across broadband, mobile, energy and
+        insurance is a pain. Paybacker does it automatically. Connect your email
+        or bank account, and our AI identifies your broadband provider, detects
+        whether you&apos;re in or out of contract, and flags when your renewal
+        date is approaching — so you never accidentally roll onto an expensive
+        out-of-contract rate.
+      </p>
+      <p>
+        We also surface the best deals available right now, personalised to your
+        area and usage, so you can switch in minutes rather than spending an
+        afternoon on comparison sites.
+      </p>
+
+      <div className="post-cta">
+        <h3>Stop overpaying on broadband</h3>
+        <p>
+          Sign up to Paybacker and we&apos;ll check your contract status and find
+          you a better deal. It takes two minutes.
+        </p>
         <Link
-          href="/blog"
-          className="text-amber-400 hover:text-amber-300 text-sm mb-8 inline-block"
+          className="btn btn-mint"
+          href="/dashboard/complaints?type=broadband_complaint&new=1"
         >
-          &larr; Back to Blog
+          Generate your broadband complaint letter free
         </Link>
+      </div>
 
-        <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
-          Your Broadband Contract Has Ended — You&apos;re Probably Being
-          Overcharged
-        </h1>
-        <p className="text-slate-500 text-sm mb-8">23 March 2026 &middot; 4 min read</p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          If you signed up for a broadband deal 18 or 24 months ago and
-          haven&apos;t thought about it since, there&apos;s a very good chance
-          you&apos;re now paying significantly more than you need to. In the UK,
-          an estimated{" "}
-          <strong className="text-white">8.8 million households</strong> are out
-          of contract on their broadband — and most of them are overpaying by
-          hundreds of pounds a year.
-        </p>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          What Happens When Your Contract Ends
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          When your initial broadband contract period ends (typically 18 or 24
-          months), you don&apos;t get cut off. Instead, your provider
-          automatically rolls you onto an out-of-contract rate — sometimes called
-          a &quot;rolling monthly&quot; plan. This rate is almost always{" "}
-          <strong className="text-white">
-            significantly higher than what you were paying
-          </strong>{" "}
-          during your contract.
-        </p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          For example, a deal that was £25 a month during contract might jump to
-          £45 or even £50 once it ends. That&apos;s an extra £240-£300 a year
-          for the exact same service — same speed, same router, same everything.
-          The only thing that changes is the price.
-        </p>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          The Loyalty Penalty Problem
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          This practice is known as the &quot;loyalty penalty&quot; — loyal
-          customers who stay with the same provider end up paying more than new
-          customers who sign up for introductory deals. Ofcom has taken steps to
-          address this, requiring providers to notify you when your contract is
-          ending and tell you about the best deals available. But many people
-          miss these notifications or simply don&apos;t act on them.
-        </p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          On top of that, most broadband providers now include annual mid-contract
-          price rises tied to inflation (often CPI + 3.9%). So even if you&apos;re
-          still in contract, you might be paying more than you expected when you
-          first signed up.
-        </p>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          How to Check If You&apos;re Out of Contract
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          There are a few quick ways to find out:
-        </p>
-
-        <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-6">
-          <li>
-            <strong className="text-white">Check your latest bill</strong> — it
-            should state whether you&apos;re in or out of contract
-          </li>
-          <li>
-            <strong className="text-white">Log into your provider&apos;s app or website</strong>{" "}
-            — most show your contract status and end date in your account
-            settings
-          </li>
-          <li>
-            <strong className="text-white">Think back to when you signed up</strong>{" "}
-            — if it was more than two years ago and you haven&apos;t renewed,
-            you&apos;re almost certainly out of contract
-          </li>
-          <li>
-            <strong className="text-white">
-              Check your email for end-of-contract notifications
-            </strong>{" "}
-            — your provider is legally required to send one
-          </li>
-        </ul>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          What to Do About It
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          If you&apos;re out of contract, you have several options — and all of
-          them are better than doing nothing:
-        </p>
-
-        <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-6">
-          <li>
-            <strong className="text-white">Switch to a new provider</strong> —
-            new customer deals are almost always the cheapest option. Switching
-            is managed by the new provider and typically takes around two weeks.
-            You won&apos;t lose your broadband during the switch.
-          </li>
-          <li>
-            <strong className="text-white">
-              Negotiate with your current provider
-            </strong>{" "}
-            — call their retentions team and ask what deals they can offer you
-            as an existing customer. They will often match or come close to new
-            customer prices to keep you.
-          </li>
-          <li>
-            <strong className="text-white">Re-contract at a lower rate</strong>{" "}
-            — some providers let you sign a new contract online at a better rate
-            than your out-of-contract price, without needing to call.
-          </li>
-        </ul>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          Since you&apos;re out of contract, there are{" "}
-          <strong className="text-white">no exit fees</strong> to worry about.
-          You&apos;re free to leave at any time, usually with just 30
-          days&apos; notice.
-        </p>
-
-        <h2 className="text-2xl font-bold text-white mt-10 mb-4">
-          How Paybacker Helps
-        </h2>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          Keeping track of contract end dates across broadband, mobile, energy
-          and insurance is a pain. Paybacker does it automatically. Connect your
-          email or bank account, and our AI identifies your broadband provider,
-          detects whether you&apos;re in or out of contract, and flags when your
-          renewal date is approaching — so you never accidentally roll onto an
-          expensive out-of-contract rate.
-        </p>
-
-        <p className="text-slate-300 leading-relaxed mb-4">
-          We also surface the best deals available right now, personalised to
-          your area and usage, so you can switch in minutes rather than spending
-          an afternoon on comparison sites.
-        </p>
-
-        {/* CTA */}
-        <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-6 mt-10">
-          <h3 className="text-xl font-bold text-white mb-2">
-            Stop overpaying on broadband
-          </h3>
-          <p className="text-slate-300 mb-4">
-            Sign up to Paybacker and we&apos;ll check your contract status and
-            find you a better deal. It takes two minutes.
-          </p>
-          <Link
-            href="/dashboard/complaints?type=broadband_complaint&new=1"
-            className="inline-block bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold px-6 py-3 rounded-lg transition-all"
-          >
-            Generate Your Broadband Complaint Letter Free
-          </Link>
-        </div>
-      </main>
-
-      <footer className="container mx-auto px-6 py-8 border-t border-slate-800 mt-16">
-        <div className="text-center text-slate-500 text-sm space-y-3">
-          <div className="flex flex-wrap justify-center gap-6">
-            <Link href="/about" className="hover:text-white transition-all">
-              About
-            </Link>
-            <Link href="/blog" className="hover:text-white transition-all">
-              Blog
-            </Link>
-            <Link
-              href="/privacy-policy"
-              className="hover:text-white transition-all"
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              href="/terms-of-service"
-              className="hover:text-white transition-all"
-            >
-              Terms of Service
-            </Link>
-            <Link href="/pricing" className="hover:text-white transition-all">
-              Pricing
-            </Link>
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="hover:text-white transition-all"
-            >
-              Contact
-            </a>
-          </div>
-          <p>
-            Need help? Email{" "}
-            <a
-              href="mailto:support@paybacker.co.uk"
-              className="text-amber-500 hover:text-amber-400"
-            >
-              support@paybacker.co.uk
-            </a>
-          </p>
-          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
-        </div>
-      </footer>
-    </div>
+      <p style={{ fontSize: 14, color: "var(--text-tertiary)", marginTop: 24 }}>
+        Prefer to browse first? <Link href={SIGNUP_HREF}>Create a free Paybacker account</Link> and connect your email — we&apos;ll scan for your broadband bill in under a minute.
+      </p>
+    </PostShell>
   );
 }

--- a/src/app/blog/how-to-claim-flight-delay-compensation-uk/page.tsx
+++ b/src/app/blog/how-to-claim-flight-delay-compensation-uk/page.tsx
@@ -1,210 +1,265 @@
-import { Metadata } from 'next';
-import Link from 'next/link';
-import Image from 'next/image';
+import type { Metadata } from "next";
+import Link from "next/link";
+import { PostShell } from "../_shared";
+import "../styles.css";
 
 export const metadata: Metadata = {
-  title: 'How to Claim Flight Delay Compensation UK 2026 - Up to £520',
-  description: 'Complete guide to claiming flight delay compensation under UK261 regulations. Claim up to £520 per person for delayed or cancelled flights. Free AI claim letter generator.',
-  keywords: ['flight delay compensation UK', 'UK261 claim', 'flight cancelled compensation', 'delayed flight refund', 'how to claim flight delay'],
+  title: "How to Claim Flight Delay Compensation UK 2026 - Up to £520",
+  description:
+    "Complete guide to claiming flight delay compensation under UK261 regulations. Claim up to £520 per person for delayed or cancelled flights. Free AI claim letter generator.",
+  keywords: [
+    "flight delay compensation UK",
+    "UK261 claim",
+    "flight cancelled compensation",
+    "delayed flight refund",
+    "how to claim flight delay",
+  ],
   openGraph: {
-    title: 'How to Claim Flight Delay Compensation UK 2026 - Up to £520',
-    description: 'Complete guide to claiming flight delay compensation under UK261 regulations. Claim up to £520 per person.',
-    url: 'https://paybacker.co.uk/blog/how-to-claim-flight-delay-compensation-uk',
-    type: 'article',
-    publishedTime: '2026-03-25T00:00:00Z',
-    authors: ['Paybacker'],
+    title: "How to Claim Flight Delay Compensation UK 2026 - Up to £520",
+    description:
+      "Complete guide to claiming flight delay compensation under UK261 regulations. Claim up to £520 per person.",
+    url: "https://paybacker.co.uk/blog/how-to-claim-flight-delay-compensation-uk",
+    type: "article",
+    publishedTime: "2026-03-25T00:00:00Z",
+    authors: ["Paybacker"],
   },
   twitter: {
-    card: 'summary',
-    title: 'How to Claim Flight Delay Compensation UK - Up to £520',
-    description: 'Complete guide to flight delay compensation under UK261.',
+    card: "summary",
+    title: "How to Claim Flight Delay Compensation UK - Up to £520",
+    description: "Complete guide to flight delay compensation under UK261.",
   },
   alternates: {
-    canonical: 'https://paybacker.co.uk/blog/how-to-claim-flight-delay-compensation-uk',
+    canonical:
+      "https://paybacker.co.uk/blog/how-to-claim-flight-delay-compensation-uk",
   },
 };
 
+const TOC = [
+  { id: "what-is-uk261", label: "What is UK261?" },
+  { id: "how-much", label: "How much can you claim?" },
+  { id: "when", label: "When can you claim?" },
+  { id: "extraordinary", label: "Extraordinary circumstances" },
+  { id: "step-by-step", label: "How to claim step by step" },
+  { id: "how-long", label: "How long do I have?" },
+  { id: "connecting", label: "Connecting flights" },
+  { id: "faq", label: "FAQ" },
+];
+
 export default function FlightDelayCompensationPost() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
-      <div className="relative">
-        <header className="container mx-auto px-4 md:px-6 py-4 md:py-6">
-          <div className="flex items-center justify-between">
-            <Link href="/" className="flex items-center gap-2">
-              <Image src="/logo.png" alt="Paybacker" width={32} height={32} className="rounded-lg" />
-              <span className="text-xl font-bold text-white">Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span></span>
-            </Link>
-            <div className="flex items-center gap-3">
-              <Link href="/blog" className="text-slate-400 hover:text-white text-sm">Blog</Link>
-              <Link href="/auth/signup" className="bg-amber-500 hover:bg-amber-600 text-slate-950 text-sm font-semibold px-4 py-2 rounded-lg transition-all">Get Started Free</Link>
-            </div>
-          </div>
-        </header>
-
-        <main className="container mx-auto px-6 py-12">
-          <article className="max-w-3xl mx-auto">
-            <div className="mb-8">
-              <div className="flex items-center gap-2 text-sm text-slate-500 mb-4">
-                <Link href="/blog" className="hover:text-white transition-all">Blog</Link>
-                <span>/</span>
-                <span className="text-slate-400">Flight Delay Compensation</span>
-              </div>
-              <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 leading-tight">How to Claim Flight Delay Compensation in the UK: Up to £520 Per Person</h1>
-              <div className="flex items-center gap-4 text-sm text-slate-500">
-                <span>25 March 2026</span>
-                <span>8 min read</span>
-              </div>
-            </div>
-
-            <div className="prose prose-invert prose-slate max-w-none">
-              <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-6 mb-8">
-                <p className="text-amber-400 font-semibold mb-2">Key takeaway</p>
-                <p className="text-slate-300 text-sm">If your flight was delayed by 3+ hours, cancelled with less than 14 days notice, or you were denied boarding, you could be owed between £220 and £520 per person. You can claim for flights in the last 6 years. Over £600 million goes unclaimed by UK passengers every year.</p>
-              </div>
-
-              <h2 className="text-2xl font-bold text-white mt-8 mb-4">What is UK261?</h2>
-              <p className="text-slate-300 leading-relaxed mb-4">After Brexit, the UK replaced EU Regulation 261/2004 with its own version known as UK261. This regulation protects passengers on flights departing from a UK airport, or arriving in the UK on a UK or EU airline.</p>
-              <p className="text-slate-300 leading-relaxed mb-4">Under UK261, airlines must compensate you if your flight was significantly delayed, cancelled, or you were denied boarding - unless the disruption was caused by extraordinary circumstances like severe weather or air traffic control strikes.</p>
-
-              <h2 className="text-2xl font-bold text-white mt-8 mb-4">How much can you claim?</h2>
-              <p className="text-slate-300 leading-relaxed mb-4">Compensation is based on the flight distance, not the ticket price:</p>
-              <div className="bg-slate-900/50 border border-slate-800 rounded-xl overflow-hidden mb-6">
-                <table className="w-full">
-                  <thead>
-                    <tr className="border-b border-slate-800">
-                      <th className="text-left py-3 px-4 text-slate-400 text-sm font-medium">Flight Distance</th>
-                      <th className="text-left py-3 px-4 text-slate-400 text-sm font-medium">Example Routes</th>
-                      <th className="text-right py-3 px-4 text-amber-400 text-sm font-medium">Compensation</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr className="border-b border-slate-800/50">
-                      <td className="py-3 px-4 text-white text-sm">Under 1,500km</td>
-                      <td className="py-3 px-4 text-slate-400 text-sm">London to Paris, Edinburgh, Amsterdam</td>
-                      <td className="py-3 px-4 text-amber-400 text-sm font-bold text-right">£220</td>
-                    </tr>
-                    <tr className="border-b border-slate-800/50">
-                      <td className="py-3 px-4 text-white text-sm">1,500km - 3,500km</td>
-                      <td className="py-3 px-4 text-slate-400 text-sm">London to Tenerife, Athens, Istanbul</td>
-                      <td className="py-3 px-4 text-amber-400 text-sm font-bold text-right">£350</td>
-                    </tr>
-                    <tr>
-                      <td className="py-3 px-4 text-white text-sm">Over 3,500km</td>
-                      <td className="py-3 px-4 text-slate-400 text-sm">London to New York, Dubai, Bangkok</td>
-                      <td className="py-3 px-4 text-amber-400 text-sm font-bold text-right">£520</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <p className="text-slate-300 leading-relaxed mb-4">This is per person, per flight. A family of four on a long-haul flight could claim up to £2,080.</p>
-
-              <h2 className="text-2xl font-bold text-white mt-8 mb-4">When can you claim?</h2>
-              <p className="text-slate-300 leading-relaxed mb-4">You can claim compensation if:</p>
-              <ul className="text-slate-300 space-y-2 mb-6">
-                <li className="flex items-start gap-2"><span className="text-amber-400 mt-1">-</span> Your flight arrived more than 3 hours late at your final destination</li>
-                <li className="flex items-start gap-2"><span className="text-amber-400 mt-1">-</span> Your flight was cancelled with less than 14 days notice</li>
-                <li className="flex items-start gap-2"><span className="text-amber-400 mt-1">-</span> You were denied boarding (e.g. overbooking)</li>
-                <li className="flex items-start gap-2"><span className="text-amber-400 mt-1">-</span> The flight departed from a UK airport (any airline)</li>
-                <li className="flex items-start gap-2"><span className="text-amber-400 mt-1">-</span> The flight arrived in the UK on a UK or EU airline</li>
-              </ul>
-
-              <h2 className="text-2xl font-bold text-white mt-8 mb-4">What counts as extraordinary circumstances?</h2>
-              <p className="text-slate-300 leading-relaxed mb-4">Airlines often reject claims citing extraordinary circumstances. Here is what does and does not count:</p>
-              <div className="grid md:grid-cols-2 gap-4 mb-6">
-                <div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4">
-                  <p className="text-red-400 font-semibold text-sm mb-2">NOT extraordinary (you CAN claim)</p>
-                  <ul className="text-slate-300 text-sm space-y-1">
-                    <li>- Technical faults with the aircraft</li>
-                    <li>- Crew shortages or illness</li>
-                    <li>- IT system failures</li>
-                    <li>- Bird strikes (debated)</li>
-                    <li>- Baggage loading issues</li>
-                    <li>- Late incoming aircraft</li>
-                  </ul>
-                </div>
-                <div className="bg-green-500/10 border border-green-500/20 rounded-xl p-4">
-                  <p className="text-green-400 font-semibold text-sm mb-2">IS extraordinary (airline exempt)</p>
-                  <ul className="text-slate-300 text-sm space-y-1">
-                    <li>- Severe weather (not just bad weather)</li>
-                    <li>- Air traffic control strikes</li>
-                    <li>- Security threats or airport closures</li>
-                    <li>- Political instability</li>
-                    <li>- Medical emergencies on board</li>
-                    <li>- Volcanic ash</li>
-                  </ul>
-                </div>
-              </div>
-
-              <h2 className="text-2xl font-bold text-white mt-8 mb-4">How to claim: step by step</h2>
-              <div className="space-y-4 mb-6">
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-                  <p className="text-amber-400 font-bold text-sm mb-1">Step 1: Gather your details</p>
-                  <p className="text-slate-300 text-sm">You need your flight number, date of travel, departure and arrival airports, and a description of what happened (delay length, cancellation notice, etc.).</p>
-                </div>
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-                  <p className="text-amber-400 font-bold text-sm mb-1">Step 2: Write a formal claim letter</p>
-                  <p className="text-slate-300 text-sm">Your claim must cite UK261 regulations specifically and state the compensation amount you are owed based on flight distance. This is where most people get stuck.</p>
-                </div>
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-                  <p className="text-amber-400 font-bold text-sm mb-1">Step 3: Send to the airline</p>
-                  <p className="text-slate-300 text-sm">Email the airline's complaints department directly. Most airlines have a dedicated compensation claims form on their website.</p>
-                </div>
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-                  <p className="text-amber-400 font-bold text-sm mb-1">Step 4: Wait for a response</p>
-                  <p className="text-slate-300 text-sm">Airlines have 8 weeks to respond. If they reject your claim or do not respond, you can escalate to CEDR (Centre for Effective Dispute Resolution) for free.</p>
-                </div>
-              </div>
-
-              <h2 className="text-2xl font-bold text-white mt-8 mb-4">How long do I have to claim?</h2>
-              <p className="text-slate-300 leading-relaxed mb-4">In the UK, you can claim for flights delayed in the <strong className="text-white">last 6 years</strong>. So if you had a delayed flight in 2020, 2021, 2022, 2023, 2024, or 2025, you could still be owed money now.</p>
-
-              <h2 className="text-2xl font-bold text-white mt-8 mb-4">Can I claim for a connecting flight?</h2>
-              <p className="text-slate-300 leading-relaxed mb-4">Yes. If your connecting flights were booked as a single itinerary and you arrived at your final destination more than 3 hours late, you can claim based on the total distance from departure to final destination.</p>
-
-              {/* CTA */}
-              <div className="bg-gradient-to-r from-amber-500/10 to-amber-600/5 border border-amber-500/20 rounded-2xl p-8 my-10 text-center">
-                <h2 className="text-2xl font-bold text-white mb-3">Generate your flight compensation claim in 30 seconds</h2>
-                <p className="text-slate-400 mb-6">Our AI writes a formal claim letter citing UK261 regulations with the exact compensation amount you are owed. Free to use.</p>
-                <Link href="/dashboard/complaints?type=flight_compensation&new=1" className="inline-block bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 text-slate-950 font-semibold px-8 py-4 rounded-xl transition-all shadow-lg shadow-amber-500/25 text-lg">
-                  Generate Your Flight Claim Letter Free
-                </Link>
-                <p className="text-slate-600 text-xs mt-3">No credit card required. 3 free letters per month.</p>
-              </div>
-
-              <h2 className="text-2xl font-bold text-white mt-8 mb-4">Frequently asked questions</h2>
-              <div className="space-y-4 mb-8">
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-                  <h3 className="text-white font-semibold mb-2">Do I need a solicitor?</h3>
-                  <p className="text-slate-400 text-sm">No. You can claim directly with the airline yourself. A formal letter citing the correct regulations is usually enough. Paybacker generates this letter for you for free.</p>
-                </div>
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-                  <h3 className="text-white font-semibold mb-2">What if the airline says no?</h3>
-                  <p className="text-slate-400 text-sm">If the airline rejects your claim, you can escalate to CEDR (Centre for Effective Dispute Resolution) or the Aviation ADR scheme for free. Their decision is binding on the airline.</p>
-                </div>
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-                  <h3 className="text-white font-semibold mb-2">Does this apply to package holidays?</h3>
-                  <p className="text-slate-400 text-sm">Yes, if the flight element was delayed or cancelled. Package holiday flights are covered by UK261 in the same way as standalone flights.</p>
-                </div>
-                <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-                  <h3 className="text-white font-semibold mb-2">Can I claim for a flight I took years ago?</h3>
-                  <p className="text-slate-400 text-sm">Yes, up to 6 years in the UK. If you had a delayed flight any time from 2020 onwards, check if you are owed compensation.</p>
-                </div>
-              </div>
-            </div>
-          </article>
-        </main>
-
-        <footer className="border-t border-slate-800 py-8 mt-16">
-          <div className="container mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
-            <div className="text-slate-500 text-sm">Paybacker LTD - paybacker.co.uk</div>
-            <div className="flex gap-4 text-slate-500 text-sm">
-              <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
-              <Link href="/about" className="hover:text-white transition-all">About</Link>
-              <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy</Link>
-            </div>
-          </div>
-        </footer>
+    <PostShell
+      category="Flight delays"
+      title="How to Claim Flight Delay Compensation in the UK: Up to £520 Per Person"
+      dek="If your flight was delayed by 3+ hours, cancelled with less than 14 days notice, or you were denied boarding, you could be owed between £220 and £520 per person — and you can go back 6 years."
+      dateLabel="25 March 2026"
+      readTime="8 min read"
+      toc={TOC}
+      aside={{
+        eyebrow: "Try Paybacker",
+        title: "Generate your UK261 claim in 30 seconds",
+        description: "Our AI writes a formal claim letter citing UK261 regulations with the exact compensation amount you're owed. Free to use.",
+        ctaLabel: "Generate your letter free",
+        ctaHref: "/dashboard/complaints?type=flight_compensation&new=1",
+      }}
+    >
+      <div className="callout">
+        <div className="label">Key takeaway</div>
+        <p style={{ margin: 0 }}>
+          If your flight was delayed by 3+ hours, cancelled with less than 14
+          days notice, or you were denied boarding, you could be owed between
+          £220 and £520 per person. You can claim for flights in the last 6
+          years. Over £600 million goes unclaimed by UK passengers every year.
+        </p>
       </div>
-    </div>
+
+      <h2 id="what-is-uk261">What is UK261?</h2>
+      <p>
+        After Brexit, the UK replaced EU Regulation 261/2004 with its own
+        version known as UK261. This regulation protects passengers on flights
+        departing from a UK airport, or arriving in the UK on a UK or EU airline.
+      </p>
+      <p>
+        Under UK261, airlines must compensate you if your flight was
+        significantly delayed, cancelled, or you were denied boarding — unless
+        the disruption was caused by extraordinary circumstances like severe
+        weather or air traffic control strikes.
+      </p>
+
+      <h2 id="how-much">How much can you claim?</h2>
+      <p>Compensation is based on the flight distance, not the ticket price:</p>
+
+      <table className="post-table">
+        <thead>
+          <tr>
+            <th>Flight distance</th>
+            <th>Example routes</th>
+            <th className="num">Compensation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Under 1,500km</td>
+            <td>London to Paris, Edinburgh, Amsterdam</td>
+            <td className="num">£220</td>
+          </tr>
+          <tr>
+            <td>1,500km – 3,500km</td>
+            <td>London to Tenerife, Athens, Istanbul</td>
+            <td className="num">£350</td>
+          </tr>
+          <tr>
+            <td>Over 3,500km</td>
+            <td>London to New York, Dubai, Bangkok</td>
+            <td className="num">£520</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        This is per person, per flight. A family of four on a long-haul flight
+        could claim up to £2,080.
+      </p>
+
+      <h2 id="when">When can you claim?</h2>
+      <p>You can claim compensation if:</p>
+      <ul>
+        <li>Your flight arrived more than 3 hours late at your final destination.</li>
+        <li>Your flight was cancelled with less than 14 days notice.</li>
+        <li>You were denied boarding (e.g. overbooking).</li>
+        <li>The flight departed from a UK airport (any airline).</li>
+        <li>The flight arrived in the UK on a UK or EU airline.</li>
+      </ul>
+
+      <h2 id="extraordinary">What counts as extraordinary circumstances?</h2>
+      <p>
+        Airlines often reject claims citing extraordinary circumstances. Here is
+        what does and does not count:
+      </p>
+
+      <div className="pair-grid">
+        <div className="pair-card warn">
+          <div className="label">Not extraordinary (you CAN claim)</div>
+          <ul>
+            <li>Technical faults with the aircraft</li>
+            <li>Crew shortages or illness</li>
+            <li>IT system failures</li>
+            <li>Bird strikes (debated)</li>
+            <li>Baggage loading issues</li>
+            <li>Late incoming aircraft</li>
+          </ul>
+        </div>
+        <div className="pair-card ok">
+          <div className="label">Is extraordinary (airline exempt)</div>
+          <ul>
+            <li>Severe weather (not just bad weather)</li>
+            <li>Air traffic control strikes</li>
+            <li>Security threats or airport closures</li>
+            <li>Political instability</li>
+            <li>Medical emergencies on board</li>
+            <li>Volcanic ash</li>
+          </ul>
+        </div>
+      </div>
+
+      <h2 id="step-by-step">How to claim: step by step</h2>
+      <div className="step-card">
+        <div className="step-num">1</div>
+        <div className="step-title">Gather your details</div>
+        <p>
+          You need your flight number, date of travel, departure and arrival
+          airports, and a description of what happened (delay length,
+          cancellation notice, etc.).
+        </p>
+      </div>
+      <div className="step-card">
+        <div className="step-num">2</div>
+        <div className="step-title">Write a formal claim letter</div>
+        <p>
+          Your claim must cite UK261 regulations specifically and state the
+          compensation amount you are owed based on flight distance. This is
+          where most people get stuck.
+        </p>
+      </div>
+      <div className="step-card">
+        <div className="step-num">3</div>
+        <div className="step-title">Send to the airline</div>
+        <p>
+          Email the airline&apos;s complaints department directly. Most airlines
+          have a dedicated compensation claims form on their website.
+        </p>
+      </div>
+      <div className="step-card">
+        <div className="step-num">4</div>
+        <div className="step-title">Wait for a response</div>
+        <p>
+          Airlines have 8 weeks to respond. If they reject your claim or do not
+          respond, you can escalate to CEDR (Centre for Effective Dispute
+          Resolution) for free.
+        </p>
+      </div>
+
+      <h2 id="how-long">How long do I have to claim?</h2>
+      <p>
+        In the UK, you can claim for flights delayed in the{" "}
+        <strong>last 6 years</strong>. So if you had a delayed flight in 2020,
+        2021, 2022, 2023, 2024, or 2025, you could still be owed money now.
+      </p>
+
+      <h2 id="connecting">Can I claim for a connecting flight?</h2>
+      <p>
+        Yes. If your connecting flights were booked as a single itinerary and
+        you arrived at your final destination more than 3 hours late, you can
+        claim based on the total distance from departure to final destination.
+      </p>
+
+      <div className="post-cta">
+        <h3>Generate your flight compensation claim in 30 seconds</h3>
+        <p>
+          Our AI writes a formal claim letter citing UK261 regulations with the
+          exact compensation amount you are owed. Free to use.
+        </p>
+        <Link
+          className="btn btn-mint"
+          href="/dashboard/complaints?type=flight_compensation&new=1"
+        >
+          Generate your flight claim letter free
+        </Link>
+        <p style={{ fontSize: 12, marginTop: 12, color: "var(--text-on-ink-dim)" }}>
+          No credit card required. 3 free letters per month.
+        </p>
+      </div>
+
+      <h2 id="faq">Frequently asked questions</h2>
+      <div className="faq-card">
+        <h3>Do I need a solicitor?</h3>
+        <p>
+          No. You can claim directly with the airline yourself. A formal letter
+          citing the correct regulations is usually enough. Paybacker generates
+          this letter for you for free.
+        </p>
+      </div>
+      <div className="faq-card">
+        <h3>What if the airline says no?</h3>
+        <p>
+          If the airline rejects your claim, you can escalate to CEDR (Centre
+          for Effective Dispute Resolution) or the Aviation ADR scheme for free.
+          Their decision is binding on the airline.
+        </p>
+      </div>
+      <div className="faq-card">
+        <h3>Does this apply to package holidays?</h3>
+        <p>
+          Yes, if the flight element was delayed or cancelled. Package holiday
+          flights are covered by UK261 in the same way as standalone flights.
+        </p>
+      </div>
+      <div className="faq-card">
+        <h3>Can I claim for a flight I took years ago?</h3>
+        <p>
+          Yes, up to 6 years in the UK. If you had a delayed flight any time
+          from 2020 onwards, check if you are owed compensation.
+        </p>
+      </div>
+    </PostShell>
   );
 }


### PR DESCRIPTION
Marketing redesign batch 4 — `/blog/[slug]` + the three hand-coded SEO post
pages. After this lands, the entire public marketing surface shares the
same light/mint/orange design. No page still uses `PublicNavbar`.

### What's in here

| Route | Type | Before | After |
|---|---|---|---|
| `/blog/[slug]` | Dynamic Supabase post | PublicNavbar + `prose prose-invert` on navy-950 | PostShell (MarkNav + TOC + body + sticky aside CTA + MarkFoot) on light |
| `/blog/broadband-contract-ended` | Static SEO post | Hand-coded dark-theme navbar/footer | PostShell, same prose preserved verbatim |
| `/blog/are-you-overpaying-on-energy` | Static SEO post | Hand-coded dark-theme navbar/footer | PostShell, same prose preserved verbatim |
| `/blog/how-to-claim-flight-delay-compensation-uk` | Static SEO post | Hand-coded dark-theme navbar/footer | PostShell, same prose + table/FAQ primitives |

### Architecture

`src/app/blog/_shared.tsx` now exports:

- `MarkNav` / `MarkFoot` — unchanged from batch 3.
- `PostShell` — wraps `.m-blog-root` + MarkNav + breadcrumb/headline/dek/meta + three-column `post-body-grid` (TOC / body / aside CTA) + MarkFoot. Accepts `category`, `title`, `dek`, `dateLabel`, `readTime`, `toc[]`, `aside` (PostAsideCTAProps), `children`, and optional `jsonLd`.
- `PostAsideCTA` — the sticky ink-panel CTA on the right rail. Exposed so post pages can override the default.

### Content fidelity

All prose is preserved verbatim from the legacy pages. The only content-level change is adding `id` attributes to the `<h2>` headings so the new TOC on the left rail can anchor-link to each section.

Dynamic `/blog/[slug]` still:

- renders HTML content via `dangerouslySetInnerHTML` (CMS-authored posts continue to work)
- includes `application/ld+json` Article schema
- renders the `deal_category` CTA if the post has one (now as a soft-mint panel)
- uses `export const dynamic = 'force-dynamic'` so newly-published posts appear instantly

### CSS primitives added

`src/app/blog/styles.css` (scoped under `.m-blog-root .post-body`):

- `h3`, `strong`, `a` — base text treatments inside a post body.
- `.post-table` — compensation table used in the flight-delay post.
- `.pair-grid` + `.pair-card.warn` / `.pair-card.ok` — the "Not extraordinary / Is extraordinary" two-col block.
- `.step-card` + `.step-num` — numbered step cards for the 4-step claim process.
- `.faq-card` — bordered Q&A tiles for the FAQ section.
- `.post-cta` — ink-panel CTA block reused across all four posts.

### Checks

- `npx tsc --noEmit`: clean for all six files. Pre-existing errors elsewhere in the repo (dashboard/money-hub, cron/trial-expiry, CareersInterestForm false positive, generated .next validator) are unchanged.
- No new API keys, no new env vars, no new database changes.
- All deep-links preserved: broadband → `/dashboard/complaints?type=broadband_complaint&new=1`, energy → `?type=energy_dispute&new=1`, flight → `?type=flight_compensation&new=1`.

### Next

With this landed, the public marketing-site redesign is complete. Remaining design debt is app-shell (dashboard, signed-in views) — not in scope for marketing batches.
