### PR TITLE
feat(dashboard): redesign dashboard layout shell to light theme (batch 7)

### DIFF
--- a/src/app/dashboard/dashboard.css
+++ b/src/app/dashboard/dashboard.css
@@ -1,0 +1,444 @@
+/*
+ * Dashboard shell — scoped stylesheet.
+ *
+ * Used only by the dashboard layout (src/app/dashboard/layout.tsx).
+ * Matches the light + mint + orange design system used across the
+ * public marketing site, but packaged as dashboard-specific primitives
+ * under `.m-dash-root` so these styles never leak to other routes.
+ */
+
+.m-dash-root {
+  /* Token aliases → globals.css Tailwind v4 theme */
+  --surface-base: var(--color-surface-base);
+  --surface-elevated: var(--color-surface-elevated);
+  --surface-ink: var(--color-surface-ink);
+
+  --text-primary: var(--color-ink-primary);
+  --text-secondary: var(--color-ink-secondary);
+  --text-tertiary: var(--color-ink-tertiary);
+  --text-on-ink: var(--color-on-ink);
+  --text-on-ink-dim: var(--color-on-ink-dim);
+
+  --accent-mint: var(--color-accent-mint);
+  --accent-mint-deep: var(--color-accent-mint-deep);
+  --accent-mint-wash: var(--color-accent-mint-wash);
+  --accent-orange: var(--color-accent-orange);
+  --accent-orange-deep: var(--color-accent-orange-deep);
+
+  --divider: var(--color-divider-light);
+
+  --r-card: var(--radius-marketing-card);
+  --r-btn: var(--radius-marketing-btn);
+  --r-input: var(--radius-marketing-input);
+  --r-pill: var(--radius-marketing-pill);
+
+  --shadow-sm: var(--shadow-marketing-sm);
+  --shadow-md: var(--shadow-marketing-md);
+
+  --sidebar-w: 272px;
+  --sidebar-pad: 24px;
+
+  min-height: 100vh;
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+.m-dash-root *,
+.m-dash-root *::before,
+.m-dash-root *::after { box-sizing: border-box; }
+
+/* Layout ---------------------------------------------------------------- */
+.m-dash-root .dash-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* Desktop sidebar ------------------------------------------------------- */
+.m-dash-root .dash-sidebar {
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  min-height: 100vh;
+  background: #fff;
+  border-right: 1px solid var(--divider);
+  padding: var(--sidebar-pad);
+  display: flex;
+  flex-direction: column;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+@media (max-width: 1023px) {
+  .m-dash-root .dash-sidebar.is-desktop { display: none; }
+}
+
+/* Sidebar logo + user block -------------------------------------------- */
+.m-dash-root .dash-brand {
+  display: flex; align-items: center; gap: 10px;
+  text-decoration: none;
+  margin-bottom: 20px;
+}
+.m-dash-root .dash-brand .logo-mark {
+  width: 34px; height: 34px;
+  border-radius: 9px;
+  background: var(--accent-mint);
+  display: grid; place-items: center;
+  color: #052E1C;
+  font-weight: 700; font-size: 15px;
+  letter-spacing: -0.02em;
+}
+.m-dash-root .dash-brand .logo-text {
+  font-weight: 700;
+  font-size: 20px;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+.m-dash-root .dash-brand .logo-text .deep { color: var(--accent-mint-deep); }
+
+.m-dash-root .dash-user {
+  padding-bottom: 20px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--divider);
+}
+.m-dash-root .dash-user-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.m-dash-root .dash-user-email {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin: 2px 0 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.m-dash-root .tier-pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  margin-top: 10px;
+  padding: 4px 10px;
+  border-radius: var(--r-pill);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background 150ms ease, color 150ms ease;
+}
+.m-dash-root .tier-pill.tier-free {
+  background: #F3F4F6;
+  color: var(--text-secondary);
+}
+.m-dash-root .tier-pill.tier-free:hover {
+  background: var(--accent-mint-wash);
+  color: var(--accent-mint-deep);
+}
+.m-dash-root .tier-pill.tier-essential {
+  background: var(--accent-mint-wash);
+  color: var(--accent-mint-deep);
+}
+.m-dash-root .tier-pill.tier-pro {
+  background: #FEF3C7;
+  color: var(--accent-orange-deep);
+}
+.m-dash-root .tier-pill.tier-trial {
+  background: #FEF3C7;
+  color: var(--accent-orange-deep);
+}
+
+.m-dash-root .upgrade-card {
+  margin-top: 14px;
+  padding: 14px 14px 12px;
+  background: var(--accent-mint-wash);
+  border: 1px solid rgba(5, 150, 105, 0.18);
+  border-radius: var(--r-input);
+}
+.m-dash-root .upgrade-card p {
+  margin: 0 0 10px;
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+.m-dash-root .upgrade-card a {
+  display: block;
+  text-align: center;
+  padding: 9px 12px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: #052E1C;
+  background: var(--accent-mint);
+  border-radius: var(--r-btn);
+  text-decoration: none;
+  transition: background 150ms ease, transform 150ms ease;
+}
+.m-dash-root .upgrade-card a:hover {
+  background: #2CC48A;
+  transform: translateY(-1px);
+}
+
+/* Nav items ------------------------------------------------------------- */
+.m-dash-root .dash-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  padding-top: 4px;
+}
+.m-dash-root .dash-nav a {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  border-radius: var(--r-input);
+  text-decoration: none;
+  min-height: 40px;
+  position: relative;
+  transition: background 150ms ease, color 150ms ease;
+}
+.m-dash-root .dash-nav a:hover {
+  background: #F5F6F3;
+  color: var(--text-primary);
+}
+.m-dash-root .dash-nav a.is-active {
+  background: var(--accent-mint-wash);
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+}
+.m-dash-root .dash-nav a.is-active::before {
+  content: '';
+  position: absolute;
+  left: -8px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 22px;
+  border-radius: 2px;
+  background: var(--accent-mint);
+}
+.m-dash-root .dash-nav a svg {
+  width: 18px; height: 18px;
+  flex-shrink: 0;
+}
+.m-dash-root .dash-nav a .nav-badge {
+  margin-left: auto;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-radius: var(--r-pill);
+}
+.m-dash-root .dash-nav a .nav-badge.new {
+  background: #FEF3C7;
+  color: var(--accent-orange-deep);
+}
+.m-dash-root .dash-nav a .nav-badge.soon {
+  background: #F3F4F6;
+  color: var(--text-tertiary);
+}
+
+.m-dash-root .dash-nav .dash-admin {
+  margin-top: 10px;
+  padding-top: 14px;
+  border-top: 1px solid var(--divider);
+  color: #B91C1C;
+}
+.m-dash-root .dash-nav .dash-admin:hover {
+  background: #FEF2F2;
+  color: #991B1B;
+}
+.m-dash-root .dash-nav .dash-admin.is-active {
+  background: #FEF2F2;
+  color: #B91C1C;
+}
+.m-dash-root .dash-nav .dash-admin.is-active::before {
+  background: #DC2626;
+}
+
+/* Sign out ------------------------------------------------------------- */
+.m-dash-root .dash-signout {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--divider);
+}
+.m-dash-root .dash-signout button {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  background: transparent;
+  border: none;
+  border-radius: var(--r-input);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+  min-height: 40px;
+}
+.m-dash-root .dash-signout button:hover {
+  background: #FEF2F2;
+  color: #B91C1C;
+}
+.m-dash-root .dash-signout svg { width: 16px; height: 16px; }
+
+/* Mobile header -------------------------------------------------------- */
+.m-dash-root .dash-mob-header {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: #fff;
+  border-bottom: 1px solid var(--divider);
+  position: sticky; top: 0;
+  z-index: 40;
+}
+@media (max-width: 1023px) {
+  .m-dash-root .dash-mob-header { display: flex; }
+}
+.m-dash-root .dash-mob-header .dash-brand { margin-bottom: 0; }
+.m-dash-root .dash-mob-header .menu-btn {
+  background: transparent;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  width: 40px; height: 40px;
+  display: grid; place-items: center;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.m-dash-root .dash-mob-header .menu-btn:hover {
+  background: #F5F6F3;
+}
+
+/* Mobile slide-out drawer --------------------------------------------- */
+.m-dash-root .dash-drawer-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(11, 18, 32, 0.45);
+  z-index: 49;
+}
+.m-dash-root .dash-drawer {
+  position: fixed;
+  top: 0; left: 0; bottom: 0;
+  width: 280px;
+  background: #fff;
+  border-right: 1px solid var(--divider);
+  padding: 20px;
+  z-index: 50;
+  overflow-y: auto;
+  display: flex; flex-direction: column;
+  box-shadow: 0 20px 60px -20px rgba(11, 18, 32, 0.3);
+}
+.m-dash-root .dash-drawer .close-btn {
+  position: absolute;
+  top: 12px; right: 12px;
+  width: 36px; height: 36px;
+  display: grid; place-items: center;
+  background: transparent;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+/* Main content column -------------------------------------------------- */
+.m-dash-root .dash-main {
+  flex: 1;
+  min-width: 0;
+  padding: 24px 24px 96px;
+  display: flex; flex-direction: column;
+  min-height: 100vh;
+}
+@media (min-width: 1024px) {
+  .m-dash-root .dash-main { padding: 28px 36px 36px; }
+}
+.m-dash-root .dash-main-top {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+@media (max-width: 1023px) {
+  .m-dash-root .dash-main-top { display: none; }
+}
+.m-dash-root .dash-body { flex: 1; }
+
+/* Dashboard footer ----------------------------------------------------- */
+.m-dash-root .dash-footer {
+  margin-top: 48px;
+  padding-top: 20px;
+  border-top: 1px solid var(--divider);
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.m-dash-root .dash-footer a {
+  color: var(--text-tertiary);
+  text-decoration: none;
+  transition: color 150ms ease;
+}
+.m-dash-root .dash-footer a:hover { color: var(--accent-mint-deep); }
+.m-dash-root .dash-footer .dot { opacity: 0.5; }
+
+/* Mobile bottom nav --------------------------------------------------- */
+.m-dash-root .dash-bottom-nav {
+  display: none;
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: saturate(180%) blur(10px);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
+  border-top: 1px solid var(--divider);
+  z-index: 40;
+}
+@media (max-width: 1023px) {
+  .m-dash-root .dash-bottom-nav { display: flex; }
+}
+.m-dash-root .dash-bottom-nav a {
+  flex: 1;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  padding: 8px 4px;
+  min-height: 60px;
+  text-decoration: none;
+  color: var(--text-tertiary);
+  font-size: 10.5px;
+  font-weight: 500;
+  transition: color 150ms ease;
+}
+.m-dash-root .dash-bottom-nav a svg {
+  width: 20px; height: 20px;
+  margin-bottom: 4px;
+}
+.m-dash-root .dash-bottom-nav a.is-active {
+  color: var(--accent-mint-deep);
+}
+.m-dash-root .dash-bottom-nav a.is-active svg {
+  color: var(--accent-mint-deep);
+}
+
+/* Auth-checking loader ------------------------------------------------ */
+.m-dash-root .dash-loader {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--surface-base);
+}
+.m-dash-root .dash-loader svg {
+  width: 32px; height: 32px;
+  color: var(--accent-mint-deep);
+  animation: dash-spin 900ms linear infinite;
+}
+@keyframes dash-spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,12 +3,10 @@
 import { createClient } from '@/lib/supabase/client';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
-import Image from 'next/image';
 import TrialBanner from '@/components/TrialBanner';
 import NotificationBell from '@/components/NotificationBell';
 import {
   LayoutDashboard,
-  ScanSearch,
   FileText,
   CreditCard,
   Tag,
@@ -18,18 +16,15 @@ import {
   ArrowRight,
   X,
   ShieldAlert,
-  Shield,
-  BarChart3,
   Gift,
-  Building2,
   Wallet,
-  BookOpen,
   FolderLock,
   MessageCircle,
   Plug,
   Loader2,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import './dashboard.css';
 
 const navItems = [
   { name: 'Overview', href: '/dashboard', icon: LayoutDashboard },
@@ -67,15 +62,27 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       setUserEmail(user.email || null);
       setAuthChecked(true);
       if (user) {
-        const { data } = await supabase.from('profiles').select('first_name, full_name, subscription_tier, subscription_status, stripe_subscription_id, trial_ends_at').eq('id', user.id).single();
-        const name = data?.first_name || user.user_metadata?.first_name || user.user_metadata?.full_name?.split(' ')[0] || null;
+        const { data } = await supabase
+          .from('profiles')
+          .select('first_name, full_name, subscription_tier, subscription_status, stripe_subscription_id, trial_ends_at')
+          .eq('id', user.id)
+          .single();
+        const name =
+          data?.first_name ||
+          user.user_metadata?.first_name ||
+          user.user_metadata?.full_name?.split(' ')[0] ||
+          null;
         setFirstName(name);
         const profileTier = data?.subscription_tier || 'free';
         setUserTier(profileTier);
 
         // Detect founding member trial
         let isFoundingTrial = false;
-        if (data?.subscription_status === 'trialing' && !data?.stripe_subscription_id && data?.subscription_tier !== 'free') {
+        if (
+          data?.subscription_status === 'trialing' &&
+          !data?.stripe_subscription_id &&
+          data?.subscription_tier !== 'free'
+        ) {
           isFoundingTrial = true;
           const trialEnd = data?.trial_ends_at ? new Date(data.trial_ends_at) : null;
           if (trialEnd) {
@@ -100,23 +107,23 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           const syncRes = await fetch('/api/stripe/sync', { method: 'POST' });
           const syncData = await syncRes.json();
           if (syncData.tier && syncData.tier !== 'free') {
-            // Stripe confirms a paid tier — always apply
             setUserTier(syncData.tier);
           } else if (syncData.tier === 'free' && syncData.synced && !isFoundingTrial) {
-            // Only downgrade to free if NOT on a founding member trial
             setUserTier('free');
           }
-          // If on founding member trial, keep the profile tier (don't let Stripe override)
         } catch {
           // Stripe sync failed — keep profile tier
         }
       }
     };
     loadUser();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Close sidebar on route change
-  useEffect(() => { setSidebarOpen(false); }, [pathname]);
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [pathname]);
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();
@@ -124,207 +131,209 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     router.refresh();
   };
 
-  const NavContent = () => (
-    <>
-      <Link href="/dashboard" className="flex items-center gap-2 mb-2">
-        <Image src="/logo.png" alt="Paybacker" width={32} height={32} className="rounded-lg" />
-        <span className="text-xl font-bold text-white">
-          Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-        </span>
-      </Link>
+  const Brand = ({ onClick }: { onClick?: () => void }) => (
+    <Link href="/dashboard" className="dash-brand" onClick={onClick}>
+      <span className="logo-mark">P</span>
+      <span className="logo-text">
+        Pay<span className="deep">backer</span>
+      </span>
+    </Link>
+  );
 
-      {/* User info below logo */}
-      <div className="mb-6 pb-6 border-b border-navy-700/50">
-        {firstName && (
-          <p className="text-sm font-medium text-white truncate" title={firstName}>{firstName}</p>
-        )}
-        <p className="text-xs text-slate-500 truncate">{userEmail || ''}</p>
-        {isTrial ? (
-          <span className="inline-block mt-1.5 text-[10px] font-medium uppercase tracking-wider px-2 py-0.5 rounded-full text-amber-400 bg-amber-400/10">
-            Pro Trial{trialDaysLeft ? ` · ${trialDaysLeft}d left` : ''}
-          </span>
-        ) : userTier === 'free' ? (
-          <Link href="/pricing" className={`inline-flex items-center gap-1 mt-1.5 text-[10px] font-medium uppercase tracking-wider px-2 py-0.5 rounded-full text-slate-400 bg-slate-400/10 hover:bg-mint-400/10 hover:text-mint-400 transition-all`}>
-            Free Plan <ArrowRight className="h-2.5 w-2.5" />
-          </Link>
-        ) : (
-          <span className={`inline-block mt-1.5 text-[10px] font-medium uppercase tracking-wider px-2 py-0.5 rounded-full ${
-            userTier === 'pro' ? 'text-brand-400 bg-brand-400/10' : 'text-mint-400 bg-mint-400/10'
-          }`}>
-            {userTier === 'pro' ? 'Pro Plan' : 'Essential Plan'}
-          </span>
-        )}
-        {userTier === 'free' && (
-          <div className="mt-2">
-            <p className="text-[10px] text-slate-500 mb-1.5">Unlock Pocket Agent, unlimited letters &amp; more</p>
-            <Link href="/pricing" className="block text-center text-[11px] font-semibold bg-mint-400 hover:bg-mint-500 text-navy-950 px-3 py-1.5 rounded-lg transition-all">
-              Upgrade Now
+  const NavContent = () => {
+    const isAdmin = (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+      .split(',')
+      .includes(userEmail || '');
+
+    return (
+      <>
+        <Brand />
+
+        <div className="dash-user">
+          {firstName && (
+            <p className="dash-user-name" title={firstName}>
+              {firstName}
+            </p>
+          )}
+          <p className="dash-user-email">{userEmail || ''}</p>
+          {isTrial ? (
+            <span className="tier-pill tier-trial">
+              Pro Trial{trialDaysLeft ? ` · ${trialDaysLeft}d left` : ''}
+            </span>
+          ) : userTier === 'free' ? (
+            <Link href="/pricing" className="tier-pill tier-free">
+              Free Plan <ArrowRight width={10} height={10} aria-hidden="true" />
             </Link>
-          </div>
-        )}
-      </div>
-
-      <nav className="space-y-0.5 flex-1">
-        {navItems.map((item) => {
-          const Icon = item.icon;
-          const isActive = item.href === '/dashboard' || item.href === '/blog'
-            ? pathname === item.href
-            : pathname.startsWith(item.href);
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`flex items-center gap-3 px-4 py-2.5 rounded-r-lg transition-all duration-200 min-h-[44px] ${
-                isActive
-                  ? 'bg-mint-400/10 text-mint-400 border-l-2 border-mint-400 font-semibold'
-                  : 'text-slate-400 hover:text-white hover:bg-navy-800/50 border-l-2 border-transparent'
+          ) : (
+            <span
+              className={`tier-pill ${
+                userTier === 'pro' ? 'tier-pro' : 'tier-essential'
               }`}
             >
-              <Icon className="h-5 w-5 flex-shrink-0" />
-              <span className="text-sm">{item.name}</span>
-              {item.name === 'Pocket Agent' && (
-                <span className="text-[10px] bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded-full ml-auto">NEW</span>
-              )}
-              {(item as any).comingSoon && (
-                <span className="text-[9px] bg-navy-700 text-slate-400 px-1.5 py-0.5 rounded-full ml-auto">Soon</span>
-              )}
-            </Link>
-          );
-        })}
-        {(process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com').split(',').includes(userEmail || '') && (
-          <Link
-            href="/dashboard/admin"
-            className={`flex items-center gap-3 px-4 py-2.5 rounded-r-lg transition-all duration-200 min-h-[44px] mt-4 border-t border-navy-700/50 pt-4 ${
-              pathname === '/dashboard/admin'
-                ? 'bg-red-500/10 text-red-400 border-l-2 border-red-400 font-semibold'
-                : 'text-red-400/70 hover:text-red-400 hover:bg-red-500/10 border-l-2 border-transparent'
-            }`}
-          >
-            <ShieldAlert className="h-5 w-5 flex-shrink-0" />
-            <span className="text-sm">Admin</span>
-          </Link>
-        )}
-      </nav>
+              {userTier === 'pro' ? 'Pro Plan' : 'Essential Plan'}
+            </span>
+          )}
+          {userTier === 'free' && !isTrial && (
+            <div className="upgrade-card">
+              <p>Unlock Pocket Agent, unlimited letters &amp; more</p>
+              <Link href="/pricing">Upgrade now</Link>
+            </div>
+          )}
+        </div>
 
-      <div className="pt-6 border-t border-navy-700/50 mt-auto">
-        <button
-          onClick={handleSignOut}
-          className="flex items-center gap-2 text-slate-500 hover:text-red-400 transition-all duration-200 w-full min-h-[44px]"
-        >
-          <LogOut className="h-4 w-4" />
-          <span className="text-sm">Sign out</span>
-        </button>
-      </div>
-    </>
-  );
+        <nav className="dash-nav">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const isActive =
+              item.href === '/dashboard'
+                ? pathname === item.href
+                : pathname.startsWith(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={isActive ? 'is-active' : ''}
+              >
+                <Icon aria-hidden="true" />
+                <span>{item.name}</span>
+                {item.name === 'Pocket Agent' && (
+                  <span className="nav-badge new">New</span>
+                )}
+              </Link>
+            );
+          })}
+          {isAdmin && (
+            <Link
+              href="/dashboard/admin"
+              className={`dash-admin ${pathname === '/dashboard/admin' ? 'is-active' : ''}`}
+            >
+              <ShieldAlert aria-hidden="true" />
+              <span>Admin</span>
+            </Link>
+          )}
+        </nav>
+
+        <div className="dash-signout">
+          <button onClick={handleSignOut} type="button">
+            <LogOut aria-hidden="true" />
+            <span>Sign out</span>
+          </button>
+        </div>
+      </>
+    );
+  };
 
   if (!authChecked) {
     return (
-      <div className="min-h-screen bg-navy-950 flex items-center justify-center">
-        <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
+      <div className="m-dash-root">
+        <div className="dash-loader">
+          <Loader2 aria-label="Loading" />
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-navy-950 overflow-x-hidden">
+    <div className="m-dash-root">
       {/* Mobile header */}
-      <header className="lg:hidden flex items-center justify-between px-4 py-3 bg-navy-900 border-b border-navy-700/50 sticky top-0 z-40">
-        <Link href="/dashboard" className="flex items-center gap-2">
-          <Image src="/logo.png" alt="Paybacker" width={28} height={28} className="rounded-lg" />
-          <span className="text-lg font-bold text-white">
-            Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span>
-          </span>
-        </Link>
-        <div className="flex items-center gap-1">
+      <header className="dash-mob-header">
+        <Brand />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
           <NotificationBell />
           <button
             onClick={() => setSidebarOpen(true)}
-            className="p-2 text-slate-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
+            className="menu-btn"
+            type="button"
+            aria-label="Open menu"
           >
-            <Menu className="h-6 w-6" />
+            <Menu width={20} height={20} />
           </button>
         </div>
       </header>
 
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
-        <div className="lg:hidden fixed inset-0 z-50 flex">
-          <div className="absolute inset-0 bg-black/70" onClick={() => setSidebarOpen(false)} />
-          <aside className="relative w-[260px] h-full overflow-y-auto bg-navy-900 border-r border-navy-700/50 p-6 flex flex-col">
+        <>
+          <div
+            className="dash-drawer-backdrop"
+            onClick={() => setSidebarOpen(false)}
+            aria-hidden="true"
+          />
+          <aside className="dash-drawer" role="dialog" aria-label="Main navigation">
             <button
+              type="button"
               onClick={() => setSidebarOpen(false)}
-              className="absolute top-4 right-4 text-slate-400 hover:text-white p-2"
+              className="close-btn"
+              aria-label="Close menu"
             >
-              <X className="h-5 w-5" />
+              <X width={18} height={18} />
             </button>
             <NavContent />
           </aside>
-        </div>
+        </>
       )}
 
-      <div className="flex">
+      <div className="dash-shell">
         {/* Desktop sidebar */}
-        <aside className="hidden lg:flex w-[260px] min-h-screen bg-navy-900 border-r border-navy-700/50 p-6 flex-col flex-shrink-0">
+        <aside className="dash-sidebar is-desktop">
           <NavContent />
         </aside>
 
         {/* Main content */}
-        <main className="flex-1 p-4 md:p-6 lg:p-8 min-w-0 bg-navy-950 pb-20 lg:pb-8 flex flex-col min-h-screen">
-          {/* Desktop top-right bell */}
-          <div className="hidden lg:flex justify-end mb-2">
+        <main className="dash-main">
+          <div className="dash-main-top">
             <NotificationBell />
           </div>
-          <div className="flex-1">
-            {(isTrial || trialExpired) && <TrialBanner daysLeft={trialDaysLeft} trialExpired={trialExpired} />}
+          <div className="dash-body">
+            {(isTrial || trialExpired) && (
+              <TrialBanner daysLeft={trialDaysLeft} trialExpired={trialExpired} />
+            )}
             {children}
           </div>
 
-          {/* Dashboard Footer */}
-          <footer className="mt-12 pt-6 border-t border-navy-800 flex flex-wrap justify-center gap-4 text-xs text-slate-500">
-            <Link href="/blog" className="hover:text-mint-400 transition-colors">Blog</Link>
-            <span>&middot;</span>
-            <Link href="/dashboard/deals" className="hover:text-mint-400 transition-colors">Deals</Link>
-            <span>&middot;</span>
-            <Link href="/about" className="hover:text-mint-400 transition-colors">About</Link>
-            <span>&middot;</span>
-            <Link href="/pricing" className="hover:text-mint-400 transition-colors">Pricing</Link>
-            <span>&middot;</span>
-            <Link href="mailto:hello@paybacker.co.uk" className="hover:text-mint-400 transition-colors">Help</Link>
+          <footer className="dash-footer">
+            <Link href="/blog">Blog</Link>
+            <span className="dot">·</span>
+            <Link href="/dashboard/deals">Deals</Link>
+            <span className="dot">·</span>
+            <Link href="/about">About</Link>
+            <span className="dot">·</span>
+            <Link href="/pricing">Pricing</Link>
+            <span className="dot">·</span>
+            <a href="mailto:hello@paybacker.co.uk">Help</a>
           </footer>
         </main>
       </div>
 
-      {/* Mobile bottom nav - show 5 key items only */}
-      <nav className="lg:hidden fixed bottom-0 left-0 right-0 bg-navy-900/95 backdrop-blur-sm border-t border-navy-700/50 flex z-40">
+      {/* Mobile bottom nav */}
+      <nav className="dash-bottom-nav" aria-label="Mobile navigation">
         {[
           { name: 'Home', href: '/dashboard', icon: LayoutDashboard },
-          { name: 'Money Hub', href: '/dashboard/money-hub', icon: Wallet },
+          { name: 'Money', href: '/dashboard/money-hub', icon: Wallet },
           { name: 'Disputes', href: '/dashboard/disputes', icon: FileText },
           { name: 'Deals', href: '/dashboard/deals', icon: Tag },
           { name: 'Subs', href: '/dashboard/subscriptions', icon: CreditCard },
         ].map((item) => {
           const Icon = item.icon;
-          const isActive = item.href === '/dashboard' || item.href === '/blog'
-            ? pathname === item.href
-            : pathname.startsWith(item.href);
+          const isActive =
+            item.href === '/dashboard'
+              ? pathname === item.href
+              : pathname.startsWith(item.href);
           return (
             <Link
               key={item.href}
               href={item.href}
-              className={`flex-1 flex flex-col items-center justify-center py-2 min-h-[56px] transition-all duration-200 ${
-                isActive ? 'text-mint-400' : 'text-slate-500'
-              }`}
+              className={isActive ? 'is-active' : ''}
             >
-              <Icon className="h-5 w-5 mb-1" />
-              <span className="text-[10px]">{item.name}</span>
+              <Icon aria-hidden="true" />
+              <span>{item.name}</span>
             </Link>
           );
         })}
       </nav>
 
       {/* Bottom padding on mobile so content isn't behind nav */}
-      <div className="h-16 lg:hidden" />
+      <div style={{ height: 60 }} className="dash-bottom-pad" aria-hidden="true" />
     </div>
   );
 }


### PR DESCRIPTION
Batch 7: dashboard layout shell moves to the light theme.

### Scope

This PR redesigns **only the dashboard chrome** — the persistent
sidebar, mobile header, drawer, bottom nav, and footer. Dashboard
page bodies (overview, money-hub, subscriptions, disputes, etc) are
unchanged and render into `<main>` exactly as before. They will come
in batch 8+.

### What's in here

| Surface | Before | After |
|---|---|---|
| Desktop sidebar | 260px `bg-navy-900` dark | 272px white sidebar, mint active stripe |
| Mobile header | Dark navy top bar | White sticky header + outlined menu button |
| Mobile drawer | Dark `bg-navy-900` slide-out | White slide-out with `shadow-md` drop |
| Bottom nav | Dark `bg-navy-900/95` | White `rgba(255,255,255,0.95)` + mint-deep active |
| Main bg | `bg-navy-950` | `--surface-base` (off-white #FAFAF7) |
| Footer | Dark, slate-500 links | Light, tertiary-ink links, mint hover |

### Design system

- New scoped stylesheet `src/app/dashboard/dashboard.css`, root
  `.m-dash-root`, consuming the shared marketing tokens from
  `globals.css` (same tokens the public marketing site uses).
- No Tailwind utility classes for chrome — all primitives are
  class-based (`.dash-nav a.is-active`, `.tier-pill.tier-pro`, etc).
- Page bodies still use Tailwind — nothing inside `<main>` was touched.

### Preserved logic (verbatim)

- Supabase auth check + redirect to `/auth/login`.
- Profile fetch (first_name, full_name, subscription_tier,
  subscription_status, stripe_subscription_id, trial_ends_at).
- Founding-member-trial detection: if `subscription_status === 'trialing'`
  and no `stripe_subscription_id`, enable the Pro-trial pill and
  countdown. If expired, fall back to `free`.
- Stripe sync via `POST /api/stripe/sync` — keeps the trial-aware
  downgrade guard so a founding trial isn't overwritten by a 'free'
  Stripe response.
- Mobile drawer auto-closes on pathname change.
- Sign-out calls `supabase.auth.signOut()` then routes to `/`.
- Admin nav entry appears only for allowlisted emails
  (`NEXT_PUBLIC_ADMIN_EMAILS`, default `aireypaul@googlemail.com`).

### Responsive breakpoints

- `≥1024px` — desktop sidebar visible, mobile header/drawer/bottom nav hidden.
- `<1024px` — desktop sidebar hidden, mobile header + bottom nav visible,
  drawer opens on hamburger tap.
- No viewport-related bugs on the critical 768px tablet width.

### Known follow-ups

- **TrialBanner** and **NotificationBell** internals are still dark.
  They still render correctly inside the new shell, but they'll
  look slightly out of place until re-skinned. Follow-up PR.
- Dashboard **page bodies** (overview, money-hub, subscriptions,
  disputes, etc.) still use the dark theme internally. They are the
  multi-session batch 8+ workstream.

### Checks

- `npx tsc --noEmit`: clean for `dashboard.css` + `layout.tsx`.
  Pre-existing errors elsewhere (`.next/dev/types/validator.ts`,
  `cron/trial-expiry/route.ts`, `careers/page.tsx` false positive,
  `money-hub/page.tsx` prop mismatch) are unchanged.
- No API keys, no new env vars, no database changes.
- Zero change to any dashboard page body.
