### PR TITLE
feat(marketing): redesign /docs/paybacker-assistant to light theme (batch 6d)

### DIFF
--- a/src/app/docs/paybacker-assistant/docs.css
+++ b/src/app/docs/paybacker-assistant/docs.css
@@ -1,0 +1,213 @@
+/*
+ * Paybacker Assistant docs — scoped stylesheet.
+ *
+ * Adds documentation-specific primitives (code blocks, tool cards,
+ * troubleshoot collapsibles, info notes) on top of the shared marketing
+ * design system. Inherits tokens from .m-land-root via the consumer
+ * page importing (marketing)/styles.css alongside this file.
+ */
+
+/* Code blocks ----------------------------------------------------------- */
+.m-land-root .doc-code {
+  display: block;
+  background: #0B1220;
+  color: #E5E7EB;
+  border-radius: var(--r-input);
+  padding: 18px 20px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  overflow-x: auto;
+  margin: 0 0 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+.m-land-root .doc-code-small {
+  padding: 14px 16px;
+  font-size: 13px;
+}
+.m-land-root .doc-code-inline {
+  background: #F3F4F6;
+  color: var(--accent-orange-deep);
+  padding: 2px 7px;
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92em;
+  font-weight: 500;
+}
+
+/* Tools grid ------------------------------------------------------------ */
+.m-land-root .tool-list {
+  max-width: 760px;
+  margin: 0 auto;
+  display: grid;
+  gap: 12px;
+}
+.m-land-root .tool-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  padding: 20px 22px;
+  box-shadow: var(--shadow-sm);
+}
+.m-land-root .tool-card code {
+  display: inline-block;
+  color: var(--accent-orange-deep);
+  font-weight: 700;
+  font-size: 14.5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  margin-bottom: 8px;
+}
+.m-land-root .tool-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 14.5px;
+  line-height: 1.6;
+}
+
+/* Prereq / numbered step (vertical list) -------------------------------- */
+.m-land-root .doc-step {
+  max-width: 760px;
+  margin: 0 auto 28px;
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-card);
+  padding: 28px 32px;
+  box-shadow: var(--shadow-sm);
+}
+.m-land-root .doc-step-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+.m-land-root .doc-step-num {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--accent-mint);
+  color: #052E1C;
+  font-weight: 700;
+  font-size: 15px;
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+.m-land-root .doc-step h2 {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: var(--track-tight);
+}
+.m-land-root .doc-step p {
+  font-size: 15.5px;
+  line-height: 1.65;
+  color: var(--text-primary);
+  margin: 0 0 14px;
+}
+.m-land-root .doc-step p:last-child { margin-bottom: 0; }
+.m-land-root .doc-step a {
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+  text-decoration: none;
+}
+.m-land-root .doc-step a:hover { text-decoration: underline; }
+
+/* Notes / tip box ------------------------------------------------------- */
+.m-land-root .doc-note {
+  background: var(--accent-mint-wash);
+  border: 1px solid rgba(5, 150, 105, 0.15);
+  border-radius: var(--r-input);
+  padding: 14px 18px;
+  font-size: 14px;
+  color: var(--text-primary);
+  line-height: 1.55;
+  margin: 16px 0 0;
+}
+
+/* Troubleshoot collapsibles -------------------------------------------- */
+.m-land-root .troubleshoot-list {
+  max-width: 760px;
+  margin: 0 auto;
+  display: grid;
+  gap: 12px;
+}
+.m-land-root .troubleshoot {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  padding: 18px 22px;
+}
+.m-land-root .troubleshoot summary {
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 15.5px;
+  color: var(--text-primary);
+  list-style: none;
+}
+.m-land-root .troubleshoot summary::-webkit-details-marker { display: none; }
+.m-land-root .troubleshoot summary::after {
+  content: '+';
+  float: right;
+  color: var(--accent-mint-deep);
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1;
+}
+.m-land-root .troubleshoot[open] summary::after { content: '−'; }
+.m-land-root .troubleshoot p,
+.m-land-root .troubleshoot ul {
+  margin: 12px 0 0;
+  font-size: 14.5px;
+  color: var(--text-secondary);
+  line-height: 1.65;
+}
+.m-land-root .troubleshoot ul {
+  list-style: disc;
+  padding-left: 22px;
+  display: grid;
+  gap: 6px;
+}
+.m-land-root .troubleshoot a {
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+  text-decoration: none;
+}
+.m-land-root .troubleshoot a:hover { text-decoration: underline; }
+
+/* Beta pill on hero ----------------------------------------------------- */
+.m-land-root .beta-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  background: #F3F4F6;
+  border-radius: var(--r-pill);
+  margin-left: 8px;
+}
+
+/* Docs footnote --------------------------------------------------------- */
+.m-land-root .doc-footnote {
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-tertiary);
+  margin-top: 40px;
+}
+.m-land-root .doc-footnote a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+.m-land-root .doc-footnote a:hover {
+  color: var(--text-primary);
+  text-decoration: underline;
+}
+
+/* Responsive tweaks ---------------------------------------------------- */
+@media (max-width: 640px) {
+  .m-land-root .doc-step { padding: 22px 24px; }
+  .m-land-root .doc-code { padding: 14px 16px; font-size: 13px; }
+  .m-land-root .tool-card { padding: 16px 18px; }
+}

