### PR TITLE
feat(dashboard): re-skin export + tutorials + spending bodies to light theme (batch 8b)

### DIFF
--- a/src/app/dashboard/export/page.tsx
+++ b/src/app/dashboard/export/page.tsx
@@ -19,11 +19,11 @@ const comingSoon: ComingSoonDestination[] = [
   {
     name: 'Notion',
     blurb: 'Sync transactions into a Notion database',
-    iconBg: 'bg-white/5',
+    iconBg: 'bg-slate-100',
     icon: (
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
-        <rect x="3" y="3" width="18" height="18" rx="2" fill="#ffffff"/>
-        <path d="M7 7h2l4 7V7h2v10h-2l-4-7v7H7z" fill="#0f172a"/>
+        <rect x="3" y="3" width="18" height="18" rx="2" fill="#0f172a"/>
+        <path d="M7 7h2l4 7V7h2v10h-2l-4-7v7H7z" fill="#ffffff"/>
       </svg>
     ),
   },
@@ -56,8 +56,8 @@ export default function ExportPage() {
     <div className="max-w-4xl mx-auto space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl md:text-3xl font-bold text-white">Export</h1>
-        <p className="mt-2 text-sm text-slate-400 max-w-2xl">
+        <h1 className="text-2xl md:text-3xl font-bold text-slate-900">Export</h1>
+        <p className="mt-2 text-sm text-slate-600 max-w-2xl">
           Send your Paybacker data to the tools you already use. Connect a destination once and
           we&rsquo;ll keep it in sync automatically.
         </p>
@@ -82,7 +82,7 @@ export default function ExportPage() {
           </h2>
           <Link
             href="mailto:hello@paybacker.co.uk?subject=Destination%20request"
-            className="text-xs text-mint-400 hover:text-mint-300 transition-colors"
+            className="text-xs text-emerald-600 hover:text-emerald-700 transition-colors"
           >
             Request a destination →
           </Link>
@@ -91,7 +91,7 @@ export default function ExportPage() {
           {comingSoon.map((d) => (
             <div
               key={d.name}
-              className="rounded-2xl border border-navy-700/50 bg-navy-900/60 p-5 opacity-80"
+              className="rounded-2xl border border-slate-200 bg-white shadow-sm p-5 opacity-80"
             >
               <div className="flex items-center gap-3">
                 <div className={`w-10 h-10 rounded-lg ${d.iconBg} flex items-center justify-center flex-shrink-0`}>
@@ -99,12 +99,12 @@ export default function ExportPage() {
                 </div>
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    <h3 className="font-semibold text-white text-sm">{d.name}</h3>
-                    <span className="text-[10px] font-medium uppercase tracking-wider px-2 py-0.5 rounded-full text-slate-400 bg-slate-400/10">
+                    <h3 className="font-semibold text-slate-900 text-sm">{d.name}</h3>
+                    <span className="text-[10px] font-medium uppercase tracking-wider px-2 py-0.5 rounded-full text-slate-600 bg-slate-100">
                       Soon
                     </span>
                   </div>
-                  <p className="text-xs text-slate-400 mt-0.5">{d.blurb}</p>
+                  <p className="text-xs text-slate-600 mt-0.5">{d.blurb}</p>
                 </div>
               </div>
             </div>

--- a/src/app/dashboard/spending/page.tsx
+++ b/src/app/dashboard/spending/page.tsx
@@ -58,7 +58,7 @@ export default function SpendingPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
+        <Loader2 className="h-8 w-8 text-emerald-600 animate-spin" />
       </div>
     );
   }
@@ -70,14 +70,14 @@ export default function SpendingPage() {
     return (
       <div className="max-w-5xl">
         <div className="mb-8">
-          <h1 className="text-4xl font-bold text-white mb-2 font-[family-name:var(--font-heading)]">Spending Insights</h1>
-          <p className="text-slate-400">Connect your bank account to see where your money goes</p>
+          <h1 className="text-4xl font-bold text-slate-900 mb-2 font-[family-name:var(--font-heading)]">Spending Insights</h1>
+          <p className="text-slate-600">Connect your bank account to see where your money goes</p>
         </div>
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-12 text-center">
-          <BarChart3 className="h-16 w-16 text-slate-600 mx-auto mb-4" />
-          <h3 className="text-xl font-bold text-white mb-2">No spending data yet</h3>
-          <p className="text-slate-400 mb-6">Connect your bank account to get personalised spending insights.</p>
-          <Link href="/dashboard/subscriptions" className="bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-6 py-3 rounded-lg transition-all">
+        <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-12 text-center">
+          <BarChart3 className="h-16 w-16 text-slate-300 mx-auto mb-4" />
+          <h3 className="text-xl font-bold text-slate-900 mb-2">No spending data yet</h3>
+          <p className="text-slate-600 mb-6">Connect your bank account to get personalised spending insights.</p>
+          <Link href="/dashboard/subscriptions" className="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-6 py-3 rounded-lg transition-all">
             Connect Bank Account
           </Link>
         </div>
@@ -91,41 +91,41 @@ export default function SpendingPage() {
   return (
     <div className="max-w-5xl">
       <div className="mb-8">
-        <h1 className="text-4xl font-bold text-white mb-2 font-[family-name:var(--font-heading)]">Spending Insights</h1>
-        <p className="text-slate-400">
+        <h1 className="text-4xl font-bold text-slate-900 mb-2 font-[family-name:var(--font-heading)]">Spending Insights</h1>
+        <p className="text-slate-600">
           Based on {summary.months_analysed} months of bank data · {summary.total_transactions.toLocaleString()} transactions
         </p>
       </div>
 
       {/* Summary Cards — Monthly Averages */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-5">
+        <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
           <p className="text-slate-500 text-xs mb-1">Average monthly spend</p>
-          <p className="text-2xl font-bold text-white">£{summary.monthly_avg_spend?.toLocaleString() || Math.round(summary.total_spend / Math.max(summary.months_analysed, 1)).toLocaleString()}</p>
+          <p className="text-2xl font-bold text-slate-900">£{summary.monthly_avg_spend?.toLocaleString() || Math.round(summary.total_spend / Math.max(summary.months_analysed, 1)).toLocaleString()}</p>
         </div>
-        <div className="bg-navy-900 border border-green-500/20 rounded-2xl p-5">
+        <div className="bg-white border border-green-200 rounded-2xl shadow-sm p-5">
           <p className="text-slate-500 text-xs mb-1">Average monthly income</p>
-          <p className="text-2xl font-bold text-green-400">£{summary.monthly_avg_income?.toLocaleString() || Math.round(summary.total_income / Math.max(summary.months_analysed, 1)).toLocaleString()}</p>
+          <p className="text-2xl font-bold text-green-600">£{summary.monthly_avg_income?.toLocaleString() || Math.round(summary.total_income / Math.max(summary.months_analysed, 1)).toLocaleString()}</p>
         </div>
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-5">
+        <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
           <p className="text-slate-500 text-xs mb-1">This month so far</p>
-          <p className="text-2xl font-bold text-white">£{summary.current_month_spend.toLocaleString()}</p>
+          <p className="text-2xl font-bold text-slate-900">£{summary.current_month_spend.toLocaleString()}</p>
           {summary.month_change_percent !== 0 && (
-            <div className={`flex items-center gap-1 mt-1 text-xs ${summary.month_change_percent > 0 ? 'text-red-400' : 'text-green-400'}`}>
+            <div className={`flex items-center gap-1 mt-1 text-xs ${summary.month_change_percent > 0 ? 'text-red-600' : 'text-green-600'}`}>
               {summary.month_change_percent > 0 ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
               {Math.abs(summary.month_change_percent)}% vs last month
             </div>
           )}
         </div>
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-5">
+        <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
           <p className="text-slate-500 text-xs mb-1">Last month</p>
-          <p className="text-2xl font-bold text-white">£{summary.previous_month_spend.toLocaleString()}</p>
+          <p className="text-2xl font-bold text-slate-900">£{summary.previous_month_spend.toLocaleString()}</p>
         </div>
       </div>
 
       {/* Monthly Breakdown — Spend vs Income */}
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6 mb-8">
-        <h2 className="text-lg font-bold text-white mb-1">Monthly Overview</h2>
+      <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 mb-8">
+        <h2 className="text-lg font-bold text-slate-900 mb-1">Monthly Overview</h2>
         <p className="text-slate-500 text-xs mb-4">Spend vs income over the last {summary.months_analysed} months</p>
         <div className="space-y-4">
           {monthly_spend.map((m) => {
@@ -137,25 +137,25 @@ export default function SpendingPage() {
             return (
               <div key={m.month}>
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-white text-sm font-medium">{monthLabel}</span>
-                  <span className={`text-xs font-semibold ${net >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                  <span className="text-slate-900 text-sm font-medium">{monthLabel}</span>
+                  <span className={`text-xs font-semibold ${net >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                     {net >= 0 ? '+' : ''}£{Math.abs(net).toLocaleString()} net
                   </span>
                 </div>
                 <div className="space-y-1">
                   <div className="flex items-center gap-2">
                     <span className="text-slate-500 text-xs w-12">Out</span>
-                    <div className="flex-1 bg-navy-800 rounded-full h-4 overflow-hidden">
-                      <div className="bg-gradient-to-r from-red-500 to-red-600 h-full rounded-full" style={{ width: `${spendWidth}%` }} />
+                    <div className="flex-1 bg-slate-100 rounded-full h-4 overflow-hidden">
+                      <div className="bg-gradient-to-r from-red-400 to-red-500 h-full rounded-full" style={{ width: `${spendWidth}%` }} />
                     </div>
-                    <span className="text-red-400 text-xs font-semibold w-20 text-right">£{m.spend.toLocaleString()}</span>
+                    <span className="text-red-600 text-xs font-semibold w-20 text-right">£{m.spend.toLocaleString()}</span>
                   </div>
                   <div className="flex items-center gap-2">
                     <span className="text-slate-500 text-xs w-12">In</span>
-                    <div className="flex-1 bg-navy-800 rounded-full h-4 overflow-hidden">
-                      <div className="bg-gradient-to-r from-green-500 to-green-600 h-full rounded-full" style={{ width: `${incomeWidth}%` }} />
+                    <div className="flex-1 bg-slate-100 rounded-full h-4 overflow-hidden">
+                      <div className="bg-gradient-to-r from-green-400 to-green-500 h-full rounded-full" style={{ width: `${incomeWidth}%` }} />
                     </div>
-                    <span className="text-green-400 text-xs font-semibold w-20 text-right">£{m.income.toLocaleString()}</span>
+                    <span className="text-green-600 text-xs font-semibold w-20 text-right">£{m.income.toLocaleString()}</span>
                   </div>
                 </div>
               </div>
@@ -165,8 +165,8 @@ export default function SpendingPage() {
       </div>
 
       {/* Category Breakdown — Expandable */}
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6 mb-8">
-        <h2 className="text-lg font-bold text-white mb-1">Where your money goes</h2>
+      <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 mb-8">
+        <h2 className="text-lg font-bold text-slate-900 mb-1">Where your money goes</h2>
         <p className="text-slate-500 text-xs mb-4">Monthly average per category · click to expand</p>
         <div className="space-y-2">
           {category_breakdown.slice(0, isPaid ? 50 : 5).map((cat) => {
@@ -178,21 +178,21 @@ export default function SpendingPage() {
                   onClick={() => setExpandedCategory(isExpanded ? null : cat.category)}
                   className="w-full text-left"
                 >
-                  <div className="flex items-center gap-3 py-2 hover:bg-navy-800/30 rounded-lg px-2 transition-all">
+                  <div className="flex items-center gap-3 py-2 hover:bg-slate-50 rounded-lg px-2 transition-all">
                     <span className="text-lg w-8 text-center">{cat.icon}</span>
                     <div className="flex-1">
                       <div className="flex items-center justify-between mb-1">
                         <div className="flex items-center gap-2">
-                          <span className="text-white text-sm font-medium">{cat.label}</span>
+                          <span className="text-slate-900 text-sm font-medium">{cat.label}</span>
                           {isExpanded ? <ChevronUp className="h-3 w-3 text-slate-500" /> : <ChevronDown className="h-3 w-3 text-slate-500" />}
                         </div>
                         <div className="flex items-center gap-3">
-                          <span className="text-mint-400 text-xs font-semibold">£{cat.monthly_avg.toLocaleString()}/mo</span>
-                          <span className="text-white text-sm font-bold">£{cat.total.toLocaleString()}</span>
+                          <span className="text-emerald-600 text-xs font-semibold">£{cat.monthly_avg.toLocaleString()}/mo</span>
+                          <span className="text-slate-900 text-sm font-bold">£{cat.total.toLocaleString()}</span>
                           <span className="text-slate-500 text-xs w-10 text-right">{cat.percentage}%</span>
                         </div>
                       </div>
-                      <div className="bg-navy-800 rounded-full h-2 overflow-hidden">
+                      <div className="bg-slate-100 rounded-full h-2 overflow-hidden">
                         <div className="h-full rounded-full transition-all" style={{ width: `${barWidth}%`, backgroundColor: cat.color }} />
                       </div>
                     </div>
@@ -201,19 +201,19 @@ export default function SpendingPage() {
 
                 {/* Expanded detail with individual payments */}
                 {isExpanded && isPaid && (
-                  <div className="ml-12 mt-2 mb-3 bg-navy-950/50 rounded-lg p-4 border border-navy-700/50">
+                  <div className="ml-12 mt-2 mb-3 bg-slate-50 rounded-lg p-4 border border-slate-200">
                     <div className="grid grid-cols-3 gap-4 mb-4">
                       <div>
                         <p className="text-slate-500 text-xs">Total ({summary.months_analysed}mo)</p>
-                        <p className="text-white font-semibold">£{cat.total.toLocaleString()}</p>
+                        <p className="text-slate-900 font-semibold">£{cat.total.toLocaleString()}</p>
                       </div>
                       <div>
                         <p className="text-slate-500 text-xs">Monthly average</p>
-                        <p className="text-mint-400 font-semibold">£{cat.monthly_avg.toLocaleString()}</p>
+                        <p className="text-emerald-600 font-semibold">£{cat.monthly_avg.toLocaleString()}</p>
                       </div>
                       <div>
                         <p className="text-slate-500 text-xs">Share of spending</p>
-                        <p className="text-white font-semibold">{cat.percentage}%</p>
+                        <p className="text-slate-900 font-semibold">{cat.percentage}%</p>
                       </div>
                     </div>
 
@@ -222,30 +222,30 @@ export default function SpendingPage() {
                       <div className="space-y-1 mb-3">
                         <p className="text-slate-500 text-xs font-semibold uppercase tracking-wide mb-2">Payments in this category</p>
                         {data.category_transactions[cat.category].map((tx, j) => (
-                          <div key={j} className="flex items-center justify-between bg-navy-900 rounded px-3 py-2 text-sm">
+                          <div key={j} className="flex items-center justify-between bg-white border border-slate-200 rounded px-3 py-2 text-sm">
                             <div>
-                              <span className="text-white">{tx.description}</span>
-                              <span className="text-slate-600 text-xs ml-2">({tx.count} payments)</span>
+                              <span className="text-slate-900">{tx.description}</span>
+                              <span className="text-slate-500 text-xs ml-2">({tx.count} payments)</span>
                             </div>
                             <div className="flex items-center gap-4 shrink-0">
-                              <span className="text-slate-400 text-xs">£{tx.monthly_avg}/mo avg</span>
-                              <span className="text-white font-medium">£{tx.total.toLocaleString()}</span>
+                              <span className="text-slate-600 text-xs">£{tx.monthly_avg}/mo avg</span>
+                              <span className="text-slate-900 font-medium">£{tx.total.toLocaleString()}</span>
                             </div>
                           </div>
                         ))}
                       </div>
                     )}
 
-                    <Link href="/dashboard/deals" className="text-mint-400 hover:text-mint-300 text-xs font-medium flex items-center gap-1">
+                    <Link href="/dashboard/deals" className="text-emerald-600 hover:text-emerald-700 text-xs font-medium flex items-center gap-1">
                       Find better deals for {cat.label.toLowerCase()} <ArrowRight className="h-3 w-3" />
                     </Link>
                   </div>
                 )}
 
                 {isExpanded && !isPaid && (
-                  <div className="ml-12 mt-2 mb-3 bg-mint-400/5 border border-mint-400/20 rounded-lg p-4 text-center">
-                    <Lock className="h-4 w-4 text-mint-400 mx-auto mb-1" />
-                    <p className="text-slate-400 text-xs">Upgrade to Essential to see detailed breakdown</p>
+                  <div className="ml-12 mt-2 mb-3 bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-center">
+                    <Lock className="h-4 w-4 text-emerald-600 mx-auto mb-1" />
+                    <p className="text-slate-600 text-xs">Upgrade to Essential to see detailed breakdown</p>
                   </div>
                 )}
               </div>
@@ -254,11 +254,11 @@ export default function SpendingPage() {
         </div>
 
         {!isPaid && category_breakdown.length > 5 && (
-          <div className="mt-6 bg-mint-400/5 border border-mint-400/20 rounded-xl p-5 text-center">
-            <Lock className="h-6 w-6 text-mint-400 mx-auto mb-2" />
-            <p className="text-white font-semibold mb-1">See all {category_breakdown.length} categories</p>
-            <p className="text-slate-400 text-sm mb-3">Upgrade to Essential to unlock full spending breakdown</p>
-            <Link href="/pricing" className="inline-block bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-5 py-2 rounded-lg text-sm transition-all">
+          <div className="mt-6 bg-emerald-50 border border-emerald-200 rounded-xl p-5 text-center">
+            <Lock className="h-6 w-6 text-emerald-600 mx-auto mb-2" />
+            <p className="text-slate-900 font-semibold mb-1">See all {category_breakdown.length} categories</p>
+            <p className="text-slate-600 text-sm mb-3">Upgrade to Essential to unlock full spending breakdown</p>
+            <Link href="/pricing" className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-5 py-2 rounded-lg text-sm transition-all">
               Upgrade Plan
             </Link>
           </div>
@@ -266,21 +266,21 @@ export default function SpendingPage() {
       </div>
 
       {/* Biggest Transactions — Pro only */}
-      <div className={`bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6 mb-8 ${!isPro ? 'relative' : ''}`}>
-        <h2 className="text-lg font-bold text-white mb-1">Biggest Transactions</h2>
+      <div className={`bg-white border border-slate-200 rounded-2xl shadow-sm p-6 mb-8 ${!isPro ? 'relative' : ''}`}>
+        <h2 className="text-lg font-bold text-slate-900 mb-1">Biggest Transactions</h2>
         <p className="text-slate-500 text-xs mb-4">Your largest single payments</p>
 
         {isPro ? (
           <div className="space-y-2">
             {biggest_transactions.map((tx, i) => (
-              <div key={i} className="flex items-center justify-between bg-navy-950/50 rounded-lg px-4 py-3 border border-navy-700/50">
+              <div key={i} className="flex items-center justify-between bg-slate-50 rounded-lg px-4 py-3 border border-slate-200">
                 <div>
-                  <p className="text-white text-sm font-medium truncate max-w-xs">{tx.description}</p>
+                  <p className="text-slate-900 text-sm font-medium truncate max-w-xs">{tx.description}</p>
                   <p className="text-slate-500 text-xs">
                     {new Date(tx.date).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })} · {tx.category}
                   </p>
                 </div>
-                <span className="text-red-400 font-bold shrink-0 ml-4">-{formatGBP(tx.amount)}</span>
+                <span className="text-red-600 font-bold shrink-0 ml-4">-{formatGBP(tx.amount)}</span>
               </div>
             ))}
           </div>
@@ -288,21 +288,21 @@ export default function SpendingPage() {
           <div className="relative">
             <div className="space-y-2 blur-sm pointer-events-none select-none">
               {[1, 2, 3, 4, 5].map((i) => (
-                <div key={i} className="flex items-center justify-between bg-navy-950/50 rounded-lg px-4 py-3 border border-navy-700/50">
+                <div key={i} className="flex items-center justify-between bg-slate-50 rounded-lg px-4 py-3 border border-slate-200">
                   <div>
-                    <p className="text-white text-sm font-medium">Transaction details hidden</p>
+                    <p className="text-slate-900 text-sm font-medium">Transaction details hidden</p>
                     <p className="text-slate-500 text-xs">Date · Category</p>
                   </div>
-                  <span className="text-red-400 font-bold">-£XXX.XX</span>
+                  <span className="text-red-600 font-bold">-£XXX.XX</span>
                 </div>
               ))}
             </div>
             <div className="absolute inset-0 flex items-center justify-center">
-              <div className="bg-navy-900 border border-mint-400/30 rounded-xl p-6 text-center">
-                <Lock className="h-6 w-6 text-mint-400 mx-auto mb-2" />
-                <p className="text-white font-semibold mb-1">Pro feature</p>
-                <p className="text-slate-400 text-sm mb-3">See your biggest transactions with Pro</p>
-                <Link href="/pricing" className="inline-block bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-5 py-2 rounded-lg text-sm transition-all">
+              <div className="bg-white border border-emerald-300 shadow-md rounded-xl p-6 text-center">
+                <Lock className="h-6 w-6 text-emerald-600 mx-auto mb-2" />
+                <p className="text-slate-900 font-semibold mb-1">Pro feature</p>
+                <p className="text-slate-600 text-sm mb-3">See your biggest transactions with Pro</p>
+                <Link href="/pricing" className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-5 py-2 rounded-lg text-sm transition-all">
                   Upgrade to Pro
                 </Link>
               </div>
@@ -312,10 +312,10 @@ export default function SpendingPage() {
       </div>
 
       {/* Deal suggestion */}
-      <div className="bg-gradient-to-r from-mint-400/10 to-mint-500/5 border border-mint-400/20 rounded-2xl p-6 text-center">
-        <p className="text-mint-400 font-semibold mb-2">Based on your spending, we can help you save</p>
-        <p className="text-slate-400 text-sm mb-4">Check our deals page for alternatives to your most expensive bills</p>
-        <Link href="/dashboard/deals" className="inline-flex items-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-6 py-3 rounded-lg transition-all">
+      <div className="bg-gradient-to-r from-emerald-50 to-emerald-100/60 border border-emerald-200 rounded-2xl p-6 text-center">
+        <p className="text-emerald-700 font-semibold mb-2">Based on your spending, we can help you save</p>
+        <p className="text-slate-600 text-sm mb-4">Check our deals page for alternatives to your most expensive bills</p>
+        <Link href="/dashboard/deals" className="inline-flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-6 py-3 rounded-lg transition-all">
           View Deals <ArrowRight className="h-4 w-4" />
         </Link>
       </div>

--- a/src/app/dashboard/tutorials/page.tsx
+++ b/src/app/dashboard/tutorials/page.tsx
@@ -23,7 +23,7 @@ const TUTORIALS: Tutorial[] = [
     title: 'Dashboard Overview',
     subtitle: 'Your financial command centre. See savings opportunities, track complaints, and monitor spending at a glance.',
     icon: LayoutDashboard,
-    colour: 'text-blue-400',
+    colour: 'text-blue-600',
     link: '/dashboard',
     steps: [
       'Your dashboard shows key stats: total subscriptions, monthly spend, complaints generated, and connected bank accounts.',
@@ -37,7 +37,7 @@ const TUTORIALS: Tutorial[] = [
     title: 'Money Hub',
     subtitle: 'Your complete financial picture. Income, spending, bank accounts, and your Financial Health Score.',
     icon: Wallet,
-    colour: 'text-purple-400',
+    colour: 'text-purple-600',
     link: '/dashboard/money-hub',
     steps: [
       'Connect your bank account to see all your transactions automatically.',
@@ -52,7 +52,7 @@ const TUTORIALS: Tutorial[] = [
     title: 'Regular Payments',
     subtitle: 'Every subscription, direct debit, and standing order in one place. Spot unused services and save money.',
     icon: CreditCard,
-    colour: 'text-green-400',
+    colour: 'text-green-600',
     link: '/dashboard/money-hub/payments',
     steps: [
       'Your payments are split into 3 tabs: Subscriptions (streaming, software, gym), Direct Debits (energy, broadband, insurance), and Other.',
@@ -67,7 +67,7 @@ const TUTORIALS: Tutorial[] = [
     title: 'Disputes',
     subtitle: 'Tell us your problem in plain English. Our AI writes a complaint letter citing exact UK law.',
     icon: FileText,
-    colour: 'text-mint-400',
+    colour: 'text-emerald-600',
     link: '/dashboard/complaints',
     steps: [
       'Click "New dispute" and tell us what happened in your own words. No legal knowledge needed.',
@@ -83,7 +83,7 @@ const TUTORIALS: Tutorial[] = [
     title: 'My Contracts',
     subtitle: 'Upload any contract and our AI reads the key terms, flags unfair clauses, and strengthens your complaints.',
     icon: Shield,
-    colour: 'text-purple-400',
+    colour: 'text-purple-600',
     link: '/dashboard/contracts',
     steps: [
       'Upload a PDF or photo of any contract you have signed.',
@@ -98,7 +98,7 @@ const TUTORIALS: Tutorial[] = [
     title: 'Subscriptions',
     subtitle: 'Track every subscription, see annual costs, and cancel with one click.',
     icon: CreditCard,
-    colour: 'text-sky-400',
+    colour: 'text-sky-600',
     link: '/dashboard/subscriptions',
     steps: [
       'Add subscriptions manually or connect your bank to auto-detect them.',
@@ -113,7 +113,7 @@ const TUTORIALS: Tutorial[] = [
     title: 'Inbox Scan',
     subtitle: 'Connect your email. We automatically detect subscriptions, overcharges, and savings opportunities.',
     icon: ScanSearch,
-    colour: 'text-amber-400',
+    colour: 'text-orange-600',
     link: '/dashboard/profile?connect_email=true',
     steps: [
       'Connect your bank account via Open Banking (read-only, secure, FCA regulated).',
@@ -128,7 +128,7 @@ const TUTORIALS: Tutorial[] = [
     title: 'Deals',
     subtitle: 'Find cheaper alternatives for your current services. We compare energy, broadband, mobile, and insurance.',
     icon: Tag,
-    colour: 'text-red-400',
+    colour: 'text-red-600',
     link: '/dashboard/deals',
     steps: [
       'Browse deals by category: energy, broadband, mobile, streaming, insurance, and more.',
@@ -144,40 +144,40 @@ function TutorialCard({ tutorial }: { tutorial: Tutorial }) {
   const Icon = tutorial.icon;
 
   return (
-    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl overflow-hidden hover:border-mint-400/20 transition-all">
+    <div className="bg-white border border-slate-200 shadow-sm rounded-2xl overflow-hidden hover:border-emerald-300 hover:shadow-md transition-all">
       <button
         onClick={() => setExpanded(!expanded)}
         className="w-full text-left p-5"
       >
         <div className="flex items-start gap-3">
-          <div className={`w-10 h-10 rounded-lg bg-navy-800 flex items-center justify-center flex-shrink-0 ${tutorial.colour}`}>
+          <div className={`w-10 h-10 rounded-lg bg-slate-100 flex items-center justify-center flex-shrink-0 ${tutorial.colour}`}>
             <Icon className="h-5 w-5" />
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center justify-between">
-              <h3 className="text-white font-semibold">{tutorial.title}</h3>
-              {expanded ? <ChevronUp className="h-4 w-4 text-slate-400" /> : <ChevronDown className="h-4 w-4 text-slate-400" />}
+              <h3 className="text-slate-900 font-semibold">{tutorial.title}</h3>
+              {expanded ? <ChevronUp className="h-4 w-4 text-slate-500" /> : <ChevronDown className="h-4 w-4 text-slate-500" />}
             </div>
-            <p className="text-slate-400 text-sm mt-1">{tutorial.subtitle}</p>
+            <p className="text-slate-600 text-sm mt-1">{tutorial.subtitle}</p>
           </div>
         </div>
       </button>
 
       {expanded && (
-        <div className="px-5 pb-5 border-t border-navy-700/50 pt-4">
+        <div className="px-5 pb-5 border-t border-slate-200 pt-4">
           <ol className="space-y-3">
             {tutorial.steps.map((step, i) => (
               <li key={i} className="flex items-start gap-3 text-sm">
-                <span className="bg-mint-400 text-navy-950 text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
+                <span className="bg-emerald-500 text-white text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
                   {i + 1}
                 </span>
-                <p className="text-slate-300">{step}</p>
+                <p className="text-slate-700">{step}</p>
               </li>
             ))}
           </ol>
           <Link
             href={tutorial.link}
-            className="inline-flex items-center gap-2 mt-4 text-sm text-mint-400 hover:text-mint-300 font-medium transition-all"
+            className="inline-flex items-center gap-2 mt-4 text-sm text-emerald-600 hover:text-emerald-700 font-medium transition-all"
           >
             Try it now <ArrowRight className="h-3 w-3" />
           </Link>
@@ -191,17 +191,17 @@ export default function TutorialsPage() {
   return (
     <div className="max-w-4xl">
       <div className="mb-6">
-        <h1 className="text-4xl font-bold text-white font-[family-name:var(--font-heading)]">How to Use Paybacker</h1>
-        <p className="text-slate-400 mt-1">Step-by-step guides for every feature</p>
+        <h1 className="text-4xl font-bold text-slate-900 font-[family-name:var(--font-heading)]">How to Use Paybacker</h1>
+        <p className="text-slate-600 mt-1">Step-by-step guides for every feature</p>
       </div>
 
-      <div className="bg-mint-400/5 border border-mint-400/20 rounded-xl p-5 mb-6">
+      <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-5 mb-6">
         <div className="flex items-start gap-3">
-          <Sparkles className="h-5 w-5 text-mint-400 mt-0.5 flex-shrink-0" />
+          <Sparkles className="h-5 w-5 text-emerald-600 mt-0.5 flex-shrink-0" />
           <div>
-            <p className="text-white font-medium text-sm">New here?</p>
-            <p className="text-slate-400 text-sm mt-1">
-              Start with <strong className="text-white">Disputes</strong> to write your first complaint letter in 30 seconds, or connect your bank in the <strong className="text-white">Money Hub</strong> to find hidden savings.
+            <p className="text-slate-900 font-medium text-sm">New here?</p>
+            <p className="text-slate-700 text-sm mt-1">
+              Start with <strong className="text-slate-900">Disputes</strong> to write your first complaint letter in 30 seconds, or connect your bank in the <strong className="text-slate-900">Money Hub</strong> to find hidden savings.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Batch 8b: three more dashboard page bodies onto the light theme.

| File | Lines | What it is |
|---|---|---|
| `src/app/dashboard/export/page.tsx` | 122 | Data export destinations (Google Sheets live, Notion/YNAB/Actual coming soon) |
| `src/app/dashboard/tutorials/page.tsx` | 215 | 8 feature walkthrough accordions |
| `src/app/dashboard/spending/page.tsx` | 324 | Pro-gated spending insights with monthly bars + category breakdown |

### Also fixed (no change to file — just confirmed)

The three redirect stubs require no change (they only call `redirect()`):

- `src/app/dashboard/disputes/page.tsx` → `/dashboard/complaints`
- `src/app/dashboard/overview/page.tsx` → `/dashboard`
- `src/app/dashboard/upgrade/page.tsx`  → `/pricing`

### Colour translation map (same as 8a)

| Before | After |
|---|---|
| `bg-navy-900` / `bg-navy-900/60` | `bg-white` + `border-slate-200 shadow-sm` |
| `bg-navy-950/50` (nested panels) | `bg-slate-50` + `border-slate-200` |
| `bg-navy-800` (progress tracks) | `bg-slate-100` |
| `text-white` | `text-slate-900` |
| `text-slate-300` / `text-slate-400` | `text-slate-600` / `text-slate-700` |
| `text-mint-400` | `text-emerald-600` |
| `bg-mint-400/5` + `border-mint-400/20` | `bg-emerald-50` + `border-emerald-200` |
| `bg-mint-400` + `text-navy-950` (CTA) | `bg-emerald-500` + `text-white` |
| accent `*-400` on dark chip | accent `*-600` on slate-100 chip |

### Tutorials colour remap (per entry)

- Overview `text-blue-400` → `text-blue-600`
- Money Hub / Contracts `text-purple-400` → `text-purple-600`
- Regular Payments `text-green-400` → `text-green-600`
- Disputes `text-mint-400` → `text-emerald-600`
- Subscriptions `text-sky-400` → `text-sky-600`
- Inbox Scan `text-amber-400` → `text-orange-600` (marketing-system accent)
- Deals `text-red-400` → `text-red-600`

### Preserved verbatim

- **export/page.tsx** — external `GoogleSheetsConnect` + `DataExportCard`
  components untouched; same coming-soon entries and blurbs; same
  `mailto:hello@paybacker.co.uk?subject=Destination%20request`.
- **tutorials/page.tsx** — exact 8 tutorial entries with identical
  `title`/`subtitle`/`steps`/`link` values. Accordion state logic
  unchanged. SVG Notion icon recoloured so the black wordmark reads on
  white.
- **spending/page.tsx** — all fetch/supabase calls preserved. tier
  detection (`free` | `essential` | `pro`), `isPaid` / `isPro`
  derivatives, 5-category gate for free users, Pro-only biggest-
  transactions blur-lock overlay, en-GB date formatting + `formatGBP`,
  all chart widths/bar mathematics — unchanged.

### Checks

- `npx tsc --noEmit`: clean for all three files.
- No API keys, no env var changes, no database changes.
- Zero behavioural change — pure visual re-skin.

### Next

Batch 8c picks up the next tier (forms, profile/report, telegram
settings, pocket-agent, admin legal-refs) around the 400–500 line range.
