### PR TITLE
feat(marketing): redesign auth pages + /join to light theme (batch 6a)

### DIFF
--- a/src/app/auth/auth.css
+++ b/src/app/auth/auth.css
@@ -1,0 +1,362 @@
+/*
+ * Auth pages — scoped additions on top of .m-land-root.
+ *
+ * Used by /auth/login, /auth/signup, /join. Those routes mount their
+ * content inside `<div className="m-land-root">` and import BOTH
+ * `@/app/(marketing)/styles.css` (for nav-shell/footer tokens) and this
+ * file (for the auth-card + form primitives below).
+ */
+
+/* Auth shell --------------------------------------------------------- */
+.m-land-root .auth-shell {
+  min-height: calc(100vh - 80px);
+  display: grid;
+  place-items: center;
+  padding: 48px 20px 80px;
+}
+.m-land-root .auth-wrap {
+  width: 100%;
+  max-width: 460px;
+}
+
+.m-land-root .auth-brand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  text-decoration: none;
+  margin: 0 auto 20px;
+  width: fit-content;
+}
+.m-land-root .auth-brand .pay { color: var(--text-primary); font-weight: 700; font-size: 22px; letter-spacing: -0.02em; }
+.m-land-root .auth-brand .backer { color: var(--accent-mint-deep); font-weight: 700; font-size: 22px; letter-spacing: -0.02em; }
+
+.m-land-root .auth-head {
+  text-align: center;
+  margin: 0 0 28px;
+}
+.m-land-root .auth-head h1 {
+  font-size: clamp(28px, 3.5vw, 34px);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.15;
+  margin: 0 0 10px;
+  color: var(--text-primary);
+}
+.m-land-root .auth-head p {
+  font-size: 16px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.m-land-root .auth-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 32px 32px 28px;
+  box-shadow: var(--shadow-md);
+}
+
+/* Google / OAuth button --------------------------------------------- */
+.m-land-root .oauth-btn {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: var(--r-input);
+  background: #fff;
+  border: 1px solid var(--divider);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+  transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+.m-land-root .oauth-btn:hover {
+  background: #F8FAFC;
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+/* OR divider -------------------------------------------------------- */
+.m-land-root .oauth-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 18px 0;
+}
+.m-land-root .oauth-divider::before,
+.m-land-root .oauth-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--divider);
+}
+.m-land-root .oauth-divider span {
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  font-weight: 600;
+}
+
+/* Segmented tabs (Password / Magic Link) ---------------------------- */
+.m-land-root .seg-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  background: var(--surface-elevated);
+  border: 1px solid var(--divider);
+  border-radius: var(--r-pill);
+  padding: 4px;
+  gap: 2px;
+  margin-bottom: 18px;
+}
+.m-land-root .seg-tabs button {
+  border: none;
+  background: transparent;
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13.5px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 150ms, color 150ms;
+}
+.m-land-root .seg-tabs button.is-active {
+  background: var(--accent-mint);
+  color: #052E1C;
+}
+
+/* Form fields ------------------------------------------------------- */
+.m-land-root .field { margin-bottom: 14px; }
+.m-land-root .field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.m-land-root .field label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+.m-land-root .field label .optional { font-weight: 500; color: var(--text-tertiary); font-size: 12.5px; }
+.m-land-root .field label a {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--accent-mint-deep);
+  text-decoration: none;
+}
+.m-land-root .field label a:hover { text-decoration: underline; }
+
+.m-land-root .field-control {
+  position: relative;
+}
+.m-land-root .field-control svg.lead {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+.m-land-root .field input {
+  width: 100%;
+  padding: 12px 14px;
+  padding-left: 38px;
+  font-size: 15px;
+  color: var(--text-primary);
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  outline: none;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+  font-family: inherit;
+}
+.m-land-root .field input.no-icon { padding-left: 14px; }
+.m-land-root .field input::placeholder { color: #9BA3AF; }
+.m-land-root .field input:focus {
+  border-color: var(--accent-mint-deep);
+  box-shadow: 0 0 0 3px var(--accent-mint-wash);
+}
+.m-land-root .field .hint {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-top: 4px;
+}
+
+/* Form error -------------------------------------------------------- */
+.m-land-root .form-error {
+  margin: 10px 0 4px;
+  padding: 10px 12px;
+  border-radius: var(--r-input);
+  font-size: 13.5px;
+  color: #B4263B;
+  background: #FEF2F2;
+  border: 1px solid #FEE2E2;
+}
+
+/* Submit ------------------------------------------------------------ */
+.m-land-root .auth-submit {
+  width: 100%;
+  padding: 13px 18px;
+  border-radius: var(--r-pill);
+  border: none;
+  cursor: pointer;
+  background: var(--accent-mint);
+  color: #052E1C;
+  font-weight: 600;
+  font-size: 15px;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  box-shadow: var(--shadow-mint);
+  margin-top: 8px;
+}
+.m-land-root .auth-submit:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: #2CC48A;
+}
+.m-land-root .auth-submit:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* Footer link in card ---------------------------------------------- */
+.m-land-root .auth-foot {
+  text-align: center;
+  margin-top: 20px;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+.m-land-root .auth-foot a {
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+  text-decoration: none;
+}
+.m-land-root .auth-foot a:hover { text-decoration: underline; }
+
+.m-land-root .auth-finepr {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--divider);
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.m-land-root .auth-finepr a {
+  color: var(--text-secondary);
+  text-decoration: underline;
+}
+
+/* Check / sent screens --------------------------------------------- */
+.m-land-root .auth-sent {
+  text-align: center;
+  padding: 12px 4px 8px;
+}
+.m-land-root .auth-sent .icon {
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  background: var(--accent-mint-wash);
+  display: grid; place-items: center;
+  margin: 0 auto 18px;
+  color: var(--accent-mint-deep);
+}
+.m-land-root .auth-sent h3 {
+  font-size: 20px; font-weight: 700; color: var(--text-primary); margin: 0 0 8px;
+}
+.m-land-root .auth-sent p { font-size: 15px; color: var(--text-secondary); margin: 0 0 16px; }
+.m-land-root .auth-sent p strong { color: var(--text-primary); }
+.m-land-root .auth-sent a.back {
+  color: var(--accent-mint-deep); font-weight: 600; text-decoration: none;
+}
+.m-land-root .auth-sent a.back:hover { text-decoration: underline; }
+
+/* /join referral landing ------------------------------------------- */
+.m-land-root .join-hero {
+  text-align: center;
+  padding: 32px 4px 8px;
+}
+.m-land-root .join-hero .gift {
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  background: rgba(251, 146, 60, 0.12);
+  border: 1px solid rgba(194, 65, 12, 0.18);
+  color: var(--accent-orange-deep);
+  display: grid; place-items: center;
+  margin: 0 auto 18px;
+}
+.m-land-root .join-hero h1 {
+  font-size: clamp(28px, 3.5vw, 34px);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  color: var(--text-primary);
+  margin: 0 0 12px;
+}
+.m-land-root .join-hero p.lead {
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  margin: 0 0 24px;
+}
+.m-land-root .join-perks {
+  text-align: left;
+  display: grid;
+  gap: 10px;
+  margin: 0 0 24px;
+}
+.m-land-root .join-perks li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 14.5px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+.m-land-root .join-perks li svg { color: var(--accent-mint-deep); margin-top: 2px; flex-shrink: 0; }
+
+.m-land-root .join-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 14px 20px;
+  border-radius: var(--r-pill);
+  background: var(--accent-mint);
+  color: #052E1C;
+  font-weight: 600;
+  font-size: 16px;
+  text-decoration: none;
+  box-shadow: var(--shadow-mint);
+  transition: transform 150ms ease, background 150ms ease;
+}
+.m-land-root .join-cta:hover { transform: translateY(-1px); background: #2CC48A; }
+.m-land-root .join-note { font-size: 12.5px; color: var(--text-tertiary); margin-top: 10px; text-align: center; }
+
+/* Loading fallback ------------------------------------------------- */
+.m-land-root .auth-loading {
+  min-height: 60vh;
+  display: grid;
+  place-items: center;
+}
+.m-land-root .auth-loading .spinner {
+  width: 36px; height: 36px;
+  border: 3px solid var(--divider);
+  border-top-color: var(--accent-mint-deep);
+  border-radius: 50%;
+  animation: spin 700ms linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Responsive ------------------------------------------------------- */
+@media (max-width: 520px) {
+  .m-land-root .auth-card { padding: 24px 22px 22px; }
+  .m-land-root .field-row { grid-template-columns: 1fr; gap: 0; }
+  .m-land-root .field-row .field { margin-bottom: 14px; }
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -7,8 +7,10 @@ import { useState, useEffect } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import Image from 'next/image';
-import { Mail, Lock, Sparkles } from 'lucide-react';
+import { Mail, Lock } from 'lucide-react';
+import { MarkNav } from '@/app/blog/_shared';
+import '../../(marketing)/styles.css';
+import '../auth.css';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -112,150 +114,128 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-navy-950 flex items-center justify-center p-6">
-      <div className="w-full max-w-md">
-        {/* Logo */}
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center gap-2 mb-4">
-            <Image src="/logo.png" alt="Paybacker" width={36} height={36} className="rounded-lg" />
-            <span className="text-2xl font-bold text-white">
-              Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-            </span>
+    <div className="m-land-root">
+      <MarkNav />
+      <main className="auth-shell">
+        <div className="auth-wrap">
+          <Link href="/" className="auth-brand">
+            <span className="pay">Pay</span>
+            <span className="backer">backer</span>
           </Link>
-          <h1 className="text-3xl font-bold text-white mb-2 font-[family-name:var(--font-heading)]">Welcome back</h1>
-          <p className="text-slate-400">Sign in to your account</p>
-        </div>
 
-        {/* Login Form */}
-        <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl p-8 shadow-2xl">
-          {magicLinkSent ? (
-            <div className="text-center py-8">
-              <Mail className="h-16 w-16 text-mint-400 mx-auto mb-4" />
-              <h3 className="text-xl font-bold text-white mb-2">Check your email</h3>
-              <p className="text-slate-400">We sent you a magic link to {email}</p>
-            </div>
-          ) : (
-            <div className="space-y-6">
-              {/* AU-007: Continue with Google */}
-              <button
-                type="button"
-                onClick={handleGoogleLogin}
-                className="w-full flex items-center justify-center gap-3 bg-white hover:bg-slate-50 text-slate-900 font-semibold py-3 rounded-xl transition-all"
-              >
-                <svg className="w-5 h-5" viewBox="0 0 24 24">
-                  <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-                  <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-                  <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-                  <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-                </svg>
-                Continue with Google
-              </button>
+          <div className="auth-head">
+            <h1>Welcome back</h1>
+            <p>Sign in to your Paybacker account.</p>
+          </div>
 
-              <div className="relative">
-                <div className="absolute inset-0 flex items-center">
-                  <div className="w-full border-t border-navy-700"></div>
+          <div className="auth-card">
+            {magicLinkSent ? (
+              <div className="auth-sent">
+                <div className="icon">
+                  <Mail className="h-6 w-6" />
                 </div>
-                <div className="relative flex justify-center text-sm">
-                  <span className="px-2 bg-navy-900 text-slate-500">Or continue with email</span>
-                </div>
+                <h3>Check your email</h3>
+                <p>
+                  We sent a magic link to <strong>{email}</strong>. Click it to
+                  finish signing in.
+                </p>
+                <Link className="back" href="/auth/login">Back to sign in</Link>
               </div>
-
-              {/* Toggle */}
-              <div className="flex gap-2 mb-6 bg-navy-950 rounded-lg p-1">
+            ) : (
+              <>
                 <button
-                  onClick={() => setUseMagicLink(false)}
-                  className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-all ${
-                    !useMagicLink
-                      ? 'bg-mint-400 text-navy-950'
-                      : 'text-slate-400 hover:text-white'
-                  }`}
+                  type="button"
+                  onClick={handleGoogleLogin}
+                  className="oauth-btn"
                 >
-                  Password
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                  </svg>
+                  Continue with Google
                 </button>
-                <button
-                  onClick={() => setUseMagicLink(true)}
-                  className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-all ${
-                    useMagicLink
-                      ? 'bg-mint-400 text-navy-950'
-                      : 'text-slate-400 hover:text-white'
-                  }`}
-                >
-                  Magic Link
-                </button>
-              </div>
 
-              <form onSubmit={useMagicLink ? handleMagicLink : handleEmailLogin} className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">
-                    Email address
-                  </label>
-                  <div className="relative">
-                    <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-slate-500" />
-                    <input
-                      type="email"
-                      required
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      className="w-full pl-10 pr-4 py-3 bg-navy-950 border border-navy-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                      placeholder="you@example.com"
-                    />
-                  </div>
+                <div className="oauth-divider">
+                  <span>Or continue with email</span>
                 </div>
 
-                {!useMagicLink && (
-                  <div>
-                    <div className="flex items-center justify-between mb-2">
-                      <label className="block text-sm font-medium text-slate-300">
-                        Password
-                      </label>
-                      <Link href="/auth/reset-password" className="text-sm text-mint-400 hover:text-mint-300 font-medium">
-                        Forgot password?
-                      </Link>
-                    </div>
-                    <div className="relative">
-                      <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-slate-500" />
+                <div className="seg-tabs">
+                  <button
+                    type="button"
+                    onClick={() => setUseMagicLink(false)}
+                    className={!useMagicLink ? 'is-active' : undefined}
+                  >
+                    Password
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setUseMagicLink(true)}
+                    className={useMagicLink ? 'is-active' : undefined}
+                  >
+                    Magic Link
+                  </button>
+                </div>
+
+                <form onSubmit={useMagicLink ? handleMagicLink : handleEmailLogin}>
+                  <div className="field">
+                    <label htmlFor="email">Email address</label>
+                    <div className="field-control">
+                      <Mail className="lead h-4 w-4" aria-hidden="true" />
                       <input
-                        type="password"
+                        id="email"
+                        type="email"
                         required
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        className="w-full pl-10 pr-4 py-3 bg-navy-950 border border-navy-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                        placeholder="••••••••"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="you@example.com"
+                        autoComplete="email"
                       />
                     </div>
                   </div>
-                )}
 
-                {error && (
-                  <div className="text-red-400 text-sm bg-red-500/10 border border-red-500/20 rounded-lg p-3">
-                    {error}
-                  </div>
-                )}
+                  {!useMagicLink && (
+                    <div className="field">
+                      <label htmlFor="password">
+                        Password
+                        <Link href="/auth/reset-password">Forgot password?</Link>
+                      </label>
+                      <div className="field-control">
+                        <Lock className="lead h-4 w-4" aria-hidden="true" />
+                        <input
+                          id="password"
+                          type="password"
+                          required
+                          value={password}
+                          onChange={(e) => setPassword(e.target.value)}
+                          placeholder="••••••••"
+                          autoComplete="current-password"
+                        />
+                      </div>
+                    </div>
+                  )}
 
-                <button
-                  type="submit"
-                  disabled={loading}
-                  className="w-full bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {loading ? 'Please wait...' : useMagicLink ? 'Send magic link' : 'Sign in'}
-                </button>
-              </form>
+                  {error && <div className="form-error">{error}</div>}
 
-              <div className="mt-6 text-center">
-                <p className="text-slate-400 text-sm">
-                  Don't have an account?{' '}
+                  <button type="submit" disabled={loading} className="auth-submit">
+                    {loading ? 'Please wait…' : useMagicLink ? 'Send magic link' : 'Sign in'}
+                  </button>
+                </form>
+
+                <div className="auth-foot">
+                  Don&apos;t have an account?{' '}
                   <Link
                     href={redirectTo !== '/dashboard' ? `/auth/signup?redirect=${encodeURIComponent(redirectTo)}` : '/auth/signup'}
-                    className="text-mint-400 hover:text-mint-300 font-medium"
                   >
                     Sign up
                   </Link>
-                </p>
-              </div>
-            </div>
-          )}
+                </div>
+              </>
+            )}
+          </div>
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -7,10 +7,12 @@ import { useState, useEffect } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import Image from 'next/image';
-import { Mail, Lock, User, Phone, Sparkles, CheckCircle2 } from 'lucide-react';
+import { Mail, Lock, User, Phone, CheckCircle2 } from 'lucide-react';
 import { WAITLIST_MODE } from '@/lib/config';
 import { capture } from '@/lib/posthog';
+import { MarkNav } from '@/app/blog/_shared';
+import '../../(marketing)/styles.css';
+import '../auth.css';
 
 export default function SignupPage() {
   const [firstName, setFirstName] = useState('');
@@ -201,177 +203,164 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="min-h-screen bg-navy-950 flex items-center justify-center p-6">
-      <div className="w-full max-w-md">
-        {/* Logo */}
-        <div className="text-center mb-8">
-          <Link href="/" className="inline-flex items-center gap-2 mb-4">
-            <Image src="/logo.png" alt="Paybacker" width={36} height={36} className="rounded-lg" />
-            <span className="text-2xl font-bold text-white">
-              Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-            </span>
+    <div className="m-land-root">
+      <MarkNav />
+      <main className="auth-shell">
+        <div className="auth-wrap">
+          <Link href="/" className="auth-brand">
+            <span className="pay">Pay</span>
+            <span className="backer">backer</span>
           </Link>
-          <h1 className="text-3xl font-bold text-white mb-2 font-[family-name:var(--font-heading)]">Create your account</h1>
-          <p className="text-slate-400">Start getting your money back today</p>
-        </div>
 
-        {/* Signup Form */}
-        <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl p-8 shadow-2xl">
-          {verifyMode ? (
-            <div className="text-center py-6">
-              <div className="bg-green-500/10 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-                <CheckCircle2 className="h-8 w-8 text-green-500" />
-              </div>
-              <h2 className="text-xl font-bold text-white mb-2">Check your email</h2>
-              <p className="text-slate-400 text-sm mb-6">
-                We sent a confirmation link to <span className="text-white font-medium">{email}</span>.
-                Click it to activate your account.
-              </p>
-              <Link href="/auth/login" className="text-mint-400 hover:text-mint-300 text-sm font-medium">
-                Back to sign in
-              </Link>
-            </div>
-          ) : (
-            <div className="space-y-6">
-              {/* AU-007: Continue with Google */}
-              <button
-                type="button"
-                onClick={handleGoogleSignup}
-                className="w-full flex items-center justify-center gap-3 bg-white hover:bg-slate-50 text-slate-900 font-semibold py-3 rounded-xl transition-all"
-              >
-                <svg className="w-5 h-5" viewBox="0 0 24 24">
-                  <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-                  <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-                  <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-                  <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-                </svg>
-                Continue with Google
-              </button>
+          <div className="auth-head">
+            <h1>Create your account</h1>
+            <p>Start getting your money back today.</p>
+          </div>
 
-              <div className="relative">
-                <div className="absolute inset-0 flex items-center">
-                  <div className="w-full border-t border-navy-700"></div>
+          <div className="auth-card">
+            {verifyMode ? (
+              <div className="auth-sent">
+                <div className="icon">
+                  <CheckCircle2 className="h-7 w-7" />
                 </div>
-                <div className="relative flex justify-center text-sm">
-                  <span className="px-2 bg-navy-900 text-slate-500">Or continue with email</span>
+                <h3>Check your email</h3>
+                <p>
+                  We sent a confirmation link to <strong>{email}</strong>. Click
+                  it to activate your account.
+                </p>
+                <Link className="back" href="/auth/login">Back to sign in</Link>
+              </div>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={handleGoogleSignup}
+                  className="oauth-btn"
+                >
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                  </svg>
+                  Continue with Google
+                </button>
+
+                <div className="oauth-divider">
+                  <span>Or continue with email</span>
                 </div>
-              </div>
 
-          <form onSubmit={handleSignup} className="space-y-4">
-            {/* First + Last name row */}
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">First name *</label>
-                <div className="relative">
-                  <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
-                  <input
-                    type="text"
-                    required
-                    value={firstName}
-                    onChange={(e) => setFirstName(e.target.value)}
-                    className="w-full pl-9 pr-3 py-3 bg-navy-950 border border-navy-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                    placeholder="Paul"
-                  />
+                <form onSubmit={handleSignup}>
+                  <div className="field-row">
+                    <div className="field">
+                      <label htmlFor="first-name">First name</label>
+                      <div className="field-control">
+                        <User className="lead h-4 w-4" aria-hidden="true" />
+                        <input
+                          id="first-name"
+                          type="text"
+                          required
+                          value={firstName}
+                          onChange={(e) => setFirstName(e.target.value)}
+                          placeholder="Paul"
+                          autoComplete="given-name"
+                        />
+                      </div>
+                    </div>
+                    <div className="field">
+                      <label htmlFor="last-name">Last name</label>
+                      <div className="field-control">
+                        <input
+                          id="last-name"
+                          type="text"
+                          required
+                          value={lastName}
+                          onChange={(e) => setLastName(e.target.value)}
+                          placeholder="Smith"
+                          autoComplete="family-name"
+                          className="no-icon"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="field">
+                    <label htmlFor="signup-email">Email address</label>
+                    <div className="field-control">
+                      <Mail className="lead h-4 w-4" aria-hidden="true" />
+                      <input
+                        id="signup-email"
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="you@example.com"
+                        autoComplete="email"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="field">
+                    <label htmlFor="signup-mobile">
+                      Mobile number <span className="optional">(optional)</span>
+                    </label>
+                    <div className="field-control">
+                      <Phone className="lead h-4 w-4" aria-hidden="true" />
+                      <input
+                        id="signup-mobile"
+                        type="tel"
+                        value={mobile}
+                        onChange={(e) => setMobile(e.target.value)}
+                        placeholder="+44 7700 900000"
+                        autoComplete="tel"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="field">
+                    <label htmlFor="signup-password">Password</label>
+                    <div className="field-control">
+                      <Lock className="lead h-4 w-4" aria-hidden="true" />
+                      <input
+                        id="signup-password"
+                        type="password"
+                        required
+                        minLength={8}
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        placeholder="••••••••"
+                        autoComplete="new-password"
+                      />
+                    </div>
+                    <p className="hint">Minimum 8 characters.</p>
+                  </div>
+
+                  {error && <div className="form-error">{error}</div>}
+
+                  <button type="submit" disabled={loading} className="auth-submit">
+                    {loading ? 'Creating account…' : 'Create account'}
+                  </button>
+                </form>
+
+                <div className="auth-foot">
+                  Already have an account?{' '}
+                  <Link
+                    href={redirectTo ? `/auth/login?redirect=${encodeURIComponent(redirectTo)}` : '/auth/login'}
+                  >
+                    Sign in
+                  </Link>
                 </div>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">Last name *</label>
-                <input
-                  type="text"
-                  required
-                  value={lastName}
-                  onChange={(e) => setLastName(e.target.value)}
-                  className="w-full px-3 py-3 bg-navy-950 border border-navy-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                  placeholder="Smith"
-                />
-              </div>
-            </div>
 
-            <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">Email address *</label>
-              <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
-                <input
-                  type="email"
-                  required
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full pl-9 pr-4 py-3 bg-navy-950 border border-navy-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                  placeholder="you@example.com"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">
-                Mobile number
-                <span className="text-slate-500 font-normal ml-1">(optional)</span>
-              </label>
-              <div className="relative">
-                <Phone className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
-                <input
-                  type="tel"
-                  value={mobile}
-                  onChange={(e) => setMobile(e.target.value)}
-                  className="w-full pl-9 pr-4 py-3 bg-navy-950 border border-navy-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                  placeholder="+44 7700 900000"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">Password *</label>
-              <div className="relative">
-                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
-                <input
-                  type="password"
-                  required
-                  minLength={8}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full pl-9 pr-4 py-3 bg-navy-950 border border-navy-700 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
-                  placeholder="••••••••"
-                />
-              </div>
-              <p className="text-xs text-slate-500 mt-1">Minimum 8 characters</p>
-            </div>
-
-            {error && (
-              <div className="text-red-400 text-sm bg-red-500/10 border border-red-500/20 rounded-lg p-3">
-                {error}
-              </div>
+                <div className="auth-finepr">
+                  By creating an account, you agree to our{' '}
+                  <Link href="/terms-of-service">Terms of Service</Link> and{' '}
+                  <Link href="/privacy-policy">Privacy Policy</Link>.
+                </div>
+              </>
             )}
-
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {loading ? 'Creating account...' : 'Create account'}
-            </button>
-
-          <div className="mt-6 text-center">
-            <p className="text-slate-400 text-sm">
-              Already have an account?{' '}
-              <Link
-                href={redirectTo ? `/auth/login?redirect=${encodeURIComponent(redirectTo)}` : '/auth/login'}
-                className="text-mint-400 hover:text-mint-300 font-medium"
-              >
-                Sign in
-              </Link>
-            </p>
           </div>
-
-          <div className="mt-6 pt-6 border-t border-navy-700/50">
-            <p className="text-xs text-slate-500 text-center">
-              By creating an account, you agree to our Terms of Service and Privacy Policy
-            </p>
-          </div>
-          </form>
-            </div>
-          )}
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -3,8 +3,10 @@
 import { useEffect, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import Image from 'next/image';
-import { Gift, CheckCircle, ArrowRight, Loader2 } from 'lucide-react';
+import { Gift, CheckCircle, ArrowRight } from 'lucide-react';
+import { MarkNav } from '@/app/blog/_shared';
+import '../(marketing)/styles.css';
+import '../auth/auth.css';
 
 function JoinContent() {
   const searchParams = useSearchParams();
@@ -19,54 +21,66 @@ function JoinContent() {
     }
   }, [ref]);
 
+  const perks = [
+    'AI complaint letters citing UK consumer law',
+    'Find hidden subscriptions draining your bank',
+    'Compare deals from top UK providers',
+    'Track contract end dates with renewal alerts',
+  ];
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 flex items-center justify-center">
-      <div className="max-w-md mx-auto px-6 py-16 text-center">
-        <Link href="/" className="inline-flex items-center gap-2 mb-8">
-          <Image src="/logo.png" alt="Paybacker" width={40} height={40} className="rounded-lg" />
-          <span className="text-2xl font-bold text-white">Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span></span>
+    <main className="auth-shell">
+      <div className="auth-wrap">
+        <Link href="/" className="auth-brand">
+          <span className="pay">Pay</span>
+          <span className="backer">backer</span>
         </Link>
 
-        <div className="bg-amber-500/10 border border-amber-500/20 rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-6">
-          <Gift className="h-8 w-8 text-amber-400" />
-        </div>
-
-        <h1 className="text-3xl font-bold text-white mb-4">You have been invited</h1>
-        <p className="text-slate-400 text-lg mb-8">
-          A Paybacker member has invited you to join. Sign up free and start claiming money back on your bills, subscriptions, and contracts.
-        </p>
-
-        <div className="space-y-3 text-left mb-8">
-          {[
-            'AI complaint letters citing UK consumer law',
-            'Find hidden subscriptions draining your bank',
-            'Compare 56 deals from top UK providers',
-            'Track contract end dates with renewal alerts',
-          ].map((item, i) => (
-            <div key={i} className="flex items-start gap-3">
-              <CheckCircle className="h-5 w-5 text-green-400 flex-shrink-0 mt-0.5" />
-              <span className="text-slate-300 text-sm">{item}</span>
+        <div className="auth-card">
+          <div className="join-hero">
+            <div className="gift">
+              <Gift className="h-7 w-7" />
             </div>
-          ))}
+            <h1>You&apos;ve been invited</h1>
+            <p className="lead">
+              A Paybacker member has invited you to join. Sign up free and start
+              claiming money back on your bills, subscriptions, and contracts.
+            </p>
+          </div>
+
+          <ul className="join-perks">
+            {perks.map((item) => (
+              <li key={item}>
+                <CheckCircle className="h-5 w-5" aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+
+          <Link href="/auth/signup" className="join-cta">
+            Create free account <ArrowRight className="h-4 w-4" />
+          </Link>
+
+          <p className="join-note">Free forever. No credit card required.</p>
         </div>
-
-        <Link
-          href="/auth/signup"
-          className="inline-flex items-center gap-2 bg-gradient-to-r from-amber-500 to-amber-600 hover:from-amber-600 hover:to-amber-700 text-slate-950 font-semibold px-8 py-4 rounded-xl transition-all shadow-lg shadow-amber-500/25 text-lg w-full justify-center"
-        >
-          Create Free Account <ArrowRight className="h-5 w-5" />
-        </Link>
-
-        <p className="text-slate-600 text-xs mt-4">Free forever. No credit card required.</p>
       </div>
-    </div>
+    </main>
   );
 }
 
 export default function JoinPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen bg-slate-950 flex items-center justify-center"><Loader2 className="h-8 w-8 text-amber-500 animate-spin" /></div>}>
-      <JoinContent />
-    </Suspense>
+    <div className="m-land-root">
+      <MarkNav />
+      <Suspense
+        fallback={
+          <div className="auth-loading" aria-busy="true">
+            <div className="spinner" />
+          </div>
+        }
+      >
+        <JoinContent />
+      </Suspense>
+    </div>
   );
 }


### PR DESCRIPTION
Batch 6a: auth pages + /join move to the light theme.

### What's in here

| Route | Before | After |
|---|---|---|
| `/auth/login` | Dark navy-950, inline PaybackerX logo | Light `.m-land-root` + MarkNav + auth-card |
| `/auth/signup` | Dark navy-950, inline PaybackerX logo | Light `.m-land-root` + MarkNav + auth-card |
| `/join` | Dark slate gradient, amber CTA | Light `.m-land-root` + MarkNav + auth-card |

### Design system

Same scoped-root pattern as the rest of the marketing redesign:

- Each auth page wraps content in `<div className="m-land-root">` and
  imports both `(marketing)/styles.css` (nav-shell, footer tokens) and
  a new `auth/auth.css` (auth-card, form fields, OAuth button, seg
  tabs, check-your-email state, join-hero).
- MarkNav from `@/app/blog/_shared` replaces the inline logo + header
  block that was on each page.
- `.auth-card` = white card on `--surface-base`, `--shadow-md`,
  `--divider` border. Matches the visual weight of `.rights-card` and
  `.post-aside-cta` elsewhere.
- `.oauth-btn` = Google continue button, white with divider border,
  lifts on hover.
- `.seg-tabs` = Password / Magic Link segmented control; active tab
  uses `--accent-mint` with `#052E1C` text (matches `.btn-mint`).
- `.field-control svg.lead` = left-inset icon, same colour as
  `--text-tertiary`, pointer-events none.
- `.form-error` = red-200 bg with B4263B text — same feedback style
  used across the marketing site.

### Auth logic is untouched

Every line of auth behaviour is preserved:

- **Login**: `signInWithPassword`, Google OAuth via
  `signInWithOAuth({provider:'google'})`, magic link via
  `signInWithOtp`, 5-attempt/1-minute lockout, redirect handling
  with path validation (`rawRedirect.startsWith('/') && !rawRedirect.
  startsWith('//')`).
- **Signup**: `signUp` with full_name/first_name/last_name/
  mobile_number metadata, email regex, phone regex, UTM + gclid/
  fbclid capture (from params + pb_* cookies), `signup_source`
  derivation, `signup_attribution` insert, `/api/referrals/process`,
  `/api/founding-member`, `/api/awin/signup` (awaited before
  navigation), `/api/auth/welcome`, PostHog `capture('user_signed_
  up')` and `capture('user_signup_verify')`, sessionStorage for Awin
  fallback pixel, WAITLIST_MODE redirect.
- **/join**: referral code from `?ref=` stored in `pb_ref` cookie
  (30 days) and localStorage, Suspense boundary for
  `useSearchParams()`.

### Accessibility

- Every `<input>` has an `id` and a matching `<label htmlFor>`.
- Icons inside labels/inputs have `aria-hidden="true"`.
- `autoComplete` hints on email (`email`), given-name / family-name,
  tel, current-password / new-password.
- The loading spinner in /join announces `aria-busy="true"`.

### Checks

- `npx tsc --noEmit`: clean for all 4 files. Pre-existing errors
  elsewhere in the repo (dashboard/money-hub, cron/trial-expiry,
  CareersInterestForm false positive, generated .next validator) are
  unchanged.
- No API keys, no new env vars, no database changes.
- No behaviour change to auth.

### What's still pending after this

- **Batch 6b** — `/deals` + `/deals/[category]` (affiliate directory).
- **Batch 6c** — `/solutions/[slug]`, `/complaints/[company]`,
  `/debt-collection-letter` (SEO content pages with FAQ JSON-LD).
- **Batch 6d** — `/docs/paybacker-assistant` (MCP setup docs).
- **Batch 7+** — dashboard shell + page bodies (behind auth).
