### PR TITLE
feat(marketing): redesign /deals + /deals/[category] to light theme (batch 6b)

### DIFF
--- a/src/app/deals/[category]/page.tsx
+++ b/src/app/deals/[category]/page.tsx
@@ -1,8 +1,10 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { CheckCircle, ArrowRight, Clock, Zap, TrendingDown, BarChart3, ShieldCheck, Star, Search } from 'lucide-react';
-import PublicNavbar from '@/components/PublicNavbar';
+import { CheckCircle, ArrowRight, Clock, Zap, TrendingDown, BarChart3 } from 'lucide-react';
+import { MarkNav, MarkFoot } from '@/app/blog/_shared';
+import '../../(marketing)/styles.css';
+import '../deals.css';
 
 interface Deal {
   id: string;
@@ -13,12 +15,6 @@ interface Deal {
   providerUrl: string;
   promoCode?: string;
   awinUrl?: string;
-  /** Direct merchant partnership — we have a trusted affiliate relationship */
-  verified?: boolean;
-  /** Our top pick / highest-value offer in the category */
-  featured?: boolean;
-  /** Accent colour for the provider avatar (Tailwind class) */
-  accent?: string;
 }
 
 const AWIN_AFF_ID = process.env.NEXT_PUBLIC_AWIN_AFF_ID || '';
@@ -39,173 +35,207 @@ const CATEGORIES: Record<string, {
   energy: {
     title: 'Best Energy Deals UK 2026 - Compare and Switch',
     h1: 'Compare the best energy deals in the UK',
-    description: 'Compare energy tariffs from top UK suppliers. Switch gas and electricity providers in minutes and save up to £200/year. Paybacker analyses your real bills to find you the cheapest deal.',
-    longDescription: 'Energy bills are one of the biggest household expenses in the UK. Most people stay on their provider\'s standard variable tariff, paying hundreds more than they need to. Paybacker connects to your bank account to see exactly what you\'re paying, then shows you cheaper alternatives from trusted suppliers.',
-    keywords: ['energy deals UK', 'switch energy provider', 'cheap gas and electricity', 'compare energy tariffs', 'best energy deals 2026'],
+    description:
+      'Compare energy tariffs from top UK suppliers. Switch gas and electricity providers in minutes and save up to £200/year. Paybacker analyses your real bills to find you the cheapest deal.',
+    longDescription:
+      "Energy bills are one of the biggest household expenses in the UK. Most people stay on their provider's standard variable tariff, paying hundreds more than they need to. Paybacker connects to your bank account to see exactly what you're paying, then shows you cheaper alternatives from trusted suppliers.",
+    keywords: [
+      'energy deals UK',
+      'switch energy provider',
+      'cheap gas and electricity',
+      'compare energy tariffs',
+      'best energy deals 2026',
+    ],
     avgSaving: '£200',
     switchTime: '17 days',
     tipTitle: 'When to switch energy',
-    tipBody: 'The best time to switch is 30 days before your fixed tariff ends. If you are on a standard variable tariff, you can switch any time with no exit fees. Paybacker alerts you automatically.',
+    tipBody:
+      'The best time to switch is 30 days before your fixed tariff ends. If you are on a standard variable tariff, you can switch any time with no exit fees. Paybacker alerts you automatically.',
     deals: [
-      { id: 'eon-next', provider: 'E.ON Next', headline: 'Next Drive tariff for EV owners', saving: 'Save up to £120/yr', awinMid: '54765', providerUrl: 'https://www.eonenergy.com', verified: true, featured: true, accent: 'from-rose-500 to-red-500' },
-      { id: 'edf-energy', provider: 'EDF', headline: 'Fixed price tariffs - price certainty', saving: 'Save up to £140/yr', awinMid: '1887', providerUrl: 'https://www.edfenergy.com/energy', verified: true, accent: 'from-orange-500 to-amber-500' },
-      { id: 'ovo-energy', provider: 'OVO Energy', headline: 'Fixed rate - lock in your price', saving: 'Save up to £150/yr', awinMid: '5318', providerUrl: 'https://www.ovoenergy.com', verified: true, accent: 'from-emerald-500 to-green-500' },
-      { id: 'msm-energy', provider: 'MoneySuperMarket', headline: 'Compare all energy suppliers in one search', saving: 'Save up to £200/yr', awinMid: '22713', providerUrl: 'https://www.moneysupermarket.com/gas-and-electricity/' },
+      { id: 'eon-next',     provider: 'E.ON Next',         headline: 'Next Drive tariff for EV owners',                saving: 'Save up to £120/yr', awinMid: '54765', providerUrl: 'https://www.eonenergy.com' },
+      { id: 'edf-energy',   provider: 'EDF',               headline: 'Fixed price tariffs — price certainty',           saving: 'Save up to £140/yr', awinMid: '1887',  providerUrl: 'https://www.edfenergy.com' },
+      { id: 'ovo-energy',   provider: 'OVO Energy',        headline: 'Fixed rate — lock in your price',                 saving: 'Save up to £150/yr', awinMid: '5318',  providerUrl: 'https://www.ovoenergy.com' },
+      { id: 'msm-energy',   provider: 'MoneySuperMarket',  headline: 'Compare all energy suppliers in one search',      saving: 'Save up to £200/yr', awinMid: '22713', providerUrl: 'https://www.moneysupermarket.com/gas-and-electricity/' },
     ],
   },
   broadband: {
     title: 'Best Broadband Deals UK 2026 - Compare and Switch',
     h1: 'Compare the best broadband deals in the UK',
-    description: 'Compare broadband packages from BT, Sky, Virgin Media, EE and more. Find the fastest, cheapest broadband for your area. Paybacker shows you deals based on what you actually pay.',
-    longDescription: 'The average UK household overpays by £120/year on broadband by staying with the same provider after their contract ends. Your provider puts you on an out-of-contract rate that is often 30-50% more expensive. Paybacker detects when your broadband contract is ending and shows you the best deals available.',
+    description:
+      'Compare broadband packages from BT, Sky, Virgin Media, EE and more. Find the fastest, cheapest broadband for your area. Paybacker shows you deals based on what you actually pay.',
+    longDescription:
+      'The average UK household overpays by £120/year on broadband by staying with the same provider after their contract ends. Your provider puts you on an out-of-contract rate that is often 30-50% more expensive. Paybacker detects when your broadband contract is ending and shows you the best deals available.',
     keywords: ['broadband deals UK', 'compare broadband', 'cheap broadband', 'best broadband deals 2026', 'switch broadband provider'],
     avgSaving: '£180',
     switchTime: '14 days',
     tipTitle: 'When to switch broadband',
-    tipBody: 'Start looking 30 days before your contract ends. You can switch penalty-free once your minimum term is up. Most new customer deals save 30-50% compared to out-of-contract rates.',
+    tipBody:
+      'Start looking 30 days before your contract ends. You can switch penalty-free once your minimum term is up. Most new customer deals save 30-50% compared to out-of-contract rates.',
     deals: [
-      { id: 'bt-broadband', provider: 'BT', headline: 'Full Fibre 500 - superfast speeds', saving: 'Save up to £240/yr', awinMid: '3041', providerUrl: 'https://www.bt.com/broadband', verified: true, featured: true, accent: 'from-purple-500 to-indigo-500' },
-      { id: 'virgin-media', provider: 'Virgin Media', headline: 'Gig1 - fastest widely available', saving: 'Save up to £200/yr', awinMid: '6399', providerUrl: 'https://www.virginmedia.com/broadband', verified: true, featured: true, accent: 'from-red-500 to-rose-500' },
-      { id: 'sky-broadband', provider: 'Sky', headline: 'Ultrafast broadband + streaming', saving: 'Save up to £180/yr', awinMid: '11005', providerUrl: 'https://www.sky.com/shop/broadband', verified: true, accent: 'from-blue-500 to-sky-500' },
-      { id: 'ee-broadband', provider: 'EE', headline: 'Full Fibre with smart hub', saving: 'Save up to £180/yr', awinMid: '3516', providerUrl: 'https://shop.ee.co.uk/broadband', verified: true, accent: 'from-teal-500 to-cyan-500' },
-      { id: 'hyperoptic', provider: 'Hyperoptic', headline: '1Gbps full fibre', saving: 'Save up to £200/yr', awinMid: '5737', providerUrl: 'https://www.hyperoptic.com/broadband', verified: true, accent: 'from-fuchsia-500 to-pink-500' },
-      { id: 'plusnet', provider: 'Plusnet', headline: 'Award-winning broadband', saving: 'Save up to £160/yr', awinMid: '2973', providerUrl: 'https://www.plus.net/broadband', verified: true, accent: 'from-amber-500 to-yellow-500' },
-      { id: 'talktalk', provider: 'TalkTalk', headline: 'Affordable fibre broadband', saving: 'Save up to £140/yr', awinMid: '3674', providerUrl: 'https://www.talktalk.co.uk/broadband', verified: true, accent: 'from-pink-500 to-fuchsia-500' },
-      { id: 'community-fibre', provider: 'Community Fibre', headline: 'London full fibre', saving: 'Save up to £180/yr', awinMid: '19595', providerUrl: 'https://communityfibre.co.uk', verified: true, accent: 'from-green-500 to-lime-500' },
-      { id: 'broadband-genie', provider: 'Broadband Genie', headline: 'Independent comparison', saving: 'Find cheapest deals', awinMid: '12213', providerUrl: 'https://www.broadbandgenie.co.uk' },
-      { id: 'msm-broadband', provider: 'MoneySuperMarket', headline: 'Compare all providers', saving: 'Compare deals', awinMid: '25756', providerUrl: 'https://www.moneysupermarket.com/broadband/' },
+      { id: 'bt-broadband',      provider: 'BT',              headline: 'Full Fibre 500 — superfast speeds',      saving: 'Save up to £240/yr', awinMid: '3041',  providerUrl: 'https://www.bt.com/broadband' },
+      { id: 'sky-broadband',     provider: 'Sky',             headline: 'Ultrafast broadband + streaming',        saving: 'Save up to £180/yr', awinMid: '11005', providerUrl: 'https://www.sky.com/shop/broadband' },
+      { id: 'virgin-media',      provider: 'Virgin Media',    headline: 'Gig1 — fastest widely available',        saving: 'Save up to £200/yr', awinMid: '6399',  providerUrl: 'https://www.virginmedia.com' },
+      { id: 'ee-broadband',      provider: 'EE',              headline: 'Full Fibre with smart hub',              saving: 'Save up to £180/yr', awinMid: '3516',  providerUrl: 'https://shop.ee.co.uk/broadband' },
+      { id: 'plusnet',           provider: 'Plusnet',         headline: 'Award-winning broadband',                saving: 'Save up to £160/yr', awinMid: '2973',  providerUrl: 'https://www.plus.net' },
+      { id: 'talktalk',          provider: 'TalkTalk',        headline: 'Affordable fibre broadband',             saving: 'Save up to £140/yr', awinMid: '3674',  providerUrl: 'https://www.talktalk.co.uk' },
+      { id: 'hyperoptic',        provider: 'Hyperoptic',      headline: '1Gbps full fibre',                       saving: 'Save up to £200/yr', awinMid: '5737',  providerUrl: 'https://www.hyperoptic.com' },
+      { id: 'community-fibre',   provider: 'Community Fibre', headline: 'London full fibre',                      saving: 'Save up to £180/yr', awinMid: '19595', providerUrl: 'https://communityfibre.co.uk' },
+      { id: 'broadband-genie',   provider: 'Broadband Genie', headline: 'Independent comparison',                 saving: 'Find cheapest deals', awinMid: '12213', providerUrl: 'https://www.broadbandgenie.co.uk' },
+      { id: 'msm-broadband',     provider: 'MoneySuperMarket',headline: 'Compare all providers',                  saving: 'Compare deals',      awinMid: '25756', providerUrl: 'https://www.moneysupermarket.com/broadband/' },
     ],
   },
   mobile: {
     title: 'Best Mobile Phone Deals UK 2026 - SIM Only and Contracts',
     h1: 'Compare the best mobile deals in the UK',
-    description: 'Compare SIM-only and contract deals from every UK network. EE, O2, Vodafone, Three, giffgaff, SMARTY and more. Paybacker finds you cheaper plans based on your actual usage.',
-    longDescription: 'Most people overpay on their mobile phone contract because they stay with the same network after their minimum term ends. You keep paying the same amount even though the handset is paid off. A SIM-only deal on the same network can save you £15-30/month. Paybacker spots this in your bank transactions and recommends the switch.',
+    description:
+      'Compare SIM-only and contract deals from every UK network. EE, O2, Vodafone, Three, giffgaff, SMARTY and more. Paybacker finds you cheaper plans based on your actual usage.',
+    longDescription:
+      'Most people overpay on their mobile phone contract because they stay with the same network after their minimum term ends. You keep paying the same amount even though the handset is paid off. A SIM-only deal on the same network can save you £15-30/month. Paybacker spots this in your bank transactions and recommends the switch.',
     keywords: ['mobile phone deals UK', 'SIM only deals', 'cheap mobile contracts', 'compare mobile phones', 'best SIM deals 2026'],
     avgSaving: '£200',
     switchTime: '1 day',
     tipTitle: 'SIM-only saves the most',
-    tipBody: 'If your contract has ended and you own your handset, switching to SIM-only can save £180-360/year. Text PAC to 65075 to keep your number when you switch.',
+    tipBody:
+      'If your contract has ended and you own your handset, switching to SIM-only can save £180-360/year. Text PAC to 65075 to keep your number when you switch.',
     deals: [
-      { id: 'lebara-save50', provider: 'Lebara', headline: 'Exclusive: SAVE50 for 50% off your first month', saving: 'Save 50% month 1', awinMid: '30681', providerUrl: 'https://www.lebara.co.uk/en/best-sim-only-deals.html', promoCode: 'SAVE50', awinUrl: 'https://www.awin1.com/cread.php?awinmid=30681&awinaffid=2825812&ued=https%3A%2F%2Fwww.lebara.co.uk%2Fen%2Fbest-sim-only-deals.html', verified: true, featured: true, accent: 'from-red-500 to-rose-500' },
-      { id: 'id-mobile', provider: 'iD Mobile', headline: 'SIM-only from £6/mo', saving: 'Save up to £240/yr', awinMid: '6366', providerUrl: 'https://www.idmobile.co.uk', verified: true, featured: true, accent: 'from-yellow-500 to-amber-500' },
-      { id: 'vodafone', provider: 'Vodafone', headline: '5G at no extra cost', saving: 'Save up to £220/yr', awinMid: '1257', providerUrl: 'https://www.vodafone.co.uk/mobile/sim-only', verified: true, accent: 'from-red-600 to-red-500' },
-      { id: 'ee-mobile', provider: 'EE', headline: 'UK largest 5G network', saving: 'Save up to £200/yr', awinMid: '31423', providerUrl: 'https://shop.ee.co.uk/sim-only', verified: true, accent: 'from-teal-500 to-cyan-500' },
-      { id: 'three-mobile', provider: 'Three', headline: '5G on all plans', saving: 'Save up to £200/yr', awinMid: '10210', providerUrl: 'https://www.three.co.uk', verified: true, accent: 'from-violet-500 to-purple-500' },
-      { id: 'o2-mobile', provider: 'O2', headline: 'Priority rewards', saving: 'Save up to £200/yr', awinMid: '3235', providerUrl: 'https://www.o2.co.uk/shop/sim-cards', verified: true, accent: 'from-blue-600 to-indigo-500' },
-      { id: 'giffgaff', provider: 'giffgaff', headline: 'Flexible - no contract', saving: 'Save up to £200/yr', awinMid: '3599', providerUrl: 'https://www.giffgaff.com/sim-only-deals', verified: true, accent: 'from-lime-500 to-green-500' },
-      { id: 'smarty', provider: 'SMARTY', headline: 'Unused data rolled over', saving: 'Save up to £200/yr', awinMid: '10933', providerUrl: 'https://smarty.co.uk/plans', verified: true, accent: 'from-pink-500 to-rose-500' },
-      { id: 'voxi', provider: 'VOXI', headline: 'Endless social media data', saving: 'Save up to £160/yr', awinMid: '10951', providerUrl: 'https://www.voxi.co.uk/sim-only-plans', verified: true, accent: 'from-fuchsia-500 to-pink-500' },
-      { id: 'tesco-mobile', provider: 'Tesco Mobile', headline: 'Clubcard prices', saving: 'Save up to £180/yr', awinMid: '101917', providerUrl: 'https://www.tescomobile.com/shop/sim-only', verified: true, accent: 'from-blue-500 to-indigo-500' },
-      { id: 'lebara10', provider: 'Lebara', headline: 'Use code LEBARA10 for £10 off', saving: 'Save £10 month 1', awinMid: '30681', providerUrl: 'https://www.lebara.co.uk/en/best-sim-only-deals.html', promoCode: 'LEBARA10', awinUrl: 'https://www.awin1.com/cread.php?awinmid=30681&awinaffid=2825812&ued=https%3A%2F%2Fwww.lebara.co.uk%2Fen%2Fbest-sim-only-deals.html', verified: true, accent: 'from-red-500 to-rose-500' },
-      { id: 'lebara5', provider: 'Lebara', headline: 'Use code LEBARA5 for £5 off', saving: 'Save £5 month 1', awinMid: '30681', providerUrl: 'https://www.lebara.co.uk/en/best-sim-only-deals.html', promoCode: 'LEBARA5', awinUrl: 'https://www.awin1.com/cread.php?awinmid=30681&awinaffid=2825812&ued=https%3A%2F%2Fwww.lebara.co.uk%2Fen%2Fbest-sim-only-deals.html', verified: true, accent: 'from-red-500 to-rose-500' },
+      { id: 'id-mobile',    provider: 'iD Mobile',   headline: 'SIM-only from £6/mo',            saving: 'Save up to £240/yr', awinMid: '6366',   providerUrl: 'https://www.idmobile.co.uk' },
+      { id: 'smarty',       provider: 'SMARTY',       headline: 'Unused data rolled over',        saving: 'Save up to £200/yr', awinMid: '10933',  providerUrl: 'https://smarty.co.uk' },
+      { id: 'giffgaff',     provider: 'giffgaff',     headline: 'Flexible — no contract',         saving: 'Save up to £200/yr', awinMid: '3599',   providerUrl: 'https://www.giffgaff.com' },
+      { id: 'voxi',         provider: 'VOXI',         headline: 'Endless social media data',      saving: 'Save up to £160/yr', awinMid: '10951',  providerUrl: 'https://www.voxi.co.uk' },
+      { id: 'ee-mobile',    provider: 'EE',           headline: 'UK largest 5G network',           saving: 'Save up to £200/yr', awinMid: '31423',  providerUrl: 'https://shop.ee.co.uk/sim-only' },
+      { id: 'vodafone',     provider: 'Vodafone',     headline: '5G at no extra cost',             saving: 'Save up to £220/yr', awinMid: '1257',   providerUrl: 'https://www.vodafone.co.uk' },
+      { id: 'three-mobile', provider: 'Three',        headline: '5G on all plans',                 saving: 'Save up to £200/yr', awinMid: '10210',  providerUrl: 'https://www.three.co.uk' },
+      { id: 'o2-mobile',    provider: 'O2',           headline: 'Priority rewards',                saving: 'Save up to £200/yr', awinMid: '3235',   providerUrl: 'https://www.o2.co.uk' },
+      { id: 'tesco-mobile', provider: 'Tesco Mobile', headline: 'Clubcard prices',                  saving: 'Save up to £180/yr', awinMid: '101917', providerUrl: 'https://www.tescomobile.com' },
+      { id: 'lebara5',      provider: 'Lebara',       headline: 'Use code LEBARA5 for £5 off',     saving: 'Save £5 off your first month',  awinMid: '30681', providerUrl: 'https://www.lebara.co.uk/en/best-sim-only-deals.html', promoCode: 'LEBARA5',  awinUrl: 'https://www.awin1.com/cread.php?awinmid=30681&awinaffid=2825812&ued=https%3A%2F%2Fwww.lebara.co.uk%2Fen%2Fbest-sim-only-deals.html' },
+      { id: 'lebara10',     provider: 'Lebara',       headline: 'Use code LEBARA10 for £10 off',   saving: 'Save £10 off your first month', awinMid: '30681', providerUrl: 'https://www.lebara.co.uk/en/best-sim-only-deals.html', promoCode: 'LEBARA10', awinUrl: 'https://www.awin1.com/cread.php?awinmid=30681&awinaffid=2825812&ued=https%3A%2F%2Fwww.lebara.co.uk%2Fen%2Fbest-sim-only-deals.html' },
+      { id: 'lebara-save50',provider: 'Lebara',       headline: 'Use code SAVE50 for 50% off',      saving: 'Save 50% off your first month', awinMid: '30681', providerUrl: 'https://www.lebara.co.uk/en/best-sim-only-deals.html', promoCode: 'SAVE50',  awinUrl: 'https://www.awin1.com/cread.php?awinmid=30681&awinaffid=2825812&ued=https%3A%2F%2Fwww.lebara.co.uk%2Fen%2Fbest-sim-only-deals.html' },
     ],
   },
   insurance: {
     title: 'Best Insurance Deals UK 2026 - Compare Car, Home and Breakdown',
     h1: 'Compare insurance deals and save hundreds',
-    description: 'Compare car insurance, home insurance, and breakdown cover from top UK comparison sites. GoCompare, MoneySuperMarket, RAC and AA. Save up to £300/year by switching.',
-    longDescription: 'Insurance auto-renewals are one of the biggest rip-offs in the UK. Your provider increases your premium every year, counting on you not shopping around. Paybacker detects your insurance payments in your bank transactions and alerts you before renewal so you can compare and switch.',
+    description:
+      'Compare car insurance, home insurance, and breakdown cover from top UK comparison sites. GoCompare, MoneySuperMarket, RAC and AA. Save up to £300/year by switching.',
+    longDescription:
+      'Insurance auto-renewals are one of the biggest rip-offs in the UK. Your provider increases your premium every year, counting on you not shopping around. Paybacker detects your insurance payments in your bank transactions and alerts you before renewal so you can compare and switch.',
     keywords: ['compare insurance UK', 'cheap car insurance', 'home insurance deals', 'breakdown cover comparison', 'insurance comparison 2026'],
     avgSaving: '£300',
     switchTime: 'Instant quote',
     tipTitle: 'Never auto-renew insurance',
-    tipBody: 'Auto-renewal typically costs 10-30% more than switching. Start comparing 3-4 weeks before your renewal date. Paybacker tracks this for you automatically.',
+    tipBody:
+      'Auto-renewal typically costs 10-30% more than switching. Start comparing 3-4 weeks before your renewal date. Paybacker tracks this for you automatically.',
     deals: [
-      { id: 'rac-breakdown', provider: 'RAC', headline: 'Breakdown cover from £6.50/mo', saving: 'Peace of mind', awinMid: '3790', providerUrl: 'https://www.rac.co.uk/breakdown-cover', verified: true, featured: true, accent: 'from-orange-500 to-amber-500' },
-      { id: 'aa-breakdown', provider: 'The AA', headline: 'UK breakdown cover', saving: 'Cover from £4/mo', awinMid: '3932', providerUrl: 'https://www.theaa.com/breakdown-cover', verified: true, featured: true, accent: 'from-yellow-500 to-amber-500' },
-      { id: 'compare-the-market', provider: 'Compare the Market', headline: 'Compare 100+ insurers', saving: 'Save up to £300/yr', awinMid: '3738', providerUrl: 'https://www.comparethemarket.com' },
-      { id: 'moneysupermarket', provider: 'MoneySuperMarket', headline: 'Car, home and life insurance', saving: 'Save up to £250/yr', awinMid: '12049', providerUrl: 'https://www.moneysupermarket.com/car-insurance/' },
-      { id: 'gocompare-car', provider: 'GoCompare Car', headline: 'Compare car insurance quotes', saving: 'Save up to £280/yr', awinMid: '117439', providerUrl: 'https://www.gocompare.com/car-insurance/' },
-      { id: 'gocompare-home', provider: 'GoCompare Home', headline: 'Compare home insurance', saving: 'Save up to £200/yr', awinMid: '117441', providerUrl: 'https://www.gocompare.com/home-insurance/' },
+      { id: 'compare-the-market', provider: 'Compare the Market', headline: 'Compare 100+ insurers',               saving: 'Save up to £300/yr', awinMid: '3738',   providerUrl: 'https://www.comparethemarket.com' },
+      { id: 'moneysupermarket',   provider: 'MoneySuperMarket',    headline: 'Car, home and life insurance',         saving: 'Save up to £250/yr', awinMid: '12049',  providerUrl: 'https://www.moneysupermarket.com/car-insurance/' },
+      { id: 'gocompare-car',      provider: 'GoCompare Car',       headline: 'Compare car insurance quotes',        saving: 'Save up to £280/yr', awinMid: '117439', providerUrl: 'https://www.gocompare.com/car-insurance/' },
+      { id: 'gocompare-home',     provider: 'GoCompare Home',      headline: 'Compare home insurance',               saving: 'Save up to £200/yr', awinMid: '117441', providerUrl: 'https://www.gocompare.com/home-insurance/' },
+      { id: 'rac-breakdown',      provider: 'RAC',                 headline: 'Breakdown cover from £6.50/mo',        saving: 'Peace of mind',       awinMid: '3790',   providerUrl: 'https://www.rac.co.uk/breakdown-cover' },
+      { id: 'aa-breakdown',       provider: 'The AA',              headline: 'UK breakdown cover',                   saving: 'Cover from £4/mo',    awinMid: '3932',   providerUrl: 'https://www.theaa.com/breakdown-cover' },
     ],
   },
   mortgages: {
     title: 'Best Mortgage Deals UK 2026 - Compare Rates and Save',
     h1: 'Compare mortgage deals and save thousands',
-    description: 'Compare mortgage rates from 90+ lenders with free online brokers. Habito, MoneySuperMarket, London & Country and more. Find the best remortgage and first-time buyer deals.',
-    longDescription: 'Your mortgage is your biggest monthly expense. When your fixed rate ends, your lender moves you to the standard variable rate (SVR) which is typically 2-3% higher. That can mean hundreds more per month. Paybacker detects mortgage payments in your bank transactions and alerts you before your fixed rate expires.',
+    description:
+      'Compare mortgage rates from 90+ lenders with free online brokers. Habito, MoneySuperMarket, London & Country and more. Find the best remortgage and first-time buyer deals.',
+    longDescription:
+      'Your mortgage is your biggest monthly expense. When your fixed rate ends, your lender moves you to the standard variable rate (SVR) which is typically 2-3% higher. That can mean hundreds more per month. Paybacker detects mortgage payments in your bank transactions and alerts you before your fixed rate expires.',
     keywords: ['mortgage deals UK', 'compare mortgage rates', 'best remortgage deals', 'first time buyer mortgage', 'mortgage comparison 2026'],
     avgSaving: '£3,000',
     switchTime: '4-8 weeks',
     tipTitle: 'Start 6 months early',
-    tipBody: 'You can lock in a new mortgage rate up to 6 months before your current deal ends. This protects you if rates rise. Most brokers on this page are fee-free.',
+    tipBody:
+      'You can lock in a new mortgage rate up to 6 months before your current deal ends. This protects you if rates rise. Most brokers on this page are fee-free.',
     warningText: 'Your home may be repossessed if you do not keep up repayments on your mortgage.',
     deals: [
-      { id: 'maze-mortgages', provider: 'Maze Mortgages', headline: 'Cashback on your mortgage', saving: 'Up to £3,700 cashback', awinMid: '80859', providerUrl: 'https://www.mazemortgages.co.uk', verified: true, featured: true, accent: 'from-purple-500 to-fuchsia-500' },
-      { id: 'habito', provider: 'Habito', headline: 'Free online broker - 90+ lenders', saving: 'Save up to £3,000/yr', awinMid: '15441', providerUrl: 'https://www.habito.com', verified: true, featured: true, accent: 'from-indigo-500 to-purple-500' },
-      { id: 'l-and-c', provider: 'London & Country', headline: 'UK largest fee-free broker', saving: 'Fee-free advice', awinMid: '7498', providerUrl: 'https://www.landc.co.uk', verified: true, accent: 'from-blue-500 to-cyan-500' },
-      { id: 'moneysupermarket-mortgages', provider: 'MoneySuperMarket', headline: 'Compare 50+ lenders', saving: 'Compare rates', awinMid: '1986', providerUrl: 'https://www.moneysupermarket.com/mortgages/' },
+      { id: 'habito',                    provider: 'Habito',              headline: 'Free online broker — 90+ lenders',     saving: 'Save up to £3,000/yr', awinMid: '15441', providerUrl: 'https://www.habito.com' },
+      { id: 'moneysupermarket-mortgages',provider: 'MoneySuperMarket',    headline: 'Compare 50+ lenders',                   saving: 'Compare rates',        awinMid: '1986',  providerUrl: 'https://www.moneysupermarket.com/mortgages/' },
+      { id: 'l-and-c',                   provider: 'London & Country',    headline: 'UK largest fee-free broker',            saving: 'Fee-free advice',      awinMid: '7498',  providerUrl: 'https://www.landc.co.uk' },
+      { id: 'maze-mortgages',            provider: 'Maze Mortgages',      headline: 'Cashback on your mortgage',             saving: 'Up to £3,700 cashback', awinMid: '80859', providerUrl: 'https://www.mazemortgages.co.uk' },
     ],
   },
   loans: {
     title: 'Best Loan Deals UK 2026 - Compare Personal and Secured Loans',
     h1: 'Compare loan deals and reduce your interest rate',
-    description: 'Compare personal loans, secured loans, and debt consolidation from trusted UK lenders. AA Loans, MoneySuperMarket, Freedom Finance and more. Lower your monthly payments.',
-    longDescription: 'If you have existing loans or credit card debt, you may be paying more interest than you need to. Consolidating multiple debts into a single lower-rate loan can save hundreds per year. Paybacker analyses your bank transactions to identify expensive borrowing and suggests better alternatives.',
+    description:
+      'Compare personal loans, secured loans, and debt consolidation from trusted UK lenders. AA Loans, MoneySuperMarket, Freedom Finance and more. Lower your monthly payments.',
+    longDescription:
+      'If you have existing loans or credit card debt, you may be paying more interest than you need to. Consolidating multiple debts into a single lower-rate loan can save hundreds per year. Paybacker analyses your bank transactions to identify expensive borrowing and suggests better alternatives.',
     keywords: ['loan deals UK', 'compare personal loans', 'debt consolidation', 'best loan rates 2026', 'cheap loans UK'],
     avgSaving: '£500',
     switchTime: '1-7 days',
     tipTitle: 'Check your eligibility first',
-    tipBody: 'Use eligibility checkers (soft search) before applying. This shows which loans you are likely to be accepted for without affecting your credit score.',
-    warningText: 'Think carefully before securing other debts against your home. If you are thinking of consolidating existing borrowing, you may be extending the terms of the debt and increasing the total amount you repay.',
+    tipBody:
+      'Use eligibility checkers (soft search) before applying. This shows which loans you are likely to be accepted for without affecting your credit score.',
+    warningText:
+      'Think carefully before securing other debts against your home. If you are thinking of consolidating existing borrowing, you may be extending the terms of the debt and increasing the total amount you repay.',
     deals: [
-      { id: 'freedom-finance', provider: 'Freedom Finance', headline: 'Compare 30+ lenders from 3.3% APR', saving: 'Rates from 3.3% APR', awinMid: '14780', providerUrl: 'https://www.freedomfinance.co.uk/loans', verified: true, featured: true, accent: 'from-teal-500 to-emerald-500' },
-      { id: 'loan-co-uk', provider: 'Loan.co.uk', headline: 'Secured loans - consolidate debt', saving: 'Up to £300 cashback', awinMid: '18915', providerUrl: 'https://www.loan.co.uk', verified: true, featured: true, accent: 'from-emerald-500 to-green-500' },
-      { id: 'aa-loans', provider: 'AA Loans', headline: 'Personal loans from 7.9% APR', saving: '£50 on completion', awinMid: '3953', providerUrl: 'https://www.theaa.com/loans', verified: true, accent: 'from-yellow-500 to-amber-500' },
-      { id: 'moneysupermarket-loans', provider: 'MoneySuperMarket', headline: 'Compare and consolidate', saving: 'Compare APRs', awinMid: '1986', providerUrl: 'https://www.moneysupermarket.com/loans/' },
-      { id: 'comparethemarket-loans', provider: 'Compare the Market', headline: 'Multiple lenders', saving: 'Reduce payments', awinMid: '3738', providerUrl: 'https://www.comparethemarket.com/loans/' },
+      { id: 'freedom-finance',         provider: 'Freedom Finance',     headline: 'Compare 30+ lenders from 3.3% APR', saving: 'Lower your rate',   awinMid: '14780', providerUrl: 'https://www.freedomfinance.co.uk/loans' },
+      { id: 'aa-loans',                provider: 'AA Loans',            headline: 'Personal loans from 7.9% APR',       saving: '£50 on completion', awinMid: '3953',  providerUrl: 'https://www.theaa.com/loans' },
+      { id: 'moneysupermarket-loans',  provider: 'MoneySuperMarket',    headline: 'Compare and consolidate',            saving: 'Compare APRs',      awinMid: '1986',  providerUrl: 'https://www.moneysupermarket.com/loans/' },
+      { id: 'comparethemarket-loans',  provider: 'Compare the Market',  headline: 'Multiple lenders',                    saving: 'Reduce payments',   awinMid: '3738',  providerUrl: 'https://www.comparethemarket.com/loans/' },
+      { id: 'loan-co-uk',              provider: 'Loan.co.uk',          headline: 'Secured loans — consolidate',         saving: 'Up to £300 cashback', awinMid: '18915', providerUrl: 'https://www.loan.co.uk' },
     ],
   },
   'credit-cards': {
     title: 'Best Credit Card Deals UK 2026 - Compare 0% and Cashback Cards',
     h1: 'Compare credit cards and save on interest',
-    description: 'Compare 0% balance transfer, cashback, and rewards credit cards. MoneySavingExpert, TotallyMoney, Compare the Market. Find the best card for your credit score.',
-    longDescription: 'If you are carrying credit card debt, switching to a 0% balance transfer card can save you hundreds in interest. Even if your credit score is not perfect, eligibility checkers can show which cards you are likely to be accepted for without affecting your score.',
+    description:
+      'Compare 0% balance transfer, cashback, and rewards credit cards. MoneySavingExpert, TotallyMoney, Compare the Market. Find the best card for your credit score.',
+    longDescription:
+      'If you are carrying credit card debt, switching to a 0% balance transfer card can save you hundreds in interest. Even if your credit score is not perfect, eligibility checkers can show which cards you are likely to be accepted for without affecting your score.',
     keywords: ['credit card deals UK', '0% balance transfer', 'best credit cards 2026', 'cashback credit cards', 'compare credit cards'],
     avgSaving: '£300',
     switchTime: '5-10 days',
     tipTitle: 'Use eligibility checkers',
-    tipBody: 'Eligibility checkers use a soft search to show which cards you qualify for without marking your credit file. Apply for the one with the highest acceptance chance.',
+    tipBody:
+      'Eligibility checkers use a soft search to show which cards you qualify for without marking your credit file. Apply for the one with the highest acceptance chance.',
     deals: [
-      { id: 'totallymoney', provider: 'TotallyMoney', headline: 'Free credit score + card match', saving: 'Best match cards', awinMid: '10983', providerUrl: 'https://www.totallymoney.com/credit-cards/', verified: true, featured: true, accent: 'from-pink-500 to-rose-500' },
-      { id: 'mse-credit-cards', provider: 'MoneySavingExpert', headline: 'Eligibility checker', saving: '0% balance transfer', awinMid: '12498', providerUrl: 'https://www.moneysavingexpert.com/credit-cards/', verified: true, accent: 'from-blue-500 to-indigo-500' },
-      { id: 'comparethemarket-cc', provider: 'Compare the Market', headline: 'Balance transfer, cashback, rewards', saving: 'Save on interest', awinMid: '3738', providerUrl: 'https://www.comparethemarket.com/credit-cards/' },
-      { id: 'msm-money', provider: 'MoneySuperMarket', headline: 'Compare credit cards', saving: 'Find best rates', awinMid: '61791', providerUrl: 'https://www.moneysupermarket.com/credit-cards/' },
+      { id: 'mse-credit-cards',   provider: 'MoneySavingExpert',   headline: 'Eligibility checker',                  saving: '0% balance transfer', awinMid: '12498', providerUrl: 'https://www.moneysavingexpert.com/credit-cards/' },
+      { id: 'comparethemarket-cc',provider: 'Compare the Market',  headline: 'Balance transfer, cashback, rewards',  saving: 'Save on interest',    awinMid: '3738',  providerUrl: 'https://www.comparethemarket.com/credit-cards/' },
+      { id: 'totallymoney',       provider: 'TotallyMoney',        headline: 'Free credit score + card match',        saving: 'Best match cards',    awinMid: '10983', providerUrl: 'https://www.totallymoney.com/credit-cards/' },
+      { id: 'msm-money',          provider: 'MoneySuperMarket',    headline: 'Compare credit cards',                   saving: 'Find best rates',     awinMid: '61791', providerUrl: 'https://www.moneysupermarket.com/credit-cards/' },
     ],
   },
   'car-finance': {
     title: 'Best Car Finance Deals UK 2026 - Compare PCP, HP and Loans',
     h1: 'Compare car finance deals and save',
-    description: 'Compare car finance deals from Carwow, Zuto and more. PCP, HP, and personal loan options. Find the best rate for your car purchase.',
-    longDescription: 'Car finance can be expensive if you do not shop around. Dealer finance is rarely the cheapest option. Comparing car finance independently before visiting the dealership can save you thousands over the term of your agreement.',
+    description:
+      'Compare car finance deals from Carwow, Zuto and more. PCP, HP, and personal loan options. Find the best rate for your car purchase.',
+    longDescription:
+      'Car finance can be expensive if you do not shop around. Dealer finance is rarely the cheapest option. Comparing car finance independently before visiting the dealership can save you thousands over the term of your agreement.',
     keywords: ['car finance deals UK', 'compare car finance', 'cheap car finance', 'PCP deals 2026', 'car loan comparison'],
     avgSaving: '£1,000',
     switchTime: 'Pre-approval in minutes',
     tipTitle: 'Get pre-approved first',
-    tipBody: 'Getting pre-approved for car finance before visiting a dealership gives you negotiating power. You know exactly what rate you qualify for and can compare it to the dealer offer.',
+    tipBody:
+      'Getting pre-approved for car finance before visiting a dealership gives you negotiating power. You know exactly what rate you qualify for and can compare it to the dealer offer.',
     deals: [
-      { id: 'carwow-finance', provider: 'Carwow', headline: 'Compare PCP, HP and loans', saving: 'Save on finance', awinMid: '18621', providerUrl: 'https://www.carwow.co.uk/car-finance', verified: true, featured: true, accent: 'from-blue-500 to-cyan-500' },
-      { id: 'zuto', provider: 'Zuto', headline: 'All credit scores welcome', saving: 'Rates from 6.9% APR', awinMid: '16944', providerUrl: 'https://www.zuto.com', verified: true, featured: true, accent: 'from-emerald-500 to-green-500' },
+      { id: 'carwow-finance', provider: 'Carwow', headline: 'Compare PCP, HP and loans', saving: 'Save on finance',   awinMid: '18621', providerUrl: 'https://www.carwow.co.uk/car-finance' },
+      { id: 'zuto',           provider: 'Zuto',   headline: 'All credit scores welcome',  saving: 'Rates from 6.9% APR', awinMid: '16944', providerUrl: 'https://www.zuto.com' },
     ],
   },
   travel: {
     title: 'Best Travel Deals UK 2026 - Cheap Flights, Hotels and Holidays',
     h1: 'Compare travel deals and save on your next trip',
-    description: 'Compare flights, hotels, package holidays and travel insurance. Trip.com, TravelSupermarket, Jet2 and more. Find the best deals for your budget.',
-    longDescription: 'Whether you are booking flights, hotels, or a package holiday, comparing prices across multiple providers can save you hundreds. Paybacker analyses your travel spending from bank transactions to help you budget for trips and find the best deals.',
+    description:
+      'Compare flights, hotels, package holidays and travel insurance. Trip.com, TravelSupermarket, Jet2 and more. Find the best deals for your budget.',
+    longDescription:
+      'Whether you are booking flights, hotels, or a package holiday, comparing prices across multiple providers can save you hundreds. Paybacker analyses your travel spending from bank transactions to help you budget for trips and find the best deals.',
     keywords: ['cheap flights UK', 'travel deals 2026', 'compare holidays', 'cheap hotels', 'travel insurance comparison'],
     avgSaving: '£400',
     switchTime: 'Book instantly',
     tipTitle: 'Book at the right time',
-    tipBody: 'For flights, booking 6-8 weeks in advance typically gets the best prices. For hotels, check multiple comparison sites as prices vary significantly. Travel insurance is cheapest when bought independently, not from the airline.',
+    tipBody:
+      'For flights, booking 6-8 weeks in advance typically gets the best prices. For hotels, check multiple comparison sites as prices vary significantly. Travel insurance is cheapest when bought independently, not from the airline.',
     deals: [
-      { id: 'jet2holidays', provider: 'Jet2holidays', headline: 'ATOL-protected packages', saving: 'Save on holidays', awinMid: '18730', providerUrl: 'https://www.jet2holidays.com', verified: true, featured: true, accent: 'from-red-500 to-rose-500' },
-      { id: 'trip-com', provider: 'Trip.com', headline: 'Flights, hotels and holidays', saving: 'Save on travel', awinMid: '22405', providerUrl: 'https://uk.trip.com', verified: true, featured: true, accent: 'from-blue-500 to-indigo-500' },
-      { id: 'jet2', provider: 'Jet2.com', headline: 'Flights from UK airports', saving: 'Save on flights', awinMid: '18729', providerUrl: 'https://www.jet2.com', verified: true, accent: 'from-red-500 to-orange-500' },
-      { id: 'gotogate', provider: 'Gotogate', headline: '700+ airlines worldwide', saving: 'Find cheapest flights', awinMid: '112834', providerUrl: 'https://www.gotogate.co.uk', verified: true, accent: 'from-sky-500 to-cyan-500' },
-      { id: 'mytrip', provider: 'Mytrip', headline: 'Cheap flights worldwide', saving: 'Compare airlines', awinMid: '112832', providerUrl: 'https://www.mytrip.com', verified: true, accent: 'from-teal-500 to-emerald-500' },
-      { id: 'travelsupermarket', provider: 'TravelSupermarket', headline: 'Insurance, car hire, holidays', saving: '17% on insurance', awinMid: '8734', providerUrl: 'https://www.travelsupermarket.com' },
+      { id: 'trip-com',          provider: 'Trip.com',           headline: 'Flights, hotels and holidays',  saving: 'Save on travel',       awinMid: '22405',  providerUrl: 'https://uk.trip.com' },
+      { id: 'travelsupermarket', provider: 'TravelSupermarket',  headline: 'Insurance, car hire, holidays', saving: '17% on insurance',     awinMid: '8734',   providerUrl: 'https://www.travelsupermarket.com' },
+      { id: 'jet2',              provider: 'Jet2.com',           headline: 'Flights from UK airports',       saving: 'Save on flights',      awinMid: '18729',  providerUrl: 'https://www.jet2.com' },
+      { id: 'jet2holidays',      provider: 'Jet2holidays',       headline: 'ATOL-protected packages',         saving: 'Save on holidays',     awinMid: '18730',  providerUrl: 'https://www.jet2holidays.com' },
+      { id: 'gotogate',          provider: 'Gotogate',           headline: '700+ airlines worldwide',         saving: 'Find cheapest flights', awinMid: '112834', providerUrl: 'https://www.gotogate.co.uk' },
+      { id: 'mytrip',            provider: 'Mytrip',             headline: 'Cheap flights worldwide',         saving: 'Compare airlines',     awinMid: '112832', providerUrl: 'https://www.mytrip.com' },
     ],
   },
 };
@@ -248,245 +278,117 @@ export async function generateMetadata({ params }: { params: Promise<{ category:
   };
 }
 
-function VerifiedDealCard({ deal, featured }: { deal: Deal; featured: boolean }) {
-  const initials = deal.provider
-    .replace(/[^A-Za-z0-9 ]/g, '')
-    .split(' ')
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((w) => w[0]?.toUpperCase() ?? '')
-    .join('') || '??';
-  const accent = deal.accent || 'from-mint-400 to-emerald-500';
-
-  return (
-    <div className={`relative group bg-gradient-to-br from-navy-900 to-navy-950 rounded-2xl p-[1px] ${featured ? 'bg-gradient-to-br from-amber-400/60 via-mint-400/40 to-emerald-500/60' : 'bg-gradient-to-br from-mint-400/40 to-navy-700/50'} transition-all hover:scale-[1.01]`}>
-      <div className="relative bg-navy-900 rounded-2xl p-6 md:p-7 h-full">
-        {featured && (
-          <div className="absolute -top-3 left-5 inline-flex items-center gap-1 bg-gradient-to-r from-amber-400 to-amber-500 text-navy-950 text-[11px] font-bold uppercase tracking-wider px-3 py-1 rounded-full shadow-lg shadow-amber-500/30">
-            <Star className="h-3 w-3 fill-current" /> Featured Deal
-          </div>
-        )}
-        <div className="flex items-start gap-5">
-          <div className={`flex-shrink-0 w-14 h-14 md:w-16 md:h-16 rounded-2xl bg-gradient-to-br ${accent} flex items-center justify-center text-white font-bold text-lg md:text-xl shadow-lg`}>
-            {initials}
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h3 className="text-white font-bold text-lg md:text-xl">{deal.provider}</h3>
-              <span className="inline-flex items-center gap-1 bg-mint-400/15 text-mint-300 text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full border border-mint-400/30">
-                <ShieldCheck className="h-3 w-3" /> Verified
-              </span>
-            </div>
-            <p className="text-slate-300 text-sm leading-relaxed">{deal.headline}</p>
-            {deal.promoCode && (
-              <p className="mt-2 text-xs text-amber-300">
-                Promo code:{' '}
-                <span className="font-mono font-bold bg-amber-500/10 border border-amber-500/30 text-amber-200 px-2 py-0.5 rounded">{deal.promoCode}</span>
-              </p>
-            )}
-          </div>
-        </div>
-        <div className="mt-5 flex items-center justify-between gap-4">
-          <div className="text-mint-400 font-bold text-base md:text-lg flex items-center gap-1.5">
-            <TrendingDown className="h-4 w-4" />
-            {deal.saving}
-          </div>
-          <a
-            href={deal.awinUrl || buildAwinUrl(deal.awinMid, deal.providerUrl)}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-5 py-2.5 rounded-xl text-sm transition-all shadow-[--shadow-glow-mint]"
-          >
-            View Deal <ArrowRight className="h-4 w-4" />
-          </a>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ComparisonDealRow({ deal }: { deal: Deal }) {
-  return (
-    <div className="bg-navy-900/60 border border-navy-700/50 rounded-xl p-5 hover:border-slate-500/40 transition-all flex items-center justify-between gap-4">
-      <div className="flex items-center gap-4 min-w-0">
-        <Search className="h-5 w-5 text-slate-500 flex-shrink-0" />
-        <div className="min-w-0">
-          <h4 className="text-slate-100 font-semibold text-sm">{deal.provider}</h4>
-          <p className="text-slate-500 text-xs mt-0.5">{deal.headline}</p>
-        </div>
-      </div>
-      <a
-        href={deal.awinUrl || buildAwinUrl(deal.awinMid, deal.providerUrl)}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center gap-1 text-slate-300 hover:text-mint-400 text-xs font-medium whitespace-nowrap transition-all"
-      >
-        Compare <ArrowRight className="h-3 w-3" />
-      </a>
-    </div>
-  );
-}
-
 export default async function CategoryDealsPage({ params }: { params: Promise<{ category: string }> }) {
   const { category } = await params;
   const cat = CATEGORIES[category];
   if (!cat) notFound();
 
-  // Split deals: verified partners first (featured within them at the top), then comparison sites
-  const verifiedDeals = cat.deals
-    .filter((d) => d.verified)
-    .sort((a, b) => Number(Boolean(b.featured)) - Number(Boolean(a.featured)));
-  const comparisonDeals = cat.deals.filter((d) => !d.verified);
-  const categoryLabel = category.replace('-', ' ');
+  const label = category.replace('-', ' ');
 
   return (
-    <div className="min-h-screen bg-navy-950">
-      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-mint-900/20 via-transparent to-transparent" />
+    <div className="m-land-root">
+      <MarkNav />
+      <main className="deals-shell">
+        <div className="wrap">
+          <nav className="deal-breadcrumb" aria-label="Breadcrumb">
+            <Link href="/">Home</Link>
+            <span className="sep">/</span>
+            <Link href="/deals">Deals</Link>
+            <span className="sep">/</span>
+            <span className="current">{label}</span>
+          </nav>
 
-      <div className="relative">
-        {/* Header */}
-        <PublicNavbar />
-        <div className="h-16" />
+          <header className="deal-hero">
+            <h1>{cat.h1}</h1>
+            <p className="intro">{cat.longDescription}</p>
+          </header>
 
-        <main className="container mx-auto px-6 py-12">
-          {/* Breadcrumb */}
-          <div className="max-w-5xl mx-auto mb-8">
-            <div className="flex items-center gap-2 text-sm text-slate-500">
-              <Link href="/" className="hover:text-white transition-all">Home</Link>
-              <span>/</span>
-              <Link href="/deals" className="hover:text-white transition-all">Deals</Link>
-              <span>/</span>
-              <span className="text-slate-300 capitalize">{categoryLabel}</span>
+          <div className="stat-row">
+            <div className="stat-card">
+              <TrendingDown className="h-6 w-6" aria-hidden="true" />
+              <div className="val">{cat.avgSaving}</div>
+              <div className="lab">Average yearly saving</div>
+            </div>
+            <div className="stat-card">
+              <Clock className="h-6 w-6" aria-hidden="true" />
+              <div className="val">{cat.switchTime}</div>
+              <div className="lab">Typical switch time</div>
+            </div>
+            <div className="stat-card blue">
+              <Zap className="h-6 w-6" aria-hidden="true" />
+              <div className="val">{cat.deals.length}</div>
+              <div className="lab">Deals to compare</div>
             </div>
           </div>
 
-          {/* Hero */}
-          <div className="max-w-5xl mx-auto mb-12">
-            <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 font-[family-name:var(--font-heading)]">{cat.h1}</h1>
-            <p className="text-xl text-slate-300 mb-8 leading-relaxed">{cat.longDescription}</p>
-
-            <div className="grid grid-cols-3 gap-4 mb-8">
-              <div className="bg-navy-900 border border-green-500/20 rounded-2xl p-4 text-center">
-                <TrendingDown className="h-6 w-6 text-green-400 mx-auto mb-2" />
-                <p className="text-green-400 font-bold text-xl">{cat.avgSaving}</p>
-                <p className="text-slate-500 text-xs">Average yearly saving</p>
-              </div>
-              <div className="bg-navy-900 border border-mint-400/20 rounded-2xl p-4 text-center">
-                <Clock className="h-6 w-6 text-mint-400 mx-auto mb-2" />
-                <p className="text-mint-400 font-bold text-xl">{cat.switchTime}</p>
-                <p className="text-slate-500 text-xs">Typical switch time</p>
-              </div>
-              <div className="bg-navy-900 border border-blue-500/20 rounded-2xl p-4 text-center">
-                <Zap className="h-6 w-6 text-blue-400 mx-auto mb-2" />
-                <p className="text-blue-400 font-bold text-xl">{cat.deals.length}</p>
-                <p className="text-slate-500 text-xs">Deals to compare</p>
-              </div>
-            </div>
-          </div>
-
-          {/* Verified Partner Deals */}
-          {verifiedDeals.length > 0 && (
-            <div className="max-w-5xl mx-auto mb-12">
-              <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
-                <div>
-                  <div className="inline-flex items-center gap-2 rounded-full bg-mint-400/10 px-3 py-1.5 text-xs text-mint-400 border border-mint-400/20 mb-3">
-                    <ShieldCheck className="h-3.5 w-3.5" />
-                    <span>Paybacker verified partners</span>
-                  </div>
-                  <h2 className="text-2xl md:text-3xl font-bold text-white font-[family-name:var(--font-heading)] capitalize">
-                    Top {categoryLabel} deals
-                  </h2>
-                  <p className="text-slate-400 text-sm mt-1">
-                    Direct partner offers — when you switch through one of these, you support Paybacker at no extra cost.
-                  </p>
+          <h2 className="deals-section-head">Top {label} deals</h2>
+          <div className="deals-list">
+            {cat.deals.map((deal) => (
+              <div key={deal.id} className="deal-row">
+                <div className="body">
+                  <p className="provider">{deal.provider}</p>
+                  <p className="headline">{deal.headline}</p>
+                  {deal.promoCode && (
+                    <p className="promo">
+                      Promo code: <span className="code">{deal.promoCode}</span>— apply at checkout
+                    </p>
+                  )}
                 </div>
-                <span className="text-xs text-slate-500 bg-navy-900 border border-navy-700/50 rounded-full px-3 py-1.5">
-                  {verifiedDeals.length} verified {verifiedDeals.length === 1 ? 'partner' : 'partners'}
-                </span>
+                <div className="right">
+                  <span className="saving">{deal.saving}</span>
+                  <a
+                    href={deal.awinUrl || buildAwinUrl(deal.awinMid, deal.providerUrl)}
+                    target="_blank"
+                    rel="noopener noreferrer sponsored"
+                    className="cta"
+                  >
+                    View deal <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </a>
+                </div>
               </div>
+            ))}
+          </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-                {verifiedDeals.map((deal) => (
-                  <VerifiedDealCard key={deal.id} deal={deal} featured={Boolean(deal.featured)} />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Comparison sites */}
-          {comparisonDeals.length > 0 && (
-            <div className="max-w-5xl mx-auto mb-12">
-              <div className="mb-4">
-                <h2 className="text-lg md:text-xl font-semibold text-slate-200 font-[family-name:var(--font-heading)]">
-                  More comparison options
-                </h2>
-                <p className="text-slate-500 text-xs mt-1">
-                  Price comparison aggregators — useful for a wider market sweep.
-                </p>
-              </div>
-              <div className="space-y-3">
-                {comparisonDeals.map((deal) => (
-                  <ComparisonDealRow key={deal.id} deal={deal} />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Warning (for mortgages/loans) */}
           {cat.warningText && (
-            <div className="max-w-5xl mx-auto mb-8">
-              <div className="bg-red-500/10 border border-red-500/20 rounded-2xl p-4 text-red-300 text-sm">
-                <strong>Important:</strong> {cat.warningText}
-              </div>
+            <div className="warning-box">
+              <strong>Important:</strong> {cat.warningText}
             </div>
           )}
 
-          {/* Tip */}
-          <div className="max-w-5xl mx-auto mb-12">
-            <div className="bg-mint-400/5 border border-mint-400/20 rounded-2xl p-6">
-              <h3 className="text-mint-400 font-semibold mb-2">{cat.tipTitle}</h3>
-              <p className="text-slate-300 text-sm">{cat.tipBody}</p>
-            </div>
+          <div className="tip-box">
+            <h3>{cat.tipTitle}</h3>
+            <p>{cat.tipBody}</p>
           </div>
 
-          {/* Paybacker CTA */}
-          <div className="max-w-5xl mx-auto mb-12">
-            <div className="bg-mint-400/10 border border-mint-400/20 rounded-2xl p-8 text-center">
-              <BarChart3 className="h-10 w-10 text-mint-400 mx-auto mb-4" />
-              <h2 className="text-2xl font-bold text-white mb-3 font-[family-name:var(--font-heading)] capitalize">Get personalised {categoryLabel} recommendations</h2>
-              <p className="text-slate-300 mb-6 max-w-xl mx-auto">Connect your bank account and Paybacker will analyse your actual bills, alert you before contracts renew, and show you the best deals based on what you really pay.</p>
-              <div className="flex flex-wrap justify-center gap-4 mb-6">
-                <span className="flex items-center gap-1.5 text-sm text-slate-400"><CheckCircle className="h-4 w-4 text-green-400" /> Free to start</span>
-                <span className="flex items-center gap-1.5 text-sm text-slate-400"><CheckCircle className="h-4 w-4 text-green-400" /> Bank-level security</span>
-                <span className="flex items-center gap-1.5 text-sm text-slate-400"><CheckCircle className="h-4 w-4 text-green-400" /> Renewal alerts at 30, 14, 7 days</span>
-              </div>
-              <Link href="/auth/signup" className="inline-block bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-8 py-4 rounded-xl transition-all text-lg">
-                Create Free Account
-              </Link>
+          <div className="deal-final-cta">
+            <div className="icon">
+              <BarChart3 className="h-6 w-6" aria-hidden="true" />
             </div>
+            <h2>Get personalised {label} recommendations</h2>
+            <p className="sub">
+              Connect your bank account and Paybacker will analyse your actual bills, alert
+              you before contracts renew, and show you the best deals based on what you
+              really pay.
+            </p>
+            <div className="tick-row">
+              <span><CheckCircle className="h-4 w-4" aria-hidden="true" /> Free to start</span>
+              <span><CheckCircle className="h-4 w-4" aria-hidden="true" /> Bank-level security</span>
+              <span><CheckCircle className="h-4 w-4" aria-hidden="true" /> Renewal alerts at 30, 14, 7 days</span>
+            </div>
+            <Link href="/auth/signup" className="btn-mint">
+              Create free account
+            </Link>
           </div>
 
-          {/* Affiliate Disclosure */}
-          <div className="max-w-5xl mx-auto mb-12">
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-4">
-              <p className="text-slate-500 text-xs"><strong className="text-slate-400">Affiliate disclosure:</strong> Some links on this page are affiliate links. If you switch through one of these links, we may receive a commission from the provider at no extra cost to you. This helps us keep Paybacker free for basic use. We only recommend providers we believe offer genuine value.</p>
-            </div>
+          <div className="disclosure">
+            <strong>Affiliate disclosure:</strong> Some links on this page are affiliate
+            links. If you switch through one of these links, we may receive a commission
+            from the provider at no extra cost to you. This helps us keep Paybacker free
+            for basic use. We only recommend providers we believe offer genuine value.
           </div>
-        </main>
-
-        {/* Footer */}
-        <footer className="border-t border-navy-700/50 py-8">
-          <div className="container mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
-            <div className="text-slate-500 text-sm">Paybacker LTD - paybacker.co.uk</div>
-            <div className="flex gap-4 text-slate-500 text-sm">
-              <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
-              <Link href="/about" className="hover:text-white transition-all">About</Link>
-              <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy</Link>
-              <Link href="/terms-of-service" className="hover:text-white transition-all">Terms</Link>
-            </div>
-          </div>
-        </footer>
-      </div>
+        </div>
+      </main>
+      <MarkFoot />
     </div>
   );
 }

--- a/src/app/deals/deals.css
+++ b/src/app/deals/deals.css
@@ -1,0 +1,382 @@
+/*
+ * Deals pages — scoped additions on top of .m-land-root.
+ *
+ * Used by /deals and /deals/[category]. Those routes mount content
+ * inside `<div className="m-land-root">` and import BOTH
+ * `@/app/(marketing)/styles.css` (for nav-shell/footer tokens) and
+ * this file (for the deals-specific primitives below).
+ */
+
+.m-land-root .deals-shell { padding: 56px 0 80px; }
+.m-land-root .deals-head {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 40px;
+}
+.m-land-root .deals-head h1 {
+  font-size: clamp(34px, 4.2vw, 44px);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.1;
+  margin: 0 0 14px;
+  color: var(--text-primary);
+}
+.m-land-root .deals-head p {
+  font-size: 17px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* Category grid ----------------------------------------------------- */
+.m-land-root .cat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  margin: 0 0 40px;
+}
+.m-land-root .cat-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 28px 26px 24px;
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+  transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+  display: block;
+}
+.m-land-root .cat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+  border-color: rgba(52, 211, 153, 0.35);
+}
+.m-land-root .cat-card .badge {
+  width: 48px; height: 48px;
+  border-radius: 12px;
+  background: var(--accent-mint-wash);
+  color: var(--accent-mint-deep);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 18px;
+  margin-bottom: 16px;
+}
+.m-land-root .cat-card h2 {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 6px;
+}
+.m-land-root .cat-card p {
+  font-size: 14.5px;
+  color: var(--text-secondary);
+  margin: 0 0 14px;
+  line-height: 1.5;
+}
+.m-land-root .cat-card .view {
+  color: var(--accent-mint-deep);
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.m-land-root .cat-hint {
+  text-align: center;
+  margin-top: 16px;
+}
+.m-land-root .cat-hint p {
+  font-size: 14px;
+  color: var(--text-tertiary);
+  margin: 0 0 16px;
+}
+.m-land-root .cat-hint .btn-mint {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 13px 22px;
+  border-radius: var(--r-pill);
+  background: var(--accent-mint);
+  color: #052E1C;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: var(--shadow-mint);
+  transition: transform 150ms ease, background 150ms ease;
+}
+.m-land-root .cat-hint .btn-mint:hover { transform: translateY(-1px); background: #2CC48A; }
+
+/* Category-detail page ---------------------------------------------- */
+.m-land-root .deal-breadcrumb {
+  font-size: 13.5px;
+  color: var(--text-tertiary);
+  margin: 0 0 16px;
+}
+.m-land-root .deal-breadcrumb a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+.m-land-root .deal-breadcrumb a:hover { color: var(--text-primary); text-decoration: underline; }
+.m-land-root .deal-breadcrumb .sep { margin: 0 8px; color: var(--text-tertiary); }
+.m-land-root .deal-breadcrumb .current { color: var(--text-primary); text-transform: capitalize; }
+
+.m-land-root .deal-hero {
+  max-width: 820px;
+  margin: 0 0 28px;
+}
+.m-land-root .deal-hero h1 {
+  font-size: clamp(34px, 4.4vw, 44px);
+  font-weight: 700;
+  letter-spacing: var(--track-tight);
+  line-height: 1.12;
+  margin: 0 0 16px;
+  color: var(--text-primary);
+}
+.m-land-root .deal-hero p.intro {
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  margin: 0 0 24px;
+}
+
+.m-land-root .stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0 0 40px;
+  max-width: 820px;
+}
+.m-land-root .stat-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 18px 16px;
+  text-align: center;
+  box-shadow: var(--shadow-sm);
+}
+.m-land-root .stat-card svg {
+  margin: 0 auto 8px;
+  color: var(--accent-mint-deep);
+}
+.m-land-root .stat-card.orange svg { color: var(--accent-orange-deep); }
+.m-land-root .stat-card.blue svg { color: #2563EB; }
+.m-land-root .stat-card .val {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: var(--track-tight);
+}
+.m-land-root .stat-card .lab {
+  font-size: 12.5px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+}
+
+/* Deal list --------------------------------------------------------- */
+.m-land-root .deals-section-head {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 16px;
+  letter-spacing: var(--track-tight);
+  text-transform: capitalize;
+}
+.m-land-root .deals-list {
+  display: grid;
+  gap: 12px;
+  max-width: 820px;
+  margin: 0 0 40px;
+}
+.m-land-root .deal-row {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 20px 22px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 150ms ease, border-color 150ms ease;
+}
+.m-land-root .deal-row:hover {
+  box-shadow: var(--shadow-md);
+  border-color: rgba(52, 211, 153, 0.35);
+}
+.m-land-root .deal-row .body { flex: 1; min-width: 0; }
+.m-land-root .deal-row .provider {
+  font-size: 16.5px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 4px;
+}
+.m-land-root .deal-row .headline {
+  font-size: 14.5px;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+.m-land-root .deal-row .promo {
+  font-size: 12.5px;
+  color: var(--accent-mint-deep);
+  margin-top: 8px;
+}
+.m-land-root .deal-row .promo .code {
+  font-family: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  font-weight: 700;
+  background: var(--accent-mint-wash);
+  color: var(--accent-mint-deep);
+  padding: 2px 8px;
+  border-radius: 6px;
+  margin: 0 4px;
+}
+.m-land-root .deal-row .right {
+  flex-shrink: 0;
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+.m-land-root .deal-row .saving {
+  font-size: 13.5px;
+  color: var(--accent-mint-deep);
+  font-weight: 700;
+}
+.m-land-root .deal-row .cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: var(--r-pill);
+  background: var(--accent-mint);
+  color: #052E1C;
+  font-weight: 600;
+  font-size: 13.5px;
+  text-decoration: none;
+  box-shadow: var(--shadow-mint);
+  transition: transform 150ms ease, background 150ms ease;
+  white-space: nowrap;
+}
+.m-land-root .deal-row .cta:hover { transform: translateY(-1px); background: #2CC48A; }
+
+/* Warning + tip ----------------------------------------------------- */
+.m-land-root .warning-box {
+  max-width: 820px;
+  margin: 0 0 24px;
+  padding: 14px 16px;
+  border-radius: var(--r-card);
+  background: #FEF2F2;
+  border: 1px solid #FEE2E2;
+  color: #991B1B;
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+.m-land-root .warning-box strong { color: #7F1D1D; }
+
+.m-land-root .tip-box {
+  max-width: 820px;
+  margin: 0 0 40px;
+  padding: 22px 24px;
+  border-radius: var(--r-card);
+  background: var(--accent-mint-wash);
+  border: 1px solid rgba(52, 211, 153, 0.25);
+}
+.m-land-root .tip-box h3 {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--accent-mint-deep);
+  margin: 0 0 6px;
+}
+.m-land-root .tip-box p {
+  font-size: 14.5px;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.55;
+}
+
+/* Final CTA --------------------------------------------------------- */
+.m-land-root .deal-final-cta {
+  max-width: 820px;
+  margin: 0 0 40px;
+  padding: 36px 32px;
+  border-radius: var(--r-card);
+  background: linear-gradient(180deg, #F5FFFB 0%, #ECFBF3 100%);
+  border: 1px solid rgba(52, 211, 153, 0.25);
+  text-align: center;
+}
+.m-land-root .deal-final-cta .icon {
+  width: 56px; height: 56px;
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: var(--shadow-sm);
+  display: grid; place-items: center;
+  margin: 0 auto 16px;
+  color: var(--accent-mint-deep);
+}
+.m-land-root .deal-final-cta h2 {
+  font-size: clamp(22px, 2.4vw, 26px);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 10px;
+  letter-spacing: var(--track-tight);
+}
+.m-land-root .deal-final-cta p.sub {
+  font-size: 15px;
+  color: var(--text-secondary);
+  margin: 0 auto 20px;
+  max-width: 480px;
+  line-height: 1.55;
+}
+.m-land-root .deal-final-cta .tick-row {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 22px;
+}
+.m-land-root .deal-final-cta .tick-row span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.m-land-root .deal-final-cta .tick-row svg { color: var(--accent-mint-deep); }
+.m-land-root .deal-final-cta .btn-mint {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 26px;
+  border-radius: var(--r-pill);
+  background: var(--accent-mint);
+  color: #052E1C;
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  box-shadow: var(--shadow-mint);
+  transition: transform 150ms ease, background 150ms ease;
+}
+.m-land-root .deal-final-cta .btn-mint:hover { transform: translateY(-1px); background: #2CC48A; }
+
+/* Disclosure -------------------------------------------------------- */
+.m-land-root .disclosure {
+  max-width: 820px;
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: var(--r-card);
+  background: var(--surface-elevated);
+  border: 1px solid var(--divider);
+  color: var(--text-tertiary);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+.m-land-root .disclosure strong { color: var(--text-secondary); }
+
+/* Responsive ------------------------------------------------------- */
+@media (max-width: 960px) {
+  .m-land-root .cat-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 640px) {
+  .m-land-root .cat-grid { grid-template-columns: 1fr; }
+  .m-land-root .stat-row { grid-template-columns: 1fr; }
+  .m-land-root .deal-row { flex-direction: column; align-items: flex-start; }
+  .m-land-root .deal-row .right { align-items: flex-start; text-align: left; }
+  .m-land-root .deals-shell { padding: 36px 0 56px; }
+}

--- a/src/app/deals/page.tsx
+++ b/src/app/deals/page.tsx
@@ -1,131 +1,69 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import PublicNavbar from '@/components/PublicNavbar';
-import { ShieldCheck, BadgeCheck, Star, ArrowRight } from 'lucide-react';
+import { MarkNav, MarkFoot } from '@/app/blog/_shared';
+import '../(marketing)/styles.css';
+import './deals.css';
 
 export const metadata: Metadata = {
   title: 'Compare UK Deals - Energy, Broadband, Mobile, Insurance | Paybacker',
-  description: 'Compare 53+ deals from verified UK providers. Energy, broadband, mobile, insurance, mortgages, loans, and more. Find cheaper alternatives and switch.',
+  description:
+    'Compare 53+ deals from verified UK providers. Energy, broadband, mobile, insurance, mortgages, loans, and more. Find cheaper alternatives and switch.',
 };
 
 const categories = [
-  { slug: 'broadband', name: 'Broadband', count: 10, verifiedCount: 7, color: 'from-blue-500 to-cyan-500', desc: 'Find faster, cheaper broadband', topPartners: 'BT, Sky, Virgin Media, Plusnet', save: 'Save up to £240/yr' },
-  { slug: 'mobile', name: 'Mobile', count: 12, verifiedCount: 10, color: 'from-green-500 to-emerald-500', desc: 'SIM-only and contract deals', topPartners: 'EE, Vodafone, O2, Three, giffgaff', save: 'Save up to £180/yr' },
-  { slug: 'energy', name: 'Energy', count: 4, verifiedCount: 3, color: 'from-amber-500 to-orange-500', desc: 'Compare gas and electricity tariffs', topPartners: 'E.ON, EDF, OVO', save: 'Save up to £450/yr' },
-  { slug: 'insurance', name: 'Insurance', count: 6, verifiedCount: 2, color: 'from-purple-500 to-violet-500', desc: 'Home, car, and life insurance', topPartners: 'RAC, AA', save: 'Save up to £320/yr' },
-  { slug: 'mortgages', name: 'Mortgages', count: 4, verifiedCount: 3, color: 'from-red-500 to-rose-500', desc: 'Compare mortgage rates', topPartners: 'Habito, Maze, L&C', save: 'Find best rate' },
-  { slug: 'loans', name: 'Loans', count: 5, verifiedCount: 3, color: 'from-sky-500 to-blue-500', desc: 'Personal and business loans', topPartners: 'Freedom Finance, AA, Loan.co.uk', save: 'From 3.9% APR' },
-  { slug: 'credit-cards', name: 'Credit Cards', count: 4, verifiedCount: 2, color: 'from-indigo-500 to-purple-500', desc: 'Balance transfer and rewards', topPartners: 'TotallyMoney, MSE', save: '0% up to 30 months' },
-  { slug: 'car-finance', name: 'Car Finance', count: 2, verifiedCount: 2, color: 'from-slate-500 to-zinc-500', desc: 'PCP, HP, and lease deals', topPartners: 'Carwow, Zuto', save: 'Beat dealer price' },
-  { slug: 'travel', name: 'Travel', count: 6, verifiedCount: 4, color: 'from-teal-500 to-cyan-500', desc: 'Flights, hotels, and packages', topPartners: 'Jet2, Trip.com, Gotogate', save: 'Save up to 40%' },
-];
-
-const featuredPartners = [
-  { name: 'BT', accent: 'from-purple-500 to-indigo-500' },
-  { name: 'Sky', accent: 'from-blue-500 to-sky-500' },
-  { name: 'Virgin Media', accent: 'from-red-500 to-rose-500' },
-  { name: 'EE', accent: 'from-teal-500 to-cyan-500' },
-  { name: 'Vodafone', accent: 'from-red-600 to-red-500' },
-  { name: 'O2', accent: 'from-blue-600 to-indigo-500' },
-  { name: 'Three', accent: 'from-slate-500 to-slate-400' },
-  { name: 'E.ON', accent: 'from-rose-500 to-pink-500' },
-  { name: 'EDF', accent: 'from-orange-500 to-amber-500' },
-  { name: 'OVO', accent: 'from-emerald-500 to-green-500' },
-  { name: 'giffgaff', accent: 'from-lime-500 to-yellow-400' },
-  { name: 'Plusnet', accent: 'from-pink-500 to-rose-500' },
-  { name: 'RAC', accent: 'from-orange-500 to-red-500' },
-  { name: 'Habito', accent: 'from-violet-500 to-purple-500' },
+  { slug: 'energy',       name: 'Energy',       count: 4,  desc: 'Compare gas and electricity tariffs' },
+  { slug: 'broadband',    name: 'Broadband',    count: 10, desc: 'Find faster, cheaper broadband' },
+  { slug: 'mobile',       name: 'Mobile',       count: 12, desc: 'SIM-only and contract deals' },
+  { slug: 'insurance',    name: 'Insurance',    count: 6,  desc: 'Home, car, and life insurance' },
+  { slug: 'mortgages',    name: 'Mortgages',    count: 4,  desc: 'Compare mortgage rates' },
+  { slug: 'loans',        name: 'Loans',        count: 5,  desc: 'Personal and business loans' },
+  { slug: 'credit-cards', name: 'Credit Cards', count: 4,  desc: 'Balance transfer and rewards' },
+  { slug: 'car-finance',  name: 'Car Finance',  count: 2,  desc: 'PCP, HP, and lease deals' },
+  { slug: 'travel',       name: 'Travel',       count: 6,  desc: 'Flights, hotels, and packages' },
 ];
 
 export default function PublicDealsPage() {
   return (
-    <div className="min-h-screen bg-navy-950">
-      <PublicNavbar />
-      <div className="h-16" />
+    <div className="m-land-root">
+      <MarkNav />
+      <main className="deals-shell">
+        <div className="wrap">
+          <header className="deals-head">
+            <h1>Compare 53+ UK deals</h1>
+            <p>
+              Find cheaper alternatives to what you&apos;re paying now. Free to browse, no
+              signup needed.
+            </p>
+          </header>
 
-      <main className="container mx-auto px-6 py-12 max-w-6xl">
-        <div className="text-center mb-10">
-          <div className="inline-flex items-center gap-2 rounded-full bg-mint-400/10 px-3 py-1.5 text-xs text-mint-400 border border-mint-400/20 mb-6">
-            <ShieldCheck className="h-3.5 w-3.5" />
-            <span>Verified UK Partners</span>
-          </div>
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">Compare 53+ Verified UK Deals</h1>
-          <p className="text-lg text-slate-300 max-w-2xl mx-auto">Trusted partnerships with the UK&apos;s biggest providers. Free to browse, no signup needed.</p>
-        </div>
-
-        {/* Verified partners strip */}
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 md:p-6 mb-10">
-          <div className="flex items-center gap-2 justify-center mb-4">
-            <BadgeCheck className="h-4 w-4 text-mint-400" />
-            <span className="text-xs uppercase tracking-wider text-slate-400 font-semibold">Our verified partners include</span>
-          </div>
-          <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3">
-            {featuredPartners.map((p) => (
-              <span
-                key={p.name}
-                className={`px-3 py-1.5 rounded-lg text-xs font-semibold text-white bg-gradient-to-br ${p.accent} shadow-sm whitespace-nowrap`}
+          <div className="cat-grid">
+            {categories.map((cat) => (
+              <Link
+                key={cat.slug}
+                href={`/deals/${cat.slug}`}
+                className="cat-card"
+                aria-label={`${cat.name} deals — ${cat.count} to compare`}
               >
-                {p.name}
-              </span>
+                <div className="badge">{cat.count}</div>
+                <h2>{cat.name}</h2>
+                <p>{cat.desc}</p>
+                <span className="view">View {cat.count} deals &rarr;</span>
+              </Link>
             ))}
-            <span className="px-3 py-1.5 rounded-lg text-xs font-semibold text-mint-400 bg-navy-800 border border-mint-400/20 whitespace-nowrap">
-              +40 more
-            </span>
           </div>
-        </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-          {categories.map(cat => (
-            <Link key={cat.slug} href={`/deals/${cat.slug}`} className="relative bg-navy-900 border border-navy-700/50 rounded-2xl p-6 hover:border-mint-400/40 transition-all group overflow-hidden shadow-[--shadow-card] hover:shadow-[--shadow-glow-mint]">
-              <div className={`absolute -top-8 -right-8 w-32 h-32 rounded-full bg-gradient-to-br ${cat.color} opacity-10 group-hover:opacity-20 blur-2xl transition-opacity`} />
-              <div className="relative">
-                <div className="flex items-start justify-between mb-4">
-                  <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${cat.color} flex items-center justify-center shadow-sm`}>
-                    <span className="text-white font-bold text-lg">{cat.count}</span>
-                  </div>
-                  {cat.verifiedCount > 0 && (
-                    <div className="inline-flex items-center gap-1 bg-mint-400/10 text-mint-400 text-[10px] font-semibold px-2 py-1 rounded-full border border-mint-400/20">
-                      <ShieldCheck className="h-3 w-3" />
-                      {cat.verifiedCount} verified
-                    </div>
-                  )}
-                </div>
-                <h2 className="text-xl font-bold text-white mb-1 group-hover:text-mint-400 transition-colors">{cat.name}</h2>
-                <p className="text-mint-400 text-xs font-semibold mb-2 flex items-center gap-1">
-                  <Star className="h-3 w-3 fill-mint-400" />
-                  {cat.save}
-                </p>
-                <p className="text-slate-400 text-sm mb-3">{cat.desc}</p>
-                <p className="text-slate-500 text-xs mb-4 truncate">Featuring {cat.topPartners}</p>
-                <span className="inline-flex items-center gap-1 text-mint-400 text-sm font-medium">
-                  Compare {cat.count} deals <ArrowRight className="h-3.5 w-3.5 group-hover:translate-x-0.5 transition-transform" />
-                </span>
-              </div>
+          <div className="cat-hint">
+            <p>
+              Already tracking your subscriptions? Sign in to see personalised deal
+              recommendations.
+            </p>
+            <Link href="/auth/signup" className="btn-mint">
+              Sign up free
             </Link>
-          ))}
-        </div>
-
-        <div className="mt-12 text-center bg-gradient-to-br from-navy-900 to-navy-800 border border-mint-400/20 rounded-2xl p-8">
-          <p className="text-white font-semibold text-lg mb-2">Get personalised recommendations</p>
-          <p className="text-slate-400 text-sm mb-5 max-w-xl mx-auto">Connect your email or bank and we&apos;ll match you to the verified partners where you can save the most.</p>
-          <Link href="/auth/signup" className="bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-8 py-3 rounded-xl transition-all inline-flex items-center gap-2 shadow-[--shadow-glow-mint]">
-            Sign Up Free <ArrowRight className="h-4 w-4" />
-          </Link>
+          </div>
         </div>
       </main>
-
-      <footer className="border-t border-navy-700/50 bg-navy-950 mt-16">
-        <div className="container mx-auto px-6 py-12 max-w-5xl">
-          <div className="flex flex-col md:flex-row items-center justify-between gap-4">
-            <span className="text-slate-500 text-sm">&copy; 2026 Paybacker LTD. All rights reserved.</span>
-            <div className="flex items-center gap-6 text-sm">
-              <Link href="/privacy-policy" className="text-slate-500 hover:text-white transition-all">Privacy Policy</Link>
-              <Link href="/terms-of-service" className="text-slate-500 hover:text-white transition-all">Terms of Service</Link>
-              <a href="mailto:hello@paybacker.co.uk" className="text-slate-500 hover:text-white transition-all">Contact</a>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <MarkFoot />
     </div>
   );
 }


### PR DESCRIPTION
Batch 6b: public deals directory moves to the light theme.

### What's in here

| Route | Before | After |
|---|---|---|
| `/deals` | Dark navy-950 + PublicNavbar, colour-gradient category squares | Light `.m-land-root` + MarkNav + `.cat-card` grid |
| `/deals/[category]` | Dark navy-950 + PublicNavbar, 9 categories | Light `.m-land-root` + MarkNav + `.deal-row` list |

### Design system

Same scoped-root pattern as the rest of the marketing redesign:

- Each deals page wraps content in `<div className="m-land-root">` and
  imports both `(marketing)/styles.css` (nav-shell, footer tokens) and a
  new `deals/deals.css` (category grid, deal rows, stats, CTA).
- MarkNav + MarkFoot from `@/app/blog/_shared` replaces the old
  `PublicNavbar` and inline footer block.
- `.cat-card` = white card, `--shadow-sm` → `--shadow-md` on hover, mint
  badge number. Matches the visual weight of blog post cards.
- `.deal-row` = white card with provider name + headline + saving badge
  + mint pill CTA. Hover lifts `--shadow-md` + mint border.
- `.stat-row` = 3-up stat cards (Average yearly saving / Typical switch
  time / Deals to compare).
- `.tip-box` = mint wash panel with coloured heading. Same rhythm as
  `.rights-card` elsewhere.
- `.deal-final-cta` = mint-gradient panel with tick row + mint CTA pill.
- `.warning-box` = red-50 / red-100 surface for mortgages + loans risk
  warnings, matching the form-error pattern from /auth.

### Content + logic untouched

Every category, deal, affiliate `awinMid`, and copy line is preserved:

- **9 categories**: energy (4 deals), broadband (10), mobile (12),
  insurance (6), mortgages (4), loans (5), credit-cards (4),
  car-finance (2), travel (6) — 53 deals total, identical IDs + merchant
  IDs to master.
- **Affiliate tracking**: `buildAwinUrl()` helper unchanged. Uses
  `NEXT_PUBLIC_AWIN_AFF_ID` env var. Lebara promo codes (LEBARA5,
  LEBARA10, SAVE50) preserved including the explicit `awinUrl` override.
- **SEO**: `generateStaticParams()`, `generateMetadata()` (title,
  description, keywords, openGraph, twitter, canonical) unchanged.
- **Regulatory copy**: mortgage + loan warning text preserved verbatim.
- **Affiliate disclosure**: full paragraph preserved verbatim.

### Accessibility

- Breadcrumb wrapped in `<nav aria-label="Breadcrumb">`.
- All decorative Lucide icons marked `aria-hidden="true"`.
- Category cards have `aria-label` describing count + category name.
- Outbound affiliate links now use `rel="noopener noreferrer sponsored"`
  (was `rel="noopener noreferrer"`) per Google's affiliate link guidance.

### Checks

- `npx tsc --noEmit`: clean for all 3 files. Pre-existing errors
  elsewhere in the repo are unchanged.
- No API keys, no new env vars, no database changes.
- Zero behaviour change to affiliate tracking.

### What's still pending after this

- **Batch 6c** — `/solutions/[slug]` (8 pages), `/complaints/[company]`,
  `/debt-collection-letter` (SEO content pages with FAQ JSON-LD).
- **Batch 6d** — `/docs/paybacker-assistant` (MCP setup docs).
- **Batch 7+** — dashboard shell + page bodies (behind auth).
