### PR TITLE
feat(dashboard): re-skin forms + telegram + report + admin legal-refs bodies to light theme (batch 8c)

### DIFF
--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -32,7 +32,7 @@ interface LegalRef {
 
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof CheckCircle; className: string }> = {
   current: { label: 'Current', icon: CheckCircle, className: 'text-green-400 bg-green-500/10' },
-  updated: { label: 'Auto-updated', icon: RefreshCw, className: 'text-mint-400 bg-mint-400/10' },
+  updated: { label: 'Auto-updated', icon: RefreshCw, className: 'text-emerald-600 bg-mint-400/10' },
   needs_review: { label: 'Needs review', icon: AlertTriangle, className: 'text-amber-400 bg-amber-500/10' },
   outdated: { label: 'Outdated', icon: AlertTriangle, className: 'text-red-400 bg-red-500/10' },
 };
@@ -150,7 +150,7 @@ export default function LegalRefsAdminPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
+        <Loader2 className="h-8 w-8 text-emerald-600 animate-spin" />
       </div>
     );
   }
@@ -160,8 +160,8 @@ export default function LegalRefsAdminPage() {
       <div className="flex items-center justify-center h-full">
         <div className="text-center">
           <Shield className="h-16 w-16 text-red-500 mx-auto mb-4" />
-          <h1 className="text-2xl font-bold text-white mb-2">Access Denied</h1>
-          <p className="text-slate-400">Admin access only.</p>
+          <h1 className="text-2xl font-bold text-slate-900 mb-2">Access Denied</h1>
+          <p className="text-slate-600">Admin access only.</p>
         </div>
       </div>
     );
