### PR TITLE
feat(marketing): redesign 11 SEO landing pages + 3 legal pages

### DIFF
--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,50 +1,19 @@
-import Link from 'next/link';
-import Image from 'next/image';
-import CookieSettingsButton from '@/components/CookieSettingsButton';
+import { MarkNav, MarkFoot } from '@/app/blog/_shared';
+import './styles.css';
 
+/**
+ * Layout for the 11 /(marketing)/* SEO landing pages.
+ *
+ * Wraps children in `.m-land-root` so the scoped stylesheet applies,
+ * and uses the same MarkNav/MarkFoot as the blog + marketing hub.
+ * Individual page bodies render via `<LandingPage data={...} />`.
+ */
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen bg-navy-950">
-      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-mint-400/5 via-transparent to-transparent pointer-events-none" />
-      <div className="relative">
-        <header className="container mx-auto px-4 md:px-6 py-4 md:py-6">
-          <div className="flex items-center justify-between">
-            <Link href="/" className="flex items-center gap-2">
-              <Image src="/logo.png" alt="Paybacker" width={32} height={32} className="rounded-lg" />
-              <span className="text-xl font-bold text-white">
-                Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-              </span>
-            </Link>
-            <div className="flex items-center gap-3">
-              <Link href="/pricing" className="hidden md:block text-slate-400 hover:text-white text-sm px-3 py-2 rounded-lg hover:bg-navy-900 transition-all">
-                Pricing
-              </Link>
-              <Link href="/auth/login" className="text-slate-300 hover:text-white text-sm font-medium px-3 py-2 rounded-lg hover:bg-navy-900 transition-all">
-                Sign In
-              </Link>
-              <Link href="/auth/signup" className="bg-mint-400 hover:bg-mint-500 text-navy-950 text-sm font-semibold px-4 py-2 rounded-xl transition-all">
-                Get Started Free
-              </Link>
-            </div>
-          </div>
-        </header>
-
-        {children}
-
-        <footer className="border-t border-navy-700/50 py-8 mt-16">
-          <div className="container mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
-            <div className="text-slate-500 text-sm">Paybacker LTD &mdash; paybacker.co.uk</div>
-            <div className="flex gap-4 text-slate-500 text-sm">
-              <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
-              <Link href="/about" className="hover:text-white transition-all">About</Link>
-              <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy</Link>
-              <Link href="/cookie-policy" className="hover:text-white transition-all">Cookies</Link>
-              <Link href="/terms-of-service" className="hover:text-white transition-all">Terms</Link>
-              <CookieSettingsButton />
-            </div>
-          </div>
-        </footer>
-      </div>
+    <div className="m-land-root">
+      <MarkNav />
+      {children}
+      <MarkFoot />
     </div>
   );
 }

