### PR TITLE
feat(marketing): redesign SEO content pages to light theme (batch 6c)

### DIFF
--- a/src/app/complaints/[company]/page.tsx
+++ b/src/app/complaints/[company]/page.tsx
@@ -1,7 +1,10 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
 import { COMPANIES, getCompanyBySlug } from '@/data/companies';
+import { MarkNav, MarkFoot } from '@/app/blog/_shared';
 import type { Metadata } from 'next';
+import '../../(marketing)/styles.css';
 
 interface Props {
   params: Promise<{ company: string }>;
@@ -103,153 +106,148 @@ export default async function CompanyPage({ params }: Props) {
   }
 
   const categoryLabel = CATEGORY_LABELS[company.category] ?? 'service provider';
-  const escalation = REGULATOR_ESCALATION[company.regulator] ?? REGULATOR_ESCALATION['Trading Standards'];
+  const escalation =
+    REGULATOR_ESCALATION[company.regulator] ?? REGULATOR_ESCALATION['Trading Standards'];
+
+  const steps = [
+    {
+      step: '1',
+      title: 'Gather your evidence',
+      body:
+        'Collect all relevant bills, invoices, emails, and account statements. Note the dates of any incorrect charges or service failures. The more specific you are, the harder it is for the company to dismiss your complaint.',
+    },
+    {
+      step: '2',
+      title: 'Submit a formal written complaint',
+      body: `Contact ${company.name} in writing — by email or letter — stating clearly: what went wrong, what you want them to do (refund, fix, compensation), and a deadline for their response (typically 14 days). Written complaints create a paper trail and trigger their formal complaints process.`,
+    },
+    {
+      step: '3',
+      title: 'Cite the law',
+      body:
+        'Reference the Consumer Rights Act 2015 in your letter. Mention that you are entitled to a service carried out with reasonable care and skill, and that you expect a resolution within 14 days. This signals you know your rights and are prepared to escalate.',
+    },
+    {
+      step: '4',
+      title: 'Keep a record',
+      body:
+        'Save all correspondence, including reference numbers. If you speak to anyone by phone, note the date, time, and name of the person you spoke to. This becomes essential if you need to escalate.',
+    },
+  ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-white">
-      {/* Background effect */}
-      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-amber-900/10 via-transparent to-transparent pointer-events-none" />
-
-      <div className="relative max-w-3xl mx-auto px-4 py-12 md:py-20">
-        {/* Header */}
-        <div className="mb-8">
-          <Link href="/" className="text-amber-400 text-sm hover:text-amber-300 transition-colors">
-            ← Paybacker
-          </Link>
-        </div>
-
-        <h1 className="text-3xl md:text-4xl font-bold text-white mb-4">
-          How to complain to {company.name} — and get results
-        </h1>
-
-        <p className="text-slate-400 text-lg mb-10">
-          If you have a dispute with {company.name}, you have strong rights under UK consumer law.
-          Here is exactly how to escalate your complaint and get the outcome you deserve.
-        </p>
-
-        {/* Section 1: Your rights */}
-        <section className="mb-10">
-          <h2 className="text-xl font-semibold text-amber-400 mb-3">
-            Your rights when complaining to {company.name}
-          </h2>
-          <div className="bg-slate-800/50 border border-slate-700 rounded-xl p-6 space-y-3 text-slate-300">
-            <p>
-              As a UK consumer, you are protected by the{' '}
-              <strong className="text-white">Consumer Rights Act 2015</strong>, which requires that
-              services are carried out with reasonable care and skill and that goods are of
-              satisfactory quality. If {company.name} has charged you incorrectly, provided a poor
-              service, or failed to deliver what was promised, you have the right to complain and
-              seek a remedy.
+    <div className="m-land-root">
+      <MarkNav />
+      <main>
+        <div className="wrap">
+          <section className="land-hero" style={{ paddingBottom: 24 }}>
+            <span className="badge">UK consumer rights</span>
+            <h1>How to complain to {company.name} — and get results</h1>
+            <p className="subtitle">
+              If you have a dispute with {company.name}, you have strong rights under UK
+              consumer law. Here is exactly how to escalate your complaint and get the
+              outcome you deserve.
             </p>
-            <p>
-              {company.name} is a regulated {categoryLabel}. Their regulator is{' '}
-              <strong className="text-white">{company.regulator}</strong>, which means they must
-              follow a formal complaints handling process. If they fail to resolve your complaint
-              satisfactorily, you can escalate to an independent ombudsman at no cost to you.
-            </p>
-            {company.phone && (
-              <p>
-                <strong className="text-white">{company.name} complaints line:</strong>{' '}
-                <span className="text-amber-400">{company.phone}</span>
-              </p>
-            )}
-          </div>
-        </section>
+          </section>
 
-        {/* Section 2: Step-by-step */}
-        <section className="mb-10">
-          <h2 className="text-xl font-semibold text-amber-400 mb-3">
-            Step-by-step: how to make a formal complaint to {company.name}
-          </h2>
-          <div className="space-y-4">
-            {[
-              {
-                step: '1',
-                title: 'Gather your evidence',
-                body: 'Collect all relevant bills, invoices, emails, and account statements. Note the dates of any incorrect charges or service failures. The more specific you are, the harder it is for the company to dismiss your complaint.',
-              },
-              {
-                step: '2',
-                title: 'Submit a formal written complaint',
-                body: `Contact ${company.name} in writing — by email or letter — stating clearly: what went wrong, what you want them to do (refund, fix, compensation), and a deadline for their response (typically 14 days). Written complaints create a paper trail and trigger their formal complaints process.`,
-              },
-              {
-                step: '3',
-                title: 'Cite the law',
-                body: 'Reference the Consumer Rights Act 2015 in your letter. Mention that you are entitled to a service carried out with reasonable care and skill, and that you expect a resolution within 14 days. This signals you know your rights and are prepared to escalate.',
-              },
-              {
-                step: '4',
-                title: 'Keep a record',
-                body: 'Save all correspondence, including reference numbers. If you speak to anyone by phone, note the date, time, and name of the person you spoke to. This becomes essential if you need to escalate.',
-              },
-            ].map(({ step, title, body }) => (
-              <div
-                key={step}
-                className="flex gap-4 bg-slate-800/40 border border-slate-700/50 rounded-xl p-5"
-              >
-                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-amber-500/20 border border-amber-500/40 flex items-center justify-center text-amber-400 font-bold text-sm">
-                  {step}
-                </div>
-                <div>
-                  <h3 className="text-white font-medium mb-1">{title}</h3>
-                  <p className="text-slate-400 text-sm leading-relaxed">{body}</p>
-                </div>
+          <section className="prose-section" style={{ paddingTop: 24 }}>
+            <div className="rights-card">
+              <h2>Your rights when complaining to {company.name}</h2>
+              <div className="prose-body" style={{ margin: 0 }}>
+                <p>
+                  As a UK consumer, you are protected by the{' '}
+                  <strong>Consumer Rights Act 2015</strong>, which requires that services
+                  are carried out with reasonable care and skill and that goods are of
+                  satisfactory quality. If {company.name} has charged you incorrectly,
+                  provided a poor service, or failed to deliver what was promised, you have
+                  the right to complain and seek a remedy.
+                </p>
+                <p>
+                  {company.name} is a regulated {categoryLabel}. Their regulator is{' '}
+                  <strong>{company.regulator}</strong>, which means they must follow a
+                  formal complaints handling process. If they fail to resolve your
+                  complaint satisfactorily, you can escalate to an independent ombudsman at
+                  no cost to you.
+                </p>
+                {company.phone && (
+                  <p>
+                    <strong>{company.name} complaints line:</strong>{' '}
+                    <span style={{ color: 'var(--accent-mint-deep)', fontWeight: 600 }}>
+                      {company.phone}
+                    </span>
+                  </p>
+                )}
               </div>
-            ))}
-          </div>
-        </section>
+            </div>
+          </section>
 
-        {/* Section 3: Escalation */}
-        <section className="mb-10">
-          <h2 className="text-xl font-semibold text-amber-400 mb-3">
-            What to do if {company.name} ignores your complaint
-          </h2>
-          <div className="bg-slate-800/50 border border-slate-700 rounded-xl p-6 space-y-3 text-slate-300">
-            <p>{escalation.description}</p>
-            <p>
-              To escalate, you will need your original complaint reference number and evidence that
-              you have tried to resolve the issue directly with {company.name} first. The process is
-              free and the ombudsman&apos;s decision is binding on {company.name}.
-            </p>
-            <p>
-              You can start the escalation process at{' '}
-              <strong className="text-white">{escalation.name}</strong>.
-            </p>
-          </div>
-        </section>
+          <section className="prose-section">
+            <h2 style={{ textAlign: 'center' }}>
+              Step-by-step: how to make a formal complaint
+            </h2>
+            <div className="step-grid" style={{ gridTemplateColumns: '1fr 1fr', maxWidth: 920 }}>
+              {steps.map(({ step, title, body }) => (
+                <div key={step} className="step" style={{ textAlign: 'left' }}>
+                  <div className="step-badge" style={{ margin: 0, marginBottom: 14 }}>
+                    {step}
+                  </div>
+                  <h3>{title}</h3>
+                  <p>{body}</p>
+                </div>
+              ))}
+            </div>
+          </section>
 
-        {/* CTA */}
-        <section className="bg-gradient-to-br from-amber-900/30 to-slate-800/50 border border-amber-500/30 rounded-2xl p-8 text-center">
-          <h2 className="text-2xl font-bold text-white mb-3">
-            Let Paybacker write your complaint letter for free
-          </h2>
-          <p className="text-slate-300 mb-6 max-w-lg mx-auto">
-            Our AI drafts a formal complaint letter citing UK consumer law — tailored to{' '}
-            {company.name} — in under 30 seconds. Used by thousands of UK consumers to recover
-            money from incorrect bills.
-          </p>
-          <Link
-            href="/auth/signup"
-            className="inline-block bg-amber-500 hover:bg-amber-400 text-slate-950 font-semibold px-8 py-3 rounded-lg transition-colors"
-          >
-            Write my complaint letter free →
-          </Link>
-          <p className="text-slate-500 text-sm mt-4">No credit card required. Free plan available.</p>
-        </section>
+          <section className="prose-section">
+            <div className="rights-card">
+              <h2>What to do if {company.name} ignores your complaint</h2>
+              <div className="prose-body" style={{ margin: 0 }}>
+                <p>{escalation.description}</p>
+                <p>
+                  To escalate, you will need your original complaint reference number and
+                  evidence that you have tried to resolve the issue directly with{' '}
+                  {company.name} first. The process is free and the ombudsman&apos;s
+                  decision is binding on {company.name}.
+                </p>
+                <p>
+                  You can start the escalation process at{' '}
+                  <a
+                    href={escalation.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      color: 'var(--accent-mint-deep)',
+                      fontWeight: 600,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    {escalation.name}
+                  </a>
+                  .
+                </p>
+              </div>
+            </div>
+          </section>
 
-        {/* Footer breadcrumb */}
-        <div className="mt-12 pt-8 border-t border-slate-800 text-slate-600 text-sm">
-          <Link href="/" className="hover:text-slate-400 transition-colors">
-            Paybacker
-          </Link>{' '}
-          ›{' '}
-          <Link href="/#disputes" className="hover:text-slate-400 transition-colors">
-            Complaints
-          </Link>{' '}
-          › {company.name}
+          <section className="prose-section">
+            <div className="final-cta">
+              <h2>Let Paybacker write your complaint letter for free</h2>
+              <p>
+                Our AI drafts a formal complaint letter citing UK consumer law — tailored
+                to {company.name} — in under 30 seconds. Used by thousands of UK consumers
+                to recover money from incorrect bills.
+              </p>
+              <Link href="/auth/signup" className="btn btn-mint btn-lg">
+                Write my complaint letter free <ArrowRight width={16} height={16} aria-hidden="true" />
+              </Link>
+              <p style={{ marginTop: 18, fontSize: 13, color: 'var(--text-on-ink-dim)' }}>
+                No credit card required. Free plan available.
+              </p>
+            </div>
+          </section>
         </div>
-      </div>
+      </main>
+      <MarkFoot />
     </div>
   );
 }

--- a/src/app/debt-collection-letter/page.tsx
+++ b/src/app/debt-collection-letter/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import PublicNavbar from '@/components/PublicNavbar';
-import { Check, ArrowRight, Scale, FileText, Shield, Clock } from 'lucide-react';
+import { ArrowRight, Shield } from 'lucide-react';
+import { MarkNav, MarkFoot } from '@/app/blog/_shared';
+import '../(marketing)/styles.css';
 
 export const metadata: Metadata = {
   title: 'How to Respond to a Debt Collection Letter UK | Paybacker',
@@ -52,6 +53,62 @@ const faqs = [
   },
 ];
 
+const lawCitations = [
+  {
+    title: 'Consumer Credit Act 1974, Sections 77-79',
+    body:
+      'You have the legal right to request a copy of your original credit agreement from any creditor or debt collector. They must provide it within 12 working days. If they cannot produce it, they cannot enforce the debt in court.',
+  },
+  {
+    title: 'Limitation Act 1980',
+    body:
+      'In England, Wales, and Northern Ireland, most debts become statute-barred after 6 years from the last payment or written acknowledgement. In Scotland, the Prescription and Limitation (Scotland) Act 1973 sets the limit at 5 years. Once statute-barred, the creditor cannot take court action.',
+  },
+  {
+    title: 'Financial Conduct Authority (FCA) Rules',
+    body:
+      'All debt collectors must be authorised by the FCA. They must treat customers fairly, not use deceptive practices, and must stop collection activity if the debt is genuinely disputed until the dispute is resolved.',
+  },
+  {
+    title: 'Protection from Harassment Act 1997',
+    body:
+      'Debt collectors must not harass you. Repeated phone calls, threatening language, contacting you at unreasonable hours, or discussing your debt with others are all potential breaches.',
+  },
+];
+
+const steps = [
+  {
+    step: '1',
+    title: 'Do not ignore the letter',
+    body:
+      'Ignoring a debt collection letter does not make it go away. Even if you do not recognise the debt, respond in writing to protect your rights and create a paper trail.',
+  },
+  {
+    step: '2',
+    title: 'Check if the debt is valid',
+    body:
+      'Think about whether you recognise the debt. Check the amount, the original creditor, and the dates. If you are unsure, do not acknowledge the debt or make any payment until you have more information.',
+  },
+  {
+    step: '3',
+    title: 'Request the original credit agreement',
+    body:
+      'Under Sections 77-79 of the Consumer Credit Act 1974, write to the debt collector requesting a copy of the original signed credit agreement. Paybacker generates this letter for you. They must respond within 12 working days.',
+  },
+  {
+    step: '4',
+    title: 'Check if the debt is statute-barred',
+    body:
+      'If more than 6 years have passed since your last payment or written acknowledgement (5 years in Scotland), the debt may be statute-barred. The creditor cannot take you to court for a statute-barred debt.',
+  },
+  {
+    step: '5',
+    title: 'Dispute or negotiate',
+    body:
+      'If the debt collector cannot produce the credit agreement, they cannot enforce the debt. If the debt is valid but you are struggling to pay, you can propose a repayment plan. Free debt advice is available from StepChange and Citizens Advice.',
+  },
+];
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
@@ -67,198 +124,132 @@ const jsonLd = {
 
 export default function DebtCollectionLetterPage() {
   return (
-    <>
+    <div className="m-land-root">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <PublicNavbar />
-      <div className="h-16" />
-
-      <main className="min-h-screen bg-navy-950 text-white">
-        {/* Hero */}
-        <section className="py-20 px-4">
-          <div className="container mx-auto max-w-3xl text-center">
-            <div className="inline-flex items-center gap-2 bg-mint-400/10 border border-mint-400/20 rounded-full px-4 py-1.5 mb-6">
-              <Shield className="h-4 w-4 text-mint-400" />
-              <span className="text-mint-400 text-sm font-medium">UK Consumer Credit Rights</span>
-            </div>
-            <h1 className="text-4xl md:text-5xl font-bold font-[family-name:var(--font-heading)] mb-6">
-              How to Respond to a Debt Collection Letter
-            </h1>
-            <p className="text-lg text-slate-300 mb-8 max-w-2xl mx-auto">
-              Received a letter from a debt collector? Do not panic. UK law gives you strong rights
-              to challenge, dispute, and defend yourself. Paybacker generates a professional response
-              letter in 30 seconds.
+      <MarkNav />
+      <main>
+        <div className="wrap">
+          <section className="land-hero">
+            <span className="badge">
+              <Shield width={14} height={14} aria-hidden="true" />
+              UK Consumer Credit Rights
+            </span>
+            <h1>How to respond to a debt collection letter</h1>
+            <p className="subtitle">
+              Received a letter from a debt collector? Do not panic. UK law gives you strong
+              rights to challenge, dispute, and defend yourself. Paybacker generates a
+              professional response letter in 30 seconds.
             </p>
-            <Link
-              href="/auth/signup"
-              className="inline-flex items-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-6 py-3 rounded-xl transition-all duration-200 text-base"
-            >
-              Generate your free debt dispute letter
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </div>
-        </section>
-
-        {/* What the law says */}
-        <section className="py-16 px-4">
-          <div className="container mx-auto max-w-3xl">
-            <h2 className="text-2xl md:text-3xl font-bold font-[family-name:var(--font-heading)] mb-8">
-              What the Law Says
-            </h2>
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 md:p-8 space-y-4">
-              <div className="flex items-start gap-3">
-                <Scale className="h-5 w-5 text-mint-400 mt-1 shrink-0" />
-                <p className="text-slate-300">
-                  <strong className="text-white">Consumer Credit Act 1974, Sections 77-79:</strong>{' '}
-                  You have the legal right to request a copy of your original credit agreement from
-                  any creditor or debt collector. They must provide it within 12 working days. If
-                  they cannot produce it, they cannot enforce the debt in court.
-                </p>
-              </div>
-              <div className="flex items-start gap-3">
-                <Scale className="h-5 w-5 text-mint-400 mt-1 shrink-0" />
-                <p className="text-slate-300">
-                  <strong className="text-white">Limitation Act 1980:</strong> In England, Wales,
-                  and Northern Ireland, most debts become statute-barred after 6 years from the last
-                  payment or written acknowledgement. In Scotland, the Prescription and Limitation
-                  (Scotland) Act 1973 sets the limit at 5 years. Once statute-barred, the creditor
-                  cannot take court action.
-                </p>
-              </div>
-              <div className="flex items-start gap-3">
-                <Scale className="h-5 w-5 text-mint-400 mt-1 shrink-0" />
-                <p className="text-slate-300">
-                  <strong className="text-white">Financial Conduct Authority (FCA) Rules:</strong>{' '}
-                  All debt collectors must be authorised by the FCA. They must treat customers
-                  fairly, not use deceptive practices, and must stop collection activity if the debt
-                  is genuinely disputed until the dispute is resolved.
-                </p>
-              </div>
-              <div className="flex items-start gap-3">
-                <Scale className="h-5 w-5 text-mint-400 mt-1 shrink-0" />
-                <p className="text-slate-300">
-                  <strong className="text-white">Protection from Harassment Act 1997:</strong> Debt
-                  collectors must not harass you. Repeated phone calls, threatening language,
-                  contacting you at unreasonable hours, or discussing your debt with others are all
-                  potential breaches.
-                </p>
-              </div>
+            <div className="hero-stat">
+              <span className="stat-value">30 sec</span>
+              <span className="stat-label">to generate your dispute letter</span>
             </div>
-          </div>
-        </section>
+            <Link href="/auth/signup" className="btn btn-mint btn-lg">
+              Generate your free debt dispute letter{' '}
+              <ArrowRight width={16} height={16} aria-hidden="true" />
+            </Link>
+            <p className="social-proof">
+              Cites the Consumer Credit Act 1974, Limitation Act 1980, and FCA rules
+            </p>
+          </section>
 
-        {/* How Paybacker helps */}
-        <section className="py-16 px-4">
-          <div className="container mx-auto max-w-3xl">
-            <h2 className="text-2xl md:text-3xl font-bold font-[family-name:var(--font-heading)] mb-8">
-              How Paybacker Helps
-            </h2>
-            <ul className="space-y-4">
-              {[
-                'Generates a formal debt dispute letter requesting proof of the debt under the Consumer Credit Act 1974',
-                'Identifies whether the debt may be statute-barred under the Limitation Act 1980',
-                'Cites FCA rules and warns the collector against harassment or unfair practices',
-                'Provides a professional response ready to send, putting you in control of the situation',
-              ].map((item) => (
-                <li key={item} className="flex items-start gap-3">
-                  <Check className="h-5 w-5 text-mint-400 mt-0.5 shrink-0" />
-                  <span className="text-slate-300">{item}</span>
+          <section className="prose-section">
+            <div className="rights-card">
+              <h2>What the law says</h2>
+              <ul className="rights-list">
+                {lawCitations.map((law) => (
+                  <li key={law.title}>
+                    <strong>{law.title}:</strong> {law.body}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <div className="rights-card">
+              <h2>How Paybacker helps</h2>
+              <ul className="rights-list">
+                <li>
+                  Generates a formal debt dispute letter requesting proof of the debt under the
+                  Consumer Credit Act 1974.
                 </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-
-        {/* Step by step */}
-        <section className="py-16 px-4">
-          <div className="container mx-auto max-w-3xl">
-            <h2 className="text-2xl md:text-3xl font-bold font-[family-name:var(--font-heading)] mb-8">
-              How to Respond to a Debt Collection Letter: Step by Step
-            </h2>
-            <ol className="space-y-6">
-              {[
-                {
-                  title: '1. Do not ignore the letter',
-                  desc: 'Ignoring a debt collection letter does not make it go away. Even if you do not recognise the debt, respond in writing to protect your rights and create a paper trail.',
-                },
-                {
-                  title: '2. Check if the debt is valid',
-                  desc: 'Think about whether you recognise the debt. Check the amount, the original creditor, and the dates. If you are unsure, do not acknowledge the debt or make any payment until you have more information.',
-                },
-                {
-                  title: '3. Request the original credit agreement',
-                  desc: 'Under Sections 77-79 of the Consumer Credit Act 1974, write to the debt collector requesting a copy of the original signed credit agreement. Paybacker generates this letter for you. They must respond within 12 working days.',
-                },
-                {
-                  title: '4. Check if the debt is statute-barred',
-                  desc: 'If more than 6 years have passed since your last payment or written acknowledgement (5 years in Scotland), the debt may be statute-barred. The creditor cannot take you to court for a statute-barred debt.',
-                },
-                {
-                  title: '5. Dispute or negotiate',
-                  desc: 'If the debt collector cannot produce the credit agreement, they cannot enforce the debt. If the debt is valid but you are struggling to pay, you can propose a repayment plan. Free debt advice is available from StepChange and Citizens Advice.',
-                },
-              ].map((step) => (
-                <li key={step.title} className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6">
-                  <h3 className="text-lg font-semibold text-white mb-2">{step.title}</h3>
-                  <p className="text-slate-300">{step.desc}</p>
+                <li>
+                  Identifies whether the debt may be statute-barred under the Limitation Act
+                  1980.
                 </li>
-              ))}
-            </ol>
-          </div>
-        </section>
+                <li>
+                  Cites FCA rules and warns the collector against harassment or unfair
+                  practices.
+                </li>
+                <li>
+                  Provides a professional response ready to send, putting you in control of the
+                  situation.
+                </li>
+              </ul>
+            </div>
+          </section>
 
-        {/* FAQ */}
-        <section className="py-16 px-4">
-          <div className="container mx-auto max-w-3xl">
-            <h2 className="text-2xl md:text-3xl font-bold font-[family-name:var(--font-heading)] mb-8">
-              Frequently Asked Questions
+          <section className="prose-section">
+            <h2 style={{ textAlign: 'center' }}>
+              How to respond to a debt collection letter: step by step
             </h2>
-            <div className="space-y-4">
+            <div className="step-grid">
+              {steps.map(({ step, title, body }) => (
+                <div key={step} className="step">
+                  <div className="step-badge">{step}</div>
+                  <h3>{title}</h3>
+                  <p>{body}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <div className="soft-cta">
+              <p>
+                Need free debt advice? <a href="https://www.stepchange.org" target="_blank" rel="noopener noreferrer">StepChange</a> and{' '}
+                <a href="https://www.citizensadvice.org.uk" target="_blank" rel="noopener noreferrer">Citizens Advice</a>{' '}
+                offer confidential, non-judgemental help at no cost.
+              </p>
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <h2 style={{ textAlign: 'center' }}>Frequently asked questions</h2>
+            <div className="faq-grid">
               {faqs.map((faq) => (
-                <article
-                  key={faq.question}
-                  className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6"
-                >
-                  <h3 className="text-lg font-semibold text-white mb-2">{faq.question}</h3>
-                  <p className="text-slate-300">{faq.answer}</p>
+                <article key={faq.question} className="faq-card">
+                  <h3>{faq.question}</h3>
+                  <p>{faq.answer}</p>
                 </article>
               ))}
             </div>
-          </div>
-        </section>
+          </section>
 
-        {/* Bottom CTA */}
-        <section className="py-20 px-4">
-          <div className="container mx-auto max-w-3xl text-center">
-            <h2 className="text-3xl md:text-4xl font-bold font-[family-name:var(--font-heading)] mb-4">
-              Know Your Rights Against Debt Collectors
-            </h2>
-            <p className="text-slate-300 mb-8 max-w-xl mx-auto">
-              Paybacker generates a professional debt dispute letter citing the Consumer Credit Act
-              and Limitation Act in 30 seconds. Do not let debt collectors pressure you into paying
-              what you may not owe.
-            </p>
-            <Link
-              href="/auth/signup"
-              className="inline-flex items-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-6 py-3 rounded-xl transition-all duration-200 text-base"
-            >
-              Generate your free debt dispute letter
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </div>
-        </section>
-
-        {/* Footer link */}
-        <footer className="py-8 px-4 border-t border-navy-700/50">
-          <div className="container mx-auto max-w-3xl text-center">
-            <Link href="/" className="text-slate-400 hover:text-white text-sm transition-colors">
-              &larr; Back to paybacker.co.uk
-            </Link>
-          </div>
-        </footer>
+          <section className="prose-section">
+            <div className="final-cta">
+              <h2>Know your rights against debt collectors</h2>
+              <p>
+                Paybacker generates a professional debt dispute letter citing the Consumer
+                Credit Act and Limitation Act in 30 seconds. Do not let debt collectors
+                pressure you into paying what you may not owe.
+              </p>
+              <Link href="/auth/signup" className="btn btn-mint btn-lg">
+                Generate your free debt dispute letter{' '}
+                <ArrowRight width={16} height={16} aria-hidden="true" />
+              </Link>
+              <p style={{ marginTop: 18, fontSize: 13, color: 'var(--text-on-ink-dim)' }}>
+                No credit card required. Free plan available.
+              </p>
+            </div>
+          </section>
+        </div>
       </main>
-    </>
+      <MarkFoot />
+    </div>
   );
 }

--- a/src/app/solutions/[slug]/page.tsx
+++ b/src/app/solutions/[slug]/page.tsx
@@ -1,8 +1,12 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
 import { notFound } from 'next/navigation';
-import { CheckCircle, ArrowRight, Clock, Shield, Zap, FileText, ScanSearch, CreditCard, TrendingDown, Plane, BarChart3, Mail, Bell } from 'lucide-react';
+import type { ComponentType, SVGProps } from 'react';
+import { ArrowRight, Shield, Zap, ScanSearch, CreditCard, Plane, BarChart3, Mail, Bell } from 'lucide-react';
+import { MarkNav, MarkFoot } from '@/app/blog/_shared';
+import '../../(marketing)/styles.css';
+
+type LucideIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
 interface SolutionPage {
   slug: string;
@@ -11,8 +15,7 @@ interface SolutionPage {
   h1: string;
   subtitle: string;
   keywords: string[];
-  icon: any;
-  iconColor: string;
+  icon: LucideIcon;
   heroStat: string;
   heroStatLabel: string;
   ctaText: string;
@@ -28,25 +31,26 @@ const PAGES: Record<string, SolutionPage> = {
   'energy-refunds': {
     slug: 'energy-refunds',
     title: 'Dispute Your Energy Bill UK - AI Complaint Letter Generator',
-    description: 'Generate a formal energy bill complaint letter citing Ofgem rules and UK consumer law in 30 seconds. Free to use. Get refunds from British Gas, EDF, E.ON, Octopus and more.',
+    description:
+      'Generate a formal energy bill complaint letter citing Ofgem rules and UK consumer law in 30 seconds. Free to use. Get refunds from British Gas, EDF, E.ON, Octopus and more.',
     h1: 'Dispute your energy bill and get your money back',
-    subtitle: 'Paybacker generates a formal complaint letter citing exact UK energy regulations in 30 seconds. No legal knowledge needed. Works with every UK energy supplier.',
+    subtitle:
+      'Paybacker generates a formal complaint letter citing exact UK energy regulations in 30 seconds. No legal knowledge needed. Works with every UK energy supplier.',
     keywords: ['dispute energy bill UK', 'energy bill complaint letter', 'Ofgem complaint', 'energy refund claim', 'overcharged energy bill'],
     icon: Zap,
-    iconColor: 'text-amber-400',
     heroStat: '30 sec',
     heroStatLabel: 'to generate your complaint',
-    ctaText: 'Generate Your Complaint Letter Free',
+    ctaText: 'Generate your complaint letter free',
     ctaLink: '/auth/signup',
     benefits: [
       'Cites Ofgem regulations and Consumer Rights Act 2015',
       'Works with British Gas, EDF, E.ON, Octopus, OVO and all UK suppliers',
       'Formal tone that gets taken seriously by complaints departments',
       'Includes specific regulatory references for your situation',
-      'Free - 3 letters per month on the free plan',
+      'Free — 3 letters per month on the free plan',
     ],
     howItWorks: [
-      { step: '1', title: 'Describe your issue', description: 'Tell us what happened - overcharged, estimated bills, price increase, poor service. Plain English is fine.' },
+      { step: '1', title: 'Describe your issue', description: 'Tell us what happened — overcharged, estimated bills, price increase, poor service. Plain English is fine.' },
       { step: '2', title: 'AI generates your letter', description: 'Our AI writes a formal complaint citing the exact UK laws and Ofgem rules that apply to your situation.' },
       { step: '3', title: 'Send and get your money back', description: 'Copy the letter and send it to your supplier. Most complaints are resolved within 8 weeks.' },
     ],
@@ -62,22 +66,23 @@ const PAGES: Record<string, SolutionPage> = {
   'broadband-compensation': {
     slug: 'broadband-compensation',
     title: 'Broadband Complaint Letter UK - Challenge Price Rises and Poor Service',
-    description: 'Generate a formal broadband complaint letter citing Ofcom rules in 30 seconds. Challenge mid-contract price rises, slow speeds, or poor service from any UK provider.',
+    description:
+      'Generate a formal broadband complaint letter citing Ofcom rules in 30 seconds. Challenge mid-contract price rises, slow speeds, or poor service from any UK provider.',
     h1: 'Challenge your broadband provider and claim compensation',
-    subtitle: 'Mid-contract price rise? Slow speeds? Service outages? Paybacker generates a formal complaint citing Ofcom rules and the Consumer Rights Act that gets results.',
+    subtitle:
+      'Mid-contract price rise? Slow speeds? Service outages? Paybacker generates a formal complaint citing Ofcom rules and the Consumer Rights Act that gets results.',
     keywords: ['broadband complaint letter UK', 'Ofcom broadband complaint', 'broadband price rise compensation', 'challenge broadband provider', 'slow broadband complaint'],
     icon: Shield,
-    iconColor: 'text-blue-400',
     heroStat: '£180/yr',
     heroStatLabel: 'average saving by switching broadband',
-    ctaText: 'Generate Your Broadband Complaint Free',
+    ctaText: 'Generate your broadband complaint free',
     ctaLink: '/auth/signup',
     benefits: [
       'Cites Ofcom automatic compensation scheme rules',
       'Challenge mid-contract price rises legally',
       'Works with BT, Sky, Virgin Media, TalkTalk, EE and all UK providers',
       'Includes speed guarantee complaint templates',
-      'Free to start - 3 letters per month',
+      'Free to start — 3 letters per month',
     ],
     howItWorks: [
       { step: '1', title: 'Tell us your problem', description: 'Price increase, slow speeds, service outage, billing error, or cancellation dispute.' },
@@ -92,25 +97,26 @@ const PAGES: Record<string, SolutionPage> = {
     socialProof: 'UK broadband customers are entitled to automatic compensation under Ofcom rules',
     featureHighlight: 'We also compare 10 broadband providers so you can switch to a cheaper deal after your complaint',
   },
-  'subscriptions': {
+  subscriptions: {
     slug: 'subscriptions',
     title: 'Find Hidden Subscriptions UK - Bank Account Subscription Finder',
-    description: 'Connect your bank account and find every subscription, direct debit, and recurring payment you are being charged for. Cancel what you do not need and save hundreds per year.',
+    description:
+      'Connect your bank account and find every subscription, direct debit, and recurring payment you are being charged for. Cancel what you do not need and save hundreds per year.',
     h1: 'Find and cancel subscriptions you forgot about',
-    subtitle: 'The average UK adult wastes £312/year on forgotten subscriptions. Connect your bank account and Paybacker finds every recurring payment in seconds. Cancel what you do not need.',
+    subtitle:
+      'The average UK adult wastes £312/year on forgotten subscriptions. Connect your bank account and Paybacker finds every recurring payment in seconds. Cancel what you do not need.',
     keywords: ['find hidden subscriptions', 'cancel unwanted subscriptions UK', 'subscription finder', 'check all my subscriptions', 'stop unwanted direct debits'],
     icon: ScanSearch,
-    iconColor: 'text-purple-400',
     heroStat: '£312/yr',
     heroStatLabel: 'wasted on forgotten subscriptions',
-    ctaText: 'Scan Your Subscriptions Free',
+    ctaText: 'Scan your subscriptions free',
     ctaLink: '/auth/signup',
     benefits: [
       'Connects to your bank via Open Banking (read-only, bank-level security)',
       'Detects every subscription, direct debit, and recurring payment',
       'Shows monthly and annual cost for each subscription',
       'AI cancellation emails with legal context for anything you want to cancel',
-      'One-time scan is free - no credit card needed',
+      'One-time scan is free — no credit card needed',
     ],
     howItWorks: [
       { step: '1', title: 'Connect your bank', description: 'Secure Open Banking connection. Read-only access. We never see your login details.' },
@@ -128,15 +134,16 @@ const PAGES: Record<string, SolutionPage> = {
   'cancel-services': {
     slug: 'cancel-services',
     title: 'Cancel Any Subscription UK - AI Cancellation Letter Generator',
-    description: 'Generate a formal cancellation email citing UK Consumer Contracts Regulations in seconds. Cancel gym memberships, mobile contracts, broadband, insurance, and more.',
+    description:
+      'Generate a formal cancellation email citing UK Consumer Contracts Regulations in seconds. Cancel gym memberships, mobile contracts, broadband, insurance, and more.',
     h1: 'Cancel any subscription or contract without the hassle',
-    subtitle: 'Providers make cancellation deliberately difficult. Paybacker generates a formal cancellation email citing the exact UK law that applies, so they cannot ignore you.',
+    subtitle:
+      'Providers make cancellation deliberately difficult. Paybacker generates a formal cancellation email citing the exact UK law that applies, so they cannot ignore you.',
     keywords: ['cancel subscription UK', 'cancel gym membership', 'cancellation letter template', 'how to cancel contract', 'cancel direct debit'],
     icon: CreditCard,
-    iconColor: 'text-green-400',
     heroStat: '90 sec',
     heroStatLabel: 'to generate your cancellation email',
-    ctaText: 'Generate Your Cancellation Email Free',
+    ctaText: 'Generate your cancellation email free',
     ctaLink: '/auth/signup',
     benefits: [
       'Cites Consumer Contracts Regulations 2013 and Consumer Rights Act 2015',
@@ -161,15 +168,16 @@ const PAGES: Record<string, SolutionPage> = {
   'flight-delay-compensation': {
     slug: 'flight-delay-compensation',
     title: 'Flight Delay Compensation UK - Claim Up to £520',
-    description: 'Claim up to £520 compensation for delayed or cancelled flights under UK261 and EU261 regulations. Free AI-generated claim letter. Works for flights in the last 6 years.',
+    description:
+      'Claim up to £520 compensation for delayed or cancelled flights under UK261 and EU261 regulations. Free AI-generated claim letter. Works for flights in the last 6 years.',
     h1: 'Claim up to £520 for your delayed or cancelled flight',
-    subtitle: 'Under UK261 regulations, you are entitled to compensation of £220-£520 for flights delayed over 3 hours, cancelled, or overbooked. Most claims are never made. Ours take 30 seconds.',
+    subtitle:
+      'Under UK261 regulations, you are entitled to compensation of £220-£520 for flights delayed over 3 hours, cancelled, or overbooked. Most claims are never made. Ours take 30 seconds.',
     keywords: ['flight delay compensation UK', 'claim flight delay', 'UK261 compensation', 'flight cancelled compensation', 'delayed flight refund'],
     icon: Plane,
-    iconColor: 'text-sky-400',
     heroStat: '£520',
     heroStatLabel: 'maximum compensation per passenger',
-    ctaText: 'Start Your Flight Claim Free',
+    ctaText: 'Start your flight claim free',
     ctaLink: '/auth/signup',
     benefits: [
       'Covers delays over 3 hours, cancellations, and denied boarding',
@@ -195,15 +203,16 @@ const PAGES: Record<string, SolutionPage> = {
   'money-hub': {
     slug: 'money-hub',
     title: 'Money Hub - See Where Every Penny Goes | Paybacker',
-    description: 'Connect your bank account and see your complete financial picture. Income, spending by category, budget tracking, net worth, and AI-powered insights. Your personal finance dashboard.',
+    description:
+      'Connect your bank account and see your complete financial picture. Income, spending by category, budget tracking, net worth, and AI-powered insights. Your personal finance dashboard.',
     h1: 'See exactly where your money goes every month',
-    subtitle: 'Connect your bank account and Paybacker categorises every transaction, tracks your income vs spending, sets budgets, and gives you a financial health score. All automated, all in one dashboard.',
+    subtitle:
+      'Connect your bank account and Paybacker categorises every transaction, tracks your income vs spending, sets budgets, and gives you a financial health score. All automated, all in one dashboard.',
     keywords: ['money management app UK', 'spending tracker', 'budget planner app', 'personal finance dashboard', 'track spending categories'],
     icon: BarChart3,
-    iconColor: 'text-emerald-400',
     heroStat: '20+',
     heroStatLabel: 'spending categories, auto-categorised',
-    ctaText: 'Connect Your Bank Free',
+    ctaText: 'Connect your bank free',
     ctaLink: '/auth/signup',
     benefits: [
       'Income vs outgoings with monthly trends',
@@ -228,18 +237,19 @@ const PAGES: Record<string, SolutionPage> = {
   'email-scanner': {
     slug: 'email-scanner',
     title: 'Email Inbox Scanner - Find Money You Are Owed | Paybacker',
-    description: 'Connect Gmail or Outlook and scan 2 years of emails for overcharges, forgotten subscriptions, flight delay compensation, debt disputes, and price increase notifications.',
+    description:
+      'Connect Gmail or Outlook and scan 2 years of emails for overcharges, forgotten subscriptions, flight delay compensation, debt disputes, and price increase notifications.',
     h1: 'Scan your email inbox and find money you are owed',
-    subtitle: 'Your email inbox contains proof of overcharges, price increase notifications, flight booking confirmations, and subscription receipts. Paybacker scans 2 years of emails and shows you exactly what you can claim.',
+    subtitle:
+      'Your email inbox contains proof of overcharges, price increase notifications, flight booking confirmations, and subscription receipts. Paybacker scans 2 years of emails and shows you exactly what you can claim.',
     keywords: ['email scanner money', 'find overcharges email', 'scan inbox subscriptions', 'email receipt scanner', 'find money owed UK'],
     icon: Mail,
-    iconColor: 'text-rose-400',
     heroStat: '2 years',
     heroStatLabel: 'of email history scanned',
-    ctaText: 'Join the Waitlist - Coming Soon',
+    ctaText: 'Join the waitlist — coming soon',
     ctaLink: '/auth/signup',
     benefits: [
-      'Coming soon - currently being verified by Google for highest security standards',
+      'Coming soon — currently being verified by Google for highest security standards',
       'Detects price increase notifications you may have missed',
       'Finds flight booking confirmations for delay compensation claims',
       'Identifies subscription receipts and renewal notices',
@@ -261,15 +271,16 @@ const PAGES: Record<string, SolutionPage> = {
   'contract-alerts': {
     slug: 'contract-alerts',
     title: 'Contract Renewal Alerts UK - Never Overpay on Auto-Renewal',
-    description: 'Get email alerts at 30, 14, and 7 days before your contracts renew. Energy, broadband, mobile, insurance, mortgages, and more. Stop overpaying on auto-renewals.',
+    description:
+      'Get email alerts at 30, 14, and 7 days before your contracts renew. Energy, broadband, mobile, insurance, mortgages, and more. Stop overpaying on auto-renewals.',
     h1: 'Stop overpaying when your contracts auto-renew',
-    subtitle: 'Every year, UK consumers lose billions to auto-renewal price hikes. Paybacker tracks your contract end dates and alerts you at 30, 14, and 7 days before renewal - so you can switch to a better deal.',
+    subtitle:
+      'Every year, UK consumers lose billions to auto-renewal price hikes. Paybacker tracks your contract end dates and alerts you at 30, 14, and 7 days before renewal — so you can switch to a better deal.',
     keywords: ['contract renewal alerts', 'stop auto renewal', 'contract end date tracker', 'renewal reminder app', 'avoid price hikes UK'],
     icon: Bell,
-    iconColor: 'text-orange-400',
     heroStat: '30/14/7',
     heroStatLabel: 'day alerts before every renewal',
-    ctaText: 'Track Your Contracts Free',
+    ctaText: 'Track your contracts free',
     ctaLink: '/auth/signup',
     benefits: [
       'Email alerts at 30, 14, and 7 days before contract end dates',
@@ -334,143 +345,104 @@ export default async function SolutionPage({ params }: { params: Promise<{ slug:
   const Icon = page.icon;
 
   return (
-    <div className="min-h-screen bg-navy-950">
-      <div className="fixed inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-mint-900/20 via-transparent to-transparent" />
-
-      <div className="relative">
-        {/* Header */}
-        <header className="container mx-auto px-4 md:px-6 py-4 md:py-6">
-          <div className="flex items-center justify-between">
-            <Link href="/" className="flex items-center gap-2">
-              <Image src="/logo.png" alt="Paybacker" width={32} height={32} className="rounded-lg" />
-              <span className="text-xl font-bold text-white">Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span></span>
-            </Link>
-            <div className="flex items-center gap-3">
-              <Link href="/pricing" className="hidden md:block text-slate-400 hover:text-white text-sm px-3 py-2 rounded-lg hover:bg-navy-900 transition-all">Pricing</Link>
-              <Link href="/auth/login" className="text-slate-300 hover:text-white text-sm font-medium px-3 py-2 rounded-lg hover:bg-navy-900 transition-all">Sign In</Link>
-              <Link href="/auth/signup" className="bg-mint-400 hover:bg-mint-500 text-navy-950 text-sm font-semibold px-4 py-2 rounded-xl transition-all">Get Started Free</Link>
+    <div className="m-land-root">
+      <MarkNav />
+      <main>
+        <div className="wrap">
+          <section className="land-hero">
+            <span className="badge">
+              <Icon width={14} height={14} aria-hidden="true" />
+              Free to use — no credit card required
+            </span>
+            <h1>{page.h1}</h1>
+            <p className="subtitle">{page.subtitle}</p>
+            <div className="hero-stat">
+              <span className="stat-value">{page.heroStat}</span>
+              <span className="stat-label">{page.heroStatLabel}</span>
             </div>
-          </div>
-        </header>
-
-        <main className="container mx-auto px-6 py-12">
-          {/* Hero */}
-          <div className="max-w-4xl mx-auto mb-16 text-center">
-            <div className="inline-flex items-center gap-2 rounded-full bg-mint-400/10 px-4 py-2 text-sm text-mint-400 border border-mint-400/20 mb-8">
-              <Icon className={`h-4 w-4 ${page.iconColor}`} />
-              <span>Free to use - no credit card required</span>
-            </div>
-
-            <h1 className="text-4xl md:text-6xl font-bold text-white mb-6 leading-tight font-[family-name:var(--font-heading)]">{page.h1}</h1>
-            <p className="text-xl text-slate-300 mb-8 max-w-2xl mx-auto leading-relaxed">{page.subtitle}</p>
-
-            <div className="flex justify-center mb-8">
-              <div className="bg-navy-900 border border-mint-400/20 rounded-2xl px-8 py-4 text-center">
-                <p className={`text-4xl font-bold ${page.iconColor}`}>{page.heroStat}</p>
-                <p className="text-slate-500 text-sm">{page.heroStatLabel}</p>
-              </div>
-            </div>
-
-            <Link href={page.ctaLink} className="inline-block bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-8 py-4 rounded-xl transition-all text-lg">
-              {page.ctaText}
-            </Link>
-
-            <p className="text-slate-500 text-sm mt-4">{page.socialProof}</p>
-          </div>
-
-          {/* Benefits */}
-          <div className="max-w-3xl mx-auto mb-16">
-            <h2 className="text-2xl font-bold text-white mb-6 text-center font-[family-name:var(--font-heading)]">What you get</h2>
-            <div className="space-y-3">
-              {page.benefits.map((b, i) => (
-                <div key={i} className="flex items-start gap-3 bg-navy-900 border border-navy-700/50 rounded-2xl p-4">
-                  <CheckCircle className="h-5 w-5 text-green-400 flex-shrink-0 mt-0.5" />
-                  <span className="text-slate-300">{b}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* How It Works */}
-          <div className="max-w-4xl mx-auto mb-16">
-            <h2 className="text-2xl font-bold text-white mb-8 text-center font-[family-name:var(--font-heading)]">How it works</h2>
-            <div className="grid md:grid-cols-3 gap-6">
-              {page.howItWorks.map((step) => (
-                <div key={step.step} className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 text-center">
-                  <div className="bg-mint-400 text-navy-950 w-10 h-10 rounded-full flex items-center justify-center mx-auto mb-4 font-bold text-lg">{step.step}</div>
-                  <h3 className="text-white font-semibold mb-2">{step.title}</h3>
-                  <p className="text-slate-400 text-sm">{step.description}</p>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Feature Highlight */}
-          <div className="max-w-3xl mx-auto mb-16">
-            <div className="bg-mint-400/10 border border-mint-400/20 rounded-2xl p-8 text-center">
-              <Icon className={`h-8 w-8 ${page.iconColor} mx-auto mb-4`} />
-              <p className="text-slate-300 text-lg">{page.featureHighlight}</p>
-              <Link href={page.ctaLink} className="inline-flex items-center gap-2 text-mint-400 font-semibold mt-4 hover:text-mint-300 transition-all">
-                Get started free <ArrowRight className="h-4 w-4" />
+            <div>
+              <Link href={page.ctaLink} className="btn btn-mint btn-lg">
+                {page.ctaText} <ArrowRight width={16} height={16} aria-hidden="true" />
               </Link>
             </div>
-          </div>
+            <p className="social-proof">{page.socialProof}</p>
+          </section>
 
-          {/* FAQs */}
-          <div className="max-w-3xl mx-auto mb-16">
-            <h2 className="text-2xl font-bold text-white mb-6 text-center font-[family-name:var(--font-heading)]">Frequently asked questions</h2>
-            <div className="space-y-4">
-              {page.faqs.map((faq, i) => (
-                <div key={i} className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6">
-                  <h3 className="text-white font-semibold mb-2">{faq.q}</h3>
-                  <p className="text-slate-400 text-sm">{faq.a}</p>
+          <section className="prose-section">
+            <div className="rights-card">
+              <h2>What you get</h2>
+              <ul className="rights-list">
+                {page.benefits.map((b) => (
+                  <li key={b}>{b}</li>
+                ))}
+              </ul>
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <h2 style={{ textAlign: 'center' }}>How it works</h2>
+            <div className="step-grid">
+              {page.howItWorks.map((step) => (
+                <div key={step.step} className="step">
+                  <div className="step-badge">{step.step}</div>
+                  <h3>{step.title}</h3>
+                  <p>{step.description}</p>
                 </div>
               ))}
             </div>
-          </div>
+          </section>
 
-          {/* Final CTA */}
-          <div className="max-w-3xl mx-auto mb-16 text-center">
-            <h2 className="text-3xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">Ready to take control?</h2>
-            <p className="text-slate-400 mb-8">Join thousands of UK consumers who are using Paybacker to save money and fight unfair charges.</p>
-            <Link href={page.ctaLink} className="inline-block bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-8 py-4 rounded-xl transition-all text-lg">
-              {page.ctaText}
-            </Link>
-          </div>
-        </main>
-
-        {/* Footer */}
-        <footer className="border-t border-navy-700/50 py-8">
-          <div className="container mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-4">
-            <div className="text-slate-500 text-sm">Paybacker LTD - paybacker.co.uk</div>
-            <div className="flex gap-4 text-slate-500 text-sm">
-              <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
-              <Link href="/about" className="hover:text-white transition-all">About</Link>
-              <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy</Link>
-              <Link href="/terms-of-service" className="hover:text-white transition-all">Terms</Link>
+          <section className="prose-section">
+            <div className="soft-cta">
+              <p>{page.featureHighlight}</p>
+              <Link href={page.ctaLink}>
+                Get started free <ArrowRight width={14} height={14} aria-hidden="true" />
+              </Link>
             </div>
-          </div>
-        </footer>
+          </section>
 
-        {/* FAQ JSON-LD */}
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              '@context': 'https://schema.org',
-              '@type': 'FAQPage',
-              mainEntity: page.faqs.map((faq) => ({
-                '@type': 'Question',
-                name: faq.q,
-                acceptedAnswer: {
-                  '@type': 'Answer',
-                  text: faq.a,
-                },
-              })),
-            }),
-          }}
-        />
-      </div>
+          <section className="prose-section">
+            <h2 style={{ textAlign: 'center' }}>Frequently asked questions</h2>
+            <div className="faq-grid">
+              {page.faqs.map((faq) => (
+                <article key={faq.q} className="faq-card">
+                  <h3>{faq.q}</h3>
+                  <p>{faq.a}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <div className="final-cta">
+              <h2>Ready to take control?</h2>
+              <p>Join thousands of UK consumers who are using Paybacker to save money and fight unfair charges.</p>
+              <Link href={page.ctaLink} className="btn btn-mint btn-lg">
+                {page.ctaText} <ArrowRight width={16} height={16} aria-hidden="true" />
+              </Link>
+            </div>
+          </section>
+        </div>
+      </main>
+      <MarkFoot />
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'FAQPage',
+            mainEntity: page.faqs.map((faq) => ({
+              '@type': 'Question',
+              name: faq.q,
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: faq.a,
+              },
+            })),
+          }),
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Batch 6c: SEO content pages move to the light theme.

### What's in here

| Route | Before | After |
|---|---|---|
| `/solutions/[slug]` (8 pages) | Dark navy-950 + PublicNavbar | Light `.m-land-root` + MarkNav + marketing primitives |
| `/complaints/[company]` (dozens of dynamic pages) | Dark navy-950 + PublicNavbar | Light `.m-land-root` + MarkNav + marketing primitives |
| `/debt-collection-letter` | Dark navy-950 + PublicNavbar | Light `.m-land-root` + MarkNav + marketing primitives |

### Design system

Same scoped-root pattern as 6a and 6b:

- Each page wraps content in `<div className="m-land-root">` and imports
  `(marketing)/styles.css` — no new CSS required, existing primitives
  (`.land-hero`, `.hero-stat`, `.rights-card`, `.rights-list`,
  `.step-grid` + `.step` + `.step-badge`, `.soft-cta`, `.faq-grid`,
  `.faq-card`, `.final-cta`) all reused.
- MarkNav + MarkFoot from `@/app/blog/_shared` replaces the old
  `PublicNavbar` and inline footer block.

### Content + logic untouched

- **solutions/[slug]**: all 8 pages (energy-refunds, broadband-
  compensation, subscriptions, cancel-services, flight-delay-
  compensation, money-hub, email-scanner, contract-alerts) keep their
  existing title/description/keywords/openGraph/canonical for SEO
  continuity. FAQPage JSON-LD structured data preserved byte-for-byte.
- **complaints/[company]**: `COMPANIES` data source, `getCompanyBySlug`,
  `generateStaticParams()`, `generateMetadata()` all unchanged. All
  15 CATEGORY_LABELS and all 8 REGULATOR_ESCALATION entries preserved
  verbatim including the ombudsman URLs.
- **debt-collection-letter**: FAQPage JSON-LD + all 4 law citations
  (Consumer Credit Act 1974 Sections 77-79, Limitation Act 1980, FCA
  rules, Protection from Harassment Act 1997) preserved verbatim.

### Accessibility

- Shield badge marked `aria-hidden="true"`.
- All decorative Lucide icons marked `aria-hidden="true"`.
- ArrowRight CTA icons marked `aria-hidden="true"`.
- External free-advice links (StepChange, Citizens Advice) use
  `rel="noopener noreferrer"`.

### Type safety

- `SolutionPage.icon` typed as `LucideIcon` (ComponentType<SVGProps<SVGSVGElement>>),
  was `any`. No runtime change — the Lucide components already matched.

### Checks

- `npx tsc --noEmit`: clean for all 3 files. Pre-existing errors
  elsewhere in the repo (dashboard/money-hub, cron/trial-expiry,
  careers/CareersInterestForm false positive, generated .next validator)
  are unchanged.
- No API keys, no new env vars, no database changes.
- Zero change to generated metadata for existing URLs.

### What's still pending after this

- **Batch 6d** — `/docs/paybacker-assistant` (MCP setup docs).
- **Batch 7+** — dashboard shell + page bodies (behind auth).