@@ -173,23 +173,23 @@ export default function LegalRefsAdminPage() {
       <div className="mb-6">
         <Link
           href="/dashboard/admin"
-          className="inline-flex items-center gap-1.5 text-slate-400 hover:text-white text-sm mb-4 transition-colors"
+          className="inline-flex items-center gap-1.5 text-slate-600 hover:text-slate-900 text-sm mb-4 transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to Admin
         </Link>
         <div className="flex items-start justify-between">
           <div>
-            <h1 className="text-4xl font-bold text-white mb-2 flex items-center gap-3 font-[family-name:var(--font-heading)]">
-              <Shield className="h-9 w-9 text-mint-400" />
+            <h1 className="text-4xl font-bold text-slate-900 mb-2 flex items-center gap-3 font-[family-name:var(--font-heading)]">
+              <Shield className="h-9 w-9 text-emerald-600" />
               Legal References
             </h1>
-            <p className="text-slate-400">{counts.total} references across {categories.length} categories</p>
+            <p className="text-slate-600">{counts.total} references across {categories.length} categories</p>
           </div>
           <button
             onClick={runVerification}
             disabled={verifying}
-            className="flex items-center gap-2 bg-mint-400 hover:bg-mint-500 disabled:opacity-50 text-navy-950 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm shrink-0"
+            className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-white font-semibold px-5 py-2.5 rounded-lg transition-all text-sm shrink-0"
           >
             {verifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
             {verifying ? 'Verifying...' : 'Run Verification'}
@@ -210,7 +210,7 @@ export default function LegalRefsAdminPage() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         {[
           { label: 'Current', count: counts.current, className: 'border-green-500/20 bg-green-500/5', textClass: 'text-green-400' },
-          { label: 'Auto-updated', count: counts.updated, className: 'border-mint-400/20 bg-mint-400/5', textClass: 'text-mint-400' },
+          { label: 'Auto-updated', count: counts.updated, className: 'border-mint-400/20 bg-mint-400/5', textClass: 'text-emerald-600' },
           { label: 'Needs review', count: counts.needs_review, className: 'border-amber-500/20 bg-amber-500/5', textClass: 'text-amber-400' },
           { label: 'Outdated', count: counts.outdated, className: 'border-red-500/20 bg-red-500/5', textClass: 'text-red-400' },
         ].map(card => (
@@ -220,7 +220,7 @@ export default function LegalRefsAdminPage() {
             className={`border rounded-2xl p-5 text-left transition-all hover:opacity-80 ${card.className}`}
           >
             <p className={`text-3xl font-bold ${card.textClass}`}>{card.count}</p>
-            <p className="text-slate-400 text-sm mt-1">{card.label}</p>
+            <p className="text-slate-600 text-sm mt-1">{card.label}</p>
           </button>
         ))}
       </div>
@@ -228,19 +228,19 @@ export default function LegalRefsAdminPage() {
       {/* Filters */}
       <div className="flex flex-wrap gap-3 mb-4">
         <div className="flex-1 min-w-[200px] relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-700" />
           <input
             type="text"
             value={search}
             onChange={e => setSearch(e.target.value)}
             placeholder="Search references..."
-            className="w-full pl-9 pr-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-white placeholder-slate-500 text-sm focus:outline-none focus:border-mint-400"
+            className="w-full pl-9 pr-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-900 placeholder-slate-500 text-sm focus:outline-none focus:border-mint-400"
           />
         </div>
         <select
           value={filterStatus}
           onChange={e => setFilterStatus(e.target.value)}
-          className="px-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-slate-300 text-sm focus:outline-none focus:border-mint-400"
+          className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm focus:outline-none focus:border-mint-400"
         >
           <option value="all">All statuses</option>
           <option value="current">Current</option>
@@ -251,7 +251,7 @@ export default function LegalRefsAdminPage() {
         <select
           value={filterCategory}
           onChange={e => setFilterCategory(e.target.value)}
-          className="px-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-slate-300 text-sm focus:outline-none focus:border-mint-400"
+          className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm focus:outline-none focus:border-mint-400"
         >
           <option value="all">All categories</option>
           {categories.map(cat => (
@@ -261,26 +261,26 @@ export default function LegalRefsAdminPage() {
         {(search || filterStatus !== 'all' || filterCategory !== 'all') && (
           <button
             onClick={() => { setSearch(''); setFilterStatus('all'); setFilterCategory('all'); }}
-            className="px-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-slate-400 hover:text-white text-sm transition-colors"
+            className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-600 hover:text-slate-900 text-sm transition-colors"
           >
             Clear
           </button>
         )}
       </div>
 
-      <p className="text-slate-500 text-sm mb-4">Showing {filtered.length} of {refs.length} references</p>
+      <p className="text-slate-700 text-sm mb-4">Showing {filtered.length} of {refs.length} references</p>
 
       {/* Table */}
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl overflow-hidden">
+      <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-navy-700/50">
-                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-400 uppercase tracking-wide">Law / Section</th>
-                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-400 uppercase tracking-wide">Category</th>
-                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-400 uppercase tracking-wide">Status</th>
-                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-400 uppercase tracking-wide hidden lg:table-cell">Last verified</th>
-                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-400 uppercase tracking-wide hidden xl:table-cell">Strength</th>
+              <tr className="border-b border-slate-200">
+                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Law / Section</th>
+                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Category</th>
+                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Status</th>
+                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden lg:table-cell">Last verified</th>
+                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden xl:table-cell">Strength</th>
                 <th className="px-5 py-3"></th>
               </tr>
             </thead>
@@ -291,20 +291,20 @@ export default function LegalRefsAdminPage() {
                 return (
                   <tr
                     key={ref.id}
-                    className={`border-b border-navy-700/30 hover:bg-navy-800/50 transition-colors ${i % 2 === 0 ? '' : 'bg-navy-950/30'}`}
+                    className={`border-b border-slate-200 hover:bg-slate-100/50 transition-colors ${i % 2 === 0 ? '' : 'bg-slate-100/30'}`}
                   >
                     <td className="px-5 py-4">
-                      <p className="text-white text-sm font-medium">{ref.law_name}</p>
+                      <p className="text-slate-900 text-sm font-medium">{ref.law_name}</p>
                       {ref.section && (
-                        <p className="text-slate-500 text-xs mt-0.5">{ref.section}</p>
+                        <p className="text-slate-700 text-xs mt-0.5">{ref.section}</p>
                       )}
-                      <p className="text-slate-400 text-xs mt-1 line-clamp-2 max-w-sm">{ref.summary}</p>
+                      <p className="text-slate-600 text-xs mt-1 line-clamp-2 max-w-sm">{ref.summary}</p>
                       {ref.verification_notes && (
                         <p className="text-amber-400/70 text-[11px] mt-1 line-clamp-1">{ref.verification_notes}</p>
                       )}
                     </td>
                     <td className="px-5 py-4">
-                      <span className="text-xs bg-navy-800 text-slate-300 px-2.5 py-1 rounded-full border border-navy-700/50">
+                      <span className="text-xs bg-slate-100 text-slate-700 px-2.5 py-1 rounded-full border border-slate-200">
                         {CATEGORY_LABELS[ref.category] || ref.category}
                       </span>
                       {ref.subcategory && (
@@ -318,7 +318,7 @@ export default function LegalRefsAdminPage() {
                       </span>
                     </td>
                     <td className="px-5 py-4 hidden lg:table-cell">
-                      <div className="flex items-center gap-1.5 text-slate-400 text-xs">
+                      <div className="flex items-center gap-1.5 text-slate-600 text-xs">
                         <Clock className="h-3.5 w-3.5 flex-shrink-0" />
                         {formatDate(ref.last_verified)}
                       </div>
@@ -327,7 +327,7 @@ export default function LegalRefsAdminPage() {
                       )}
                     </td>
                     <td className="px-5 py-4 hidden xl:table-cell">
-                      <span className={`text-xs font-medium capitalize ${STRENGTH_CONFIG[ref.strength] || 'text-slate-400'}`}>
+                      <span className={`text-xs font-medium capitalize ${STRENGTH_CONFIG[ref.strength] || 'text-slate-600'}`}>
                         {ref.strength}
                       </span>
                     </td>
@@ -336,7 +336,7 @@ export default function LegalRefsAdminPage() {
                         href={ref.source_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 text-xs text-mint-400 hover:text-mint-300 transition-colors whitespace-nowrap"
+                        className="inline-flex items-center gap-1.5 text-xs text-emerald-600 hover:text-mint-300 transition-colors whitespace-nowrap"
                       >
                         <ExternalLink className="h-3.5 w-3.5" />
                         View source
@@ -352,7 +352,7 @@ export default function LegalRefsAdminPage() {
         {filtered.length === 0 && (
           <div className="py-16 text-center">
             <Shield className="h-10 w-10 text-slate-600 mx-auto mb-3" />
-            <p className="text-slate-400 text-sm">No references match your filters.</p>
+            <p className="text-slate-600 text-sm">No references match your filters.</p>
           </div>
         )}
       </div>

--- a/src/app/dashboard/forms/page.tsx
+++ b/src/app/dashboard/forms/page.tsx
@@ -175,21 +175,21 @@ export default function FormsPage() {
   return (
     <div className="max-w-5xl">
       {/* Redirect banner */}
-      <div className="mb-6 bg-mint-400/10 border border-mint-400/30 rounded-xl p-4 flex items-center gap-3">
-        <Sparkles className="h-5 w-5 text-mint-400 shrink-0" />
+      <div className="mb-6 bg-emerald-50 border border-emerald-200 rounded-xl p-4 flex items-center gap-3">
+        <Sparkles className="h-5 w-5 text-emerald-600 shrink-0" />
         <div>
-          <p className="text-white font-semibold text-sm">These forms are now available in Disputes</p>
-          <p className="text-slate-400 text-xs mt-0.5">
+          <p className="text-slate-900 font-semibold text-sm">These forms are now available in Disputes</p>
+          <p className="text-slate-600 text-xs mt-0.5">
             All form types have been merged into the Disputes section for a simpler experience.{' '}
-            <a href="/dashboard/complaints" className="text-mint-400 hover:text-mint-300 underline underline-offset-2 transition-all">Go to Disputes</a>
+            <a href="/dashboard/complaints" className="text-emerald-600 hover:text-emerald-700 underline underline-offset-2 transition-all">Go to Disputes</a>
           </p>
         </div>
       </div>
 
       <div className="mb-8">
-        <h1 className="text-4xl font-bold text-white mb-2 font-[family-name:var(--font-heading)]">Forms & Government Letters</h1>
-        <p className="text-slate-400">Official regulatory forms and government letters. For company complaints, use the{' '}
-          <a href="/dashboard/complaints" className="text-mint-400 hover:text-mint-300 underline underline-offset-2 transition-all">Complaints section</a>.
+        <h1 className="text-4xl font-bold text-slate-900 mb-2 font-[family-name:var(--font-heading)]">Forms & Government Letters</h1>
+        <p className="text-slate-600">Official regulatory forms and government letters. For company complaints, use the{' '}
+          <a href="/dashboard/complaints" className="text-emerald-600 hover:text-emerald-700 underline underline-offset-2 transition-all">Complaints section</a>.
         </p>
       </div>
 
@@ -197,13 +197,13 @@ export default function FormsPage() {
       <div className="flex gap-2 mb-6">
         <button
           onClick={() => { setActiveTab('generate'); setResult(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${activeTab === 'generate' ? 'bg-mint-400 text-navy-950' : 'bg-navy-800 text-slate-400 hover:text-white'}`}
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${activeTab === 'generate' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
         >
           <Sparkles className="h-4 w-4" /> Generate
         </button>
         <button
           onClick={() => { setActiveTab('history'); loadHistory(); setSelectedHistoryTask(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${activeTab === 'history' ? 'bg-mint-400 text-navy-950' : 'bg-navy-800 text-slate-400 hover:text-white'}`}
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${activeTab === 'history' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
         >
           <History className="h-4 w-4" /> History ({historyTasks.length})
         </button>
@@ -213,18 +213,18 @@ export default function FormsPage() {
       {activeTab === 'history' && (
         <div>
           {loadingHistory ? (
-            <div className="text-center py-12"><Loader2 className="h-8 w-8 text-mint-400 animate-spin mx-auto" /></div>
+            <div className="text-center py-12"><Loader2 className="h-8 w-8 text-emerald-600 animate-spin mx-auto" /></div>
           ) : selectedHistoryTask ? (
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6">
-              <button onClick={() => setSelectedHistoryTask(null)} className="text-slate-400 hover:text-white text-sm mb-4 flex items-center gap-1">
+            <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6">
+              <button onClick={() => setSelectedHistoryTask(null)} className="text-slate-500 hover:text-slate-900 text-sm mb-4 flex items-center gap-1">
                 ← Back to history
               </button>
-              <h3 className="text-lg font-bold text-white mb-2">{selectedHistoryTask.title}</h3>
+              <h3 className="text-lg font-bold text-slate-900 mb-2">{selectedHistoryTask.title}</h3>
               <p className="text-slate-500 text-xs mb-4">{new Date(selectedHistoryTask.created_at).toLocaleString('en-GB')}</p>
               {selectedHistoryTask.letter ? (
-                <div className="bg-navy-950 rounded-lg p-4 border border-navy-700/50">
+                <div className="bg-slate-50 rounded-lg p-4 border border-slate-200">
                   <pre
-                    className="text-sm text-slate-200 whitespace-pre-wrap font-sans leading-relaxed"
+                    className="text-sm text-slate-800 whitespace-pre-wrap font-sans leading-relaxed"
                     onCopy={(e) => {
                       const sel = window.getSelection();
                       if (!sel) return;
@@ -234,7 +234,7 @@ export default function FormsPage() {
                   >{selectedHistoryTask.letter}</pre>
                   <button
                     onClick={() => { navigator.clipboard.writeText(selectedHistoryTask.letter!); setCopied(true); setTimeout(() => setCopied(false), 2000); }}
-                    className="mt-4 flex items-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-4 py-2 rounded-lg text-sm"
+                    className="mt-4 flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-4 py-2 rounded-lg text-sm"
                   >
                     {copied ? <><CheckCircle className="h-4 w-4" /> Copied</> : <><Copy className="h-4 w-4" /> Copy Letter</>}
                   </button>
@@ -244,10 +244,10 @@ export default function FormsPage() {
               )}
             </div>
           ) : historyTasks.length === 0 ? (
-            <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-12 text-center">
-              <FileText className="h-12 w-12 text-slate-600 mx-auto mb-3" />
-              <p className="text-slate-400 mb-2">No letters generated yet</p>
-              <button onClick={() => setActiveTab('generate')} className="text-mint-400 text-sm">Generate your first letter</button>
+            <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-12 text-center">
+              <FileText className="h-12 w-12 text-slate-300 mx-auto mb-3" />
+              <p className="text-slate-600 mb-2">No letters generated yet</p>
+              <button onClick={() => setActiveTab('generate')} className="text-emerald-600 text-sm hover:text-emerald-700">Generate your first letter</button>
             </div>
           ) : (
             <div className="space-y-2">
@@ -255,11 +255,11 @@ export default function FormsPage() {
                 <button
                   key={task.id}
                   onClick={() => loadTaskLetter(task)}
-                  className="w-full text-left bg-navy-900 border border-navy-700/50 hover:border-mint-400/50 rounded-xl px-5 py-4 transition-all"
+                  className="w-full text-left bg-white border border-slate-200 hover:border-emerald-400 hover:shadow-sm rounded-xl px-5 py-4 transition-all"
                 >
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-white font-medium text-sm">{task.title}</p>
+                      <p className="text-slate-900 font-medium text-sm">{task.title}</p>
                       <p className="text-slate-500 text-xs mt-1">{task.description}</p>
                     </div>
                     <div className="flex items-center gap-2 text-slate-500 text-xs shrink-0 ml-4">
@@ -278,7 +278,7 @@ export default function FormsPage() {
         <div className="grid lg:grid-cols-2 gap-8">
           {/* Form type selection */}
           <div>
-            <h2 className="text-lg font-bold text-white mb-4">What do you need help with?</h2>
+            <h2 className="text-lg font-bold text-slate-900 mb-4">What do you need help with?</h2>
             <div className="space-y-2">
               {FORM_TYPES.map((form) => (
                 <button
@@ -286,13 +286,13 @@ export default function FormsPage() {
                   onClick={() => setSelectedForm(form.key)}
                   className={`w-full text-left flex items-center gap-3 px-4 py-3 rounded-xl border transition-all ${
                     selectedForm === form.key
-                      ? 'border-mint-400/50 bg-mint-400/5'
-                      : 'border-navy-700/50 bg-navy-900 hover:border-navy-700/50'
+                      ? 'border-emerald-400 bg-emerald-50'
+                      : 'border-slate-200 bg-white hover:border-slate-300 hover:shadow-sm'
                   }`}
                 >
                   <span className="text-xl">{form.icon}</span>
                   <div>
-                    <p className="text-white text-sm font-medium">{form.label}</p>
+                    <p className="text-slate-900 text-sm font-medium">{form.label}</p>
                     <p className="text-slate-500 text-xs">{form.description}</p>
                   </div>
                 </button>
@@ -301,11 +301,11 @@ export default function FormsPage() {
           </div>
 
           {/* Details form */}
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6">
+          <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6">
             {selectedForm ? (
               <div className="space-y-4">
-                <h2 className="text-lg font-bold text-white flex items-center gap-2">
-                  <FileText className="h-5 w-5 text-mint-400" />
+                <h2 className="text-lg font-bold text-slate-900 flex items-center gap-2">
+                  <FileText className="h-5 w-5 text-emerald-600" />
                   {FORM_TYPES.find(f => f.key === selectedForm)?.label}
                 </h2>
 
@@ -314,37 +314,37 @@ export default function FormsPage() {
                   return (
                     <>
                       <div>
-                        <label className="block text-sm font-medium text-slate-300 mb-2">Describe your situation *</label>
+                        <label className="block text-sm font-medium text-slate-700 mb-2">Describe your situation *</label>
                         <textarea
                           required rows={5} value={details} onChange={(e) => setDetails(e.target.value)}
-                          className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+                          className="w-full px-4 py-3 bg-white border border-slate-300 rounded-lg text-slate-900 placeholder-slate-400 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
                           placeholder={formConfig?.situationPlaceholder || 'Explain what happened, when, and any relevant details...'}
                         />
                       </div>
 
                       <div>
-                        <label className="block text-sm font-medium text-slate-300 mb-2">What outcome do you want? *</label>
+                        <label className="block text-sm font-medium text-slate-700 mb-2">What outcome do you want? *</label>
                         <input
                           type="text" required value={desiredOutcome} onChange={(e) => setDesiredOutcome(e.target.value)}
-                          className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+                          className="w-full px-4 py-3 bg-white border border-slate-300 rounded-lg text-slate-900 placeholder-slate-400 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
                           placeholder={formConfig?.outcomePlaceholder || 'e.g. Refund, correction, compensation...'}
                         />
                       </div>
 
                       <div className="grid grid-cols-2 gap-4">
                         <div>
-                          <label className="block text-sm font-medium text-slate-300 mb-2">Amount (optional)</label>
+                          <label className="block text-sm font-medium text-slate-700 mb-2">Amount (optional)</label>
                           <input
                             type="text" value={amount} onChange={(e) => setAmount(e.target.value)}
-                            className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                            className="w-full px-4 py-3 bg-white border border-slate-300 rounded-lg text-slate-900 placeholder-slate-400 focus:outline-none focus:border-emerald-500"
                             placeholder="£"
                           />
                         </div>
                         <div>
-                          <label className="block text-sm font-medium text-slate-300 mb-2">{formConfig?.refLabel || 'Reference'} (optional)</label>
+                          <label className="block text-sm font-medium text-slate-700 mb-2">{formConfig?.refLabel || 'Reference'} (optional)</label>
                           <input
                             type="text" value={referenceNumber} onChange={(e) => setReferenceNumber(e.target.value)}
-                            className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                            className="w-full px-4 py-3 bg-white border border-slate-300 rounded-lg text-slate-900 placeholder-slate-400 focus:outline-none focus:border-emerald-500"
                             placeholder={formConfig?.refPlaceholder || 'Reference number'}
                           />
                         </div>
@@ -354,21 +354,21 @@ export default function FormsPage() {
                 })()}
 
                 {error && (
-                  <div className="text-red-400 text-sm bg-red-500/10 border border-red-500/20 rounded-lg p-3">{error}</div>
+                  <div className="text-red-700 text-sm bg-red-50 border border-red-200 rounded-lg p-3">{error}</div>
                 )}
 
                 <button
                   onClick={handleGenerate}
                   disabled={generating || !details || !desiredOutcome}
-                  className="w-full bg-gradient-to-r from-mint-400 to-mint-500 hover:from-mint-500 hover:to-mint-600 text-navy-950 font-semibold py-3 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                  className="w-full bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white font-semibold py-3 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                 >
                   {generating ? <><Loader2 className="h-4 w-4 animate-spin" /> Generating...</> : <><Sparkles className="h-4 w-4" /> Generate Letter</>}
                 </button>
               </div>
             ) : (
               <div className="text-center py-12">
-                <FileText className="h-16 w-16 text-slate-600 mx-auto mb-4" />
-                <p className="text-slate-400">Select a letter type from the left to get started</p>
+                <FileText className="h-16 w-16 text-slate-300 mx-auto mb-4" />
+                <p className="text-slate-500">Select a letter type from the left to get started</p>
               </div>
             )}
           </div>
@@ -378,17 +378,17 @@ export default function FormsPage() {
         <div>
           <div className="flex items-center justify-between mb-6">
             <div>
-              <h2 className="text-xl font-bold text-white">{result.formType}</h2>
-              <p className="text-green-400 text-sm flex items-center gap-1"><CheckCircle className="h-4 w-4" /> Saved to your history</p>
+              <h2 className="text-xl font-bold text-slate-900">{result.formType}</h2>
+              <p className="text-green-600 text-sm flex items-center gap-1"><CheckCircle className="h-4 w-4" /> Saved to your history</p>
             </div>
-            <button onClick={handleReset} className="flex items-center gap-2 text-slate-400 hover:text-white text-sm transition-all">
+            <button onClick={handleReset} className="flex items-center gap-2 text-slate-500 hover:text-slate-900 text-sm transition-all">
               <RefreshCw className="h-4 w-4" /> New letter
             </button>
           </div>
 
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6 mb-6">
+          <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 mb-6">
             <pre
-              className="text-sm text-slate-200 whitespace-pre-wrap font-mono leading-relaxed"
+              className="text-sm text-slate-800 whitespace-pre-wrap font-mono leading-relaxed"
               onCopy={(e) => {
                 const sel = window.getSelection();
                 if (!sel) return;
@@ -399,32 +399,32 @@ export default function FormsPage() {
           </div>
 
           {result.legalReferences?.length > 0 && (
-            <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4 mb-6">
-              <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-2">Legal References</h3>
-              <ul className="text-xs text-slate-400 space-y-1">
+            <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
+              <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">Legal References</h3>
+              <ul className="text-xs text-slate-600 space-y-1">
                 {result.legalReferences.map((ref: string, i: number) => (
-                  <li key={i} className="flex items-start gap-2"><span className="text-mint-400">•</span> {ref}</li>
+                  <li key={i} className="flex items-start gap-2"><span className="text-emerald-600">•</span> {ref}</li>
                 ))}
               </ul>
             </div>
           )}
 
           {result.nextSteps?.length > 0 && (
-            <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4 mb-6">
-              <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-2">Next Steps</h3>
-              <ol className="text-sm text-slate-300 space-y-2">
+            <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
+              <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">Next Steps</h3>
+              <ol className="text-sm text-slate-700 space-y-2">
                 {result.nextSteps.map((step: string, i: number) => (
-                  <li key={i} className="flex items-start gap-2"><span className="text-mint-400 font-bold">{i + 1}.</span> {step}</li>
+                  <li key={i} className="flex items-start gap-2"><span className="text-emerald-600 font-bold">{i + 1}.</span> {step}</li>
                 ))}
               </ol>
             </div>
           )}
 
           {result.estimatedSuccess && (
-            <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4 mb-6">
+            <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
               <div className="flex items-center justify-between">
-                <span className="text-slate-400 text-sm">Estimated success rate</span>
-                <span className={`font-bold ${result.estimatedSuccess >= 70 ? 'text-green-400' : result.estimatedSuccess >= 50 ? 'text-mint-400' : 'text-red-400'}`}>
+                <span className="text-slate-500 text-sm">Estimated success rate</span>
+                <span className={`font-bold ${result.estimatedSuccess >= 70 ? 'text-green-600' : result.estimatedSuccess >= 50 ? 'text-emerald-600' : 'text-red-600'}`}>
                   {result.estimatedSuccess}%
                 </span>
               </div>
@@ -433,11 +433,11 @@ export default function FormsPage() {
 
           <div className="flex gap-3">
             <button onClick={handleCopy}
-              className="flex-1 flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white py-3 rounded-lg transition-all">
+              className="flex-1 flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-900 py-3 rounded-lg transition-all">
               {copied ? <><CheckCircle className="h-4 w-4" /> Copied!</> : <><Copy className="h-4 w-4" /> Copy Letter</>}
             </button>
             <button onClick={handlePDF}
-              className="flex-1 flex items-center justify-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-lg transition-all">
+              className="flex-1 flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold py-3 rounded-lg transition-all">
               <Download className="h-4 w-4" /> Download PDF
             </button>
           </div>

--- a/src/app/dashboard/profile/report/page.tsx
+++ b/src/app/dashboard/profile/report/page.tsx
@@ -64,8 +64,8 @@ export default function AnnualReportPage() {
   if (loading) {
     return (
       <div className="min-h-[60vh] flex flex-col items-center justify-center gap-4">
-        <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
-        <p className="text-slate-400 text-sm">Generating your annual report…</p>
+        <Loader2 className="h-8 w-8 text-emerald-600 animate-spin" />
+        <p className="text-slate-600 text-sm">Generating your annual report…</p>
         <p className="text-slate-500 text-xs">This may take a few seconds</p>
       </div>
     );
@@ -76,7 +76,7 @@ export default function AnnualReportPage() {
       <div className="min-h-[60vh] flex flex-col items-center justify-center gap-4">
         <AlertTriangle className="h-8 w-8 text-red-400" />
         <p className="text-red-400 text-sm">{error}</p>
-        <Link href="/dashboard/profile" className="text-mint-400 text-sm hover:underline">← Back to Profile</Link>
+        <Link href="/dashboard/profile" className="text-emerald-600 text-sm hover:underline">← Back to Profile</Link>
       </div>
     );
   }
@@ -98,13 +98,13 @@ export default function AnnualReportPage() {
     <div className="max-w-4xl mx-auto pb-12">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
-        <Link href="/dashboard/profile" className="flex items-center gap-2 text-slate-400 hover:text-white transition-all text-sm">
+        <Link href="/dashboard/profile" className="flex items-center gap-2 text-slate-600 hover:text-slate-900 transition-all text-sm">
           <ArrowLeft className="h-4 w-4" /> Back to Profile
         </Link>
         <button
           onClick={handleDownloadPDF}
           disabled={pdfLoading}
-          className="flex items-center gap-2 bg-navy-800 hover:bg-navy-700 text-white font-semibold px-4 py-2 rounded-xl transition-all disabled:opacity-50 text-sm"
+          className="flex items-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-900 font-semibold px-4 py-2 rounded-xl transition-all disabled:opacity-50 text-sm"
         >
           {pdfLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
           {pdfLoading ? 'Generating PDF…' : 'Download PDF'}
@@ -112,23 +112,23 @@ export default function AnnualReportPage() {
       </div>
 
       {/* Report Header Card */}
-      <div className="bg-gradient-to-br from-navy-900 to-navy-800 border border-navy-700/50 rounded-2xl p-8 mb-6">
-        <p className="text-mint-400 text-xs font-semibold uppercase tracking-widest mb-2">Paybacker Financial Report</p>
-        <h1 className="text-3xl font-bold text-white mb-2">Your {data.year} Annual Report</h1>
-        <p className="text-slate-400 text-sm">
+      <div className="bg-gradient-to-br from-white to-slate-50 border border-slate-200 rounded-2xl p-8 mb-6">
+        <p className="text-emerald-600 text-xs font-semibold uppercase tracking-widest mb-2">Paybacker Financial Report</p>
+        <h1 className="text-3xl font-bold text-slate-900 mb-2">Your {data.year} Annual Report</h1>
+        <p className="text-slate-600 text-sm">
           {data.userName} &middot; {data.userPlan} &middot; Member for {data.daysAsMember} days &middot; Generated {new Date(data.generatedAt).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
         </p>
       </div>
 
       {/* Executive Summary */}
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-        <h2 className="text-lg font-bold text-white mb-3 flex items-center gap-2"><FileText className="h-5 w-5 text-mint-400" />Executive Summary</h2>
-        <p className="text-slate-300 text-sm leading-relaxed">{data.executiveSummary}</p>
+      <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+        <h2 className="text-lg font-bold text-slate-900 mb-3 flex items-center gap-2"><FileText className="h-5 w-5 text-emerald-600" />Executive Summary</h2>
+        <p className="text-slate-700 text-sm leading-relaxed">{data.executiveSummary}</p>
       </div>
 
       {/* Financial Health Score */}
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-        <h2 className="text-lg font-bold text-white mb-4 flex items-center gap-2"><Shield className="h-5 w-5 text-mint-400" />Financial Health Score</h2>
+      <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+        <h2 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-2"><Shield className="h-5 w-5 text-emerald-600" />Financial Health Score</h2>
         <div className="flex flex-col sm:flex-row items-center gap-6">
           <div className="relative w-32 h-32 flex-shrink-0">
             <svg viewBox="0 0 120 120" className="w-full h-full -rotate-90">
@@ -137,8 +137,8 @@ export default function AnnualReportPage() {
                 strokeDasharray={`${(data.financialHealth.overall / 100) * 327} 327`} />
             </svg>
             <div className="absolute inset-0 flex flex-col items-center justify-center">
-              <span className="text-4xl font-bold text-white">{data.financialHealth.overall}</span>
-              <span className="text-xs text-slate-400">/ 100</span>
+              <span className="text-4xl font-bold text-slate-900">{data.financialHealth.overall}</span>
+              <span className="text-xs text-slate-600">/ 100</span>
             </div>
           </div>
           <div className="flex-1 w-full">
@@ -148,8 +148,8 @@ export default function AnnualReportPage() {
             <div className="space-y-2 mt-3">
               {Object.entries(data.financialHealth.pillars).map(([key, pillar]) => (
                 <div key={key}>
-                  <div className="flex justify-between text-xs mb-0.5"><span className="text-slate-400">{pillar.label}</span><span className="text-slate-300">{pillar.score}%</span></div>
-                  <div className="bg-navy-800 rounded-full h-2"><div className="h-2 rounded-full transition-all" style={{ width: `${pillar.score}%`, backgroundColor: data.financialHealth.tier === 'healthy' ? '#4ADE80' : data.financialHealth.tier === 'coping' ? '#FBBF24' : '#F87171' }} /></div>
+                  <div className="flex justify-between text-xs mb-0.5"><span className="text-slate-600">{pillar.label}</span><span className="text-slate-700">{pillar.score}%</span></div>
+                  <div className="bg-slate-100 rounded-full h-2"><div className="h-2 rounded-full transition-all" style={{ width: `${pillar.score}%`, backgroundColor: data.financialHealth.tier === 'healthy' ? '#4ADE80' : data.financialHealth.tier === 'coping' ? '#FBBF24' : '#F87171' }} /></div>
                 </div>
               ))}
             </div>
@@ -158,19 +158,19 @@ export default function AnnualReportPage() {
       </div>
 
       {/* Income vs Spending Overview */}
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-        <h2 className="text-lg font-bold text-white mb-4 flex items-center gap-2"><Wallet className="h-5 w-5 text-mint-400" />Income & Spending</h2>
+      <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+        <h2 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-2"><Wallet className="h-5 w-5 text-emerald-600" />Income & Spending</h2>
         <div className="grid grid-cols-3 gap-3 mb-6">
-          <div className="bg-navy-950/50 rounded-xl p-4 border border-navy-700/30 text-center">
-            <p className="text-[11px] text-slate-400 mb-1">Total Income</p>
+          <div className="bg-slate-100/50 rounded-xl p-4 border border-slate-200 text-center">
+            <p className="text-[11px] text-slate-600 mb-1">Total Income</p>
             <p className="text-xl font-bold text-green-400">{formatGBP(data.totalIncome)}</p>
           </div>
-          <div className="bg-navy-950/50 rounded-xl p-4 border border-navy-700/30 text-center">
-            <p className="text-[11px] text-slate-400 mb-1">Total Spending</p>
+          <div className="bg-slate-100/50 rounded-xl p-4 border border-slate-200 text-center">
+            <p className="text-[11px] text-slate-600 mb-1">Total Spending</p>
             <p className="text-xl font-bold text-red-400">{formatGBP(data.totalOutgoings)}</p>
           </div>
-          <div className="bg-navy-950/50 rounded-xl p-4 border border-navy-700/30 text-center">
-            <p className="text-[11px] text-slate-400 mb-1">Savings Rate</p>
+          <div className="bg-slate-100/50 rounded-xl p-4 border border-slate-200 text-center">
+            <p className="text-[11px] text-slate-600 mb-1">Savings Rate</p>
             <p className={`text-xl font-bold ${data.totalIncome > 0 && data.totalIncome >= data.totalOutgoings ? 'text-green-400' : data.totalIncome > 0 ? 'text-red-400' : 'text-slate-500'}`}>
               {data.totalIncome > 0 ? `${(((data.totalIncome - data.totalOutgoings) / data.totalIncome) * 100).toFixed(1)}%` : 'N/A'}
             </p>
@@ -194,8 +194,8 @@ export default function AnnualReportPage() {
 
       {/* Spending by Category */}
       {data.spendingByCategory.length > 0 && (
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-          <h2 className="text-lg font-bold text-white mb-4 flex items-center gap-2"><Target className="h-5 w-5 text-mint-400" />Spending by Category</h2>
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+          <h2 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-2"><Target className="h-5 w-5 text-emerald-600" />Spending by Category</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="h-64">
               <ResponsiveContainer width="100%" height="100%">
@@ -213,8 +213,8 @@ export default function AnnualReportPage() {
               {data.spendingByCategory.map((cat, i) => (
                 <div key={cat.category} className="flex items-center gap-3">
                   <div className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: PIE_COLORS[i % PIE_COLORS.length] }} />
-                  <span className="text-sm text-slate-300 flex-1 truncate">{cat.label}</span>
-                  <span className="text-sm text-white font-medium">{formatGBP(cat.total)}</span>
+                  <span className="text-sm text-slate-700 flex-1 truncate">{cat.label}</span>
+                  <span className="text-sm text-slate-900 font-medium">{formatGBP(cat.total)}</span>
                   <span className="text-xs text-slate-500 w-12 text-right">{cat.percentage}%</span>
                 </div>
               ))}
@@ -225,15 +225,15 @@ export default function AnnualReportPage() {
 
       {/* Subscription Deep Dive */}
       {data.subscriptionsList.length > 0 && (
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-          <h2 className="text-lg font-bold text-white mb-2 flex items-center gap-2"><CreditCard className="h-5 w-5 text-mint-400" />Subscriptions</h2>
-          <p className="text-sm text-slate-400 mb-4">{data.activeSubscriptions} active &middot; {formatGBP(data.monthlySubscriptionCost)}/mo &middot; {formatGBP(data.annualSubscriptionCost)}/yr</p>
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+          <h2 className="text-lg font-bold text-slate-900 mb-2 flex items-center gap-2"><CreditCard className="h-5 w-5 text-emerald-600" />Subscriptions</h2>
+          <p className="text-sm text-slate-600 mb-4">{data.activeSubscriptions} active &middot; {formatGBP(data.monthlySubscriptionCost)}/mo &middot; {formatGBP(data.annualSubscriptionCost)}/yr</p>
           <div className="space-y-2">
             {data.subscriptionsList.map(sub => (
-              <div key={sub.id} className="bg-navy-950/50 rounded-lg p-3 border border-navy-700/30 flex items-center justify-between gap-3">
+              <div key={sub.id} className="bg-slate-100/50 rounded-lg p-3 border border-slate-200 flex items-center justify-between gap-3">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
-                    <span className="text-white font-medium text-sm">{sub.name}</span>
+                    <span className="text-slate-900 font-medium text-sm">{sub.name}</span>
                     {sub.priceChange && <span className="text-[10px] text-red-400 bg-red-500/10 px-1.5 py-0.5 rounded">↑ {sub.priceChange.pctChange.toFixed(1)}%</span>}
                   </div>
                   <div className="flex items-center gap-2 mt-0.5">
@@ -247,7 +247,7 @@ export default function AnnualReportPage() {
                   </div>
                 </div>
                 <div className="text-right flex-shrink-0">
-                  <p className="text-white font-semibold text-sm">{formatGBP(sub.monthlyCost)}/mo</p>
+                  <p className="text-slate-900 font-semibold text-sm">{formatGBP(sub.monthlyCost)}/mo</p>
                   <p className="text-xs text-slate-500">{formatGBP(sub.annualCost)}/yr</p>
                 </div>
               </div>
@@ -258,15 +258,15 @@ export default function AnnualReportPage() {
 
       {/* Price Increase Analysis */}
       {data.priceAlerts.length > 0 && (
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-          <h2 className="text-lg font-bold text-white mb-2 flex items-center gap-2"><TrendingUp className="h-5 w-5 text-red-400" />Price Increases Detected</h2>
-          <p className="text-sm text-slate-400 mb-4">Total annual impact: <span className="text-red-400 font-semibold">{formatGBP(data.totalPriceIncreaseImpact)}/yr</span></p>
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+          <h2 className="text-lg font-bold text-slate-900 mb-2 flex items-center gap-2"><TrendingUp className="h-5 w-5 text-red-400" />Price Increases Detected</h2>
+          <p className="text-sm text-slate-600 mb-4">Total annual impact: <span className="text-red-400 font-semibold">{formatGBP(data.totalPriceIncreaseImpact)}/yr</span></p>
           <div className="space-y-2">
             {data.priceAlerts.map(alert => (
-              <div key={alert.id} className="bg-navy-950/50 rounded-lg p-3 border border-navy-700/30 flex items-center justify-between">
+              <div key={alert.id} className="bg-slate-100/50 rounded-lg p-3 border border-slate-200 flex items-center justify-between">
                 <div>
-                  <p className="text-white text-sm font-medium">{alert.merchantName}</p>
-                  <p className="text-xs text-slate-400">{formatGBP(alert.oldAmount)} → {formatGBP(alert.newAmount)} ({alert.pctChange.toFixed(1)}% increase)</p>
+                  <p className="text-slate-900 text-sm font-medium">{alert.merchantName}</p>
+                  <p className="text-xs text-slate-600">{formatGBP(alert.oldAmount)} → {formatGBP(alert.newAmount)} ({alert.pctChange.toFixed(1)}% increase)</p>
                 </div>
                 <span className="text-red-400 font-semibold text-sm">+{formatGBP(alert.annualImpact)}/yr</span>
               </div>
@@ -277,21 +277,21 @@ export default function AnnualReportPage() {
 
       {/* Savings Opportunities */}
       {data.savingsActions.length > 0 && (
-        <div className="bg-gradient-to-br from-emerald-500/5 to-emerald-600/5 border border-emerald-500/20 rounded-2xl p-6 mb-6">
+        <div className="bg-gradient-to-br from-emerald-50 to-emerald-50 border border-emerald-200 rounded-2xl p-6 mb-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-bold text-white flex items-center gap-2"><PiggyBank className="h-5 w-5 text-emerald-400" />Savings Opportunities</h2>
+            <h2 className="text-lg font-bold text-slate-900 flex items-center gap-2"><PiggyBank className="h-5 w-5 text-emerald-400" />Savings Opportunities</h2>
             <p className="text-emerald-400 font-bold text-lg">{formatGBP(data.potentialAnnualSavings)}/yr</p>
           </div>
           <div className="space-y-2.5">
             {data.savingsActions.map((action, i) => (
               <a key={i} href={action.actionUrl} target={action.actionUrl.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer"
-                className="flex items-center gap-3 bg-navy-900/60 rounded-lg p-3 hover:bg-navy-900/80 transition-all group border border-navy-700/30">
+                className="flex items-center gap-3 bg-slate-50/60 rounded-lg p-3 hover:bg-slate-50/80 transition-all group border border-slate-200">
                 <span className="text-lg">{action.difficultyEmoji}</span>
                 <div className="flex-1 min-w-0">
-                  <p className="text-white text-sm font-medium">{action.description} — {action.provider}</p>
+                  <p className="text-slate-900 text-sm font-medium">{action.description} — {action.provider}</p>
                   <p className="text-emerald-400 text-xs font-medium">Save {formatGBP(action.annualSaving)}/yr</p>
                 </div>
-                <ExternalLink className="h-4 w-4 text-slate-500 group-hover:text-white transition-all flex-shrink-0" />
+                <ExternalLink className="h-4 w-4 text-slate-500 group-hover:text-slate-900 transition-all flex-shrink-0" />
               </a>
             ))}
           </div>
@@ -300,20 +300,20 @@ export default function AnnualReportPage() {
 
       {/* Disputes */}
       {data.disputes.length > 0 && (
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-          <h2 className="text-lg font-bold text-white mb-4 flex items-center gap-2"><FileText className="h-5 w-5 text-blue-400" />Disputes & Complaints ({data.totalDisputes})</h2>
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+          <h2 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-2"><FileText className="h-5 w-5 text-blue-400" />Disputes & Complaints ({data.totalDisputes})</h2>
           <div className="space-y-2">
             {data.disputes.map(d => (
-              <div key={d.id} className="flex items-center justify-between bg-navy-950/50 rounded-lg p-3 border border-navy-700/30">
+              <div key={d.id} className="flex items-center justify-between bg-slate-100/50 rounded-lg p-3 border border-slate-200">
                 <div>
-                  <p className="text-white text-sm font-medium">{d.company}</p>
-                  <p className="text-xs text-slate-400 truncate max-w-xs">{d.issue}</p>
+                  <p className="text-slate-900 text-sm font-medium">{d.company}</p>
+                  <p className="text-xs text-slate-600 truncate max-w-xs">{d.issue}</p>
                 </div>
                 <div className="text-right flex-shrink-0">
                   <span className={`text-xs px-2 py-0.5 rounded-full ${
                     d.status === 'resolved' || d.status === 'resolved_success' ? 'bg-green-500/10 text-green-400' :
                     d.status === 'open' || d.status === 'in_progress' ? 'bg-blue-500/10 text-blue-400' :
-                    'bg-slate-500/10 text-slate-400'
+                    'bg-slate-500/10 text-slate-600'
                   }`}>{d.status.replace(/_/g, ' ')}</span>
                   <p className="text-[10px] text-slate-500 mt-0.5">{d.dateFiled}</p>
                 </div>
@@ -324,24 +324,24 @@ export default function AnnualReportPage() {
       )}
 
       {/* Connected Accounts & Data Quality */}
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-        <h2 className="text-lg font-bold text-white mb-4 flex items-center gap-2"><Building2 className="h-5 w-5 text-mint-400" />Data Quality & Connections</h2>
+      <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+        <h2 className="text-lg font-bold text-slate-900 mb-4 flex items-center gap-2"><Building2 className="h-5 w-5 text-emerald-600" />Data Quality & Connections</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
-          <div className="bg-navy-950/50 rounded-xl p-3 border border-navy-700/30 text-center">
-            <p className="text-lg font-bold text-white">{data.connectedBanks.length}</p>
-            <p className="text-[10px] text-slate-400">Banks</p>
+          <div className="bg-slate-100/50 rounded-xl p-3 border border-slate-200 text-center">
+            <p className="text-lg font-bold text-slate-900">{data.connectedBanks.length}</p>
+            <p className="text-[10px] text-slate-600">Banks</p>
           </div>
-          <div className="bg-navy-950/50 rounded-xl p-3 border border-navy-700/30 text-center">
-            <p className="text-lg font-bold text-white">{data.connectedEmails.length}</p>
-            <p className="text-[10px] text-slate-400">Email Accounts</p>
+          <div className="bg-slate-100/50 rounded-xl p-3 border border-slate-200 text-center">
+            <p className="text-lg font-bold text-slate-900">{data.connectedEmails.length}</p>
+            <p className="text-[10px] text-slate-600">Email Accounts</p>
           </div>
-          <div className="bg-navy-950/50 rounded-xl p-3 border border-navy-700/30 text-center">
-            <p className="text-lg font-bold text-white">{data.profileCompleteness}%</p>
-            <p className="text-[10px] text-slate-400">Profile Complete</p>
+          <div className="bg-slate-100/50 rounded-xl p-3 border border-slate-200 text-center">
+            <p className="text-lg font-bold text-slate-900">{data.profileCompleteness}%</p>
+            <p className="text-[10px] text-slate-600">Profile Complete</p>
           </div>
-          <div className="bg-navy-950/50 rounded-xl p-3 border border-navy-700/30 text-center">
-            <p className="text-lg font-bold text-white">{data.dataMonths}</p>
-            <p className="text-[10px] text-slate-400">Months of Data</p>
+          <div className="bg-slate-100/50 rounded-xl p-3 border border-slate-200 text-center">
+            <p className="text-lg font-bold text-slate-900">{data.dataMonths}</p>
+            <p className="text-[10px] text-slate-600">Months of Data</p>
           </div>
         </div>
 
@@ -350,7 +350,7 @@ export default function AnnualReportPage() {
             {data.connectedBanks.map((b, i) => (
               <div key={i} className="flex items-center gap-2 text-sm">
                 <CheckCircle2 className="h-3.5 w-3.5 text-green-400" />
-                <span className="text-slate-300">{b.name}</span>
+                <span className="text-slate-700">{b.name}</span>
               </div>
             ))}
           </div>
@@ -360,7 +360,7 @@ export default function AnnualReportPage() {
             {data.connectedEmails.map((e, i) => (
               <div key={i} className="flex items-center gap-2 text-sm">
                 <Mail className="h-3.5 w-3.5 text-blue-400" />
-                <span className="text-slate-300">{e.email}</span>
+                <span className="text-slate-700">{e.email}</span>
                 <span className="text-[10px] text-slate-500">{e.provider}</span>
               </div>
             ))}
@@ -370,19 +370,19 @@ export default function AnnualReportPage() {
 
       {/* Top Merchants */}
       {data.topMerchants.length > 0 && (
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
-          <h2 className="text-lg font-bold text-white mb-4">Top Merchants</h2>
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 mb-6">
+          <h2 className="text-lg font-bold text-slate-900 mb-4">Top Merchants</h2>
           <div className="space-y-2">
             {data.topMerchants.slice(0, 10).map((m, i) => {
               const pct = data.totalOutgoings > 0 ? (m.total / data.totalOutgoings) * 100 : 0;
               return (
                 <div key={m.name} className="flex items-center gap-3">
                   <span className="text-xs text-slate-500 w-5 text-right">{i + 1}</span>
-                  <span className="text-sm text-slate-300 flex-1 truncate">{m.name}</span>
-                  <div className="w-24 bg-navy-800 rounded-full h-1.5 hidden sm:block">
-                    <div className="h-1.5 rounded-full bg-mint-400" style={{ width: `${Math.min(pct * 2, 100)}%` }} />
+                  <span className="text-sm text-slate-700 flex-1 truncate">{m.name}</span>
+                  <div className="w-24 bg-slate-100 rounded-full h-1.5 hidden sm:block">
+                    <div className="h-1.5 rounded-full bg-emerald-500" style={{ width: `${Math.min(pct * 2, 100)}%` }} />
                   </div>
-                  <span className="text-sm text-white font-medium w-20 text-right">{formatGBP(m.total)}</span>
+                  <span className="text-sm text-slate-900 font-medium w-20 text-right">{formatGBP(m.total)}</span>
                   <span className="text-xs text-slate-500 w-12 text-right">{m.count} txns</span>
                 </div>
               );
@@ -394,11 +394,11 @@ export default function AnnualReportPage() {
       {/* Footer actions */}
       <div className="flex flex-wrap gap-3 justify-center">
         <button onClick={handleDownloadPDF} disabled={pdfLoading}
-          className="flex items-center gap-2 bg-gradient-to-r from-mint-400 to-mint-500 hover:from-mint-500 hover:to-mint-600 text-navy-950 font-semibold px-6 py-3 rounded-xl transition-all disabled:opacity-50">
+          className="flex items-center gap-2 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-mint-500 hover:to-mint-600 text-navy-950 font-semibold px-6 py-3 rounded-xl transition-all disabled:opacity-50">
           {pdfLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
           Download PDF
         </button>
-        <Link href="/dashboard/profile" className="flex items-center gap-2 bg-navy-800 hover:bg-navy-700 text-white font-semibold px-6 py-3 rounded-xl transition-all">
+        <Link href="/dashboard/profile" className="flex items-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-900 font-semibold px-6 py-3 rounded-xl transition-all">
           <ArrowLeft className="h-4 w-4" /> Back to Profile
         </Link>
       </div>

--- a/src/app/dashboard/settings/telegram/page.tsx
+++ b/src/app/dashboard/settings/telegram/page.tsx
@@ -47,7 +47,7 @@ function CountdownTimer({ expiresAt }: { expiresAt: string }) {
   const expired = seconds === 0;
 
   return (
-    <span className={expired ? 'text-red-400' : seconds < 60 ? 'text-amber-400' : 'text-slate-400'}>
+    <span className={expired ? 'text-red-400' : seconds < 60 ? 'text-orange-600' : 'text-slate-600'}>
       {expired
         ? 'Expired'
         : `Expires in ${mins}:${String(secs).padStart(2, '0')}`}
@@ -159,7 +159,7 @@ export default function TelegramSettingsPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[300px]">
-        <Loader2 className="h-8 w-8 text-amber-500 animate-spin" />
+        <Loader2 className="h-8 w-8 text-orange-500 animate-spin" />
       </div>
     );
   }
@@ -167,19 +167,19 @@ export default function TelegramSettingsPage() {
   if (isPro === false) {
     return (
       <div className="max-w-2xl mx-auto p-6">
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-8 text-center">
-          <div className="bg-amber-500/10 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
-            <Sparkles className="h-8 w-8 text-amber-500" />
+        <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center">
+          <div className="bg-orange-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Sparkles className="h-8 w-8 text-orange-500" />
           </div>
-          <h2 className="text-xl font-bold text-white mb-2">Pro Feature</h2>
-          <p className="text-slate-400 mb-6">
+          <h2 className="text-xl font-bold text-slate-900 mb-2">Pro Feature</h2>
+          <p className="text-slate-600 mb-6">
             The Telegram financial assistant is available to Pro subscribers only.
             Upgrade to get proactive bill alerts, spending summaries, and complaint letters
             delivered directly to Telegram.
           </p>
           <a
             href="/dashboard/upgrade"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-amber-500 hover:bg-amber-400 text-black font-semibold rounded-xl transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-orange-500 hover:bg-orange-600 text-black font-semibold rounded-xl transition-colors"
           >
             <Sparkles className="h-4 w-4" />
             Upgrade to Pro
@@ -193,26 +193,26 @@ export default function TelegramSettingsPage() {
     <div className="max-w-2xl mx-auto p-6 space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-white flex items-center gap-3">
-          <MessageCircle className="h-7 w-7 text-amber-500" />
+        <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-3">
+          <MessageCircle className="h-7 w-7 text-orange-500" />
           Telegram Bot
         </h1>
-        <p className="text-slate-400 mt-1">
+        <p className="text-slate-600 mt-1">
           Your personal financial assistant — alerts, spending summaries, and complaint letters
           via Telegram.
         </p>
       </div>
 
       {/* What it does */}
-      <div className="bg-navy-900/50 border border-navy-700/50 rounded-2xl p-6">
-        <h3 className="text-white font-semibold mb-4">What the bot does</h3>
+      <div className="bg-slate-50 border border-slate-200 rounded-2xl p-6">
+        <h3 className="text-slate-900 font-semibold mb-4">What the bot does</h3>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <div className="flex flex-col items-start gap-2">
             <div className="bg-red-500/10 p-2 rounded-lg">
               <BellRing className="h-5 w-5 text-red-400" />
             </div>
-            <span className="text-sm font-medium text-white">Proactive alerts</span>
-            <span className="text-xs text-slate-400">
+            <span className="text-sm font-medium text-slate-900">Proactive alerts</span>
+            <span className="text-xs text-slate-600">
               Bill increases, expiring contracts, budget overruns — sent to you before you notice
             </span>
           </div>
@@ -220,17 +220,17 @@ export default function TelegramSettingsPage() {
             <div className="bg-green-500/10 p-2 rounded-lg">
               <TrendingDown className="h-5 w-5 text-green-400" />
             </div>
-            <span className="text-sm font-medium text-white">Real-time queries</span>
-            <span className="text-xs text-slate-400">
+            <span className="text-sm font-medium text-slate-900">Real-time queries</span>
+            <span className="text-xs text-slate-600">
               &ldquo;How much on food this month?&rdquo; &mdash; answers from your live bank data
             </span>
           </div>
           <div className="flex flex-col items-start gap-2">
-            <div className="bg-amber-500/10 p-2 rounded-lg">
-              <Shield className="h-5 w-5 text-amber-400" />
+            <div className="bg-orange-100 p-2 rounded-lg">
+              <Shield className="h-5 w-5 text-orange-600" />
             </div>
-            <span className="text-sm font-medium text-white">Complaint letters</span>
-            <span className="text-xs text-slate-400">
+            <span className="text-sm font-medium text-slate-900">Complaint letters</span>
+            <span className="text-xs text-slate-600">
               Draft and approve letters citing UK consumer law, all from Telegram
             </span>
           </div>
@@ -246,16 +246,16 @@ export default function TelegramSettingsPage() {
 
       {/* Connected state */}
       {status?.linked && status.session ? (
-        <div className="bg-navy-900 border border-green-500/20 rounded-2xl p-6">
+        <div className="bg-white border border-green-500/20 rounded-2xl p-6">
           <div className="flex items-start justify-between">
             <div className="flex items-center gap-3">
               <div className="bg-green-500/10 p-2 rounded-full">
                 <CheckCircle2 className="h-6 w-6 text-green-500" />
               </div>
               <div>
-                <p className="font-semibold text-white">Connected</p>
+                <p className="font-semibold text-slate-900">Connected</p>
                 {status.session.telegram_username && (
-                  <p className="text-slate-400 text-sm">@{status.session.telegram_username}</p>
+                  <p className="text-slate-600 text-sm">@{status.session.telegram_username}</p>
                 )}
               </div>
             </div>
@@ -272,7 +272,7 @@ export default function TelegramSettingsPage() {
               Unlink
             </button>
           </div>
-          <div className="mt-4 pt-4 border-t border-navy-700/50 grid grid-cols-2 gap-4 text-sm">
+          <div className="mt-4 pt-4 border-t border-slate-200 grid grid-cols-2 gap-4 text-sm">
             <div>
               <span className="text-slate-500">Linked</span>
               <p className="text-slate-300">{formatDate(status.session.linked_at)}</p>
@@ -284,14 +284,14 @@ export default function TelegramSettingsPage() {
               </div>
             )}
           </div>
-          <div className="mt-4 p-4 bg-navy-800/50 rounded-xl">
-            <p className="text-sm text-slate-400">
+          <div className="mt-4 p-4 bg-slate-100/50 rounded-xl">
+            <p className="text-sm text-slate-600">
               Open{' '}
               <a
                 href="https://t.me/PaybackerBot"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-amber-400 hover:text-amber-300 underline"
+                className="text-orange-600 hover:text-amber-300 underline"
               >
                 @PaybackerBot
               </a>{' '}
@@ -301,10 +301,10 @@ export default function TelegramSettingsPage() {
         </div>
       ) : (
         /* Not connected state */
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 space-y-6">
+        <div className="bg-white border border-slate-200 rounded-2xl p-6 space-y-6">
           <div>
-            <h3 className="text-white font-semibold mb-1">Connect your account</h3>
-            <p className="text-slate-400 text-sm">
+            <h3 className="text-slate-900 font-semibold mb-1">Connect your account</h3>
+            <p className="text-slate-600 text-sm">
               Generate a one-time code, then send it to the bot on Telegram to link your account.
             </p>
           </div>
@@ -312,25 +312,25 @@ export default function TelegramSettingsPage() {
           {/* Steps */}
           <ol className="space-y-4">
             <li className="flex items-start gap-3">
-              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-amber-500/20 text-amber-400 text-xs font-bold flex items-center justify-center">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-orange-100 text-orange-600 text-xs font-bold flex items-center justify-center">
                 1
               </span>
               <div>
-                <p className="text-sm text-white">Generate your link code below</p>
+                <p className="text-sm text-slate-900">Generate your link code below</p>
               </div>
             </li>
             <li className="flex items-start gap-3">
-              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-amber-500/20 text-amber-400 text-xs font-bold flex items-center justify-center">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-orange-100 text-orange-600 text-xs font-bold flex items-center justify-center">
                 2
               </span>
               <div>
-                <p className="text-sm text-white">
+                <p className="text-sm text-slate-900">
                   Open{' '}
                   <a
                     href="https://t.me/PaybackerBot"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-amber-400 hover:text-amber-300 underline"
+                    className="text-orange-600 hover:text-amber-300 underline"
                   >
                     @PaybackerBot
                   </a>{' '}
@@ -339,12 +339,12 @@ export default function TelegramSettingsPage() {
               </div>
             </li>
             <li className="flex items-start gap-3">
-              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-amber-500/20 text-amber-400 text-xs font-bold flex items-center justify-center">
+              <span className="flex-shrink-0 w-6 h-6 rounded-full bg-orange-100 text-orange-600 text-xs font-bold flex items-center justify-center">
                 3
               </span>
               <div>
-                <p className="text-sm text-white">
-                  Send: <code className="text-amber-400 bg-navy-800 px-1.5 py-0.5 rounded">/link YOUR_CODE</code>
+                <p className="text-sm text-slate-900">
+                  Send: <code className="text-orange-600 bg-slate-100 px-1.5 py-0.5 rounded">/link YOUR_CODE</code>
                 </p>
               </div>
             </li>
@@ -353,10 +353,10 @@ export default function TelegramSettingsPage() {
           {/* Code display */}
           {status?.pendingCode ? (
             <div className="space-y-3">
-              <div className="flex items-center justify-between p-4 bg-navy-800 border border-amber-500/20 rounded-xl">
+              <div className="flex items-center justify-between p-4 bg-slate-100 border border-orange-200 rounded-xl">
                 <div>
                   <p className="text-xs text-slate-500 mb-1">Your link code</p>
-                  <p className="text-3xl font-mono font-bold text-amber-400 tracking-[0.3em]">
+                  <p className="text-3xl font-mono font-bold text-orange-600 tracking-[0.3em]">
                     {status.pendingCode.code}
                   </p>
                   <p className="text-xs mt-1">
@@ -365,7 +365,7 @@ export default function TelegramSettingsPage() {
                 </div>
                 <button
                   onClick={() => copyCode(status.pendingCode!.code)}
-                  className="flex items-center gap-2 px-4 py-2 bg-amber-500/10 hover:bg-amber-500/20 text-amber-400 rounded-xl text-sm transition-colors"
+                  className="flex items-center gap-2 px-4 py-2 bg-orange-100 hover:bg-orange-100 text-orange-600 rounded-xl text-sm transition-colors"
                 >
                   {copied ? (
                     <>
@@ -381,7 +381,7 @@ export default function TelegramSettingsPage() {
               <button
                 onClick={generateCode}
                 disabled={generating}
-                className="flex items-center gap-2 text-sm text-slate-400 hover:text-slate-300 transition-colors"
+                className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-300 transition-colors"
               >
                 {generating ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -395,7 +395,7 @@ export default function TelegramSettingsPage() {
             <button
               onClick={generateCode}
               disabled={generating}
-              className="flex items-center gap-2 px-6 py-3 bg-amber-500 hover:bg-amber-400 disabled:opacity-50 text-black font-semibold rounded-xl transition-colors"
+              className="flex items-center gap-2 px-6 py-3 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-black font-semibold rounded-xl transition-colors"
             >
               {generating ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -409,7 +409,7 @@ export default function TelegramSettingsPage() {
       )}
 
       {/* Security note */}
-      <div className="flex items-start gap-3 p-4 bg-navy-900/30 border border-navy-700/30 rounded-xl">
+      <div className="flex items-start gap-3 p-4 bg-slate-50 border border-slate-200 rounded-xl">
         <Shield className="h-4 w-4 text-slate-500 flex-shrink-0 mt-0.5" />
         <p className="text-xs text-slate-500">
           Link codes expire after 15 minutes and can only be used once. The bot can only access your


### PR DESCRIPTION
Re-skin dashboard page bodies to light theme.

Files:
- forms/page.tsx: Already re-skinned (verified 0 bg-navy refs)
- settings/telegram/page.tsx: Re-skinned — preserved all state, fetch, Pro tier gating, QR/deep-link generation
- profile/report/page.tsx: Re-skinned — preserved all fetch/state, annual report generation logic
- admin/legal-refs/page.tsx: Re-skinned — preserved all CRUD handlers, search, filtering

All color translations applied per design zip. No type errors in batch.