--- a/src/app/(marketing)/styles.css
+++ b/src/app/(marketing)/styles.css
@@ -1,0 +1,424 @@
+/*
+ * Marketing SEO landing pages — scoped stylesheet.
+ *
+ * Used by the 11 /(marketing)/* routes that render <LandingPage />.
+ * Scoped under `.m-land-root` so these styles never leak to the rest
+ * of the app.
+ *
+ * Design language matches /blog + /blog/[slug] (light surface,
+ * mint/orange accents, pill nav). Token aliases point at the shared
+ * marketing tokens in globals.css.
+ */
+
+.m-land-root {
+  /* Token aliases → globals.css Tailwind v4 theme */
+  --surface-base: var(--color-surface-base);
+  --surface-elevated: var(--color-surface-elevated);
+  --surface-ink: var(--color-surface-ink);
+  --surface-ink-2: var(--color-surface-ink-2);
+  --surface-soft-mint: var(--color-surface-soft-mint);
+
+  --text-primary: var(--color-ink-primary);
+  --text-secondary: var(--color-ink-secondary);
+  --text-tertiary: var(--color-ink-tertiary);
+  --text-on-ink: var(--color-on-ink);
+  --text-on-ink-dim: var(--color-on-ink-dim);
+
+  --accent-mint: var(--color-accent-mint);
+  --accent-mint-deep: var(--color-accent-mint-deep);
+  --accent-mint-wash: var(--color-accent-mint-wash);
+  --accent-orange: var(--color-accent-orange);
+  --accent-orange-deep: var(--color-accent-orange-deep);
+
+  --divider: var(--color-divider-light);
+  --divider-ink: var(--color-divider-ink);
+
+  --r-card: var(--radius-marketing-card);
+  --r-figure: var(--radius-marketing-figure);
+  --r-btn: var(--radius-marketing-btn);
+  --r-input: var(--radius-marketing-input);
+  --r-pill: var(--radius-marketing-pill);
+
+  --shadow-sm: var(--shadow-marketing-sm);
+  --shadow-md: var(--shadow-marketing-md);
+  --shadow-lg: var(--shadow-marketing-lg);
+  --shadow-xl: var(--shadow-marketing-xl);
+  --shadow-mint: var(--shadow-marketing-mint);
+  --shadow-orange: var(--shadow-marketing-orange);
+
+  --fs-display: var(--text-display);
+  --fs-h1: var(--text-h1-marketing);
+  --fs-h2: var(--text-h2-marketing);
+  --fs-body: 17px;
+  --fs-sm: 14px;
+  --fs-xs: 12px;
+  --track-tight: var(--tracking-marketing-tight);
+  --track-eyebrow: var(--tracking-marketing-eyebrow);
+
+  min-height: 100vh;
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-body);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+.m-land-root *,
+.m-land-root *::before,
+.m-land-root *::after { box-sizing: border-box; }
+.m-land-root img,
+.m-land-root svg { display: block; max-width: 100%; }
+
+/* Shared -------------------------------------------------------------- */
+.m-land-root .wrap { max-width: 1240px; margin: 0 auto; padding: 0 32px; }
+.m-land-root .eyebrow {
+  font-size: var(--fs-xs);
+  letter-spacing: var(--track-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+
+.m-land-root .btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 14px 22px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+.m-land-root .btn-mint { background: var(--accent-mint); color: #052E1C; box-shadow: var(--shadow-mint); }
+.m-land-root .btn-mint:hover { transform: scale(1.02); box-shadow: 0 24px 55px -18px rgba(52, 211, 153, 0.65); background: #2CC48A; }
+.m-land-root .btn-ghost { background: transparent; color: var(--text-primary); border: 1px solid var(--divider); }
+.m-land-root .btn-ghost:hover { transform: scale(1.02); background: #fff; box-shadow: var(--shadow-sm); }
+.m-land-root .btn-lg { padding: 16px 28px; font-size: 16px; }
+
+.m-land-root section { position: relative; }
+.m-land-root .section-light { background: var(--surface-base); }
+.m-land-root .section-ink { background: var(--surface-ink); color: var(--text-on-ink); }
+
+/* Nav ---------------------------------------------------------------- */
+.m-land-root .nav-shell {
+  position: sticky; top: 18px; left: 0; right: 0;
+  display: flex; justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+.m-land-root .nav-pill {
+  pointer-events: auto;
+  display: flex; align-items: center; gap: 10px;
+  background: rgba(255,255,255,0.85);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border: 1px solid rgba(11,18,32,0.06);
+  padding: 10px 10px 10px 20px;
+  border-radius: var(--r-pill);
+  box-shadow: var(--shadow-md);
+}
+.m-land-root .nav-logo { font-weight: 700; font-size: 18px; letter-spacing: -0.02em; text-decoration: none; }
+.m-land-root .nav-logo .pay { color: var(--text-primary); }
+.m-land-root .nav-logo .backer { color: var(--accent-mint-deep); }
+.m-land-root .nav-links { display: flex; gap: 6px; margin: 0 14px; }
+.m-land-root .nav-links a {
+  font-size: 14px; font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: var(--r-pill);
+  transition: background 150ms, color 150ms;
+}
+.m-land-root .nav-links a:hover { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-land-root .nav-links a.is-active { background: rgba(11,18,32,0.05); color: var(--text-primary); }
+.m-land-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
+.m-land-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+.m-land-root .nav-start {
+  background: var(--accent-mint); color: #052E1C;
+  padding: 10px 18px; border-radius: var(--r-pill);
+  font-weight: 600; font-size: 14px; text-decoration: none;
+  transition: transform 150ms, box-shadow 150ms;
+}
+.m-land-root .nav-start:hover { transform: scale(1.03); box-shadow: var(--shadow-mint); }
+
+/* Hero --------------------------------------------------------------- */
+.m-land-root .land-hero {
+  padding: 72px 0 56px;
+  text-align: center;
+}
+.m-land-root .land-hero .badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px;
+  font-size: 13px; font-weight: 600;
+  color: var(--accent-mint-deep);
+  background: var(--accent-mint-wash);
+  border: 1px solid rgba(5, 150, 105, 0.15);
+  border-radius: var(--r-pill);
+  margin-bottom: 28px;
+}
+.m-land-root .land-hero h1 {
+  font-size: clamp(38px, 5.2vw, 64px);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.05;
+  margin: 0 auto 20px;
+  max-width: 900px;
+}
+.m-land-root .land-hero .subtitle {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  max-width: 680px;
+  margin: 0 auto 36px;
+}
+.m-land-root .land-hero .hero-stat {
+  display: inline-flex; flex-direction: column;
+  align-items: center;
+  padding: 20px 36px;
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  box-shadow: var(--shadow-md);
+  margin-bottom: 32px;
+}
+.m-land-root .land-hero .hero-stat .stat-value {
+  font-size: 44px; font-weight: 700;
+  color: var(--accent-orange-deep);
+  letter-spacing: var(--track-tight);
+  line-height: 1;
+}
+.m-land-root .land-hero .hero-stat .stat-label {
+  font-size: 13px; color: var(--text-tertiary);
+  margin-top: 8px;
+}
+.m-land-root .land-hero .social-proof {
+  font-size: 14px;
+  color: var(--text-tertiary);
+  margin-top: 20px;
+}
+
+/* Prose sections ----------------------------------------------------- */
+.m-land-root .prose-section {
+  padding: 56px 0;
+}
+.m-land-root .prose-section h2 {
+  font-size: var(--fs-h2);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.1;
+  margin: 0 0 28px;
+}
+.m-land-root .prose-body {
+  max-width: 720px;
+  margin: 0 auto;
+}
+.m-land-root .prose-body p {
+  font-size: 17px;
+  line-height: 1.75;
+  color: var(--text-primary);
+  margin: 0 0 20px;
+}
+.m-land-root .prose-body p:last-child { margin-bottom: 0; }
+
+/* Rights list -------------------------------------------------------- */
+.m-land-root .rights-card {
+  max-width: 760px; margin: 0 auto;
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 40px 44px;
+  box-shadow: var(--shadow-sm);
+}
+.m-land-root .rights-card h2 {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  margin: 0 0 24px;
+}
+.m-land-root .rights-list {
+  list-style: none; padding: 0; margin: 0;
+  display: grid; gap: 14px;
+}
+.m-land-root .rights-list li {
+  position: relative;
+  padding-left: 34px;
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--text-primary);
+}
+.m-land-root .rights-list li::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 2px;
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--accent-mint-wash);
+  border: 1.5px solid var(--accent-mint);
+}
+.m-land-root .rights-list li::after {
+  content: "";
+  position: absolute;
+  left: 6px; top: 8px;
+  width: 10px; height: 6px;
+  border-left: 2px solid var(--accent-mint-deep);
+  border-bottom: 2px solid var(--accent-mint-deep);
+  transform: rotate(-45deg);
+}
+
+/* Step grid (how it works) ------------------------------------------- */
+.m-land-root .step-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  max-width: 1040px;
+  margin: 0 auto;
+}
+.m-land-root .step-grid .step {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 28px 24px;
+  text-align: center;
+  box-shadow: var(--shadow-sm);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+.m-land-root .step-grid .step:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); }
+.m-land-root .step-grid .step .step-badge {
+  width: 44px; height: 44px; border-radius: 50%;
+  background: var(--accent-mint);
+  color: #052E1C;
+  font-weight: 700; font-size: 18px;
+  display: grid; place-items: center;
+  margin: 0 auto 18px;
+}
+.m-land-root .step-grid .step h3 {
+  font-size: 17px; font-weight: 700;
+  margin: 0 0 10px;
+  color: var(--text-primary);
+}
+.m-land-root .step-grid .step p {
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* FAQ ---------------------------------------------------------------- */
+.m-land-root .faq-grid {
+  max-width: 760px;
+  margin: 0 auto;
+  display: grid; gap: 14px;
+}
+.m-land-root .faq-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  padding: 22px 24px;
+}
+.m-land-root .faq-card h3 {
+  font-size: 16.5px;
+  font-weight: 700;
+  margin: 0 0 8px;
+  color: var(--text-primary);
+}
+.m-land-root .faq-card p {
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* Secondary / soft CTA strip ----------------------------------------- */
+.m-land-root .soft-cta {
+  max-width: 760px; margin: 0 auto;
+  background: var(--accent-mint-wash);
+  border: 1px solid rgba(5, 150, 105, 0.15);
+  border-radius: var(--r-card);
+  padding: 22px 28px;
+  display: flex; justify-content: space-between; align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.m-land-root .soft-cta p {
+  margin: 0;
+  font-size: 15px;
+  color: var(--text-primary);
+}
+.m-land-root .soft-cta a {
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+  font-size: 14.5px;
+  text-decoration: none;
+  display: inline-flex; align-items: center; gap: 6px;
+  white-space: nowrap;
+}
+.m-land-root .soft-cta a:hover { text-decoration: underline; }
+
+/* Final CTA (ink panel) --------------------------------------------- */
+.m-land-root .final-cta {
+  max-width: 900px; margin: 0 auto;
+  background: var(--surface-ink);
+  color: var(--text-on-ink);
+  border-radius: var(--r-card);
+  padding: 56px 48px;
+  text-align: center;
+}
+.m-land-root .final-cta h2 {
+  font-size: clamp(28px, 3.5vw, 40px);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.1;
+  margin: 0 0 14px;
+  color: var(--text-on-ink);
+}
+.m-land-root .final-cta p {
+  font-size: 17px;
+  color: var(--text-on-ink-dim);
+  max-width: 520px; margin: 0 auto 28px;
+}
+
+/* Footer ------------------------------------------------------------- */
+.m-land-root footer { padding: 80px 0 40px; background: var(--surface-ink); color: var(--text-on-ink); border-top: 1px solid var(--divider-ink); }
+.m-land-root .footer-grid { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr; gap: 32px; }
+.m-land-root .footer-brand .logo { font-size: 22px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 10px; }
+.m-land-root .footer-brand .logo .backer { color: var(--accent-mint); }
+.m-land-root .footer-brand p { color: var(--text-on-ink-dim); font-size: 14px; max-width: 280px; }
+.m-land-root .footer-col h5 { font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-on-ink-dim); font-weight: 600; margin: 0 0 16px; }
+.m-land-root .footer-col a { display: block; color: var(--text-on-ink); text-decoration: none; font-size: 14px; margin-bottom: 10px; opacity: 0.85; }
+.m-land-root .footer-col a:hover { opacity: 1; color: var(--accent-mint); }
+.m-land-root .footer-bottom {
+  border-top: 1px solid var(--divider-ink);
+  margin-top: 56px; padding-top: 24px;
+  display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px;
+  font-size: 12px; color: var(--text-on-ink-dim);
+}
+.m-land-root .footer-socials { display: flex; gap: 10px; }
+.m-land-root .footer-socials a {
+  width: 32px; height: 32px; border-radius: 8px;
+  border: 1px solid var(--divider-ink);
+  display: grid; place-items: center; font-size: 13px;
+  transition: background 150ms ease;
+  margin-bottom: 0;
+}
+.m-land-root .footer-socials a:hover { background: rgba(255,255,255,0.06); }
+
+/* Responsive --------------------------------------------------------- */
+@media (max-width: 980px) {
+  .m-land-root .nav-links { display: none; }
+  .m-land-root .step-grid { grid-template-columns: 1fr; gap: 14px; max-width: 520px; }
+  .m-land-root .rights-card { padding: 32px 28px; }
+  .m-land-root .final-cta { padding: 44px 28px; }
+  .m-land-root .soft-cta { padding: 20px 22px; }
+  .m-land-root .footer-grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 480px) {
+  .m-land-root .wrap { padding: 0 20px; }
+  .m-land-root .land-hero { padding: 40px 0 32px; }
+  .m-land-root .land-hero .hero-stat { padding: 16px 24px; }
+  .m-land-root .land-hero .hero-stat .stat-value { font-size: 36px; }
+}

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,98 +1,135 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import CookieSettingsButton from '@/components/CookieSettingsButton';
+import { PostShell, SIGNUP_HREF } from '../blog/_shared';
+import '../blog/styles.css';
 
 export const metadata: Metadata = {
   title: 'Cookie Policy',
   description: 'How Paybacker uses cookies and similar technologies.',
 };
 
+const TOC = [
+  { id: 'what-are-cookies', label: 'What are cookies?' },
+  { id: 'how-we-use', label: 'How we use cookies' },
+  { id: 'manage', label: 'Managing your preferences' },
+  { id: 'third-party', label: 'Third-party cookies' },
+  { id: 'your-rights', label: 'Your rights' },
+  { id: 'contact', label: 'Contact' },
+];
+
 export default function CookiePolicyPage() {
   return (
-    <div className="min-h-screen bg-navy-950 text-slate-300">
-      <div className="container mx-auto px-6 py-16 max-w-3xl">
-        <Link href="/" className="text-mint-400 text-sm hover:underline">&larr; Back to home</Link>
-        <h1 className="text-3xl font-bold text-white mt-6 mb-8">Cookie Policy</h1>
-        <p className="text-sm text-slate-400 mb-8">Last updated: 4 April 2026</p>
+    <PostShell
+      category="Legal"
+      title="Cookie Policy"
+      dek="How Paybacker uses cookies and similar technologies on paybacker.co.uk."
+      dateLabel="Last updated 4 April 2026"
+      toc={TOC}
+      aside={{
+        eyebrow: 'Manage cookies',
+        title: 'Change your cookie choice',
+        description:
+          "Open the cookie settings panel at any time. You can also use the cookie settings button in the footer.",
+        ctaLabel: 'Start free',
+        ctaHref: SIGNUP_HREF,
+      }}
+    >
+      <h2 id="what-are-cookies">What are cookies?</h2>
+      <p>
+        Cookies are small text files stored on your device when you visit a
+        website. They help the site remember your preferences and understand how
+        you use it.
+      </p>
 
-        <div className="space-y-8 text-sm leading-relaxed">
-          <section>
-            <h2 className="text-xl font-semibold text-white mb-3">What are cookies?</h2>
-            <p>
-              Cookies are small text files stored on your device when you visit a website.
-              They help the site remember your preferences and understand how you use it.
-            </p>
-          </section>
+      <h2 id="how-we-use">How we use cookies</h2>
+      <p>
+        Paybacker uses cookies and similar technologies in the following
+        categories:
+      </p>
 
-          <section>
-            <h2 className="text-xl font-semibold text-white mb-3">How we use cookies</h2>
-            <p className="mb-4">Paybacker uses cookies and similar technologies in the following categories:</p>
+      <h3>Essential cookies</h3>
+      <p>Required for the site to function. Cannot be disabled.</p>
+      <ul>
+        <li>
+          <strong>Supabase auth cookies</strong> — maintain your login session.
+        </li>
+        <li>
+          <strong>pb_consent</strong> — stores your cookie consent preferences.
+        </li>
+      </ul>
 
-            <h3 className="text-lg font-medium text-white mt-4 mb-2">Essential cookies</h3>
-            <p className="mb-2">Required for the site to function. Cannot be disabled.</p>
-            <ul className="list-disc list-inside space-y-1 text-slate-400">
-              <li><strong className="text-slate-300">Supabase auth cookies</strong> — maintain your login session</li>
-              <li><strong className="text-slate-300">pb_consent</strong> — stores your cookie consent preferences</li>
-            </ul>
+      <h3>Analytics cookies</h3>
+      <p>Help us understand how visitors use Paybacker. Only set with your consent.</p>
+      <ul>
+        <li>
+          <strong>Google Analytics (GA4)</strong> — page views, user journeys,
+          performance metrics. ID: <code>G-GRL9XKYTN1</code>.
+        </li>
+        <li>
+          <strong>PostHog</strong> — product analytics sent via our server (no
+          client-side cookies set).
+        </li>
+      </ul>
 
-            <h3 className="text-lg font-medium text-white mt-4 mb-2">Analytics cookies</h3>
-            <p className="mb-2">Help us understand how visitors use Paybacker. Only set with your consent.</p>
-            <ul className="list-disc list-inside space-y-1 text-slate-400">
-              <li><strong className="text-slate-300">Google Analytics (GA4)</strong> — page views, user journeys, performance metrics. ID: G-GRL9XKYTN1</li>
-              <li><strong className="text-slate-300">PostHog</strong> — product analytics sent via our server (no client-side cookies set)</li>
-            </ul>
+      <h3>Marketing cookies</h3>
+      <p>Used for advertising and affiliate tracking. Only set with your consent.</p>
+      <ul>
+        <li>
+          <strong>Meta Pixel</strong> — measures ad effectiveness and enables
+          retargeting. Pixel ID: <code>722806327584909</code>.
+        </li>
+        <li>
+          <strong>Meta Conversions API</strong> — server-side event tracking for
+          ad optimisation.
+        </li>
+        <li>
+          <strong>Awin</strong> — affiliate tracking for partner deals.
+        </li>
+      </ul>
 
-            <h3 className="text-lg font-medium text-white mt-4 mb-2">Marketing cookies</h3>
-            <p className="mb-2">Used for advertising and affiliate tracking. Only set with your consent.</p>
-            <ul className="list-disc list-inside space-y-1 text-slate-400">
-              <li><strong className="text-slate-300">Meta Pixel</strong> — measures ad effectiveness and enables retargeting</li>
-              <li><strong className="text-slate-300">Meta Conversions API</strong> — server-side event tracking for ad optimisation</li>
-              <li><strong className="text-slate-300">Awin</strong> — affiliate tracking for partner deals</li>
-            </ul>
+      <h3>Functional cookies</h3>
+      <p>Enable enhanced features. Only set with your consent.</p>
+      <ul>
+        <li>
+          <strong>Chat preferences</strong> — remembers your chatbot interaction
+          state.
+        </li>
+      </ul>
 
-            <h3 className="text-lg font-medium text-white mt-4 mb-2">Functional cookies</h3>
-            <p className="mb-2">Enable enhanced features. Only set with your consent.</p>
-            <ul className="list-disc list-inside space-y-1 text-slate-400">
-              <li><strong className="text-slate-300">Chat preferences</strong> — remembers your chatbot interaction state</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-xl font-semibold text-white mb-3">Managing your preferences</h2>
-            <p className="mb-3">
-              You can change your cookie preferences at any time using the Cookie Settings button
-              in the website footer, or by clicking below:
-            </p>
-            <CookieSettingsButton />
-          </section>
-
-          <section>
-            <h2 className="text-xl font-semibold text-white mb-3">Third-party cookies</h2>
-            <p>
-              Some cookies are set by third-party services that appear on our pages (Google, Meta, Awin).
-              We do not control these cookies. Please refer to the respective privacy policies of
-              these providers for more information.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-xl font-semibold text-white mb-3">Your rights</h2>
-            <p>
-              Under UK GDPR and PECR, you have the right to refuse non-essential cookies.
-              Essential cookies that are strictly necessary for the site to function cannot be
-              disabled as they are required to provide the service you have requested.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-xl font-semibold text-white mb-3">Contact</h2>
-            <p>
-              If you have questions about our use of cookies, contact us at{' '}
-              <a href="mailto:hello@paybacker.co.uk" className="text-mint-400 hover:underline">hello@paybacker.co.uk</a>.
-            </p>
-          </section>
-        </div>
+      <h2 id="manage">Managing your preferences</h2>
+      <p>
+        You can change your cookie preferences at any time using the Cookie
+        Settings button in the website footer, or by clicking below:
+      </p>
+      <div style={{ margin: '8px 0 20px' }}>
+        <CookieSettingsButton />
       </div>
-    </div>
+
+      <h2 id="third-party">Third-party cookies</h2>
+      <p>
+        Some cookies are set by third-party services that appear on our pages
+        (Google, Meta, Awin). We do not control these cookies. Please refer to
+        the respective privacy policies of these providers for more information.
+      </p>
+
+      <h2 id="your-rights">Your rights</h2>
+      <p>
+        Under UK GDPR and PECR, you have the right to refuse non-essential
+        cookies. Essential cookies that are strictly necessary for the site to
+        function cannot be disabled as they are required to provide the service
+        you have requested.
+      </p>
+      <p>
+        For the full detail of how we handle personal data, see our{' '}
+        <Link href="/privacy-policy">Privacy Policy</Link>.
+      </p>
+
+      <h2 id="contact">Contact</h2>
+      <p>
+        If you have questions about our use of cookies, contact us at{' '}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>.
+      </p>
+    </PostShell>
   );
 }

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
+import { PostShell, SIGNUP_HREF } from "../blog/_shared";
+import "../blog/styles.css";
 
 export const metadata: Metadata = {
   title: "Privacy Policy — Paybacker LTD",
@@ -8,405 +9,237 @@ export const metadata: Metadata = {
     "How Paybacker LTD collects, uses and protects your personal data under UK GDPR.",
 };
 
+const TOC = [
+  { id: "who-we-are", label: "1. Who we are" },
+  { id: "data-we-collect", label: "2. Data we collect" },
+  { id: "how-we-use", label: "3. How we use your data" },
+  { id: "data-storage", label: "4. Data storage" },
+  { id: "data-sharing", label: "5. Data sharing" },
+  { id: "affiliate-disclosure", label: "6. Affiliate disclosure" },
+  { id: "retention", label: "7. Data retention and deletion" },
+  { id: "cookies", label: "8. Cookies" },
+  { id: "your-rights", label: "9. Your rights" },
+  { id: "changes", label: "10. Changes to this policy" },
+  { id: "contact", label: "11. Contact" },
+];
+
 export default function PrivacyPolicyPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
-      <header className="container mx-auto px-6 py-6 border-b border-slate-800">
-        <div className="flex items-center justify-between">
-          <Link href="/" className="flex items-center gap-2">
-            <Image src="/logo.png" alt="Paybacker" width={32} height={32} className="rounded-lg" />
-            <span className="text-xl font-bold text-white">
-              Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-            </span>
-          </Link>
-          <nav className="flex items-center gap-1 md:gap-3 text-sm">
-            <Link
-              href="/about"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              About
-            </Link>
-            <Link
-              href="/blog"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Blog
-            </Link>
-            <Link
-              href="/pricing"
-              className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Pricing
-            </Link>
-            <Link
-              href="/auth/login"
-              className="text-slate-300 hover:text-white font-medium px-3 py-2 rounded-lg hover:bg-slate-800 transition-all"
-            >
-              Sign In
-            </Link>
-          </nav>
-        </div>
-      </header>
+    <PostShell
+      category="Legal"
+      title="Privacy Policy"
+      dek="How Paybacker LTD collects, uses and protects your personal data under the UK GDPR."
+      dateLabel="Last updated March 2026"
+      toc={TOC}
+      aside={{
+        eyebrow: "Questions?",
+        title: "Contact our privacy team",
+        description:
+          "Email hello@paybacker.co.uk with any privacy question — we respond within 30 days.",
+        ctaLabel: "Start free",
+        ctaHref: SIGNUP_HREF,
+      }}
+    >
+      <h2 id="who-we-are">1. Who we are</h2>
+      <p>
+        Paybacker LTD (&ldquo;Paybacker&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;,
+        &ldquo;our&rdquo;) is a company registered in the United Kingdom. We
+        operate the website <a href="https://paybacker.co.uk">paybacker.co.uk</a>{" "}
+        and provide AI-powered bill analysis and savings recommendation services.
+      </p>
+      <p>
+        For any privacy-related enquiries, you can contact us at{" "}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>.
+      </p>
 
-      <main className="container mx-auto px-6 py-16 max-w-3xl">
-        <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
-          Privacy Policy
-        </h1>
-        <p className="text-slate-500 text-sm mb-10">
-          Last updated: March 2026
+      <h2 id="data-we-collect">2. Data we collect</h2>
+      <p>We collect the following categories of personal data:</p>
+      <div className="callout">
+        <div className="label">Account information</div>
+        <p style={{ margin: 0 }}>
+          Your name, email address and password when you create an account.
         </p>
+      </div>
+      <div className="callout">
+        <div className="label">Email data (with your consent)</div>
+        <p style={{ margin: 0 }}>
+          Read-only access to your Gmail or Outlook inbox to identify bills,
+          contracts and renewal notices. We only read emails relevant to
+          household bills and subscriptions.
+        </p>
+      </div>
+      <div className="callout">
+        <div className="label">Banking data (with your consent)</div>
+        <p style={{ margin: 0 }}>
+          Read-only access to your bank transactions via Open Banking (powered by
+          Yapily, FCA-regulated) to identify recurring payments and spending
+          patterns. We can never move your money or make payments on your behalf.
+        </p>
+      </div>
 
-        {/* 1. Who We Are */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            1. Who We Are
-          </h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Paybacker LTD (&quot;Paybacker&quot;, &quot;we&quot;, &quot;us&quot;,
-            &quot;our&quot;) is a company registered in the United Kingdom. We
-            operate the website{" "}
-            <a
-              href="https://paybacker.co.uk"
-              className="text-amber-400 hover:text-amber-300"
-            >
-              paybacker.co.uk
-            </a>{" "}
-            and provide AI-powered bill analysis and savings recommendation
-            services.
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            For any privacy-related enquiries, you can contact us at{" "}
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="text-amber-400 hover:text-amber-300"
-            >
-              hello@paybacker.co.uk
-            </a>
-            .
-          </p>
-        </section>
+      <h2 id="how-we-use">3. How we use your data</h2>
+      <p>
+        We use your personal data solely to provide and improve our savings
+        identification service. Specifically, we use your data to:
+      </p>
+      <ul>
+        <li>Identify bills, subscriptions and recurring payments.</li>
+        <li>Analyse your current tariffs and contracts against available market deals.</li>
+        <li>Surface personalised switching recommendations in your dashboard.</li>
+        <li>
+          Send you alerts when contract end dates are approaching or better deals
+          become available.
+        </li>
+        <li>Provide customer support and respond to your enquiries.</li>
+      </ul>
+      <p>
+        Our legal basis for processing is your consent (for email and banking
+        data) and legitimate interest (for account management and service
+        delivery).
+      </p>
 
-        {/* 2. Data We Collect */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            2. Data We Collect
-          </h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We collect the following categories of personal data:
-          </p>
-          <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5 mb-4">
-            <h3 className="text-white font-semibold mb-2">
-              Account information
-            </h3>
-            <p className="text-slate-300 text-sm leading-relaxed">
-              Your name, email address and password when you create an account.
-            </p>
-          </div>
-          <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5 mb-4">
-            <h3 className="text-white font-semibold mb-2">
-              Email data (with your consent)
-            </h3>
-            <p className="text-slate-300 text-sm leading-relaxed">
-              Read-only access to your Gmail or Outlook inbox to identify bills,
-              contracts and renewal notices. We only read emails relevant to
-              household bills and subscriptions.
-            </p>
-          </div>
-          <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-            <h3 className="text-white font-semibold mb-2">
-              Banking data (with your consent)
-            </h3>
-            <p className="text-slate-300 text-sm leading-relaxed">
-              Read-only access to your bank transactions via Open Banking
-              (powered by Yapily) to identify recurring payments and spending
-              patterns. We can never move your money or make payments on your
-              behalf.
-            </p>
-          </div>
-        </section>
+      <h2 id="data-storage">4. Data storage</h2>
+      <p>
+        Your data is stored securely in Supabase, our database provider, which
+        hosts data on encrypted servers within the UK and EU. All data is
+        encrypted in transit (TLS) and at rest. We follow industry best practices
+        for access control and regularly review our security measures.
+      </p>
 
-        {/* 3. How We Use Your Data */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            3. How We Use Your Data
-          </h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We use your personal data solely to provide and improve our savings
-            identification service. Specifically, we use your data to:
-          </p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-4">
-            <li>Identify bills, subscriptions and recurring payments</li>
-            <li>
-              Analyse your current tariffs and contracts against available market
-              deals
-            </li>
-            <li>
-              Surface personalised switching recommendations in your dashboard
-            </li>
-            <li>
-              Send you alerts when contract end dates are approaching or better
-              deals become available
-            </li>
-            <li>Provide customer support and respond to your enquiries</li>
-          </ul>
-          <p className="text-slate-300 leading-relaxed">
-            Our legal basis for processing is your consent (for email and banking
-            data) and legitimate interest (for account management and service
-            delivery).
-          </p>
-        </section>
+      <h2 id="data-sharing">5. Data sharing</h2>
+      <p>
+        We do not sell, rent or trade your personal data to any third party. We
+        may share limited data with the following categories of service
+        providers, solely to operate our platform:
+      </p>
+      <ul>
+        <li>
+          <strong>Supabase</strong> — database hosting and authentication.
+        </li>
+        <li>
+          <strong>Stripe</strong> — payment processing (we never see or store
+          your full card details).
+        </li>
+        <li>
+          <strong>Yapily</strong> — Open Banking data access (read-only bank
+          transactions).
+        </li>
+        <li>
+          <strong>Resend</strong> — transactional email delivery.
+        </li>
+      </ul>
 
-        {/* 4. Data Storage */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            4. Data Storage
-          </h2>
-          <p className="text-slate-300 leading-relaxed">
-            Your data is stored securely in Supabase, our database provider,
-            which hosts data on encrypted servers within the UK and EU. All data
-            is encrypted in transit (TLS) and at rest. We follow industry best
-            practices for access control and regularly review our security
-            measures.
-          </p>
-        </section>
+      <h2 id="affiliate-disclosure">6. Affiliate disclosure</h2>
+      <div className="callout">
+        <div className="label">How we make money</div>
+        <p style={{ margin: 0 }}>
+          Paybacker earns referral commissions when you switch to a new provider
+          through links on our platform. These are paid by the provider, not by
+          you. This does <strong>not</strong> affect the price you pay — you will
+          always pay the same price as if you had gone directly to the provider.
+          Our recommendations are based on genuine savings potential for you, and
+          we clearly disclose all affiliate relationships.
+        </p>
+      </div>
 
-        {/* 5. Data Sharing */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            5. Data Sharing
-          </h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We do not sell, rent or trade your personal data to any third party.
-            We may share limited data with the following categories of service
-            providers, solely to operate our platform:
-          </p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300">
-            <li>
-              <strong className="text-white">Supabase</strong> — database
-              hosting and authentication
-            </li>
-            <li>
-              <strong className="text-white">Stripe</strong> — payment
-              processing (we never see or store your full card details)
-            </li>
-            <li>
-              <strong className="text-white">Yapily</strong> — Open Banking
-              data access (read-only bank transactions)
-            </li>
-            <li>
-              <strong className="text-white">Resend</strong> — transactional
-              email delivery
-            </li>
-          </ul>
-        </section>
+      <h2 id="retention">7. Data retention and deletion</h2>
+      <p>
+        We retain your personal data for as long as your account is active or as
+        needed to provide our services. If you close your account, we will delete
+        your personal data within 30 days, except where we are legally required
+        to retain it (for example, financial records for tax purposes).
+      </p>
+      <p>
+        You can request deletion of your data at any time by emailing{" "}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>. We will
+        process your request within 30 days.
+      </p>
 
-        {/* 6. Affiliate Disclosure */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            6. Affiliate Disclosure
-          </h2>
-          <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-            <p className="text-slate-300 leading-relaxed mb-4">
-              Paybacker earns referral commissions when you switch to a new
-              provider through links on our platform. These are paid by the
-              provider, not by you.
-            </p>
-            <p className="text-slate-300 leading-relaxed">
-              This does <strong className="text-white">not</strong> affect the
-              price you pay. You will always pay the same price as if you had
-              gone directly to the provider. Our recommendations are based on
-              genuine savings potential for you, and we clearly disclose all
-              affiliate relationships.
-            </p>
-          </div>
-        </section>
+      <h2 id="cookies">8. Cookies</h2>
+      <p>
+        We use cookies and similar technologies on our website. These fall into
+        two categories:
+      </p>
+      <ul>
+        <li>
+          <strong>Essential cookies</strong> — required for the website to
+          function (authentication, session management). These cannot be
+          disabled.
+        </li>
+        <li>
+          <strong>Analytics cookies</strong> — we use PostHog and Google
+          Analytics to understand how visitors use our website so we can improve
+          it. These are only set with your consent.
+        </li>
+      </ul>
+      <p>
+        For full detail including every third-party service we use, see our{" "}
+        <Link href="/cookie-policy">Cookie Policy</Link>.
+      </p>
 
-        {/* 7. Data Retention and Deletion */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            7. Data Retention and Deletion
-          </h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We retain your personal data for as long as your account is active or
-            as needed to provide our services. If you close your account, we will
-            delete your personal data within 30 days, except where we are legally
-            required to retain it (for example, financial records for tax
-            purposes).
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            You can request deletion of your data at any time by emailing{" "}
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="text-amber-400 hover:text-amber-300"
-            >
-              hello@paybacker.co.uk
-            </a>
-            . We will process your request within 30 days.
-          </p>
-        </section>
+      <h2 id="your-rights">9. Your rights under UK GDPR</h2>
+      <p>
+        Under UK GDPR and the Data Protection Act 2018, you have the following
+        rights:
+      </p>
+      <ul>
+        <li>
+          <strong>Right of access</strong> — request a copy of the personal data
+          we hold about you.
+        </li>
+        <li>
+          <strong>Right to rectification</strong> — ask us to correct any
+          inaccurate or incomplete data.
+        </li>
+        <li>
+          <strong>Right to erasure</strong> — request that we delete your
+          personal data.
+        </li>
+        <li>
+          <strong>Right to data portability</strong> — receive your data in a
+          structured, commonly used format.
+        </li>
+        <li>
+          <strong>Right to object</strong> — object to certain types of
+          processing, including direct marketing.
+        </li>
+        <li>
+          <strong>Right to restrict processing</strong> — ask us to limit how we
+          use your data.
+        </li>
+        <li>
+          <strong>Right to withdraw consent</strong> — withdraw your consent at
+          any time where processing is based on consent.
+        </li>
+      </ul>
+      <p>
+        To exercise any of these rights, email us at{" "}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>. If you
+        are not satisfied with our response, you have the right to lodge a
+        complaint with the Information Commissioner&apos;s Office (ICO) at{" "}
+        <a href="https://ico.org.uk">ico.org.uk</a>.
+      </p>
 
-        {/* 8. Cookies */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">8. Cookies</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We use cookies and similar technologies on our website. These fall
-            into two categories:
-          </p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300">
-            <li>
-              <strong className="text-white">Essential cookies</strong> —
-              required for the website to function (authentication, session
-              management). These cannot be disabled.
-            </li>
-            <li>
-              <strong className="text-white">Analytics cookies</strong> — we use
-              PostHog and Google Analytics to understand how visitors use our
-              website so we can improve it. These are only set with your consent.
-            </li>
-          </ul>
-        </section>
+      <h2 id="changes">10. Changes to this policy</h2>
+      <p>
+        We may update this privacy policy from time to time to reflect changes in
+        our practices or legal requirements. If we make significant changes, we
+        will notify you by email or by placing a prominent notice on our
+        website. We encourage you to review this policy periodically.
+      </p>
 
-        {/* 9. Your Rights */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            9. Your Rights Under UK GDPR
-          </h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Under UK GDPR and the Data Protection Act 2018, you have the
-            following rights:
-          </p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300">
-            <li>
-              <strong className="text-white">Right of access</strong> — request
-              a copy of the personal data we hold about you
-            </li>
-            <li>
-              <strong className="text-white">Right to rectification</strong> —
-              ask us to correct any inaccurate or incomplete data
-            </li>
-            <li>
-              <strong className="text-white">Right to erasure</strong> — request
-              that we delete your personal data
-            </li>
-            <li>
-              <strong className="text-white">Right to data portability</strong>{" "}
-              — receive your data in a structured, commonly used format
-            </li>
-            <li>
-              <strong className="text-white">Right to object</strong> — object
-              to certain types of processing, including direct marketing
-            </li>
-            <li>
-              <strong className="text-white">
-                Right to restrict processing
-              </strong>{" "}
-              — ask us to limit how we use your data
-            </li>
-            <li>
-              <strong className="text-white">Right to withdraw consent</strong>{" "}
-              — withdraw your consent at any time where processing is based on
-              consent
-            </li>
-          </ul>
-          <p className="text-slate-300 leading-relaxed mt-4">
-            To exercise any of these rights, email us at{" "}
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="text-amber-400 hover:text-amber-300"
-            >
-              hello@paybacker.co.uk
-            </a>
-            . If you are not satisfied with our response, you have the right to
-            lodge a complaint with the Information Commissioner&apos;s Office
-            (ICO) at{" "}
-            <a
-              href="https://ico.org.uk"
-              className="text-amber-400 hover:text-amber-300"
-            >
-              ico.org.uk
-            </a>
-            .
-          </p>
-        </section>
-
-        {/* 10. Changes to This Policy */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">
-            10. Changes to This Policy
-          </h2>
-          <p className="text-slate-300 leading-relaxed">
-            We may update this privacy policy from time to time to reflect
-            changes in our practices or legal requirements. If we make
-            significant changes, we will notify you by email or by placing a
-            prominent notice on our website. We encourage you to review this
-            policy periodically.
-          </p>
-        </section>
-
-        {/* 11. Contact */}
-        <section>
-          <h2 className="text-2xl font-bold text-white mb-4">11. Contact</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Paybacker LTD is a company registered in England and Wales.<br/>
-            Registered Address: 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ, United Kingdom
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            If you have any questions about this privacy policy or how we handle
-            your data, please contact us at{" "}
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="text-amber-400 hover:text-amber-300"
-            >
-              hello@paybacker.co.uk
-            </a>
-            .
-          </p>
-        </section>
-      </main>
-
-      <footer className="container mx-auto px-6 py-8 border-t border-slate-800 mt-16">
-        <div className="text-center text-slate-500 text-sm space-y-3">
-          <div className="flex flex-wrap justify-center gap-6">
-            <Link href="/about" className="hover:text-white transition-all">
-              About
-            </Link>
-            <Link href="/blog" className="hover:text-white transition-all">
-              Blog
-            </Link>
-            <Link
-              href="/privacy-policy"
-              className="hover:text-white transition-all"
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              href="/terms-of-service"
-              className="hover:text-white transition-all"
-            >
-              Terms of Service
-            </Link>
-            <Link href="/pricing" className="hover:text-white transition-all">
-              Pricing
-            </Link>
-            <a
-              href="mailto:hello@paybacker.co.uk"
-              className="hover:text-white transition-all"
-            >
-              Contact
-            </a>
-          </div>
-          <p>
-            Need help? Email{" "}
-            <a
-              href="mailto:support@paybacker.co.uk"
-              className="text-amber-500 hover:text-amber-400"
-            >
-              support@paybacker.co.uk
-            </a>
-          </p>
-          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
-        </div>
-      </footer>
-    </div>
+      <h2 id="contact">11. Contact</h2>
+      <p>
+        Paybacker LTD is a company registered in England and Wales.
+        <br />
+        Registered address: 71-75 Shelton Street, Covent Garden, London, WC2H
+        9JQ, United Kingdom.
+      </p>
+      <p>
+        If you have any questions about this privacy policy or how we handle your
+        data, please contact us at{" "}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>.
+      </p>
+    </PostShell>
   );
 }

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,225 +1,242 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
+import { PostShell, SIGNUP_HREF } from "../blog/_shared";
+import "../blog/styles.css";
 
 export const metadata: Metadata = {
   title: "Terms of Service — Paybacker LTD",
   description: "Terms and conditions for using the Paybacker platform.",
 };
 
+const TOC = [
+  { id: "introduction", label: "1. Introduction" },
+  { id: "service-description", label: "2. Service description" },
+  { id: "account-registration", label: "3. Account registration" },
+  { id: "plans", label: "4. Free and paid plans" },
+  { id: "data-privacy", label: "5. User data and privacy" },
+  { id: "ai-content", label: "6. AI-generated content" },
+  { id: "affiliate", label: "7. Affiliate relationships" },
+  { id: "acceptable-use", label: "8. Acceptable use" },
+  { id: "liability", label: "9. Limitation of liability" },
+  { id: "termination", label: "10. Termination" },
+  { id: "changes", label: "11. Changes to terms" },
+  { id: "governing-law", label: "12. Governing law" },
+  { id: "contact", label: "13. Contact" },
+];
+
 export default function TermsOfServicePage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
-      <header className="container mx-auto px-6 py-6 border-b border-slate-800">
-        <div className="flex items-center justify-between">
-          <Link href="/" className="flex items-center gap-2">
-            <Image src="/logo.png" alt="Paybacker" width={32} height={32} className="rounded-lg" />
-            <span className="text-xl font-bold text-white">
-              Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-            </span>
-          </Link>
-          <nav className="flex items-center gap-1 md:gap-3 text-sm">
-            <Link href="/about" className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all">
-              About
-            </Link>
-            <Link href="/blog" className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all">
-              Blog
-            </Link>
-            <Link href="/pricing" className="text-slate-400 hover:text-white px-3 py-2 rounded-lg hover:bg-slate-800 transition-all">
-              Pricing
-            </Link>
-            <Link href="/auth/login" className="text-slate-300 hover:text-white font-medium px-3 py-2 rounded-lg hover:bg-slate-800 transition-all">
-              Sign In
-            </Link>
-          </nav>
-        </div>
-      </header>
+    <PostShell
+      category="Legal"
+      title="Terms of Service"
+      dek="The terms that apply when you use the Paybacker platform."
+      dateLabel="Last updated March 2026"
+      toc={TOC}
+      aside={{
+        eyebrow: "Questions?",
+        title: "Contact our team",
+        description:
+          "Email hello@paybacker.co.uk with any question about these terms.",
+        ctaLabel: "Start free",
+        ctaHref: SIGNUP_HREF,
+      }}
+    >
+      <h2 id="introduction">1. Introduction</h2>
+      <p>
+        Paybacker LTD (&ldquo;Paybacker&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;,
+        &ldquo;our&rdquo;) operates the website{" "}
+        <a href="https://paybacker.co.uk">paybacker.co.uk</a>.
+      </p>
+      <p>
+        By using our platform, you agree to be bound by these Terms of Service.
+        If you do not agree to these terms, please do not use our services.
+      </p>
 
-      <main className="container mx-auto px-6 py-16 max-w-3xl">
-        <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
-          Terms of Service
-        </h1>
-        <p className="text-slate-500 text-sm mb-10">
-          Last updated: March 2026
+      <h2 id="service-description">2. Service description</h2>
+      <p>
+        Paybacker is an AI-powered consumer finance platform for UK consumers. We
+        provide a range of services including:
+      </p>
+      <ul>
+        <li>Bill analysis and contextual savings recommendations.</li>
+        <li>Subscription tracking and automated cancellation workflows.</li>
+        <li>Deal comparisons and price increase alerts.</li>
+        <li>Dispute letter generation assisted by AI.</li>
+        <li>Annual financial reports.</li>
+      </ul>
+      <p>
+        To provide these services, we connect to your bank accounts via Open
+        Banking using our partner Yapily (FCA-regulated) using read-only access.
+      </p>
+      <p>
+        We may also connect to your email accounts (such as Gmail or Outlook)
+        with read-only access to reliably identify bills, contracts, and renewal
+        notices automatically.
+      </p>
+
+      <h2 id="account-registration">3. Account registration</h2>
+      <p>
+        To use Paybacker, you must be 18 years of age or older and a resident of
+        the United Kingdom.
+      </p>
+      <ul>
+        <li>
+          You must provide accurate, complete, and up-to-date registration
+          information.
+        </li>
+        <li>
+          You are strictly responsible for maintaining the security of your
+          account credentials.
+        </li>
+        <li>
+          We permit one account per person. Creating multiple accounts may result
+          in suspension.
+        </li>
+      </ul>
+
+      <h2 id="plans">4. Free and paid plans</h2>
+      <p>We offer our services across free and paid subscription models:</p>
+      <ul>
+        <li>
+          <strong>Free plan:</strong> 3 AI letters per month, one-time bank and
+          email scans, basic spending overview, AI chatbot.
+        </li>
+        <li>
+          <strong>Essential — £4.99/month or £44.99/year:</strong> Unlimited AI
+          letters, 1 bank account with daily auto-sync, monthly email and
+          opportunity re-scans, full spending intelligence dashboard, renewal
+          reminders, contract end-date tracking.
+        </li>
+        <li>
+          <strong>Pro — £9.99/month or £94.99/year:</strong> Everything in
+          Essential, plus unlimited bank accounts, unlimited email and
+          opportunity scans, priority support.
+        </li>
+      </ul>
+      <p>
+        Our current pricing is displayed at{" "}
+        <Link href="/pricing">paybacker.co.uk/pricing</Link>. We reserve the
+        right to change our pricing with 30 days written notice.
+      </p>
+
+      <h2 id="data-privacy">5. User data and privacy</h2>
+      <p>
+        Our <Link href="/privacy-policy">Privacy Policy</Link> globally governs
+        how we collect, store, and use your personal data.
+      </p>
+      <ul>
+        <li>
+          We operate exclusively using read-only access to your banking and email
+          data. We can <strong>never</strong> move your money, make payments, or
+          send emails on your behalf.
+        </li>
+        <li>
+          We do not sell, share, or monetise your personal data to third-party
+          data brokers.
+        </li>
+        <li>
+          You can request complete data deletion at any time in accordance with
+          UK GDPR.
+        </li>
+      </ul>
+
+      <h2 id="ai-content">6. AI-generated content</h2>
+      <div className="callout">
+        <div className="label">Important</div>
+        <p style={{ margin: 0 }}>
+          Our AI automatically generates complaint letters, financial summaries,
+          and switching recommendations based on your data. This AI-generated
+          content is provided for informational and guidance purposes only and{" "}
+          <strong>does not constitute legal or financial advice</strong>. Users
+          should always review and verify all AI-generated letters before
+          sending them to third-party providers. We do not guarantee the outcomes
+          of any disputes, claims, or complaints pursued through our platform.
         </p>
+      </div>
 
-        {/* Section 1 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">1. Introduction</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Paybacker LTD (&quot;Paybacker&quot;, &quot;we&quot;, &quot;us&quot;,
-            &quot;our&quot;) operates the website <a href="https://paybacker.co.uk" className="text-amber-400 hover:text-amber-300">paybacker.co.uk</a>.
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            By using our platform, you agree to be bound by these Terms of Service. If you do not agree to these terms, please do not use our services.
-          </p>
-        </section>
+      <h2 id="affiliate">7. Affiliate relationships</h2>
+      <p>
+        We may earn a commission from partners when you successfully switch
+        providers through our platform. Our transparent affiliate relationships
+        will never influence our recommendations, nor do they ever affect the
+        price you pay. Our priority is finding genuine savings for you.
+      </p>
 
-        {/* Section 2 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">2. Service Description</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Paybacker is an AI-powered consumer finance platform for UK consumers. We provide a range of services including:
-          </p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-4">
-            <li>Bill analysis and contextual savings recommendations</li>
-            <li>Subscription tracking and automated cancellation workflows</li>
-            <li>Deal comparisons and price increase alerts</li>
-            <li>Dispute letter generation assisted by AI</li>
-            <li>Annual financial reports</li>
-          </ul>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            To provide these services, we connect to your bank accounts via Open Banking using our partner Yapily (FCA-regulated) using read-only access.
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            We may also connect to your email accounts (such as Gmail or Outlook) with read-only access to reliably identify bills, contracts, and renewal notices automatically.
-          </p>
-        </section>
+      <h2 id="acceptable-use">8. Acceptable use</h2>
+      <p>When using our platform, you agree that you will not:</p>
+      <ul>
+        <li>Use the platform for any fraudulent or malicious purposes.</li>
+        <li>
+          Attempt to circumvent, disable, or tamper with any of our security
+          measures.
+        </li>
+        <li>
+          Scrape, copy, or redistribute any platform content or underlying
+          technology.
+        </li>
+        <li>
+          Create accounts using false or misleading identity information.
+        </li>
+      </ul>
 
-        {/* Section 3 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">3. Account Registration</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            To use Paybacker, you must be 18 years of age or older and a resident of the United Kingdom.
-          </p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-4">
-            <li>You must provide accurate, complete, and up-to-date registration information.</li>
-            <li>You are strictly responsible for maintaining the security of your account credentials.</li>
-            <li>We permit one account per person. Creating multiple accounts may result in suspension.</li>
-          </ul>
-        </section>
+      <h2 id="liability">9. Limitation of liability</h2>
+      <p>
+        Paybacker is provided on an &ldquo;as is&rdquo; and &ldquo;as
+        available&rdquo; basis strictly without any warranties of any kind. We
+        are not liable for the financial decisions you make based on our
+        recommendations.
+      </p>
+      <p>
+        To the maximum extent permitted by law, our total cumulative liability to
+        you is limited strictly to the amount you paid to us for the services in
+        the 12 months immediately preceding the claim.
+      </p>
+      <p>
+        We accept zero liability for any losses, delays, or issues arising
+        directly or indirectly from actions taken by third-party services,
+        including but not limited to banks, energy providers, telecommunications
+        companies, or subscription services.
+      </p>
 
-        {/* Section 4 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">4. Free and Paid Plans</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We offer our services across free and paid subscription models:
-          </p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-4">
-            <li><strong>Free plan:</strong> Provides limited access to features and basic recommendations.</li>
-            <li><strong>Pro plan:</strong> Grants full access to advanced features including premium AI letter generation, continuous bank connectivity, email scanning, and your annual report.</li>
-          </ul>
-          <p className="text-slate-300 leading-relaxed">
-            Our current pricing is displayed at <Link href="/pricing" className="text-amber-400 hover:text-amber-300">paybacker.co.uk/pricing</Link>. We reserve the right to change our pricing with 30 days written notice.
-          </p>
-        </section>
+      <h2 id="termination">10. Termination</h2>
+      <p>
+        You may close your account at any time via your Profile settings or by
+        emailing{" "}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>.
+      </p>
+      <p>
+        We reserve the right to suspend or terminate accounts indefinitely that
+        violate these terms or local laws. Upon termination, we will permanently
+        delete your user data in accordance with our Privacy Policy.
+      </p>
 
-        {/* Section 5 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">5. User Data and Privacy</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Our <Link href="/privacy-policy" className="text-amber-400 hover:text-amber-300">Privacy Policy</Link> globally governs how we collect, store, and use your personal data.
-          </p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-4">
-            <li>We operate exclusively using read-only access to your banking and email data. We can <strong>never</strong> move your money, make payments, or send emails on your behalf.</li>
-            <li>We do not sell, share, or monetise your personal data to third-party data brokers.</li>
-            <li>You can request complete data deletion at any time in accordance with UK GDPR.</li>
-          </ul>
-        </section>
+      <h2 id="changes">11. Changes to terms</h2>
+      <p>
+        We may update these terms occasionally. If we make material changes, we
+        will communicate them to you via email. Your continued use of the
+        platform after changes have been posted explicitly constitutes your
+        acceptance of the updated terms.
+      </p>
 
-        {/* Section 6 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">6. AI-Generated Content</h2>
-          <div className="bg-slate-900/50 border border-slate-800 rounded-xl p-5">
-            <p className="text-slate-300 leading-relaxed mb-4">
-              Our AI automatically generates complaint letters, financial summaries, and switching recommendations based on your data. This AI-generated content is provided for informational and guidance purposes only and <strong>does not constitute legal or financial advice</strong>.
-            </p>
-            <p className="text-slate-300 leading-relaxed mb-4">
-              Users should always manually deeply review and verify all AI-generated letters before sending them to third-party providers. We do not guarantee the outcomes of any disputes, claims, or complaints pursued through our platform.
-            </p>
-          </div>
-        </section>
+      <h2 id="governing-law">12. Governing law</h2>
+      <p>
+        These terms are governed collectively by the laws of England and Wales.
+        Any disputes arising from these Terms of Service will be subject
+        exclusively to the jurisdiction of the English courts.
+      </p>
 
-        {/* Section 7 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">7. Affiliate Relationships</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We may earn a commission from partners when you successfully switch providers through our platform. Our transparent affiliate relationships will never influence our recommendations, nor do they ever affect the price you pay. Our priority is finding genuine savings for you.
-          </p>
-        </section>
-
-        {/* Section 8 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">8. Acceptable Use</h2>
-          <p className="text-slate-300 leading-relaxed mb-2">When using our platform, you agree that you will not:</p>
-          <ul className="list-disc pl-6 space-y-2 text-slate-300 mb-4">
-            <li>Use the platform for any fraudulent or malicious purposes.</li>
-            <li>Attempt to circumvent, disable, or tamper with any of our security measures.</li>
-            <li>Scrape, copy, or redistribute any platform content or underlying technology.</li>
-            <li>Create accounts using false or misleading identity information.</li>
-          </ul>
-        </section>
-
-        {/* Section 9 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">9. Limitation of Liability</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Paybacker is provided on an &quot;as is&quot; and &quot;as available&quot; basis strictly without any warranties of any kind. We are not liable for the financial decisions you make based on our recommendations.
-          </p>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            To the maximum extent permitted by law, our total cumulative liability to you is limited strictly to the amount you paid to us for the services in the 12 months immediately preceding the claim.
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            We accept zero liability for any losses, delays, or issues arising directly or indirectly from actions taken by third-party services, including but not limited to banks, energy providers, telecommunications companies, or subscription services.
-          </p>
-        </section>
-
-        {/* Section 10 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">10. Termination</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            You may close your account at any time via your Profile settings or by emailing <a href="mailto:hello@paybacker.co.uk" className="text-amber-400 hover:text-amber-300">hello@paybacker.co.uk</a>.
-          </p>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We reserve the right to suspend or terminate accounts indefinitely that violate these terms or local laws. Upon termination, we will permanently delete your user data in accordance with our Privacy Policy.
-          </p>
-        </section>
-
-        {/* Section 11 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">11. Changes to Terms</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            We may update these terms occasionally. If we make material changes, we will communicate them to you via email. Your continued use of the platform after changes have been posted explicitly constitutes your acceptance of the updated terms.
-          </p>
-        </section>
-
-        {/* Section 12 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">12. Governing Law</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            These terms are governed collectively by the laws of England and Wales. Any disputes arising from these Terms of Service will be subject exclusively to the jurisdiction of the English courts.
-          </p>
-        </section>
-
-        {/* Section 13 */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-white mb-4">13. Contact</h2>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Paybacker LTD is a company registered in England and Wales.<br/>
-            Registered Address: 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ, United Kingdom
-          </p>
-          <p className="text-slate-300 leading-relaxed mb-2">Email: <a href="mailto:hello@paybacker.co.uk" className="text-amber-400 hover:text-amber-300">hello@paybacker.co.uk</a></p>
-          <p className="text-slate-300 leading-relaxed">Website: <a href="https://paybacker.co.uk" className="text-amber-400 hover:text-amber-300">paybacker.co.uk</a></p>
-        </section>
-
-      </main>
-
-      <footer className="container mx-auto px-6 py-8 border-t border-slate-800 mt-16">
-        <div className="text-center text-slate-500 text-sm space-y-3">
-          <div className="flex flex-wrap justify-center gap-6">
-            <Link href="/about" className="hover:text-white transition-all">About</Link>
-            <Link href="/blog" className="hover:text-white transition-all">Blog</Link>
-            <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy Policy</Link>
-            <Link href="/terms-of-service" className="hover:text-white transition-all">Terms of Service</Link>
-            <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
-            <a href="mailto:hello@paybacker.co.uk" className="hover:text-white transition-all">Contact</a>
-          </div>
-          <p>
-            Need help? Email <a href="mailto:support@paybacker.co.uk" className="text-amber-500 hover:text-amber-400">support@paybacker.co.uk</a>
-          </p>
-          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
-        </div>
-      </footer>
-    </div>
+      <h2 id="contact">13. Contact</h2>
+      <p>
+        Paybacker LTD is a company registered in England and Wales.
+        <br />
+        Registered address: 71-75 Shelton Street, Covent Garden, London, WC2H
+        9JQ, United Kingdom.
+      </p>
+      <p>
+        Email: <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>
+        <br />
+        Website: <a href="https://paybacker.co.uk">paybacker.co.uk</a>
+      </p>
+    </PostShell>
   );
 }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { CheckCircle, ArrowRight } from 'lucide-react';
 
 export interface LandingPageData {
   h1: string;
@@ -7,7 +6,9 @@ export interface LandingPageData {
   badge: string;
   heroStat: string;
   heroStatLabel: string;
-  heroStatColor: string;
+  /** Retained for backwards compatibility with existing landing-page data objects.
+   *  The new light theme drives stat colour from tokens, not per-page overrides. */
+  heroStatColor?: string;
   ctaPrimary: string;
   socialProof: string;
   legislationTitle: string;
@@ -20,6 +21,13 @@ export interface LandingPageData {
   finalCtaSubtitle: string;
 }
 
+/**
+ * Marketing SEO landing page shell.
+ *
+ * Renders inside `(marketing)/layout.tsx`, which wraps everything in
+ * `.m-land-root` and includes MarkNav + MarkFoot. Styles live in
+ * `(marketing)/styles.css`.
+ */
 export default function LandingPage({ data }: { data: LandingPageData }) {
   const faqSchema = {
     '@context': 'https://schema.org',
@@ -32,123 +40,133 @@ export default function LandingPage({ data }: { data: LandingPageData }) {
   };
 
   return (
-    <main className="container mx-auto px-4 md:px-6 py-12">
+    <main>
       {/* Hero */}
-      <div className="max-w-4xl mx-auto mb-16 text-center">
-        <div className="inline-flex items-center gap-2 rounded-full bg-mint-400/10 px-4 py-2 text-sm text-mint-400 border border-mint-400/20 mb-8">
-          <span>{data.badge}</span>
-        </div>
-        <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 leading-tight font-[family-name:var(--font-heading)]">
-          {data.h1}
-        </h1>
-        <p className="text-xl text-slate-300 mb-8 max-w-2xl mx-auto leading-relaxed">
-          {data.subtitle}
-        </p>
-        <div className="flex justify-center mb-8">
-          <div className="bg-navy-900 border border-mint-400/20 rounded-2xl px-8 py-4 text-center">
-            <p className={`text-4xl font-bold ${data.heroStatColor}`}>{data.heroStat}</p>
-            <p className="text-slate-500 text-sm mt-1">{data.heroStatLabel}</p>
+      <section className="section-light">
+        <div className="wrap">
+          <div className="land-hero">
+            <div className="badge">{data.badge}</div>
+            <h1>{data.h1}</h1>
+            <p className="subtitle">{data.subtitle}</p>
+            <div className="hero-stat">
+              <span className="stat-value">{data.heroStat}</span>
+              <span className="stat-label">{data.heroStatLabel}</span>
+            </div>
+            <div>
+              <Link href="/auth/signup" className="btn btn-mint btn-lg">
+                {data.ctaPrimary}
+              </Link>
+            </div>
+            <p className="social-proof">{data.socialProof}</p>
           </div>
         </div>
-        <Link
-          href="/auth/signup"
-          className="inline-block bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-8 py-4 rounded-xl transition-all text-lg"
-        >
-          {data.ctaPrimary}
-        </Link>
-        <p className="text-slate-500 text-sm mt-4">{data.socialProof}</p>
-      </div>
+      </section>
 
-      {/* Legislation */}
-      <div className="max-w-3xl mx-auto mb-16">
-        <h2 className="text-2xl font-bold text-white mb-6 font-[family-name:var(--font-heading)]">
-          {data.legislationTitle}
-        </h2>
-        <div className="space-y-4">
-          {data.legislationParagraphs.map((para, i) => (
-            <p key={i} className="text-slate-300 leading-relaxed">{para}</p>
-          ))}
-        </div>
-      </div>
-
-      {/* Your Rights */}
-      <div className="max-w-3xl mx-auto mb-16">
-        <div className="bg-navy-900 border border-mint-400/20 rounded-2xl p-8">
-          <h2 className="text-2xl font-bold text-white mb-6 font-[family-name:var(--font-heading)]">
-            {data.rightsTitle}
-          </h2>
-          <ul className="space-y-3">
-            {data.rights.map((right, i) => (
-              <li key={i} className="flex items-start gap-3">
-                <CheckCircle className="h-5 w-5 text-mint-400 flex-shrink-0 mt-0.5" />
-                <span className="text-slate-300">{right}</span>
-              </li>
+      {/* Legislation prose */}
+      <section className="section-light prose-section">
+        <div className="wrap">
+          <div className="prose-body">
+            <h2>{data.legislationTitle}</h2>
+            {data.legislationParagraphs.map((para, i) => (
+              <p key={i}>{para}</p>
             ))}
-          </ul>
+          </div>
         </div>
-      </div>
+      </section>
+
+      {/* Rights checklist */}
+      <section className="section-light prose-section">
+        <div className="wrap">
+          <div className="rights-card">
+            <h2>{data.rightsTitle}</h2>
+            <ul className="rights-list">
+              {data.rights.map((right, i) => (
+                <li key={i}>{right}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
 
       {/* How it works */}
-      <div className="max-w-4xl mx-auto mb-16">
-        <h2 className="text-2xl font-bold text-white mb-8 text-center font-[family-name:var(--font-heading)]">
-          How Paybacker helps
-        </h2>
-        <div className="grid md:grid-cols-3 gap-6">
-          {data.howItWorks.map((step) => (
-            <div key={step.step} className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 text-center">
-              <div className="bg-mint-400 text-navy-950 w-10 h-10 rounded-full flex items-center justify-center mx-auto mb-4 font-bold text-lg">
-                {step.step}
+      <section className="section-light prose-section">
+        <div className="wrap">
+          <div style={{ textAlign: 'center', marginBottom: 36 }}>
+            <h2
+              style={{
+                fontSize: 'var(--fs-h2)',
+                fontWeight: 700,
+                letterSpacing: 'var(--track-tight)',
+                lineHeight: 1.1,
+                margin: 0,
+              }}
+            >
+              How Paybacker helps
+            </h2>
+          </div>
+          <div className="step-grid">
+            {data.howItWorks.map((step) => (
+              <div key={step.step} className="step">
+                <div className="step-badge">{step.step}</div>
+                <h3>{step.title}</h3>
+                <p>{step.description}</p>
               </div>
-              <h3 className="text-white font-semibold mb-2">{step.title}</h3>
-              <p className="text-slate-400 text-sm">{step.description}</p>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
+      </section>
 
       {/* FAQs */}
-      <div className="max-w-3xl mx-auto mb-16">
-        <h2 className="text-2xl font-bold text-white mb-6 text-center font-[family-name:var(--font-heading)]">
-          Frequently asked questions
-        </h2>
-        <div className="space-y-4">
-          {data.faqs.map((faq, i) => (
-            <div key={i} className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6">
-              <h3 className="text-white font-semibold mb-2">{faq.q}</h3>
-              <p className="text-slate-400 text-sm leading-relaxed">{faq.a}</p>
-            </div>
-          ))}
+      <section className="section-light prose-section">
+        <div className="wrap">
+          <div style={{ textAlign: 'center', marginBottom: 28 }}>
+            <h2
+              style={{
+                fontSize: 'var(--fs-h2)',
+                fontWeight: 700,
+                letterSpacing: 'var(--track-tight)',
+                lineHeight: 1.1,
+                margin: 0,
+              }}
+            >
+              Frequently asked questions
+            </h2>
+          </div>
+          <div className="faq-grid">
+            {data.faqs.map((faq, i) => (
+              <div key={i} className="faq-card">
+                <h3>{faq.q}</h3>
+                <p>{faq.a}</p>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      </section>
 
-      {/* Secondary CTA */}
-      <div className="max-w-3xl mx-auto mb-16">
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 flex flex-col md:flex-row items-center justify-between gap-4">
-          <p className="text-slate-300 text-sm">Or scan your bank account to find more savings</p>
-          <Link
-            href="/auth/signup"
-            className="inline-flex items-center gap-2 text-mint-400 font-semibold hover:text-mint-300 transition-all text-sm whitespace-nowrap"
-          >
-            Scan my bank free <ArrowRight className="h-4 w-4" />
-          </Link>
+      {/* Soft CTA strip — scan bank */}
+      <section className="section-light prose-section" style={{ paddingTop: 8, paddingBottom: 56 }}>
+        <div className="wrap">
+          <div className="soft-cta">
+            <p>Or scan your bank account to find more savings.</p>
+            <Link href="/auth/signup">Scan my bank free →</Link>
+          </div>
         </div>
-      </div>
+      </section>
 
       {/* Final CTA */}
-      <div className="max-w-3xl mx-auto mb-16 text-center">
-        <h2 className="text-3xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-          {data.finalCtaTitle}
-        </h2>
-        <p className="text-slate-400 mb-8">{data.finalCtaSubtitle}</p>
-        <Link
-          href="/auth/signup"
-          className="inline-block bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-8 py-4 rounded-xl transition-all text-lg"
-        >
-          {data.ctaPrimary}
-        </Link>
-      </div>
+      <section className="section-light" style={{ paddingBottom: 96 }}>
+        <div className="wrap">
+          <div className="final-cta">
+            <h2>{data.finalCtaTitle}</h2>
+            <p>{data.finalCtaSubtitle}</p>
+            <Link href="/auth/signup" className="btn btn-mint btn-lg">
+              {data.ctaPrimary}
+            </Link>
+          </div>
+        </div>
+      </section>
 
-      {/* JSON-LD */}
+      {/* JSON-LD FAQPage schema */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}


### PR DESCRIPTION
Batch 5 completes the public marketing redesign. After this lands,
the entire logged-out surface on paybacker.co.uk shares the same
light/mint/orange design. No public page still uses `navy-950` or
`PublicNavbar`.

### What's in here

| Route | Type | Before | After |
|---|---|---|---|
| `/dispute-energy-bill` | SEO landing | Dark navy-950 via `(marketing)/layout.tsx` + `LandingPage.tsx` | Light `.m-land-root` + MarkNav/MarkFoot |
| `/flight-delay-compensation` | SEO landing | same | same |
| `/cancel-gym-membership` | SEO landing | same | same |
| `/council-tax-challenge` | SEO landing | same | same |
| `/debt-collection-response` | SEO landing | same | same |
| `/broadband-overcharging` | SEO landing | same | same |
| `/hidden-subscriptions` | SEO landing | same | same |
| `/insurance-complaint` | SEO landing | same | same |
| `/mobile-contract-dispute` | SEO landing | same | same |
| `/parking-appeal` | SEO landing | same | same |
| `/unfair-bank-charges` | SEO landing | same | same |
| `/privacy-policy` | Legal | Inline dark navbar + `prose` | PostShell with TOC |
| `/terms-of-service` | Legal | Inline dark navbar + `prose` | PostShell with TOC |
| `/cookie-policy` | Legal | Dark navy-950 + slate | PostShell with TOC |

### Why one component change covers 11 routes

`src/components/LandingPage.tsx` is the shared shell for all 11
`/(marketing)/*` routes. Rewriting the single component (plus the
route-group `layout.tsx` and a new scoped `styles.css`) redesigns
all 11 landing pages in one shot. Per-page `page.tsx` files are not
touched — their `LandingPageData` objects still render correctly.

### Design system

Same scoped-root pattern as the rest of the marketing redesign:

- `.m-land-root` aliases marketing tokens from `globals.css`
  (`--color-surface-base`, `--color-accent-mint`, etc.)
- MarkNav + MarkFoot imported from `@/app/blog/_shared` (the same
  ones already used by `/blog`, `/about`, `/pricing`, `/careers`,
  `/how-it-works`)
- Legal pages render inside `PostShell` — same three-column TOC /
  body / aside layout as `/blog/[slug]` and the 3 static SEO posts

### Content fidelity — legal pages

All three legal pages preserve their prose verbatim. The Cookie
Policy still lists every specific service we've documented:

- Supabase auth cookies, `pb_consent`
- Google Analytics (GA4) with ID `G-GRL9XKYTN1`
- PostHog (server-side)
- Meta Pixel with ID `722806327584909`
- Meta Conversions API
- Awin (affiliate tracking)
- Chat preferences (functional)

`CookieSettingsButton` is still embedded in the "Managing your
preferences" section so users can re-open the consent modal without
navigating away.

### Content fidelity — SEO landing pages

Every page's existing `LandingPageData` object renders unchanged —
`h1`, `subtitle`, `badge`, `heroStat`, `heroStatLabel`,
`ctaPrimary`, `socialProof`, `legislationTitle`,
`legislationParagraphs`, `rightsTitle`, `rights`, `howItWorks`,
`faqs`, `finalCtaTitle`, `finalCtaSubtitle`. JSON-LD FAQPage schema
is preserved. `heroStatColor` is now optional (the field is still
on the interface, so existing data objects don't need updating; it's
just ignored now).

### Checks

- `npx tsc --noEmit`: clean for all 6 files in this PR. Pre-existing
  errors elsewhere in the repo (dashboard/money-hub, cron/trial-
  expiry, CareersInterestForm false positive, generated .next
  validator) are unchanged.
- No API keys, no new env vars, no database changes.
- `/auth/signup` CTA on every surface.
- JSON-LD FAQPage schema preserved on every SEO landing page.

### What's still pending after this

1. **Batch 6** — auth pages (login, signup), `/join`, public `/deals`,
   `/solutions/[slug]`, `/complaints/[company]`, `/debt-collection-
   letter`, `/docs/*`.
2. **Batch 7+** — app shell (`dashboard/layout.tsx`) and dashboard
   page bodies. These are behind auth and are separate from the
   public marketing work.

No user-facing surface is still on the legacy dark theme after batch 5
merges.