--- a/src/app/docs/paybacker-assistant/page.tsx
+++ b/src/app/docs/paybacker-assistant/page.tsx
@@ -1,227 +1,208 @@
-import type { Metadata } from "next";
-import Link from "next/link";
-import PublicNavbar from "@/components/PublicNavbar";
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { MarkNav, MarkFoot } from '@/app/blog/_shared';
+import '../../(marketing)/styles.css';
+import './docs.css';
 
 export const metadata: Metadata = {
-  title: "Connect Paybacker to your desktop AI assistant",
+  title: 'Connect Paybacker to your desktop AI assistant',
   description:
-    "Ask your desktop AI assistant natural-language questions about your Paybacker data — transactions, subscriptions, budgets and net worth. Read-only, Pro feature.",
+    'Ask your desktop AI assistant natural-language questions about your Paybacker data — transactions, subscriptions, budgets and net worth. Read-only, Pro feature.',
   openGraph: {
-    title: "Connect Paybacker to your desktop AI assistant",
+    title: 'Connect Paybacker to your desktop AI assistant',
     description:
-      "Ask your desktop AI assistant natural-language questions about your Paybacker data — transactions, subscriptions, budgets and net worth.",
-    url: "https://paybacker.co.uk/docs/paybacker-assistant",
-    siteName: "Paybacker",
-    type: "article",
+      'Ask your desktop AI assistant natural-language questions about your Paybacker data — transactions, subscriptions, budgets and net worth.',
+    url: 'https://paybacker.co.uk/docs/paybacker-assistant',
+    siteName: 'Paybacker',
+    type: 'article',
   },
   twitter: {
-    card: "summary",
-    title: "Connect Paybacker to your desktop AI assistant",
+    card: 'summary',
+    title: 'Connect Paybacker to your desktop AI assistant',
     description:
-      "Ask your desktop AI assistant natural-language questions about your Paybacker data — transactions, subscriptions, budgets and net worth.",
-    images: ["/logo.png"],
+      'Ask your desktop AI assistant natural-language questions about your Paybacker data — transactions, subscriptions, budgets and net worth.',
+    images: ['/logo.png'],
   },
   alternates: {
-    canonical: "https://paybacker.co.uk/docs/paybacker-assistant",
+    canonical: 'https://paybacker.co.uk/docs/paybacker-assistant',
   },
 };
 
 const TOOLS: Array<{ name: string; blurb: string }> = [
   {
-    name: "get_transactions",
+    name: 'get_transactions',
     blurb:
-      "All your bank transactions, newest first. Your assistant can filter by date range and category.",
+      'All your bank transactions, newest first. Your assistant can filter by date range and category.',
   },
   {
-    name: "get_subscriptions",
+    name: 'get_subscriptions',
     blurb:
       "Every tracked subscription with monthly and annual totals so your assistant can answer 'what am I spending on streaming?'.",
   },
   {
-    name: "get_budget_summary",
+    name: 'get_budget_summary',
     blurb:
       "This month's spending against each of your budget categories, with on-track / warning / over-budget status.",
   },
   {
-    name: "get_net_worth_snapshot",
+    name: 'get_net_worth_snapshot',
     blurb:
-      "Assets minus liabilities, plus progress against each of your savings goals.",
+      'Assets minus liabilities, plus progress against each of your savings goals.',
   },
   {
-    name: "get_open_disputes",
+    name: 'get_open_disputes',
     blurb:
       "Every open complaint or dispute you've logged, including the amount being disputed.",
   },
   {
-    name: "search_transactions",
+    name: 'search_transactions',
     blurb:
       "Free-text search across descriptions and merchants — 'did I pay Netflix last month?', 'how much did I spend at Tesco?'.",
   },
 ];
 
 const EXAMPLE_PROMPTS: string[] = [
-  "How much did I spend on food and drink last month?",
-  "Summarise my subscriptions, highest first, and flag anything I probably forgot about.",
-  "Am I over budget on anything this month?",
-  "How close am I to my holiday savings goal?",
-  "Did I pay British Gas twice in March?",
+  'How much did I spend on food and drink last month?',
+  'Summarise my subscriptions, highest first, and flag anything I probably forgot about.',
+  'Am I over budget on anything this month?',
+  'How close am I to my holiday savings goal?',
+  'Did I pay British Gas twice in March?',
   "List every open dispute and tell me the total amount I'm trying to recover.",
 ];
 
 export default function PaybackerAssistantDocsPage() {
   return (
-    <div className="min-h-screen bg-navy-950">
-      <PublicNavbar />
-      <div className="h-16" />
-
-      <main className="container mx-auto px-4 md:px-6 py-10 md:py-16 max-w-3xl">
-        {/* Hero */}
-        <div className="mb-10">
-          <div className="flex items-center gap-2 mb-4">
-            <span className="text-xs font-semibold tracking-wider uppercase text-mint-400 bg-mint-400/10 border border-mint-400/30 rounded-full px-3 py-1">
+    <div className="m-land-root">
+      <MarkNav />
+      <main>
+        <div className="wrap">
+          <section className="land-hero" style={{ paddingBottom: 32 }}>
+            <span className="badge">
               Pro feature
+              <span className="beta-pill">Beta</span>
             </span>
-            <span className="text-xs text-slate-500">Beta</span>
-          </div>
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Connect Paybacker to your desktop AI assistant
-          </h1>
-          <p className="text-lg text-slate-300 leading-relaxed mb-4">
-            Ask natural-language questions about your own finances —
-            transactions, subscriptions, budgets and net worth — without
-            copying and pasting CSVs.
-          </p>
-          <p className="text-slate-400 leading-relaxed">
-            Paybacker ships a small open-source MCP server that any
-            MCP-compatible desktop AI app can spawn locally. It reads your
-            Paybacker data over HTTPS using a personal access token you mint
-            yourself. Read-only — your assistant cannot move money, cancel
-            anything or change your account.
-          </p>
-        </div>
-
-        {/* Prerequisites */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Before you start
-          </h2>
-          <ul className="space-y-3 text-slate-300">
-            <li className="flex items-start gap-3">
-              <span className="text-mint-400 mt-1">&#8226;</span>
-              <span>
-                <strong className="text-white">A Paybacker Pro plan.</strong>{" "}
-                The Paybacker Assistant is a Pro-tier feature. You can{" "}
-                <Link
-                  href="/pricing"
-                  className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
-                >
-                  upgrade here
-                </Link>
-                .
-              </span>
-            </li>
-            <li className="flex items-start gap-3">
-              <span className="text-mint-400 mt-1">&#8226;</span>
-              <span>
-                <strong className="text-white">
-                  An MCP-compatible desktop AI app
-                </strong>{" "}
-                installed on macOS or Windows. Any desktop AI client that
-                supports the open{" "}
-                <a
-                  href="https://modelcontextprotocol.io"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
-                >
-                  Model Context Protocol
-                </a>{" "}
-                will work.
-              </span>
-            </li>
-            <li className="flex items-start gap-3">
-              <span className="text-mint-400 mt-1">&#8226;</span>
-              <span>
-                <strong className="text-white">Node.js 18 or later.</strong>{" "}
-                Most desktop AI apps ship with their own Node runtime, so{" "}
-                <code className="text-orange-300">npx</code> will work out of
-                the box on most machines.
-              </span>
-            </li>
-          </ul>
-        </section>
-
-        {/* Step 1 */}
-        <section className="mb-12">
-          <div className="flex items-center gap-3 mb-4">
-            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-mint-400/10 border border-mint-400/40 text-mint-400 font-bold">
-              1
-            </span>
-            <h2 className="text-2xl font-bold text-white font-[family-name:var(--font-heading)]">
-              Mint a personal access token
-            </h2>
-          </div>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            In Paybacker, open{" "}
-            <Link
-              href="/dashboard/settings/mcp"
-              className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
-            >
-              Settings &rarr; Paybacker Assistant (MCP)
-            </Link>{" "}
-            and click <strong className="text-white">Generate token</strong>.
-            Give it a name like &quot;MacBook&quot; or &quot;Work laptop&quot;
-            so you can tell tokens apart if you revoke one later.
-          </p>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            You&apos;ll see the token{" "}
-            <strong className="text-white">exactly once</strong>. Copy it
-            immediately — it starts with{" "}
-            <code className="text-orange-300">pbk_</code>. Paybacker only
-            stores a hash, so we can&apos;t show it to you again if you lose
-            it (you&apos;d just revoke it and mint a new one).
-          </p>
-          <div className="bg-navy-900/60 border border-navy-700/50 rounded-2xl p-4 text-sm text-slate-400">
-            Tokens expire after 180 days and you can have up to 10 active at
-            once. Revoke any token instantly from the same settings page — the
-            next request using it will fail with a clear error.
-          </div>
-        </section>
-
-        {/* Step 2 */}
-        <section className="mb-12">
-          <div className="flex items-center gap-3 mb-4">
-            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-mint-400/10 border border-mint-400/40 text-mint-400 font-bold">
-              2
-            </span>
-            <h2 className="text-2xl font-bold text-white font-[family-name:var(--font-heading)]">
-              Run the one-command setup
-            </h2>
-          </div>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Open Terminal (macOS) or PowerShell (Windows) and run:
-          </p>
-          <pre className="bg-navy-900 border border-navy-700/50 rounded-2xl p-4 overflow-x-auto text-sm text-slate-200 mb-4">
-            <code>npx @paybacker/mcp setup</code>
-          </pre>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Paste the token when prompted. The setup script finds your AI
-            app&apos;s MCP config file, adds a{" "}
-            <code className="text-orange-300">paybacker</code> entry under{" "}
-            <code className="text-orange-300">mcpServers</code>, and saves the
-            token locally so your assistant can spawn the server with it. It
-            doesn&apos;t touch any of your other MCP servers.
-          </p>
-          <details className="bg-navy-900/60 border border-navy-700/50 rounded-2xl p-4 text-sm">
-            <summary className="cursor-pointer text-slate-200 font-semibold">
-              Prefer to edit the config yourself?
-            </summary>
-            <p className="text-slate-400 mt-3 mb-3">
-              Add this block to your AI desktop app&apos;s MCP config file
-              (check your app&apos;s docs for the exact path):
+            <h1>Connect Paybacker to your desktop AI assistant</h1>
+            <p className="subtitle">
+              Ask natural-language questions about your own finances — transactions,
+              subscriptions, budgets and net worth — without copying and pasting CSVs.
             </p>
-            <pre className="bg-navy-950 border border-navy-700/50 rounded-xl p-3 overflow-x-auto text-xs text-slate-300">
-              <code>{`{
+          </section>
+
+          <section className="prose-section" style={{ paddingTop: 24 }}>
+            <div className="rights-card">
+              <div className="prose-body" style={{ margin: 0 }}>
+                <p>
+                  Paybacker ships a small open-source MCP server that any MCP-compatible
+                  desktop AI app can spawn locally. It reads your Paybacker data over HTTPS
+                  using a personal access token you mint yourself. Read-only — your assistant
+                  cannot move money, cancel anything or change your account.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <div className="rights-card">
+              <h2>Before you start</h2>
+              <ul className="rights-list">
+                <li>
+                  <strong>A Paybacker Pro plan.</strong> The Paybacker Assistant is a Pro-tier
+                  feature. You can{' '}
+                  <Link
+                    href="/pricing"
+                    style={{
+                      color: 'var(--accent-mint-deep)',
+                      fontWeight: 600,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    upgrade here
+                  </Link>
+                  .
+                </li>
+                <li>
+                  <strong>An MCP-compatible desktop AI app</strong> installed on macOS or
+                  Windows. Any desktop AI client that supports the open{' '}
+                  <a
+                    href="https://modelcontextprotocol.io"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      color: 'var(--accent-mint-deep)',
+                      fontWeight: 600,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    Model Context Protocol
+                  </a>{' '}
+                  will work.
+                </li>
+                <li>
+                  <strong>Node.js 18 or later.</strong> Most desktop AI apps ship with their
+                  own Node runtime, so <code className="doc-code-inline">npx</code> will work
+                  out of the box on most machines.
+                </li>
+              </ul>
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <h2 style={{ textAlign: 'center' }}>Setup in four steps</h2>
+
+            <div className="doc-step">
+              <div className="doc-step-head">
+                <div className="doc-step-num">1</div>
+                <h2>Mint a personal access token</h2>
+              </div>
+              <p>
+                In Paybacker, open{' '}
+                <Link href="/dashboard/settings/mcp">
+                  Settings → Paybacker Assistant (MCP)
+                </Link>{' '}
+                and click <strong>Generate token</strong>. Give it a name like
+                &quot;MacBook&quot; or &quot;Work laptop&quot; so you can tell tokens apart
+                if you revoke one later.
+              </p>
+              <p>
+                You&apos;ll see the token <strong>exactly once</strong>. Copy it immediately
+                — it starts with <code className="doc-code-inline">pbk_</code>. Paybacker
+                only stores a hash, so we can&apos;t show it to you again if you lose it
+                (you&apos;d just revoke it and mint a new one).
+              </p>
+              <div className="doc-note">
+                Tokens expire after 180 days and you can have up to 10 active at once. Revoke
+                any token instantly from the same settings page — the next request using it
+                will fail with a clear error.
+              </div>
+            </div>
+
+            <div className="doc-step">
+              <div className="doc-step-head">
+                <div className="doc-step-num">2</div>
+                <h2>Run the one-command setup</h2>
+              </div>
+              <p>Open Terminal (macOS) or PowerShell (Windows) and run:</p>
+              <pre className="doc-code">
+                <code>npx @paybacker/mcp setup</code>
+              </pre>
+              <p>
+                Paste the token when prompted. The setup script finds your AI app&apos;s MCP
+                config file, adds a <code className="doc-code-inline">paybacker</code> entry
+                under <code className="doc-code-inline">mcpServers</code>, and saves the
+                token locally so your assistant can spawn the server with it. It doesn&apos;t
+                touch any of your other MCP servers.
+              </p>
+              <details className="troubleshoot" style={{ marginTop: 12 }}>
+                <summary>Prefer to edit the config yourself?</summary>
+                <p>
+                  Add this block to your AI desktop app&apos;s MCP config file (check your
+                  app&apos;s docs for the exact path):
+                </p>
+                <pre
+                  className="doc-code doc-code-small"
+                  style={{ marginTop: 12, marginBottom: 0 }}
+                >
+                  <code>{`{
   "mcpServers": {
     "paybacker": {
       "command": "npx",
@@ -232,355 +213,245 @@ export default function PaybackerAssistantDocsPage() {
     }
   }
 }`}</code>
-            </pre>
-          </details>
-        </section>
+                </pre>
+              </details>
+            </div>
 
-        {/* Step 3 */}
-        <section className="mb-12">
-          <div className="flex items-center gap-3 mb-4">
-            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-mint-400/10 border border-mint-400/40 text-mint-400 font-bold">
-              3
-            </span>
-            <h2 className="text-2xl font-bold text-white font-[family-name:var(--font-heading)]">
-              Restart your AI desktop app
-            </h2>
-          </div>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Fully quit the app (not just close the window) and reopen it. When
-            it starts, it will spawn the Paybacker MCP server in the
-            background.
-          </p>
-          <p className="text-slate-300 leading-relaxed">
-            You can confirm it&apos;s connected by opening a new chat and
-            looking for{" "}
-            <strong className="text-white">&quot;paybacker&quot;</strong> in
-            the tools menu. If you don&apos;t see it, see{" "}
-            <a
-              href="#troubleshooting"
-              className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
-            >
-              troubleshooting
-            </a>{" "}
-            below.
-          </p>
-        </section>
-
-        {/* Step 4 */}
-        <section className="mb-12">
-          <div className="flex items-center gap-3 mb-4">
-            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-mint-400/10 border border-mint-400/40 text-mint-400 font-bold">
-              4
-            </span>
-            <h2 className="text-2xl font-bold text-white font-[family-name:var(--font-heading)]">
-              Ask Paybacker about your money
-            </h2>
-          </div>
-          <p className="text-slate-300 leading-relaxed mb-4">
-            Open a new chat in your AI desktop app and try one of these:
-          </p>
-          <ul className="space-y-2 mb-4">
-            {EXAMPLE_PROMPTS.map((p) => (
-              <li
-                key={p}
-                className="bg-navy-900 border border-navy-700/50 rounded-xl px-4 py-3 text-slate-200 text-sm"
-              >
-                &ldquo;{p}&rdquo;
-              </li>
-            ))}
-          </ul>
-          <p className="text-slate-400 text-sm">
-            Your assistant will ask for permission the first time it uses each
-            Paybacker tool. You can approve each tool individually, or allow
-            the whole server for the session.
-          </p>
-        </section>
-
-        {/* What the assistant can see */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            What your assistant can see
-          </h2>
-          <p className="text-slate-400 leading-relaxed mb-4 text-sm">
-            Every tool is read-only. None of them can change, move, or delete
-            anything in your Paybacker account.
-          </p>
-          <div className="space-y-3">
-            {TOOLS.map((t) => (
-              <div
-                key={t.name}
-                className="bg-navy-900 border border-navy-700/50 rounded-2xl p-4"
-              >
-                <code className="text-orange-300 font-semibold text-sm">
-                  {t.name}
-                </code>
-                <p className="text-slate-300 text-sm mt-1 leading-relaxed">
-                  {t.blurb}
-                </p>
+            <div className="doc-step">
+              <div className="doc-step-head">
+                <div className="doc-step-num">3</div>
+                <h2>Restart your AI desktop app</h2>
               </div>
-            ))}
-          </div>
-        </section>
+              <p>
+                Fully quit the app (not just close the window) and reopen it. When it starts,
+                it will spawn the Paybacker MCP server in the background.
+              </p>
+              <p>
+                You can confirm it&apos;s connected by opening a new chat and looking for{' '}
+                <strong>&quot;paybacker&quot;</strong> in the tools menu. If you don&apos;t
+                see it, see <a href="#troubleshooting">troubleshooting</a> below.
+              </p>
+            </div>
 
-        {/* Security */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Security notes
-          </h2>
-          <ul className="space-y-3 text-slate-300 text-sm">
-            <li className="flex items-start gap-3">
-              <span className="text-mint-400 mt-1">&#8226;</span>
-              <span>
-                <strong className="text-white">
-                  Your token stays on your machine.
-                </strong>{" "}
-                It&apos;s saved into your AI app&apos;s MCP config file and
-                only sent back to{" "}
-                <code className="text-orange-300">paybacker.co.uk</code> over
-                HTTPS.
-              </span>
-            </li>
-            <li className="flex items-start gap-3">
-              <span className="text-mint-400 mt-1">&#8226;</span>
-              <span>
-                <strong className="text-white">
-                  We never see it in plaintext.
-                </strong>{" "}
-                Paybacker only stores a SHA-256 hash of the token and a short
-                prefix so you can identify it in the UI.
-              </span>
-            </li>
-            <li className="flex items-start gap-3">
-              <span className="text-mint-400 mt-1">&#8226;</span>
-              <span>
-                <strong className="text-white">Revoke any time.</strong>{" "}
-                Revoke from{" "}
-                <Link
-                  href="/dashboard/settings/mcp"
-                  className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
-                >
-                  Settings &rarr; Paybacker Assistant
-                </Link>{" "}
-                and the next request will fail immediately.
-              </span>
-            </li>
-            <li className="flex items-start gap-3">
-              <span className="text-mint-400 mt-1">&#8226;</span>
-              <span>
-                <strong className="text-white">
-                  Pro-gated on every call.
-                </strong>{" "}
-                If your Pro subscription lapses, all tool calls start
-                returning a clear &quot;MCP access requires an active Pro
-                plan&quot; error.
-              </span>
-            </li>
-            <li className="flex items-start gap-3">
-              <span className="text-mint-400 mt-1">&#8226;</span>
-              <span>
-                <strong className="text-white">Open source.</strong> The{" "}
-                <code className="text-orange-300">@paybacker/mcp</code>{" "}
-                package is MIT-licensed and available on{" "}
-                <a
-                  href="https://github.com/airpau/paybacker-mcp"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
-                >
-                  GitHub
-                </a>{" "}
-                — audit every line of code before you run it.
-              </span>
-            </li>
-          </ul>
-        </section>
+            <div className="doc-step">
+              <div className="doc-step-head">
+                <div className="doc-step-num">4</div>
+                <h2>Ask Paybacker about your money</h2>
+              </div>
+              <p>Open a new chat in your AI desktop app and try one of these:</p>
+              <div className="tool-list" style={{ marginBottom: 14 }}>
+                {EXAMPLE_PROMPTS.map((p) => (
+                  <div key={p} className="tool-card">
+                    <p style={{ fontStyle: 'italic' }}>&ldquo;{p}&rdquo;</p>
+                  </div>
+                ))}
+              </div>
+              <p style={{ color: 'var(--text-tertiary)', fontSize: 14 }}>
+                Your assistant will ask for permission the first time it uses each Paybacker
+                tool. You can approve each tool individually, or allow the whole server for
+                the session.
+              </p>
+            </div>
+          </section>
 
-        {/* Troubleshooting */}
-        <section id="troubleshooting" className="mb-12 scroll-mt-24">
-          <h2 className="text-2xl font-bold text-white mb-4 font-[family-name:var(--font-heading)]">
-            Troubleshooting
-          </h2>
-          <div className="space-y-4">
-            <details className="bg-navy-900 border border-navy-700/50 rounded-2xl p-4">
-              <summary className="cursor-pointer text-slate-200 font-semibold">
-                My AI app doesn&apos;t show the Paybacker tools
-              </summary>
-              <ul className="mt-3 space-y-2 text-sm text-slate-400">
+          <section className="prose-section">
+            <h2 style={{ textAlign: 'center' }}>What your assistant can see</h2>
+            <p
+              style={{
+                textAlign: 'center',
+                maxWidth: 640,
+                margin: '0 auto 24px',
+                color: 'var(--text-secondary)',
+                fontSize: 15,
+              }}
+            >
+              Every tool is read-only. None of them can change, move, or delete anything in
+              your Paybacker account.
+            </p>
+            <div className="tool-list">
+              {TOOLS.map((t) => (
+                <div key={t.name} className="tool-card">
+                  <code>{t.name}</code>
+                  <p>{t.blurb}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <div className="rights-card">
+              <h2>Security notes</h2>
+              <ul className="rights-list">
                 <li>
-                  &bull; Fully quit the app (not just close the window) and
-                  reopen.
+                  <strong>Your token stays on your machine.</strong> It&apos;s saved into
+                  your AI app&apos;s MCP config file and only sent back to{' '}
+                  <code className="doc-code-inline">paybacker.co.uk</code> over HTTPS.
                 </li>
                 <li>
-                  &bull; Open your app&apos;s MCP config file and confirm the{" "}
-                  <code className="text-orange-300">paybacker</code> entry is
-                  there under{" "}
-                  <code className="text-orange-300">mcpServers</code>.
+                  <strong>We never see it in plaintext.</strong> Paybacker only stores a
+                  SHA-256 hash of the token and a short prefix so you can identify it in the
+                  UI.
                 </li>
                 <li>
-                  &bull; Check the file is valid JSON (a missing comma will
-                  stop the app loading any MCP server).
+                  <strong>Revoke any time.</strong> Revoke from{' '}
+                  <Link
+                    href="/dashboard/settings/mcp"
+                    style={{
+                      color: 'var(--accent-mint-deep)',
+                      fontWeight: 600,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    Settings → Paybacker Assistant
+                  </Link>{' '}
+                  and the next request will fail immediately.
                 </li>
                 <li>
-                  &bull; Re-run{" "}
-                  <code className="text-orange-300">
-                    npx @paybacker/mcp setup
-                  </code>
-                  .
+                  <strong>Pro-gated on every call.</strong> If your Pro subscription lapses,
+                  all tool calls start returning a clear &quot;MCP access requires an active
+                  Pro plan&quot; error.
+                </li>
+                <li>
+                  <strong>Open source.</strong> The{' '}
+                  <code className="doc-code-inline">@paybacker/mcp</code> package is
+                  MIT-licensed and available on{' '}
+                  <a
+                    href="https://github.com/airpau/paybacker-mcp"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      color: 'var(--accent-mint-deep)',
+                      fontWeight: 600,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    GitHub
+                  </a>{' '}
+                  — audit every line of code before you run it.
                 </li>
               </ul>
-            </details>
-            <details className="bg-navy-900 border border-navy-700/50 rounded-2xl p-4">
-              <summary className="cursor-pointer text-slate-200 font-semibold">
-                Your assistant says &ldquo;Token revoked&rdquo; or
-                &ldquo;Token expired&rdquo;
-              </summary>
-              <p className="mt-3 text-sm text-slate-400">
-                Generate a new token from{" "}
-                <Link
-                  href="/dashboard/settings/mcp"
-                  className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
-                >
-                  Settings &rarr; Paybacker Assistant
-                </Link>{" "}
-                and run{" "}
-                <code className="text-orange-300">
-                  npx @paybacker/mcp setup
-                </code>{" "}
-                again. Tokens expire after 180 days by default.
+            </div>
+          </section>
+
+          <section
+            id="troubleshooting"
+            className="prose-section"
+            style={{ scrollMarginTop: 96 }}
+          >
+            <h2 style={{ textAlign: 'center' }}>Troubleshooting</h2>
+            <div className="troubleshoot-list">
+              <details className="troubleshoot">
+                <summary>My AI app doesn&apos;t show the Paybacker tools</summary>
+                <ul>
+                  <li>Fully quit the app (not just close the window) and reopen.</li>
+                  <li>
+                    Open your app&apos;s MCP config file and confirm the{' '}
+                    <code className="doc-code-inline">paybacker</code> entry is there under{' '}
+                    <code className="doc-code-inline">mcpServers</code>.
+                  </li>
+                  <li>
+                    Check the file is valid JSON (a missing comma will stop the app loading
+                    any MCP server).
+                  </li>
+                  <li>
+                    Re-run{' '}
+                    <code className="doc-code-inline">npx @paybacker/mcp setup</code>.
+                  </li>
+                </ul>
+              </details>
+              <details className="troubleshoot">
+                <summary>
+                  Your assistant says &ldquo;Token revoked&rdquo; or &ldquo;Token
+                  expired&rdquo;
+                </summary>
+                <p>
+                  Generate a new token from{' '}
+                  <Link href="/dashboard/settings/mcp">
+                    Settings → Paybacker Assistant
+                  </Link>{' '}
+                  and run <code className="doc-code-inline">npx @paybacker/mcp setup</code>{' '}
+                  again. Tokens expire after 180 days by default.
+                </p>
+              </details>
+              <details className="troubleshoot">
+                <summary>
+                  Your assistant says &ldquo;MCP access requires an active Pro plan&rdquo;
+                </summary>
+                <p>
+                  Your Paybacker subscription isn&apos;t currently Pro. You can{' '}
+                  <Link href="/pricing">upgrade here</Link>. Your existing tokens will start
+                  working again immediately once Pro is active.
+                </p>
+              </details>
+              <details className="troubleshoot">
+                <summary>
+                  Nothing happens when I run{' '}
+                  <code className="doc-code-inline">npx @paybacker/mcp setup</code>
+                </summary>
+                <p>
+                  Check your Node version with{' '}
+                  <code className="doc-code-inline">node --version</code>. You need 18 or
+                  later. On macOS you can install Node with{' '}
+                  <a
+                    href="https://brew.sh"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Homebrew
+                  </a>{' '}
+                  (<code className="doc-code-inline">brew install node</code>).
+                </p>
+              </details>
+            </div>
+          </section>
+
+          <section className="prose-section">
+            <div className="final-cta">
+              <h2>Ready to ask Paybacker about your money?</h2>
+              <p>
+                Upgrade to Pro, mint a token, and be chatting to your own transactions in
+                under two minutes.
               </p>
-            </details>
-            <details className="bg-navy-900 border border-navy-700/50 rounded-2xl p-4">
-              <summary className="cursor-pointer text-slate-200 font-semibold">
-                Your assistant says &ldquo;MCP access requires an active Pro
-                plan&rdquo;
-              </summary>
-              <p className="mt-3 text-sm text-slate-400">
-                Your Paybacker subscription isn&apos;t currently Pro. You can{" "}
+              <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+                <Link href="/dashboard/settings/mcp" className="btn btn-mint btn-lg">
+                  Generate your token
+                </Link>
                 <Link
                   href="/pricing"
-                  className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
+                  className="btn btn-lg"
+                  style={{
+                    background: 'transparent',
+                    color: 'var(--text-on-ink)',
+                    border: '1px solid rgba(255,255,255,0.25)',
+                  }}
                 >
-                  upgrade here
+                  See Pro pricing
                 </Link>
-                . Your existing tokens will start working again immediately
-                once Pro is active.
-              </p>
-            </details>
-            <details className="bg-navy-900 border border-navy-700/50 rounded-2xl p-4">
-              <summary className="cursor-pointer text-slate-200 font-semibold">
-                Nothing happens when I run{" "}
-                <code className="text-orange-300">
-                  npx @paybacker/mcp setup
-                </code>
-              </summary>
-              <p className="mt-3 text-sm text-slate-400">
-                Check your Node version with{" "}
-                <code className="text-orange-300">node --version</code>. You
-                need 18 or later. On macOS you can install Node with{" "}
-                <a
-                  href="https://brew.sh"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-mint-400 hover:text-mint-300 underline-offset-2 hover:underline"
-                >
-                  Homebrew
-                </a>{" "}
-                (<code className="text-orange-300">brew install node</code>).
-              </p>
-            </details>
-          </div>
-        </section>
+              </div>
+            </div>
+          </section>
 
-        {/* CTA */}
-        <section className="mb-4 bg-gradient-to-br from-mint-400/10 via-navy-900 to-orange-500/10 border border-navy-700/50 rounded-3xl p-6 md:p-8 text-center">
-          <h2 className="text-2xl md:text-3xl font-bold text-white mb-3 font-[family-name:var(--font-heading)]">
-            Ready to ask Paybacker about your money?
-          </h2>
-          <p className="text-slate-300 mb-6 max-w-md mx-auto">
-            Upgrade to Pro, mint a token, and be chatting to your own
-            transactions in under two minutes.
-          </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <Link
-              href="/dashboard/settings/mcp"
-              className="inline-flex items-center justify-center rounded-full bg-mint-400 text-navy-950 font-semibold px-6 py-3 hover:bg-mint-300 transition-all"
-            >
-              Generate your token
-            </Link>
-            <Link
-              href="/pricing"
-              className="inline-flex items-center justify-center rounded-full border border-navy-600 text-white font-semibold px-6 py-3 hover:bg-navy-800 transition-all"
-            >
-              See Pro pricing
-            </Link>
-          </div>
-        </section>
-
-        <p className="text-xs text-slate-500 text-center">
-          Source code:{" "}
-          <a
-            href="https://github.com/airpau/paybacker-mcp"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-slate-400 hover:text-white underline-offset-2 hover:underline"
-          >
-            github.com/airpau/paybacker-mcp
-          </a>{" "}
-          &middot; Published on npm as{" "}
-          <a
-            href="https://www.npmjs.com/package/@paybacker/mcp"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-slate-400 hover:text-white underline-offset-2 hover:underline"
-          >
-            @paybacker/mcp
-          </a>
-        </p>
-      </main>
-
-      <footer className="container mx-auto px-4 md:px-6 py-8 border-t border-navy-700/50 mt-16">
-        <div className="text-center text-slate-500 text-sm space-y-3">
-          <div className="flex flex-wrap justify-center gap-4 md:gap-6">
-            <Link href="/about" className="hover:text-white transition-all">
-              About
-            </Link>
-            <Link href="/blog" className="hover:text-white transition-all">
-              Blog
-            </Link>
-            <Link
-              href="/privacy-policy"
-              className="hover:text-white transition-all"
-            >
-              Privacy Policy
-            </Link>
-            <Link
-              href="/terms-of-service"
-              className="hover:text-white transition-all"
-            >
-              Terms of Service
-            </Link>
-            <Link href="/pricing" className="hover:text-white transition-all">
-              Pricing
-            </Link>
+          <p className="doc-footnote">
+            Source code:{' '}
             <a
-              href="mailto:hello@paybacker.co.uk"
-              className="hover:text-white transition-all"
+              href="https://github.com/airpau/paybacker-mcp"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              Contact
-            </a>
-          </div>
-          <p>
-            Need help? Email{" "}
+              github.com/airpau/paybacker-mcp
+            </a>{' '}
+            · Published on npm as{' '}
             <a
-              href="mailto:support@paybacker.co.uk"
-              className="text-mint-400 hover:text-mint-300"
+              href="https://www.npmjs.com/package/@paybacker/mcp"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              support@paybacker.co.uk
+              @paybacker/mcp
             </a>
           </p>
-          <p>&copy; 2026 Paybacker LTD. All rights reserved.</p>
         </div>
-      </footer>
+      </main>
+      <MarkFoot />
     </div>
   );
 }


### PR DESCRIPTION
Batch 6d: MCP setup docs page moves to the light theme. Final batch of the public marketing redesign.

### What's in here

| Route | Before | After |
|---|---|---|
| `/docs/paybacker-assistant` | Dark navy-950 + PublicNavbar, 4 numbered steps, dark code blocks | Light `.m-land-root` + MarkNav + marketing primitives + new `docs.css` |

### Design system

Same scoped-root pattern as 6a / 6b / 6c:

- Wraps content in `<div className="m-land-root">` and imports both
  `(marketing)/styles.css` (nav shell, hero, rights-card, final-cta) and
  a new `docs/paybacker-assistant/docs.css` (code blocks, tool cards,
  numbered steps, collapsibles).
- MarkNav + MarkFoot from `@/app/blog/_shared` replaces the old
  `PublicNavbar` and inline footer block.

### New docs primitives (`docs.css`)

- `.doc-code`, `.doc-code-small`, `.doc-code-inline` — the only dark
  surface on the page (monospace code blocks need contrast). Inline
  code renders as a light chip with orange-deep text.
- `.tool-card` + `.tool-list` — white cards for the 6 MCP tools and
  the 6 example prompts.
- `.doc-step` + `.doc-step-num` — vertically-stacked numbered cards
  (different from `.step-grid` which is a horizontal 3-up grid).
- `.doc-note` — mint-wash panel for the 180-day / 10-token warning.
- `.troubleshoot` — white `<details>` card with a +/− indicator, used
  for the 4 FAQ-style troubleshooting entries and the alternate
  manual-config JSON disclosure.
- `.beta-pill` — subtle grey pill for the &quot;Beta&quot; label next to
  &quot;Pro feature&quot; in the hero badge.

### Content preserved verbatim

- All 6 MCP tools with exact blurbs: `get_transactions`,
  `get_subscriptions`, `get_budget_summary`, `get_net_worth_snapshot`,
  `get_open_disputes`, `search_transactions`.
- All 6 example prompts.
- All 5 security notes (token storage, SHA-256 hashing, revoke-any-time,
  Pro-gated, open source).
- All 4 troubleshooting entries + the manual-config JSON block.
- Links to `/dashboard/settings/mcp`, `/pricing`,
  `modelcontextprotocol.io`, `github.com/airpau/paybacker-mcp`,
  `npmjs.com/package/@paybacker/mcp`, and `brew.sh`.
- Token format reference (`pbk_` prefix), 180-day expiry, 10-token limit.

### Accessibility

- External links use `rel="noopener noreferrer"`.
- `<details>` summaries include +/− affordance via CSS pseudo-element.
- `#troubleshooting` anchor target preserved with `scroll-margin-top`
  so the &quot;see troubleshooting&quot; link in step 3 still lands
  correctly under the sticky nav.

### Checks

- `npx tsc --noEmit`: clean for both files. Pre-existing errors
  elsewhere in the repo are unchanged.
- `generateMetadata` unchanged for SEO continuity.
- No API keys, no new env vars, no database changes.

### Marketing redesign complete

After this merges, every public-facing marketing/SEO/docs route is on
the light design system:

- Homepage + legal + auth (batches 1–6a)
- Blog index + post pages (earlier batches)
- Public deals directory (6b)
- SEO content pages (6c)
- MCP setup docs (6d — this PR)

Next up is **Batch 7**: dashboard shell (behind auth) — a separate
workstream, unaffected by this PR.
