### PR TITLE
feat(dashboard): re-skin complaints + subscriptions + admin/legal-updates to light theme (batch 9)

### DIFF
--- a/src/app/dashboard/admin/legal-updates/page.tsx
+++ b/src/app/dashboard/admin/legal-updates/page.tsx
@@ -56,15 +56,15 @@ const CHANGE_TYPE_LABELS: Record<ChangeType, string> = {
 
 const CONFIDENCE_CONFIG: Record<Confidence, { label: string; className: string; dotClass: string }> = {
   high: { label: 'High', className: 'text-green-400 bg-green-500/10 border-green-500/20', dotClass: 'bg-green-400' },
-  medium: { label: 'Medium', className: 'text-amber-400 bg-amber-500/10 border-amber-500/20', dotClass: 'bg-amber-400' },
+  medium: { label: 'Medium', className: 'text-amber-600 bg-amber-100 border-amber-200', dotClass: 'bg-amber-500' },
   low: { label: 'Low', className: 'text-red-400 bg-red-500/10 border-red-500/20', dotClass: 'bg-red-400' },
 };
 
 const STATUS_CONFIG: Record<QueueStatus, { label: string; className: string }> = {
-  pending: { label: 'Pending review', className: 'text-amber-400 bg-amber-500/10' },
+  pending: { label: 'Pending review', className: 'text-amber-600 bg-amber-100' },
   approved: { label: 'Approved', className: 'text-green-400 bg-green-500/10' },
-  rejected: { label: 'Rejected', className: 'text-slate-400 bg-slate-500/10' },
-  auto_applied: { label: 'Auto-applied', className: 'text-mint-400 bg-mint-400/10' },
+  rejected: { label: 'Rejected', className: 'text-slate-600 bg-slate-100' },
+  auto_applied: { label: 'Auto-applied', className: 'text-emerald-600 bg-emerald-500/10' },
 };
 
 function formatDate(d: string | null) {
@@ -213,7 +213,7 @@ export default function LegalUpdatesAdminPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
-        <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
+        <Loader2 className="h-8 w-8 text-emerald-600 animate-spin" />
       </div>
     );
   }
@@ -223,8 +223,8 @@ export default function LegalUpdatesAdminPage() {
       <div className="flex items-center justify-center h-full">
         <div className="text-center">
           <Shield className="h-16 w-16 text-red-500 mx-auto mb-4" />
-          <h1 className="text-2xl font-bold text-white mb-2">Access Denied</h1>
-          <p className="text-slate-400">Admin access only.</p>
+          <h1 className="text-2xl font-bold text-slate-900 mb-2">Access Denied</h1>
+          <p className="text-slate-600">Admin access only.</p>
         </div>
       </div>
     );
@@ -236,18 +236,18 @@ export default function LegalUpdatesAdminPage() {
       <div className="mb-6">
         <Link
           href="/dashboard/admin"
-          className="inline-flex items-center gap-1.5 text-slate-400 hover:text-white text-sm mb-4 transition-colors"
+          className="inline-flex items-center gap-1.5 text-slate-600 hover:text-slate-900 text-sm mb-4 transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to Admin
         </Link>
         <div className="flex items-start justify-between flex-wrap gap-3">
           <div>
-            <h1 className="text-4xl font-bold text-white mb-2 flex items-center gap-3 font-[family-name:var(--font-heading)]">
-              <Zap className="h-9 w-9 text-amber-400" />
+            <h1 className="text-4xl font-bold text-slate-900 mb-2 flex items-center gap-3 font-[family-name:var(--font-heading)]">
+              <Zap className="h-9 w-9 text-amber-600" />
               Legal Updates
             </h1>
-            <p className="text-slate-400">
+            <p className="text-slate-600">
               Self-learning legal intelligence queue.
               {stats.lastScanDate && ` Last scan: ${formatDate(stats.lastScanDate)}`}
             </p>
@@ -255,7 +255,7 @@ export default function LegalUpdatesAdminPage() {
           <div className="flex gap-2">
             <Link
               href="/dashboard/admin/legal-refs"
-              className="flex items-center gap-2 bg-navy-800 hover:bg-navy-700 text-slate-300 font-medium px-4 py-2.5 rounded-lg transition-all text-sm border border-navy-700/50"
+              className="flex items-center gap-2 bg-white hover:bg-slate-50 text-slate-600 font-medium px-4 py-2.5 rounded-lg transition-all text-sm border border-slate-200/50"
             >
               <FileText className="h-4 w-4" />
               All References
@@ -263,7 +263,7 @@ export default function LegalUpdatesAdminPage() {
             <button
               onClick={runScan}
               disabled={scanning}
-              className="flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:opacity-50 text-navy-950 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm"
+              className="flex items-center gap-2 bg-orange-500 hover:bg-amber-300 disabled:opacity-50 text-slate-900 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm"
             >
               {scanning ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
               {scanning ? 'Scanning...' : 'Run Scan Now'}
@@ -284,18 +284,18 @@ export default function LegalUpdatesAdminPage() {
       {/* Stats cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         {[
-          { label: 'Pending review', count: stats.pending, cls: 'border-amber-500/20 bg-amber-500/5', textCls: 'text-amber-400', statusKey: 'pending' },
-          { label: 'Auto-applied', count: stats.autoApplied, cls: 'border-mint-400/20 bg-mint-400/5', textCls: 'text-mint-400', statusKey: 'auto_applied' },
+          { label: 'Pending review', count: stats.pending, cls: 'border-amber-200 bg-amber-50', textCls: 'text-amber-600', statusKey: 'pending' },
+          { label: 'Auto-applied', count: stats.autoApplied, cls: 'border-emerald-500/20 bg-emerald-500/5', textCls: 'text-emerald-600', statusKey: 'auto_applied' },
           { label: 'Approved', count: stats.approved, cls: 'border-green-500/20 bg-green-500/5', textCls: 'text-green-400', statusKey: 'approved' },
-          { label: 'Rejected', count: stats.rejected, cls: 'border-slate-500/20 bg-slate-500/5', textCls: 'text-slate-400', statusKey: 'rejected' },
+          { label: 'Rejected', count: stats.rejected, cls: 'border-slate-200 bg-slate-50', textCls: 'text-slate-600', statusKey: 'rejected' },
         ].map(card => (
           <button
             key={card.label}
             onClick={() => setFilterStatus(filterStatus === card.statusKey ? 'all' : card.statusKey)}
-            className={`border rounded-2xl p-5 text-left transition-all hover:opacity-80 ${card.cls} ${filterStatus === card.statusKey ? 'ring-1 ring-white/20' : ''}`}
+            className={`border rounded-2xl p-5 text-left transition-all hover:opacity-80 ${card.cls} ${filterStatus === card.statusKey ? 'ring-1 ring-slate-300' : ''}`}
           >
             <p className={`text-3xl font-bold ${card.textCls}`}>{card.count}</p>
-            <p className="text-slate-400 text-sm mt-1">{card.label}</p>
+            <p className="text-slate-600 text-sm mt-1">{card.label}</p>
           </button>
         ))}
       </div>
@@ -309,13 +309,13 @@ export default function LegalUpdatesAdminPage() {
             value={search}
             onChange={e => setSearch(e.target.value)}
             placeholder="Search changes..."
-            className="w-full pl-9 pr-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-white placeholder-slate-500 text-sm focus:outline-none focus:border-amber-400"
+            className="w-full pl-9 pr-4 py-2.5 bg-white border border-slate-200/50 rounded-xl text-slate-900 placeholder-slate-500 text-sm focus:outline-none focus:border-amber-300"
           />
         </div>
         <select
           value={filterStatus}
           onChange={e => setFilterStatus(e.target.value)}
-          className="px-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-slate-300 text-sm focus:outline-none focus:border-amber-400"
+          className="px-4 py-2.5 bg-white border border-slate-200/50 rounded-xl text-slate-600 text-sm focus:outline-none focus:border-amber-300"
         >
           <option value="all">All statuses</option>
           <option value="pending">Pending</option>
@@ -326,7 +326,7 @@ export default function LegalUpdatesAdminPage() {
         <select
           value={filterConfidence}
           onChange={e => setFilterConfidence(e.target.value)}
-          className="px-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-slate-300 text-sm focus:outline-none focus:border-amber-400"
+          className="px-4 py-2.5 bg-white border border-slate-200/50 rounded-xl text-slate-600 text-sm focus:outline-none focus:border-amber-300"
         >
           <option value="all">All confidence</option>
           <option value="high">High</option>
@@ -336,7 +336,7 @@ export default function LegalUpdatesAdminPage() {
         <select
           value={filterType}
           onChange={e => setFilterType(e.target.value)}
-          className="px-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-slate-300 text-sm focus:outline-none focus:border-amber-400"
+          className="px-4 py-2.5 bg-white border border-slate-200/50 rounded-xl text-slate-600 text-sm focus:outline-none focus:border-amber-300"
         >
           <option value="all">All types</option>
           {Object.entries(CHANGE_TYPE_LABELS).map(([k, v]) => (
@@ -346,7 +346,7 @@ export default function LegalUpdatesAdminPage() {
         {(search || filterStatus !== 'pending' || filterConfidence !== 'all' || filterType !== 'all') && (
           <button
             onClick={() => { setSearch(''); setFilterStatus('pending'); setFilterConfidence('all'); setFilterType('all'); }}
-            className="px-4 py-2.5 bg-navy-900 border border-navy-700/50 rounded-xl text-slate-400 hover:text-white text-sm transition-colors"
+            className="px-4 py-2.5 bg-white border border-slate-200/50 rounded-xl text-slate-600 hover:text-slate-900 text-sm transition-colors"
           >
             Reset
           </button>
@@ -368,11 +368,11 @@ export default function LegalUpdatesAdminPage() {
           return (
             <div
               key={item.id}
-              className="bg-navy-900 border border-navy-700/50 rounded-2xl overflow-hidden"
+              className="bg-white border border-slate-200/50 rounded-2xl overflow-hidden"
             >
               {/* Item header */}
               <button
-                className="w-full px-5 py-4 text-left flex items-start gap-4 hover:bg-navy-800/50 transition-colors"
+                className="w-full px-5 py-4 text-left flex items-start gap-4 hover:bg-white/50 transition-colors"
                 onClick={() => setExpandedId(isExpanded ? null : item.id)}
               >
                 {/* Confidence dot */}
@@ -381,11 +381,11 @@ export default function LegalUpdatesAdminPage() {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 flex-wrap mb-1">
                     {ref ? (
-                      <span className="text-white text-sm font-medium">
+                      <span className="text-slate-900 text-sm font-medium">
                         {ref.law_name}{ref.section ? ` — ${ref.section}` : ''}
                       </span>
                     ) : (
-                      <span className="text-amber-400 text-sm font-medium">
+                      <span className="text-amber-600 text-sm font-medium">
                         {CHANGE_TYPE_LABELS[item.change_type]} (no existing ref)
                       </span>
                     )}
@@ -395,11 +395,11 @@ export default function LegalUpdatesAdminPage() {
                     <span className={`text-xs px-2.5 py-0.5 rounded-full font-medium ${status.className}`}>
                       {status.label}
                     </span>
-                    <span className="text-xs bg-navy-800 text-slate-400 px-2 py-0.5 rounded-full border border-navy-700/50">
+                    <span className="text-xs bg-white text-slate-600 px-2 py-0.5 rounded-full border border-slate-200/50">
                       {CHANGE_TYPE_LABELS[item.change_type]}
                     </span>
                   </div>
-                  <p className="text-slate-300 text-sm leading-relaxed line-clamp-2">
+                  <p className="text-slate-600 text-sm leading-relaxed line-clamp-2">
                     {item.detected_change_summary}
                   </p>
                   <p className="text-slate-600 text-xs mt-1">{formatDate(item.created_at)}</p>
@@ -432,14 +432,14 @@ export default function LegalUpdatesAdminPage() {
 
               {/* Expanded detail: diff view + edit */}
               {isExpanded && (
-                <div className="border-t border-navy-700/50 px-5 py-4 space-y-4">
+                <div className="border-t border-slate-200/50 px-5 py-4 space-y-4">
                   {/* Side-by-side diff */}
                   {ref && (
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                       <div>
                         <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">Current reference</p>
-                        <div className="bg-navy-950/60 border border-navy-700/30 rounded-xl p-4">
-                          <p className="text-slate-300 text-sm leading-relaxed">{ref.summary}</p>
+                        <div className="bg-white/60 border border-slate-200/30 rounded-xl p-4">
+                          <p className="text-slate-600 text-sm leading-relaxed">{ref.summary}</p>
                         </div>
                       </div>
                       <div>
@@ -456,7 +456,7 @@ export default function LegalUpdatesAdminPage() {
                                   setEditText(item.proposed_update || '');
                                 }
                               }}
-                              className="flex items-center gap-1 text-slate-400 hover:text-white text-xs transition-colors"
+                              className="flex items-center gap-1 text-slate-600 hover:text-slate-900 text-xs transition-colors"
                             >
                               <Edit3 className="h-3 w-3" />
                               {isEditing ? 'Cancel edit' : 'Edit'}
@@ -468,11 +468,11 @@ export default function LegalUpdatesAdminPage() {
                             value={editText}
                             onChange={e => setEditText(e.target.value)}
                             rows={5}
-                            className="w-full bg-navy-950/60 border border-amber-500/30 rounded-xl p-4 text-white text-sm leading-relaxed focus:outline-none focus:border-amber-400 resize-none"
+                            className="w-full bg-white/60 border border-amber-300 rounded-xl p-4 text-slate-900 text-sm leading-relaxed focus:outline-none focus:border-amber-300 resize-none"
                           />
                         ) : (
                           <div className="bg-green-500/5 border border-green-500/20 rounded-xl p-4">
-                            <p className="text-slate-200 text-sm leading-relaxed">
+                            <p className="text-slate-700 text-sm leading-relaxed">
                               {item.proposed_update || 'No proposed text — this is a new legislation alert.'}
                             </p>
                           </div>
@@ -485,8 +485,8 @@ export default function LegalUpdatesAdminPage() {
                   {!ref && item.proposed_update && (
                     <div>
                       <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">Proposed addition</p>
-                      <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-4">
-                        <p className="text-slate-200 text-sm leading-relaxed">{item.proposed_update}</p>
+                      <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+                        <p className="text-slate-700 text-sm leading-relaxed">{item.proposed_update}</p>
                       </div>
                     </div>
                   )}
@@ -499,7 +499,7 @@ export default function LegalUpdatesAdminPage() {
                         href={item.source_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-xs text-mint-400 hover:text-mint-300 transition-colors"
+                        className="inline-flex items-center gap-1 text-xs text-emerald-600 hover:text-emerald-500 transition-colors"
                       >
                         <ExternalLink className="h-3 w-3" />
                         {item.source_url.slice(0, 80)}{item.source_url.length > 80 ? '...' : ''}
@@ -537,7 +537,7 @@ export default function LegalUpdatesAdminPage() {
       {filtered.length === 0 && (
         <div className="py-20 text-center">
           <AlertTriangle className="h-10 w-10 text-slate-600 mx-auto mb-3" />
-          <p className="text-slate-400 text-sm">
+          <p className="text-slate-600 text-sm">
             {items.length === 0 ? 'No items in queue. Run a scan to check for legal updates.' : 'No items match your filters.'}
           </p>
         </div>

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -132,7 +132,7 @@ const CATEGORY_ALIAS: Record<string, string> = {
 
 
 const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
-  open: { label: 'Open', className: 'bg-amber-500/10 text-amber-400 border border-amber-500/20' },
+  open: { label: 'Open', className: 'bg-amber-100 text-amber-600 border border-amber-200' },
   in_progress: { label: 'In Progress', className: 'bg-blue-500/10 text-blue-400 border border-blue-500/20' },
   awaiting_response: { label: 'Waiting for reply', className: 'bg-purple-500/10 text-purple-400 border border-purple-500/20' },
   escalated: { label: 'Escalated', className: 'bg-orange-500/10 text-orange-400 border border-orange-500/20' },
@@ -141,10 +141,10 @@ const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   won: { label: 'Won', className: 'bg-green-500/10 text-green-500 border border-green-500/20' },
   resolved_partial: { label: 'Partially Won', className: 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' },
   partial: { label: 'Partially Won', className: 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' },
-  resolved_lost: { label: 'Not resolved', className: 'bg-slate-500/10 text-slate-400 border border-slate-500/20' },
-  lost: { label: 'Not resolved', className: 'bg-slate-500/10 text-slate-400 border border-slate-500/20' },
-  withdrawn: { label: 'Withdrawn', className: 'bg-slate-500/10 text-slate-400 border border-slate-500/20' },
-  closed: { label: 'Closed', className: 'bg-slate-500/10 text-slate-400 border border-slate-500/20' },
+  resolved_lost: { label: 'Not resolved', className: 'bg-slate-100 text-slate-600 border border-slate-200' },
+  lost: { label: 'Not resolved', className: 'bg-slate-100 text-slate-600 border border-slate-200' },
+  withdrawn: { label: 'Withdrawn', className: 'bg-slate-100 text-slate-600 border border-slate-200' },
+  closed: { label: 'Closed', className: 'bg-slate-100 text-slate-600 border border-slate-200' },
 };
 
 // Active statuses that can be changed via the status dropdown
@@ -164,7 +164,7 @@ interface DisputeSummary {
 }
 
 const ENTRY_TYPE_CONFIG: Record<string, { label: string; icon: typeof FileText; className: string }> = {
-  ai_letter: { label: 'Your letter', icon: FileText, className: 'border-mint-400/30 bg-mint-400/5' },
+  ai_letter: { label: 'Your letter', icon: FileText, className: 'border-emerald-500/30 bg-emerald-500/5' },
   company_email: { label: 'Their email', icon: Mail, className: 'border-orange-400/30 bg-orange-400/5' },
   company_letter: { label: 'Their letter', icon: FileText, className: 'border-orange-400/30 bg-orange-400/5' },
   phone_call: { label: 'Phone call', icon: Phone, className: 'border-blue-400/30 bg-blue-400/5' },
@@ -226,10 +226,10 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose }: {
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center p-4 pt-8">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-3xl max-h-[90vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-navy-700/50 flex-shrink-0">
+      <div className="relative bg-white border border-slate-200/50 rounded-2xl w-full max-w-3xl max-h-[90vh] flex flex-col shadow-2xl">
+        <div className="flex items-center justify-between p-6 border-b border-slate-200/50 flex-shrink-0">
           <div className="flex items-center gap-3 min-w-0">
-            <h2 className="text-xl font-bold text-white truncate">{title}</h2>
+            <h2 className="text-xl font-bold text-slate-900 truncate">{title}</h2>
             {(() => {
               const count = rightsPills?.length ?? 0;
               if (count >= 3) return (
@@ -238,7 +238,7 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose }: {
                 </span>
               );
               if (count >= 1) return (
-                <span className="flex-shrink-0 text-[11px] font-semibold px-2.5 py-1 rounded-full bg-amber-500/10 text-amber-400 border border-amber-500/20">
+                <span className="flex-shrink-0 text-[11px] font-semibold px-2.5 py-1 rounded-full bg-amber-100 text-amber-600 border border-amber-200">
                   Some legal backing
                 </span>
               );
@@ -249,12 +249,12 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose }: {
               );
             })()}
           </div>
-          <button onClick={onClose} className="text-slate-400 hover:text-white p-1 flex-shrink-0"><X className="h-5 w-5" /></button>
+          <button onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1 flex-shrink-0"><X className="h-5 w-5" /></button>
         </div>
         <div className="flex-1 overflow-y-auto p-6">
-          <div className="bg-navy-950 rounded-xl p-6 border border-navy-700/50 mb-4">
+          <div className="bg-white rounded-xl p-6 border border-slate-200/50 mb-4">
             <pre
-              className="text-sm text-slate-200 whitespace-pre-wrap font-mono leading-relaxed"
+              className="text-sm text-slate-700 whitespace-pre-wrap font-mono leading-relaxed"
               onCopy={(e) => {
                 // Override browser's default rich-text copy (which carries white colour styling).
                 // Force plain text so the letter pastes correctly into Gmail, Outlook, etc.
@@ -266,8 +266,8 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose }: {
             >{content}</pre>
           </div>
           {(rightsPills && rightsPills.length > 0 || legalRefs.length > 0) && (
-            <div className="bg-navy-950/50 rounded-lg p-4 border border-navy-700/50 mb-3">
-              <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-2">Your rights used in this letter</h3>
+            <div className="bg-white/50 rounded-lg p-4 border border-slate-200/50 mb-3">
+              <h3 className="text-xs font-semibold text-slate-600 uppercase tracking-wide mb-2">Your rights used in this letter</h3>
               <div className="flex flex-wrap gap-1.5">
                 {rightsPills && rightsPills.length > 0
                   ? rightsPills.map((pill, i) => (
@@ -276,19 +276,19 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose }: {
                         href={pill.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-[11px] bg-mint-400/10 text-mint-400 px-2.5 py-1 rounded-full border border-mint-400/20 hover:bg-mint-400/20 transition-colors inline-flex items-center gap-1"
+                        className="text-[11px] bg-emerald-500/10 text-emerald-600 px-2.5 py-1 rounded-full border border-emerald-500/20 hover:bg-emerald-500/20 transition-colors inline-flex items-center gap-1"
                         title={pill.strength === 'strong' ? 'Strong legal protection' : pill.strength === 'moderate' ? 'Moderate legal protection' : 'Legal reference'}
                       >
                         <span className={`inline-block w-1.5 h-1.5 rounded-full ${
                           pill.strength === 'strong' ? 'bg-green-500' :
-                          pill.strength === 'moderate' ? 'bg-amber-500' :
+                          pill.strength === 'moderate' ? 'bg-orange-500' :
                           'bg-gray-400'
                         }`} />
                         {pill.label}
                       </a>
                     ))
                   : legalRefs.map((ref, i) => (
-                      <span key={i} className="text-[11px] bg-mint-400/10 text-mint-400 px-2.5 py-1 rounded-full border border-mint-400/20">
+                      <span key={i} className="text-[11px] bg-emerald-500/10 text-emerald-600 px-2.5 py-1 rounded-full border border-emerald-500/20">
                         {ref}
                       </span>
                     ))
@@ -298,12 +298,12 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose }: {
           )}
           <p className="text-[10px] text-slate-600 text-center mt-3 leading-relaxed">{AI_LETTER_DISCLAIMER_HTML}</p>
         </div>
-        <div className="flex gap-3 p-6 border-t border-navy-700/50 flex-shrink-0">
-          <button onClick={handleCopy} className="flex-1 flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white py-3 rounded-lg transition-all font-medium">
+        <div className="flex gap-3 p-6 border-t border-slate-200/50 flex-shrink-0">
+          <button onClick={handleCopy} className="flex-1 flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-900 py-3 rounded-lg transition-all font-medium">
             {copied ? <CheckCircle className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
             {copied ? 'Copied!' : 'Copy Letter'}
           </button>
-          <button onClick={handlePDF} className="flex-1 flex items-center justify-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 py-3 rounded-lg transition-all font-semibold">
+          <button onClick={handlePDF} className="flex-1 flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 py-3 rounded-lg transition-all font-semibold">
             <Download className="h-4 w-4" /> Download PDF
           </button>
         </div>
@@ -379,16 +379,16 @@ function AddCorrespondenceModal({ disputeId, onClose, onAdded }: {
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border border-navy-700/50 rounded-t-2xl sm:rounded-2xl w-full max-w-lg shadow-2xl" style={{ maxHeight: 'calc(100vh - env(safe-area-inset-top, 20px) - env(safe-area-inset-bottom, 0px))' }}>
+      <div className="relative bg-white border border-slate-200/50 rounded-t-2xl sm:rounded-2xl w-full max-w-lg shadow-2xl" style={{ maxHeight: 'calc(100vh - env(safe-area-inset-top, 20px) - env(safe-area-inset-bottom, 0px))' }}>
         <form onSubmit={handleSubmit} className="flex flex-col" style={{ maxHeight: 'calc(100vh - env(safe-area-inset-top, 20px) - env(safe-area-inset-bottom, 0px))' }}>
-        <div className="flex items-center justify-between p-5 border-b border-navy-700/50 flex-shrink-0">
-          <h2 className="text-lg font-bold text-white">Add to your dispute</h2>
-          <button type="button" onClick={onClose} className="text-slate-400 hover:text-white p-1"><X className="h-5 w-5" /></button>
+        <div className="flex items-center justify-between p-5 border-b border-slate-200/50 flex-shrink-0">
+          <h2 className="text-lg font-bold text-slate-900">Add to your dispute</h2>
+          <button type="button" onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1"><X className="h-5 w-5" /></button>
         </div>
         <div className="p-5 space-y-4 overflow-y-auto flex-1 min-h-0"
           style={{ WebkitOverflowScrolling: 'touch' as any }}>
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">What are you adding?</label>
+            <label className="block text-sm font-medium text-slate-600 mb-2">What are you adding?</label>
             <div className="grid grid-cols-1 gap-2">
               {typeOptions.map((opt) => {
                 const Icon = opt.icon;
@@ -399,8 +399,8 @@ function AddCorrespondenceModal({ disputeId, onClose, onAdded }: {
                     onClick={() => setEntryType(opt.value)}
                     className={`flex items-center gap-3 px-4 py-3 rounded-lg text-sm text-left transition-all ${
                       entryType === opt.value
-                        ? 'bg-mint-400/10 border border-mint-400/30 text-white'
-                        : 'bg-navy-950 border border-navy-700/50 text-slate-400 hover:border-navy-600'
+                        ? 'bg-emerald-500/10 border border-emerald-500/30 text-slate-900'
+                        : 'bg-white border border-slate-200/50 text-slate-600 hover:border-slate-200'
                     }`}
                   >
                     <Icon className="h-4 w-4 flex-shrink-0" />
@@ -412,20 +412,20 @@ function AddCorrespondenceModal({ disputeId, onClose, onAdded }: {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">
+            <label className="block text-sm font-medium text-slate-600 mb-2">
               Title <span className="text-slate-500 font-normal">(optional)</span>
             </label>
             <input
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
               placeholder={entryType === 'phone_call' ? 'e.g. Spoke to customer service' : 'e.g. Their response to my complaint'}
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">
+            <label className="block text-sm font-medium text-slate-600 mb-2">
               {entryType === 'phone_call' ? 'What happened on the call?' : 'Paste or type the content'} *
             </label>
             <textarea
@@ -433,7 +433,7 @@ function AddCorrespondenceModal({ disputeId, onClose, onAdded }: {
               rows={6}
               value={content}
               onChange={(e) => setContent(e.target.value)}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
               placeholder={
                 entryType === 'phone_call'
                   ? 'Summarise the phone call - who you spoke to, what they said, any reference numbers...'
@@ -446,20 +446,20 @@ function AddCorrespondenceModal({ disputeId, onClose, onAdded }: {
 
           {/* File attachment */}
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">
+            <label className="block text-sm font-medium text-slate-600 mb-2">
               Attach a file <span className="text-slate-500 font-normal">(optional - screenshot, scan, or photo)</span>
             </label>
             {attachedFile ? (
-              <div className="flex items-center justify-between bg-mint-400/10 border border-mint-400/20 rounded-lg px-3 py-2">
+              <div className="flex items-center justify-between bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-3 py-2">
                 <div className="flex items-center gap-2">
-                  <Paperclip className="h-4 w-4 text-mint-400" />
-                  <span className="text-mint-400 text-xs font-medium truncate max-w-[200px]">{attachedFile.name}</span>
+                  <Paperclip className="h-4 w-4 text-emerald-600" />
+                  <span className="text-emerald-600 text-xs font-medium truncate max-w-[200px]">{attachedFile.name}</span>
                 </div>
-                <button type="button" onClick={() => setAttachedFile(null)} className="text-slate-500 hover:text-white text-xs">Remove</button>
+                <button type="button" onClick={() => setAttachedFile(null)} className="text-slate-500 hover:text-slate-900 text-xs">Remove</button>
               </div>
             ) : (
-              <label className="flex items-center gap-3 w-full px-4 py-3 bg-navy-950 border border-dashed border-navy-700/50 rounded-lg text-slate-500 hover:border-mint-400/50 hover:text-slate-300 cursor-pointer transition-all text-sm">
-                <Paperclip className="h-4 w-4 text-mint-400" />
+              <label className="flex items-center gap-3 w-full px-4 py-3 bg-white border border-dashed border-slate-200/50 rounded-lg text-slate-500 hover:border-emerald-500/50 hover:text-slate-700 cursor-pointer transition-all text-sm">
+                <Paperclip className="h-4 w-4 text-emerald-600" />
                 <span>Upload a screenshot, scan or photo</span>
                 <input
                   type="file"
@@ -479,21 +479,21 @@ function AddCorrespondenceModal({ disputeId, onClose, onAdded }: {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">When did this happen?</label>
+            <label className="block text-sm font-medium text-slate-600 mb-2">When did this happen?</label>
             <input
               type="date"
               value={entryDate}
               onChange={(e) => setEntryDate(e.target.value)}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
             />
           </div>
 
         </div>
-        <div className="p-5 pt-3 border-t border-navy-700/50 flex-shrink-0" style={{ paddingBottom: 'max(1.25rem, env(safe-area-inset-bottom, 1.25rem))' }}>
+        <div className="p-5 pt-3 border-t border-slate-200/50 flex-shrink-0" style={{ paddingBottom: 'max(1.25rem, env(safe-area-inset-bottom, 1.25rem))' }}>
           <button
             type="submit"
             disabled={saving || uploading || !content.trim()}
-            className="w-full bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-lg transition-all disabled:opacity-50"
+            className="w-full bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold py-3 rounded-lg transition-all disabled:opacity-50"
           >
             {uploading ? 'Uploading file...' : saving ? 'Saving...' : 'Add to dispute'}
           </button>
@@ -523,8 +523,8 @@ function ResolveDisputeModal({ disputeId, disputedAmount, onClose, onResolved }:
   const outcomeOptions = [
     { value: 'won', label: 'Won', desc: 'Full resolution in your favour', icon: '🏆', className: 'border-green-500/30 bg-green-500/5 text-green-400' },
     { value: 'partial', label: 'Partially Won', desc: 'Some money or partial resolution', icon: '🤝', className: 'border-emerald-500/30 bg-emerald-500/5 text-emerald-400' },
-    { value: 'lost', label: 'Lost', desc: 'Company rejected your complaint', icon: '😔', className: 'border-slate-500/30 bg-slate-500/5 text-slate-400' },
-    { value: 'withdrawn', label: 'Withdrawn', desc: 'You decided not to pursue this', icon: '🚫', className: 'border-slate-500/30 bg-slate-500/5 text-slate-400' },
+    { value: 'lost', label: 'Lost', desc: 'Company rejected your complaint', icon: '😔', className: 'border-slate-500/30 bg-slate-50 text-slate-600' },
+    { value: 'withdrawn', label: 'Withdrawn', desc: 'You decided not to pursue this', icon: '🚫', className: 'border-slate-500/30 bg-slate-50 text-slate-600' },
   ];
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -554,18 +554,18 @@ function ResolveDisputeModal({ disputeId, disputedAmount, onClose, onResolved }:
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center p-4 pt-8">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-lg shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-navy-700/50">
+      <div className="relative bg-white border border-slate-200/50 rounded-2xl w-full max-w-lg shadow-2xl">
+        <div className="flex items-center justify-between p-6 border-b border-slate-200/50">
           <div>
-            <h2 className="text-lg font-bold text-white">Resolve Dispute</h2>
+            <h2 className="text-lg font-bold text-slate-900">Resolve Dispute</h2>
             <p className="text-slate-500 text-sm mt-0.5">Record the outcome of your dispute</p>
           </div>
-          <button onClick={onClose} className="text-slate-400 hover:text-white p-1"><X className="h-5 w-5" /></button>
+          <button onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1"><X className="h-5 w-5" /></button>
         </div>
         <form onSubmit={handleSubmit} className="p-6 space-y-5">
           {/* Outcome selector */}
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">What was the outcome?</label>
+            <label className="block text-sm font-medium text-slate-600 mb-2">What was the outcome?</label>
             <div className="grid grid-cols-2 gap-2">
               {outcomeOptions.map((opt) => (
                 <button
@@ -575,12 +575,12 @@ function ResolveDisputeModal({ disputeId, disputedAmount, onClose, onResolved }:
                   className={`flex items-center gap-3 px-4 py-3 rounded-lg text-sm text-left transition-all border ${
                     outcome === opt.value
                       ? opt.className
-                      : 'bg-navy-950 border-navy-700/50 text-slate-400 hover:border-navy-600'
+                      : 'bg-white border-slate-200/50 text-slate-600 hover:border-slate-200'
                   }`}
                 >
                   <span className="text-lg">{opt.icon}</span>
                   <div>
-                    <p className={`font-medium ${outcome === opt.value ? '' : 'text-slate-300'}`}>{opt.label}</p>
+                    <p className={`font-medium ${outcome === opt.value ? '' : 'text-slate-600'}`}>{opt.label}</p>
                     <p className="text-[11px] text-slate-500 mt-0.5">{opt.desc}</p>
                   </div>
                 </button>
@@ -591,18 +591,18 @@ function ResolveDisputeModal({ disputeId, disputedAmount, onClose, onResolved }:
           {/* Money recovered — only for won/partial */}
           {showMoneyField && (
             <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">
+              <label className="block text-sm font-medium text-slate-600 mb-2">
                 How much did you recover?
               </label>
               <div className="relative">
-                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-amber-400 font-semibold">£</span>
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-amber-600 font-semibold">£</span>
                 <input
                   type="number"
                   step="0.01"
                   min="0"
                   value={moneyRecovered}
                   onChange={(e) => setMoneyRecovered(e.target.value)}
-                  className="w-full pl-8 pr-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-amber-400 focus:ring-1 focus:ring-amber-400"
+                  className="w-full pl-8 pr-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-300 focus:ring-1 focus:ring-amber-400"
                   placeholder={disputedAmount ? disputedAmount.toFixed(2) : '0.00'}
                 />
               </div>
@@ -610,7 +610,7 @@ function ResolveDisputeModal({ disputeId, disputedAmount, onClose, onResolved }:
                 <button
                   type="button"
                   onClick={() => setMoneyRecovered(disputedAmount.toFixed(2))}
-                  className="text-xs text-amber-400/70 hover:text-amber-400 mt-1 transition-colors"
+                  className="text-xs text-amber-600/70 hover:text-amber-600 mt-1 transition-colors"
                 >
                   Use full disputed amount (£{disputedAmount.toFixed(2)})
                 </button>
@@ -620,14 +620,14 @@ function ResolveDisputeModal({ disputeId, disputedAmount, onClose, onResolved }:
 
           {/* Notes */}
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">
+            <label className="block text-sm font-medium text-slate-600 mb-2">
               Notes <span className="text-slate-500 font-normal">(optional)</span>
             </label>
             <textarea
               rows={3}
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
               placeholder="Any notes about the resolution..."
             />
           </div>
@@ -635,7 +635,7 @@ function ResolveDisputeModal({ disputeId, disputedAmount, onClose, onResolved }:
           <button
             type="submit"
             disabled={saving}
-            className="w-full bg-amber-400 hover:bg-amber-500 text-navy-950 font-semibold py-3 rounded-lg transition-all disabled:opacity-50"
+            className="w-full bg-amber-500 hover:bg-orange-600 text-slate-900 font-semibold py-3 rounded-lg transition-all disabled:opacity-50"
           >
             {saving ? 'Saving...' : 'Resolve Dispute'}
           </button>
@@ -709,18 +709,18 @@ function DisputeProgressTracker({ dispute, providerInfo }: {
   const fillWidthPct = ((currentStage - 1) / totalSteps) * 100; // 0 to 83.33%
 
   return (
-    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 mb-6">
+    <div className="bg-white border border-slate-200/50 rounded-2xl p-5 mb-6">
       <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-4">Dispute Progress</p>
       <div className="relative pb-1">
         {/* Background track */}
         <div
-          className="absolute top-3 h-0.5 bg-navy-700"
+          className="absolute top-3 h-0.5 bg-slate-50"
           style={{ left: `${fillStartPct}%`, right: `${fillStartPct}%` }}
         />
         {/* Filled track */}
         {fillWidthPct > 0 && (
           <div
-            className="absolute top-3 h-0.5 bg-mint-400 transition-all duration-500"
+            className="absolute top-3 h-0.5 bg-emerald-500 transition-all duration-500"
             style={{ left: `${fillStartPct}%`, width: `${fillWidthPct}%` }}
           />
         )}
@@ -733,23 +733,23 @@ function DisputeProgressTracker({ dispute, providerInfo }: {
               <div key={step.stage} className="flex flex-col items-center" style={{ width: `${100 / totalSteps}%` }}>
                 <div className={`relative z-10 w-6 h-6 rounded-full flex items-center justify-center border-2 transition-all ${
                   done
-                    ? 'bg-mint-400 border-mint-400'
+                    ? 'bg-emerald-500 border-emerald-500'
                     : current
-                    ? 'bg-navy-900 border-amber-400'
-                    : 'bg-navy-900 border-navy-700'
+                    ? 'bg-white border-amber-300'
+                    : 'bg-white border-slate-200'
                 }`}>
                   {done ? (
-                    <svg className="h-3 w-3 text-navy-950" viewBox="0 0 12 12" fill="none">
+                    <svg className="h-3 w-3 text-slate-900" viewBox="0 0 12 12" fill="none">
                       <path d="M2 6l3 3 5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                     </svg>
                   ) : current ? (
-                    <div className="w-2 h-2 rounded-full bg-amber-400 animate-pulse" />
+                    <div className="w-2 h-2 rounded-full bg-amber-500 animate-pulse" />
                   ) : (
-                    <div className="w-1.5 h-1.5 rounded-full bg-navy-700" />
+                    <div className="w-1.5 h-1.5 rounded-full bg-slate-50" />
                   )}
                 </div>
                 <span className={`mt-2 text-center font-medium transition-all leading-tight px-0.5 ${
-                  done ? 'text-mint-400' : current ? 'text-amber-400' : 'text-slate-600'
+                  done ? 'text-emerald-600' : current ? 'text-amber-600' : 'text-slate-600'
                 } text-[9px] sm:text-[10px]`}>
                   <span className="hidden sm:block">{step.label}</span>
                   <span className="sm:hidden">{step.shortLabel}</span>
@@ -792,53 +792,53 @@ function PreviewConfirmModal({ formData, issueLabel, onConfirm, onClose }: {
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
-        className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-lg shadow-2xl"
+        className="relative bg-white border border-slate-200/50 rounded-2xl w-full max-w-lg shadow-2xl"
       >
-        <div className="flex items-center justify-between p-6 border-b border-navy-700/50">
+        <div className="flex items-center justify-between p-6 border-b border-slate-200/50">
           <div>
-            <h2 className="text-lg font-bold text-white">Review your dispute</h2>
-            <p className="text-slate-400 text-sm mt-0.5">Check the details before we write your letter</p>
+            <h2 className="text-lg font-bold text-slate-900">Review your dispute</h2>
+            <p className="text-slate-600 text-sm mt-0.5">Check the details before we write your letter</p>
           </div>
-          <button onClick={onClose} className="text-slate-400 hover:text-white p-1">
+          <button onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1">
             <X className="h-5 w-5" />
           </button>
         </div>
         <div className="p-6 space-y-4">
           <div>
-            <span className="text-xs px-2.5 py-1 rounded-full bg-mint-400/10 text-mint-400 border border-mint-400/20 font-medium">
+            <span className="text-xs px-2.5 py-1 rounded-full bg-emerald-500/10 text-emerald-600 border border-emerald-500/20 font-medium">
               {issueLabel}
             </span>
           </div>
-          <p className="text-2xl font-bold text-white">{formData.provider_name}</p>
+          <p className="text-2xl font-bold text-slate-900">{formData.provider_name}</p>
           <div className="space-y-3">
-            <div className="bg-navy-950 rounded-xl p-4">
+            <div className="bg-white rounded-xl p-4">
               <p className="text-[10px] text-slate-500 uppercase tracking-wide mb-1">What happened</p>
-              <p className="text-sm text-slate-300 leading-relaxed line-clamp-4">{formData.issue_summary}</p>
+              <p className="text-sm text-slate-600 leading-relaxed line-clamp-4">{formData.issue_summary}</p>
             </div>
-            <div className="bg-navy-950 rounded-xl p-4">
+            <div className="bg-white rounded-xl p-4">
               <p className="text-[10px] text-slate-500 uppercase tracking-wide mb-1">What you want</p>
-              <p className="text-sm text-slate-300">{formData.desired_outcome}</p>
+              <p className="text-sm text-slate-600">{formData.desired_outcome}</p>
             </div>
             {(formData.disputed_amount || formData.account_number) && (
               <div className="flex gap-3">
                 {formData.disputed_amount && (
-                  <div className="bg-navy-950 rounded-xl p-4 flex-1">
+                  <div className="bg-white rounded-xl p-4 flex-1">
                     <p className="text-[10px] text-slate-500 uppercase tracking-wide mb-1">Amount</p>
-                    <p className="text-sm text-amber-400 font-semibold">£{formData.disputed_amount}</p>
+                    <p className="text-sm text-amber-600 font-semibold">£{formData.disputed_amount}</p>
                   </div>
                 )}
                 {formData.account_number && (
-                  <div className="bg-navy-950 rounded-xl p-4 flex-1">
+                  <div className="bg-white rounded-xl p-4 flex-1">
                     <p className="text-[10px] text-slate-500 uppercase tracking-wide mb-1">Account</p>
-                    <p className="text-sm text-slate-300">{formData.account_number}</p>
+                    <p className="text-sm text-slate-600">{formData.account_number}</p>
                   </div>
                 )}
               </div>
             )}
           </div>
-          <div className="bg-mint-400/5 border border-mint-400/20 rounded-xl px-4 py-3 flex items-start gap-2">
-            <Sparkles className="h-4 w-4 text-mint-400 flex-shrink-0 mt-0.5" />
-            <p className="text-xs text-slate-400">
+          <div className="bg-emerald-500/5 border border-emerald-500/20 rounded-xl px-4 py-3 flex items-start gap-2">
+            <Sparkles className="h-4 w-4 text-emerald-600 flex-shrink-0 mt-0.5" />
+            <p className="text-xs text-slate-600">
               Our AI will write a formal complaint letter citing the exact UK consumer law that protects you in this situation.
             </p>
           </div>
@@ -846,13 +846,13 @@ function PreviewConfirmModal({ formData, issueLabel, onConfirm, onClose }: {
         <div className="flex gap-3 p-6 pt-0 flex-shrink-0">
           <button
             onClick={onClose}
-            className="px-5 py-3 bg-navy-800 hover:bg-navy-700 text-slate-300 rounded-lg transition-all text-sm font-medium"
+            className="px-5 py-3 bg-white hover:bg-slate-50 text-slate-600 rounded-lg transition-all text-sm font-medium"
           >
             Edit
           </button>
           <button
             onClick={onConfirm}
-            className="flex-1 flex items-center justify-center gap-2 bg-gradient-to-r from-mint-400 to-mint-500 hover:from-mint-500 hover:to-mint-600 text-navy-950 font-semibold py-3 rounded-lg transition-all"
+            className="flex-1 flex items-center justify-center gap-2 bg-gradient-to-r from-emerald-500 to-emerald-500 hover:from-emerald-500 hover:to-emerald-600 text-slate-900 font-semibold py-3 rounded-lg transition-all"
           >
             <Sparkles className="h-4 w-4" />
             Generate Letter
@@ -996,7 +996,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
-        <Loader2 className="h-8 w-8 animate-spin text-mint-400" />
+        <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
       </div>
     );
   }
@@ -1004,13 +1004,13 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
   if (!dispute) {
     return (
       <div className="text-center py-20">
-        <p className="text-slate-400">Dispute not found</p>
-        <button onClick={onBack} className="text-mint-400 mt-2">Go back</button>
+        <p className="text-slate-600">Dispute not found</p>
+        <button onClick={onBack} className="text-emerald-600 mt-2">Go back</button>
       </div>
     );
   }
 
-  const statusConf = STATUS_CONFIG[dispute.status] || { label: dispute.status, className: 'bg-slate-500/10 text-slate-400' };
+  const statusConf = STATUS_CONFIG[dispute.status] || { label: dispute.status, className: 'bg-slate-100 text-slate-600' };
 
   return (
     <div className="max-w-4xl">
@@ -1042,21 +1042,21 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
       )}
 
       {/* Back + header */}
-      <button onClick={onBack} className="flex items-center gap-1 text-slate-400 hover:text-white mb-4 text-sm transition-all">
+      <button onClick={onBack} className="flex items-center gap-1 text-slate-600 hover:text-slate-900 mb-4 text-sm transition-all">
         <ChevronLeft className="h-4 w-4" /> Back to all disputes
       </button>
 
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
+      <div className="bg-white border border-slate-200/50 rounded-2xl p-6 mb-6">
         <div className="flex items-start justify-between mb-3">
           <div>
-            <h1 className="text-2xl font-bold text-white font-[family-name:var(--font-heading)]">
+            <h1 className="text-2xl font-bold text-slate-900 font-[family-name:var(--font-heading)]">
               {dispute.provider_name}
             </h1>
-            <p className="text-slate-400 text-sm mt-1">{ISSUE_TYPE_LABELS[dispute.issue_type] || dispute.issue_type}</p>
+            <p className="text-slate-600 text-sm mt-1">{ISSUE_TYPE_LABELS[dispute.issue_type] || dispute.issue_type}</p>
           </div>
           <div className="flex items-center gap-3">
             {dispute.disputed_amount && dispute.disputed_amount > 0 && (
-              <span className="text-amber-400 font-bold text-lg">£{dispute.disputed_amount.toFixed(2)}</span>
+              <span className="text-amber-600 font-bold text-lg">£{dispute.disputed_amount.toFixed(2)}</span>
             )}
             <div className="relative">
               <button
@@ -1069,8 +1069,8 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                 {statusConf.label}
               </button>
               {statusDropdown && !isResolved(dispute.status) && (
-                <div className="absolute right-0 top-full mt-2 bg-navy-800 border border-navy-700/50 rounded-lg shadow-xl z-10 min-w-[200px]">
-                  <div className="px-3 py-2 border-b border-navy-700/50">
+                <div className="absolute right-0 top-full mt-2 bg-white border border-slate-200/50 rounded-lg shadow-xl z-10 min-w-[200px]">
+                  <div className="px-3 py-2 border-b border-slate-200/50">
                     <p className="text-[10px] text-slate-500 uppercase tracking-wide font-semibold">Update Status</p>
                   </div>
                   {ACTIVE_STATUSES.map((key) => {
@@ -1079,12 +1079,12 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                       <button
                         key={key}
                         onClick={() => updateStatus(key)}
-                        className={`w-full text-left px-4 py-2.5 text-sm hover:bg-navy-700 transition-all flex items-center gap-2 ${
-                          dispute.status === key ? 'text-amber-400' : 'text-slate-300'
+                        className={`w-full text-left px-4 py-2.5 text-sm hover:bg-slate-50 transition-all flex items-center gap-2 ${
+                          dispute.status === key ? 'text-amber-600' : 'text-slate-600'
                         }`}
                       >
                         <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                          key === 'open' ? 'bg-amber-400' :
+                          key === 'open' ? 'bg-amber-500' :
                           key === 'in_progress' ? 'bg-blue-400' :
                           key === 'awaiting_response' ? 'bg-purple-400' :
                           key === 'escalated' ? 'bg-orange-400' :
@@ -1100,7 +1100,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
             </div>
           </div>
         </div>
-        <p className="text-slate-300 text-sm">{dispute.issue_summary}</p>
+        <p className="text-slate-600 text-sm">{dispute.issue_summary}</p>
         {dispute.desired_outcome && (
           <p className="text-slate-500 text-xs mt-2">Outcome wanted: {dispute.desired_outcome}</p>
         )}
@@ -1109,7 +1109,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
           {!isResolved(dispute.status) && (
             <button
               onClick={() => setShowResolveModal(true)}
-              className="flex items-center gap-1.5 text-xs px-3 py-1.5 bg-amber-400/10 text-amber-400 hover:bg-amber-400/20 rounded-lg transition-all border border-amber-400/20 font-medium"
+              className="flex items-center gap-1.5 text-xs px-3 py-1.5 bg-amber-100 text-amber-600 hover:bg-amber-300/20 rounded-lg transition-all border border-amber-300/20 font-medium"
             >
               <Trophy className="h-3.5 w-3.5" />
               Resolve Dispute
@@ -1136,48 +1136,48 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
 
       {/* Provider Info Card */}
       {providerInfo && (
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 mb-6">
-          <h3 className="text-sm font-semibold text-white mb-3">About {providerInfo.display_name}</h3>
+        <div className="bg-white border border-slate-200/50 rounded-2xl p-5 mb-6">
+          <h3 className="text-sm font-semibold text-slate-900 mb-3">About {providerInfo.display_name}</h3>
           <div className="grid sm:grid-cols-2 gap-3 text-xs">
             {providerInfo.cancellation_method && (
-              <div className="bg-navy-950 rounded-lg px-3 py-2">
+              <div className="bg-white rounded-lg px-3 py-2">
                 <p className="text-slate-500 uppercase tracking-wide text-[10px] mb-1">How to cancel</p>
-                <p className="text-slate-300 capitalize">{providerInfo.cancellation_method}</p>
-                {providerInfo.cancellation_phone && <p className="text-mint-400">{providerInfo.cancellation_phone}</p>}
+                <p className="text-slate-600 capitalize">{providerInfo.cancellation_method}</p>
+                {providerInfo.cancellation_phone && <p className="text-emerald-600">{providerInfo.cancellation_phone}</p>}
                 {providerInfo.cancellation_url && (
-                  <a href={providerInfo.cancellation_url} target="_blank" rel="noopener noreferrer" className="text-mint-400 hover:underline">Cancel online</a>
+                  <a href={providerInfo.cancellation_url} target="_blank" rel="noopener noreferrer" className="text-emerald-600 hover:underline">Cancel online</a>
                 )}
               </div>
             )}
             {providerInfo.complaints_url && (
-              <div className="bg-navy-950 rounded-lg px-3 py-2">
+              <div className="bg-white rounded-lg px-3 py-2">
                 <p className="text-slate-500 uppercase tracking-wide text-[10px] mb-1">How to complain</p>
-                {providerInfo.complaints_email && <p className="text-slate-300">{providerInfo.complaints_email}</p>}
-                {providerInfo.complaints_phone && <p className="text-slate-300">{providerInfo.complaints_phone}</p>}
-                <a href={providerInfo.complaints_url} target="_blank" rel="noopener noreferrer" className="text-mint-400 hover:underline">Complaints page</a>
+                {providerInfo.complaints_email && <p className="text-slate-600">{providerInfo.complaints_email}</p>}
+                {providerInfo.complaints_phone && <p className="text-slate-600">{providerInfo.complaints_phone}</p>}
+                <a href={providerInfo.complaints_url} target="_blank" rel="noopener noreferrer" className="text-emerald-600 hover:underline">Complaints page</a>
               </div>
             )}
             {providerInfo.complaints_response_days && (
-              <div className="bg-navy-950 rounded-lg px-3 py-2">
+              <div className="bg-white rounded-lg px-3 py-2">
                 <p className="text-slate-500 uppercase tracking-wide text-[10px] mb-1">Response deadline</p>
-                <p className="text-slate-300">{providerInfo.complaints_response_days} days to respond</p>
+                <p className="text-slate-600">{providerInfo.complaints_response_days} days to respond</p>
               </div>
             )}
             {providerInfo.ombudsman_name && (
-              <div className="bg-navy-950 rounded-lg px-3 py-2">
+              <div className="bg-white rounded-lg px-3 py-2">
                 <p className="text-slate-500 uppercase tracking-wide text-[10px] mb-1">Escalate to</p>
-                <a href={providerInfo.ombudsman_url} target="_blank" rel="noopener noreferrer" className="text-mint-400 hover:underline">{providerInfo.ombudsman_name}</a>
+                <a href={providerInfo.ombudsman_url} target="_blank" rel="noopener noreferrer" className="text-emerald-600 hover:underline">{providerInfo.ombudsman_name}</a>
               </div>
             )}
             {providerInfo.early_exit_fee_info && (
-              <div className="bg-navy-950 rounded-lg px-3 py-2 sm:col-span-2">
+              <div className="bg-white rounded-lg px-3 py-2 sm:col-span-2">
                 <p className="text-slate-500 uppercase tracking-wide text-[10px] mb-1">Exit fees</p>
-                <p className="text-slate-300">{providerInfo.early_exit_fee_info}</p>
+                <p className="text-slate-600">{providerInfo.early_exit_fee_info}</p>
               </div>
             )}
           </div>
           {providerInfo.terms_url && (
-            <a href={providerInfo.terms_url} target="_blank" rel="noopener noreferrer" className="text-xs text-slate-500 hover:text-mint-400 mt-3 inline-block">
+            <a href={providerInfo.terms_url} target="_blank" rel="noopener noreferrer" className="text-xs text-slate-500 hover:text-emerald-600 mt-3 inline-block">
               View {providerInfo.display_name} T&Cs
             </a>
           )}
@@ -1187,17 +1187,17 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
       {/* Thread */}
       <div className="mb-6">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
-          <h2 className="text-lg font-bold text-white">Your dispute timeline</h2>
+          <h2 className="text-lg font-bold text-slate-900">Your dispute timeline</h2>
           <div className="flex gap-2">
             <button
               onClick={() => setShowAddModal(true)}
-              className="flex items-center gap-2 px-3 py-2 bg-navy-800 hover:bg-navy-700 text-slate-300 rounded-lg text-sm transition-all"
+              className="flex items-center gap-2 px-3 py-2 bg-white hover:bg-slate-50 text-slate-600 rounded-lg text-sm transition-all"
             >
               <Plus className="h-4 w-4" /> Add update
             </button>
             <button
               onClick={generateFollowUp}
-              className="flex items-center gap-2 px-3 py-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold rounded-lg text-sm transition-all disabled:opacity-50 min-w-[200px] justify-center"
+              className="flex items-center gap-2 px-3 py-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-lg text-sm transition-all disabled:opacity-50 min-w-[200px] justify-center"
             >
               {generating ? (
                 <>
@@ -1215,21 +1215,21 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
         </div>
 
         {(!dispute.correspondence || dispute.correspondence.length === 0) ? (
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-12 text-center">
+          <div className="bg-white border border-slate-200/50 rounded-2xl p-12 text-center">
             <MessageSquare className="h-16 w-16 text-slate-600 mx-auto mb-4" />
-            <p className="text-slate-400 mb-2">No correspondence yet</p>
+            <p className="text-slate-600 mb-2">No correspondence yet</p>
             <p className="text-slate-500 text-sm mb-6">Generate your first letter or add what the company has sent you</p>
             <div className="flex justify-center gap-3">
               <button
                 onClick={() => setShowAddModal(true)}
-                className="flex items-center gap-2 px-4 py-2.5 bg-navy-800 hover:bg-navy-700 text-slate-300 rounded-lg text-sm transition-all"
+                className="flex items-center gap-2 px-4 py-2.5 bg-white hover:bg-slate-50 text-slate-600 rounded-lg text-sm transition-all"
               >
                 <Plus className="h-4 w-4" /> Add their response
               </button>
               <button
                 onClick={generateFollowUp}
                 disabled={generating}
-                className="flex items-center gap-2 px-4 py-2.5 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold rounded-lg text-sm transition-all disabled:opacity-50"
+                className="flex items-center gap-2 px-4 py-2.5 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-lg text-sm transition-all disabled:opacity-50"
               >
                 {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
                 Write your first letter
@@ -1250,7 +1250,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                   ref={index === (dispute.correspondence?.length || 0) - 1 ? latestLetterRef : null}
                   key={entry.id}
                   className={`border rounded-2xl p-5 transition-all ${config.className} ${
-                    isAiLetter ? 'cursor-pointer hover:border-mint-400/50' : ''
+                    isAiLetter ? 'cursor-pointer hover:border-emerald-500/50' : ''
                   }`}
                   onClick={() => {
                     if (isAiLetter) {
@@ -1265,15 +1265,15 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                 >
                   <div className="flex items-start justify-between mb-2">
                     <div className="flex items-center gap-2">
-                      <Icon className={`h-4 w-4 ${isFromCompany ? 'text-orange-400' : isAiLetter ? 'text-mint-400' : 'text-slate-400'}`} />
-                      <span className={`text-sm font-medium ${isFromCompany ? 'text-orange-300' : isAiLetter ? 'text-mint-300' : 'text-slate-300'}`}>
+                      <Icon className={`h-4 w-4 ${isFromCompany ? 'text-orange-400' : isAiLetter ? 'text-emerald-600' : 'text-slate-600'}`} />
+                      <span className={`text-sm font-medium ${isFromCompany ? 'text-orange-300' : isAiLetter ? 'text-emerald-500' : 'text-slate-600'}`}>
                         {config.label}
                       </span>
                       {entry.title && (
                         <span className="text-slate-500 text-sm">— {entry.title}</span>
                       )}
                       {entry.detected_from_email && (
-                        <span className="text-[10px] bg-mint-400/15 text-mint-400 border border-mint-400/20 px-1.5 py-0.5 rounded-full font-medium uppercase tracking-wide">
+                        <span className="text-[10px] bg-emerald-500/15 text-emerald-600 border border-emerald-500/20 px-1.5 py-0.5 rounded-full font-medium uppercase tracking-wide">
                           Auto-imported
                         </span>
                       )}
@@ -1304,7 +1304,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                               })
                               .catch(() => alert('Failed to move reply'));
                           }}
-                          className="text-slate-600 hover:text-mint-400 transition-colors p-0.5"
+                          className="text-slate-600 hover:text-emerald-600 transition-colors p-0.5"
                           title="Move to a different dispute"
                         >
                           <ArrowRight className="h-3 w-3" />
@@ -1329,7 +1329,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
 
                   {isAiLetter ? (
                     <>
-                      <pre className="text-sm text-slate-300 whitespace-pre-wrap font-mono leading-relaxed line-clamp-6">
+                      <pre className="text-sm text-slate-600 whitespace-pre-wrap font-mono leading-relaxed line-clamp-6">
                         {entry.content}
                       </pre>
                       {/* Confidence indicator */}
@@ -1337,7 +1337,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                         {entry.estimated_success != null && (
                           <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
                             entry.estimated_success >= 80 ? 'bg-green-500/10 text-green-400' :
-                            entry.estimated_success >= 50 ? 'bg-amber-500/10 text-amber-400' :
+                            entry.estimated_success >= 50 ? 'bg-amber-100 text-amber-600' :
                             'bg-red-500/10 text-red-400'
                           }`}>
                             {entry.estimated_success >= 80 ? 'Strong case' :
@@ -1356,7 +1356,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                               pills: entry.rights_pills || [],
                             });
                           }}
-                          className="text-xs text-mint-400 ml-auto hover:text-mint-300 transition-colors"
+                          className="text-xs text-emerald-600 ml-auto hover:text-emerald-500 transition-colors"
                         >
                           Click to view full letter
                         </button>
@@ -1372,19 +1372,19 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                                   href={pill.url}
                                   target="_blank"
                                   rel="noopener noreferrer"
-                                  className="text-[10px] bg-mint-400/10 text-mint-400 px-2 py-0.5 rounded-full border border-mint-400/20 hover:bg-mint-400/20 transition-colors inline-flex items-center gap-1"
+                                  className="text-[10px] bg-emerald-500/10 text-emerald-600 px-2 py-0.5 rounded-full border border-emerald-500/20 hover:bg-emerald-500/20 transition-colors inline-flex items-center gap-1"
                                   title={pill.strength === 'strong' ? 'Strong legal protection' : pill.strength === 'moderate' ? 'Moderate legal protection' : 'Legal reference'}
                                 >
                                   <span className={`inline-block w-1.5 h-1.5 rounded-full ${
                                     pill.strength === 'strong' ? 'bg-green-500' :
-                                    pill.strength === 'moderate' ? 'bg-amber-500' :
+                                    pill.strength === 'moderate' ? 'bg-orange-500' :
                                     'bg-gray-400'
                                   }`} />
                                   {pill.label}
                                 </a>
                               ))
                             : (entry.legal_references || []).slice(0, 4).map((ref: string, i: number) => (
-                                <span key={i} className="text-[10px] bg-mint-400/10 text-mint-400 px-2 py-0.5 rounded-full border border-mint-400/20">
+                                <span key={i} className="text-[10px] bg-emerald-500/10 text-emerald-600 px-2 py-0.5 rounded-full border border-emerald-500/20">
                                   {ref}
                                 </span>
                               ))
@@ -1396,19 +1396,19 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                       )}
                     </>
                   ) : (
-                    <p className="text-sm text-slate-300 whitespace-pre-wrap">{entry.content}</p>
+                    <p className="text-sm text-slate-600 whitespace-pre-wrap">{entry.content}</p>
                   )}
 
                   {/* Draft response button — shown on company responses */}
                   {isFromCompany && !isResolved(dispute.status) && (
-                    <div className="mt-3 pt-3 border-t border-navy-700/30">
+                    <div className="mt-3 pt-3 border-t border-slate-200/30">
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
                           generateFollowUp();
                         }}
                         disabled={generating}
-                        className="flex items-center gap-2 px-4 py-2 bg-amber-500/10 hover:bg-amber-500/20 text-amber-400 rounded-lg text-sm transition-all border border-amber-500/20 font-medium"
+                        className="flex items-center gap-2 px-4 py-2 bg-amber-100 hover:bg-amber-200 text-amber-600 rounded-lg text-sm transition-all border border-amber-200 font-medium"
                       >
                         {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
                         Draft response to this
@@ -1422,24 +1422,24 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
 
           {/* Action buttons at bottom of thread */}
           {!isResolved(dispute.status) && (
-            <div className="flex flex-col sm:flex-row gap-3 mt-6 pt-4 border-t border-navy-700/30">
+            <div className="flex flex-col sm:flex-row gap-3 mt-6 pt-4 border-t border-slate-200/30">
               <button
                 onClick={generateFollowUp}
                 disabled={generating}
-                className="flex items-center justify-center gap-2 px-5 py-3 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold rounded-xl text-sm transition-all disabled:opacity-50 flex-1"
+                className="flex items-center justify-center gap-2 px-5 py-3 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-xl text-sm transition-all disabled:opacity-50 flex-1"
               >
                 {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
                 Write next letter
               </button>
               <button
                 onClick={() => setShowAddModal(true)}
-                className="flex items-center justify-center gap-2 px-5 py-3 bg-navy-800 hover:bg-navy-700 text-slate-300 rounded-xl text-sm transition-all flex-1"
+                className="flex items-center justify-center gap-2 px-5 py-3 bg-white hover:bg-slate-50 text-slate-600 rounded-xl text-sm transition-all flex-1"
               >
                 <Plus className="h-4 w-4" /> Add their response
               </button>
               <button
                 onClick={() => setShowResolveModal(true)}
-                className="flex items-center justify-center gap-2 px-5 py-3 bg-amber-500/10 hover:bg-amber-500/20 text-amber-400 rounded-xl text-sm transition-all border border-amber-500/20 font-medium flex-1"
+                className="flex items-center justify-center gap-2 px-5 py-3 bg-amber-100 hover:bg-amber-200 text-amber-600 rounded-xl text-sm transition-all border border-amber-200 font-medium flex-1"
               >
                 <Trophy className="h-3.5 w-3.5" /> Resolve dispute
               </button>
@@ -1450,18 +1450,18 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
       </div>
 
       {/* Contract Upload Section */}
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 mb-6">
+      <div className="bg-white border border-slate-200/50 rounded-2xl p-6 mb-6">
         <div className="flex items-center gap-2 mb-3">
           <Shield className="h-5 w-5 text-purple-400" />
-          <h2 className="text-lg font-bold text-white">Your contract</h2>
+          <h2 className="text-lg font-bold text-slate-900">Your contract</h2>
         </div>
 
         {dispute.contract_extractions && dispute.contract_extractions.length > 0 ? (
           <div>
             {justExtracted && (
-              <div className="flex items-center gap-2 mb-3 bg-mint-400/10 border border-mint-400/20 rounded-lg px-3 py-2">
-                <CheckCircle className="h-4 w-4 text-mint-400 flex-shrink-0" />
-                <p className="text-xs text-mint-400 font-medium">Contract analysed successfully — terms loaded below</p>
+              <div className="flex items-center gap-2 mb-3 bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-3 py-2">
+                <CheckCircle className="h-4 w-4 text-emerald-600 flex-shrink-0" />
+                <p className="text-xs text-emerald-600 font-medium">Contract analysed successfully — terms loaded below</p>
               </div>
             )}
 
@@ -1470,7 +1470,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
               {(dispute.contract_extractions[0].provider_name || dispute.contract_extractions[0].contract_type) && (
                 <div className="flex items-center gap-3 mb-3">
                   {dispute.contract_extractions[0].provider_name && (
-                    <span className="text-sm font-semibold text-white">{dispute.contract_extractions[0].provider_name}</span>
+                    <span className="text-sm font-semibold text-slate-900">{dispute.contract_extractions[0].provider_name}</span>
                   )}
                   {dispute.contract_extractions[0].contract_type && (
                     <span className="text-[10px] uppercase tracking-wide bg-purple-500/20 text-purple-300 px-2 py-0.5 rounded-full capitalize">
@@ -1480,33 +1480,33 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                 </div>
               )}
 
-              <p className="text-xs text-slate-400 mb-3 leading-relaxed">{dispute.contract_extractions[0].raw_summary}</p>
+              <p className="text-xs text-slate-600 mb-3 leading-relaxed">{dispute.contract_extractions[0].raw_summary}</p>
 
               <div className="grid sm:grid-cols-2 gap-2">
                 {/* Dates */}
                 {dispute.contract_extractions[0].contract_start_date && (
-                  <div className="bg-navy-950 rounded-lg px-3 py-2">
+                  <div className="bg-white rounded-lg px-3 py-2">
                     <p className="text-[10px] text-slate-500 uppercase tracking-wide">Contract start</p>
-                    <p className="text-xs text-slate-300">{new Date(dispute.contract_extractions[0].contract_start_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</p>
+                    <p className="text-xs text-slate-600">{new Date(dispute.contract_extractions[0].contract_start_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</p>
                   </div>
                 )}
                 {dispute.contract_extractions[0].contract_end_date && (
-                  <div className="bg-navy-950 rounded-lg px-3 py-2">
+                  <div className="bg-white rounded-lg px-3 py-2">
                     <p className="text-[10px] text-slate-500 uppercase tracking-wide">Contract end</p>
-                    <p className="text-xs text-slate-300">{new Date(dispute.contract_extractions[0].contract_end_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</p>
+                    <p className="text-xs text-slate-600">{new Date(dispute.contract_extractions[0].contract_end_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</p>
                   </div>
                 )}
                 {/* Costs */}
                 {dispute.contract_extractions[0].monthly_cost != null && (
-                  <div className="bg-navy-950 rounded-lg px-3 py-2">
+                  <div className="bg-white rounded-lg px-3 py-2">
                     <p className="text-[10px] text-slate-500 uppercase tracking-wide">Monthly cost</p>
-                    <p className="text-xs text-slate-300">£{dispute.contract_extractions[0].monthly_cost.toFixed(2)}</p>
+                    <p className="text-xs text-slate-600">£{dispute.contract_extractions[0].monthly_cost.toFixed(2)}</p>
                   </div>
                 )}
                 {dispute.contract_extractions[0].annual_cost != null && (
-                  <div className="bg-navy-950 rounded-lg px-3 py-2">
+                  <div className="bg-white rounded-lg px-3 py-2">
                     <p className="text-[10px] text-slate-500 uppercase tracking-wide">Annual cost</p>
-                    <p className="text-xs text-slate-300">£{dispute.contract_extractions[0].annual_cost.toFixed(2)}</p>
+                    <p className="text-xs text-slate-600">£{dispute.contract_extractions[0].annual_cost.toFixed(2)}</p>
                   </div>
                 )}
                 {/* Key terms */}
@@ -1518,18 +1518,18 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                   { label: 'Auto-renewal', value: dispute.contract_extractions[0].auto_renewal },
                   { label: 'Cooling-off period', value: dispute.contract_extractions[0].cooling_off_period },
                 ].filter(t => t.value).map((term) => (
-                  <div key={term.label} className="bg-navy-950 rounded-lg px-3 py-2">
+                  <div key={term.label} className="bg-white rounded-lg px-3 py-2">
                     <p className="text-[10px] text-slate-500 uppercase tracking-wide">{term.label}</p>
-                    <p className="text-xs text-slate-300">{term.value}</p>
+                    <p className="text-xs text-slate-600">{term.value}</p>
                   </div>
                 ))}
               </div>
 
               {/* Price increase clause gets its own row */}
               {dispute.contract_extractions[0].price_increase_clause && (
-                <div className="mt-2 bg-amber-500/5 border border-amber-500/20 rounded-lg px-3 py-2">
-                  <p className="text-[10px] text-amber-400 uppercase tracking-wide mb-1">Price increase clause</p>
-                  <p className="text-xs text-slate-300">{dispute.contract_extractions[0].price_increase_clause}</p>
+                <div className="mt-2 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+                  <p className="text-[10px] text-amber-600 uppercase tracking-wide mb-1">Price increase clause</p>
+                  <p className="text-xs text-slate-600">{dispute.contract_extractions[0].price_increase_clause}</p>
                 </div>
               )}
             </div>
@@ -1540,7 +1540,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                   <AlertCircle className="h-4 w-4 inline mr-1" />
                   {dispute.contract_extractions[0].unfair_clauses.length} potentially unfair clause{dispute.contract_extractions[0].unfair_clauses.length !== 1 ? 's' : ''} found
                 </p>
-                <ul className="text-xs text-slate-400 space-y-1.5">
+                <ul className="text-xs text-slate-600 space-y-1.5">
                   {dispute.contract_extractions[0].unfair_clauses.map((clause: string, i: number) => (
                     <li key={i} className="flex items-start gap-2">
                       <AlertCircle className="h-3 w-3 text-red-400 mt-0.5 flex-shrink-0" />
@@ -1552,16 +1552,16 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
             )}
 
             <p className="text-xs text-slate-500">
-              <CheckCircle className="h-3 w-3 text-mint-400 inline mr-1" />
+              <CheckCircle className="h-3 w-3 text-emerald-600 inline mr-1" />
               These terms will be used to strengthen your next letter
             </p>
           </div>
         ) : (
           <div>
-            <p className="text-sm text-slate-400 mb-3">
+            <p className="text-sm text-slate-600 mb-3">
               Got a copy of your contract? Upload it and we&apos;ll find the clauses that help your case.
             </p>
-            <label className={`flex items-center gap-3 w-full px-4 py-3 bg-navy-950 border border-dashed border-purple-500/30 rounded-lg text-slate-400 hover:border-purple-400/50 hover:text-slate-300 cursor-pointer transition-all text-sm ${contractUploading ? 'opacity-50 pointer-events-none' : ''}`}>
+            <label className={`flex items-center gap-3 w-full px-4 py-3 bg-white border border-dashed border-purple-500/30 rounded-lg text-slate-600 hover:border-purple-400/50 hover:text-slate-700 cursor-pointer transition-all text-sm ${contractUploading ? 'opacity-50 pointer-events-none' : ''}`}>
               {contractUploading ? (
                 <Loader2 className="h-5 w-5 text-purple-400 animate-spin flex-shrink-0" />
               ) : (
@@ -1604,11 +1604,11 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
       </div>
 
       {/* Tip */}
-      <div className="bg-mint-400/5 border border-mint-400/20 rounded-xl px-4 py-3">
+      <div className="bg-emerald-500/5 border border-emerald-500/20 rounded-xl px-4 py-3">
         <div className="flex items-start gap-2">
-          <Sparkles className="h-4 w-4 text-mint-400 mt-0.5 flex-shrink-0" />
-          <p className="text-xs text-slate-400">
-            <strong className="text-mint-400">Tip:</strong> Add the company&apos;s replies to your thread. The more context our AI has, the stronger your next letter will be. Every response they send gives us more ammunition.
+          <Sparkles className="h-4 w-4 text-emerald-600 mt-0.5 flex-shrink-0" />
+          <p className="text-xs text-slate-600">
+            <strong className="text-emerald-600">Tip:</strong> Add the company&apos;s replies to your thread. The more context our AI has, the stronger your next letter will be. Every response they send gives us more ammunition.
           </p>
         </div>
       </div>
@@ -1804,15 +1804,15 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
   if (generating) {
     return (
       <div className="max-w-2xl mx-auto">
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-12 text-center">
+        <div className="bg-white border border-slate-200/50 rounded-2xl p-12 text-center">
           <div className="relative mx-auto w-20 h-20 mb-6">
-            <div className="absolute inset-0 rounded-full border-4 border-navy-700" />
-            <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-mint-400 animate-spin" />
+            <div className="absolute inset-0 rounded-full border-4 border-slate-200" />
+            <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-emerald-500 animate-spin" />
             <span className="absolute inset-0 flex items-center justify-center text-3xl">
               {LOADING_CAPTIONS[loadingCaption].icon}
             </span>
           </div>
-          <p className="text-white font-semibold text-lg mb-2">{LOADING_CAPTIONS[loadingCaption].text}</p>
+          <p className="text-slate-900 font-semibold text-lg mb-2">{LOADING_CAPTIONS[loadingCaption].text}</p>
           <p className="text-slate-500 text-sm">This usually takes 15-30 seconds</p>
         </div>
       </div>
@@ -1841,21 +1841,21 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
         />
       )}
 
-      <button onClick={onCancel} className="flex items-center gap-1 text-slate-400 hover:text-white mb-4 text-sm transition-all">
+      <button onClick={onCancel} className="flex items-center gap-1 text-slate-600 hover:text-slate-900 mb-4 text-sm transition-all">
         <ChevronLeft className="h-4 w-4" /> Back
       </button>
 
-      <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6">
-        <h2 className="text-xl font-bold text-white mb-1 font-[family-name:var(--font-heading)]">Start a new dispute</h2>
-        <p className="text-slate-400 text-sm mb-6">Tell us what happened and we will write the perfect response</p>
+      <div className="bg-white border border-slate-200/50 rounded-2xl p-6">
+        <h2 className="text-xl font-bold text-slate-900 mb-1 font-[family-name:var(--font-heading)]">Start a new dispute</h2>
+        <p className="text-slate-600 text-sm mb-6">Tell us what happened and we will write the perfect response</p>
 
         <form ref={formRef} onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">What type of issue?</label>
+            <label className="block text-sm font-medium text-slate-600 mb-2">What type of issue?</label>
             <select
               value={formData.issue_type}
               onChange={(e) => setFormData({ ...formData, issue_type: e.target.value })}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
             >
               {Object.entries(ISSUE_TYPE_LABELS).map(([value, label]) => (
                 <option key={value} value={value}>{label}</option>
@@ -1864,25 +1864,25 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">Who is it with? *</label>
+            <label className="block text-sm font-medium text-slate-600 mb-2">Who is it with? *</label>
             <input
               type="text"
               required
               value={formData.provider_name}
               onChange={(e) => setFormData({ ...formData, provider_name: e.target.value })}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
               placeholder="e.g. British Gas, Sky, Virgin Media"
             />
           </div>
 
           {/* Bill upload */}
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-1">
+            <label className="block text-sm font-medium text-slate-600 mb-1">
               Got a bill to dispute? <span className="text-slate-500 font-normal">(optional)</span>
             </label>
             <p className="text-[11px] text-slate-600 mb-2">Files are scanned by AI then immediately deleted. We never store your uploads.</p>
-            <label className="flex items-center gap-3 w-full px-4 py-3 bg-navy-950 border border-dashed border-navy-700/50 rounded-lg text-slate-500 hover:border-mint-400/50 hover:text-slate-300 cursor-pointer transition-all text-sm">
-              <Upload className="h-5 w-5 text-mint-400 flex-shrink-0" />
+            <label className="flex items-center gap-3 w-full px-4 py-3 bg-white border border-dashed border-slate-200/50 rounded-lg text-slate-500 hover:border-emerald-500/50 hover:text-slate-700 cursor-pointer transition-all text-sm">
+              <Upload className="h-5 w-5 text-emerald-600 flex-shrink-0" />
               <span>{scanning ? 'Scanning bill...' : 'Upload a photo or PDF of the bill'}</span>
               <input
                 type="file"
@@ -1897,80 +1897,80 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
               />
             </label>
             {uploadedBillContext && (
-              <div className="mt-2 flex items-center justify-between bg-mint-400/10 border border-mint-400/20 rounded-lg px-3 py-2">
+              <div className="mt-2 flex items-center justify-between bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-3 py-2">
                 <div className="flex items-center gap-2">
-                  <CheckCircle className="h-4 w-4 text-mint-400 flex-shrink-0" />
+                  <CheckCircle className="h-4 w-4 text-emerald-600 flex-shrink-0" />
                   <div>
-                    <p className="text-mint-400 text-xs font-medium">Bill scanned</p>
+                    <p className="text-emerald-600 text-xs font-medium">Bill scanned</p>
                     <p className="text-slate-500 text-[10px]">{uploadedBillName}</p>
                   </div>
                 </div>
-                <button type="button" onClick={() => { setUploadedBillContext(null); setUploadedBillName(null); }} className="text-slate-500 hover:text-white text-xs ml-2">Remove</button>
+                <button type="button" onClick={() => { setUploadedBillContext(null); setUploadedBillName(null); }} className="text-slate-500 hover:text-slate-900 text-xs ml-2">Remove</button>
               </div>
             )}
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">What happened? *</label>
+            <label className="block text-sm font-medium text-slate-600 mb-2">What happened? *</label>
             <textarea
               required
               minLength={40}
               rows={4}
               value={formData.issue_summary}
               onChange={(e) => setFormData({ ...formData, issue_summary: e.target.value })}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
               placeholder="Explain what went wrong, when it happened, and any impact on you. Paste email content here too."
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">What outcome do you want? *</label>
+            <label className="block text-sm font-medium text-slate-600 mb-2">What outcome do you want? *</label>
             <input
               type="text"
               required
               value={formData.desired_outcome}
               onChange={(e) => setFormData({ ...formData, desired_outcome: e.target.value })}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
               placeholder="e.g. Full refund, £200 compensation, contract cancellation"
             />
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">Amount (£)</label>
+              <label className="block text-sm font-medium text-slate-600 mb-2">Amount (£)</label>
               <input
                 type="text"
                 value={formData.disputed_amount}
                 onChange={(e) => setFormData({ ...formData, disputed_amount: e.target.value })}
-                className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+                className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
                 placeholder="150.00"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-slate-300 mb-2">Account number</label>
+              <label className="block text-sm font-medium text-slate-600 mb-2">Account number</label>
               <input
                 type="text"
                 value={formData.account_number}
                 onChange={(e) => setFormData({ ...formData, account_number: e.target.value })}
-                className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+                className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
                 placeholder="12345678"
               />
             </div>
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-2">Incident date</label>
+            <label className="block text-sm font-medium text-slate-600 mb-2">Incident date</label>
             <input
               type="date"
               value={incidentDate}
               onChange={(e) => setIncidentDate(e.target.value)}
-              className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400 focus:ring-1 focus:ring-mint-400"
+              className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500"
             />
           </div>
 
           {/* Contract upload */}
           <div>
-            <label className="block text-sm font-medium text-slate-300 mb-1">
+            <label className="block text-sm font-medium text-slate-600 mb-1">
               Got a copy of your contract? <span className="text-slate-500 font-normal">(optional)</span>
             </label>
             <p className="text-[11px] text-slate-600 mb-2">We&apos;ll find the clauses that strengthen your case</p>
@@ -1983,10 +1983,10 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
                     <p className="text-slate-500 text-[10px]">{contractFile.name}</p>
                   </div>
                 </div>
-                <button type="button" onClick={() => setContractFile(null)} className="text-slate-500 hover:text-white text-xs ml-2">Remove</button>
+                <button type="button" onClick={() => setContractFile(null)} className="text-slate-500 hover:text-slate-900 text-xs ml-2">Remove</button>
               </div>
             ) : (
-              <label className="flex items-center gap-3 w-full px-4 py-3 bg-navy-950 border border-dashed border-purple-500/30 rounded-lg text-slate-500 hover:border-purple-400/50 hover:text-slate-300 cursor-pointer transition-all text-sm">
+              <label className="flex items-center gap-3 w-full px-4 py-3 bg-white border border-dashed border-purple-500/30 rounded-lg text-slate-500 hover:border-purple-400/50 hover:text-slate-700 cursor-pointer transition-all text-sm">
                 <Shield className="h-5 w-5 text-purple-400 flex-shrink-0" />
                 <span>Upload contract (PDF or photo)</span>
                 <input
@@ -2009,12 +2009,12 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
           {usageInfo && usageInfo.limit !== null && (
             <p className="text-xs text-slate-500 text-right">
               {usageInfo.used} of {usageInfo.limit} letters used this month
-              {usageInfo.used >= usageInfo.limit && <span className="text-mint-400 ml-1">— upgrade for unlimited</span>}
+              {usageInfo.used >= usageInfo.limit && <span className="text-emerald-600 ml-1">— upgrade for unlimited</span>}
             </p>
           )}
 
           <div className="flex gap-3">
-            <button type="button" onClick={onCancel} className="px-6 py-4 bg-navy-800 hover:bg-navy-700 text-slate-300 rounded-lg transition-all">
+            <button type="button" onClick={onCancel} className="px-6 py-4 bg-white hover:bg-slate-50 text-slate-600 rounded-lg transition-all">
               Cancel
             </button>
             <button
@@ -2024,7 +2024,7 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
                 if (formRef.current && !formRef.current.reportValidity()) return;
                 setShowPreviewModal(true);
               }}
-              className="flex-1 bg-gradient-to-r from-mint-400 to-mint-500 hover:from-mint-500 hover:to-mint-600 text-navy-950 font-semibold py-4 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
+              className="flex-1 bg-gradient-to-r from-emerald-500 to-emerald-500 hover:from-emerald-500 hover:to-emerald-600 text-slate-900 font-semibold py-4 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
             >
               <Eye className="h-5 w-5" />
               {saving ? 'Starting dispute...' : 'Preview & Confirm'}
@@ -2117,23 +2117,23 @@ function GuidedTour({ onComplete }: { onComplete: () => void }) {
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -10 }}
           transition={{ duration: 0.2 }}
-          className="absolute z-[101] bg-navy-800 border border-mint-400/30 rounded-xl p-4 shadow-2xl max-w-[280px]"
+          className="absolute z-[101] bg-white border border-emerald-500/30 rounded-xl p-4 shadow-2xl max-w-[280px]"
           style={{
             top: rect.bottom + 12 + 200 > window.innerHeight ? rect.top - 120 : rect.bottom + 12,
             left: Math.min(Math.max(rect.left, 16), window.innerWidth - 296),
           }}
         >
-          <p className="text-mint-400 text-sm font-semibold mb-1">{TOUR_STEPS[step].title}</p>
-          <p className="text-slate-300 text-sm mb-3">{TOUR_STEPS[step].text}</p>
+          <p className="text-emerald-600 text-sm font-semibold mb-1">{TOUR_STEPS[step].title}</p>
+          <p className="text-slate-600 text-sm mb-3">{TOUR_STEPS[step].text}</p>
           <div className="flex items-center justify-between">
             <div className="flex gap-1">
               {TOUR_STEPS.map((_, i) => (
-                <div key={i} className={`w-2 h-2 rounded-full ${i <= step ? 'bg-mint-400' : 'bg-navy-600'}`} />
+                <div key={i} className={`w-2 h-2 rounded-full ${i <= step ? 'bg-emerald-500' : 'bg-slate-50'}`} />
               ))}
             </div>
             <div className="flex gap-2">
-              <button onClick={onComplete} className="text-slate-500 hover:text-slate-300 text-xs transition-all">Skip</button>
-              <button onClick={handleNext} className="bg-mint-400 hover:bg-mint-500 text-navy-950 text-xs font-semibold px-3 py-1.5 rounded-lg transition-all">
+              <button onClick={onComplete} className="text-slate-500 hover:text-slate-700 text-xs transition-all">Skip</button>
+              <button onClick={handleNext} className="bg-emerald-500 hover:bg-emerald-600 text-slate-900 text-xs font-semibold px-3 py-1.5 rounded-lg transition-all">
                 {step === TOUR_STEPS.length - 1 ? 'Got it' : 'Next'}
               </button>
             </div>
@@ -2205,13 +2205,13 @@ function DisputesList({ onSelect, onNew }: { onSelect: (id: string) => void; onN
 
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-4xl font-bold text-white font-[family-name:var(--font-heading)]">Disputes</h1>
-          <p className="text-slate-400 mt-1">Manage complaints, generate legal letters, and track your cases.</p>
+          <h1 className="text-4xl font-bold text-slate-900 font-[family-name:var(--font-heading)]">Disputes</h1>
+          <p className="text-slate-600 mt-1">Manage complaints, generate legal letters, and track your cases.</p>
         </div>
         <button
           id="tour-new-btn"
           onClick={onNew}
-          className="flex items-center gap-2 px-4 py-2.5 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold rounded-lg transition-all"
+          className="flex items-center gap-2 px-4 py-2.5 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-lg transition-all"
         >
           <Plus className="h-4 w-4" />
           New dispute
@@ -2221,36 +2221,36 @@ function DisputesList({ onSelect, onNew }: { onSelect: (id: string) => void; onN
       {/* Dispute Summary Stats */}
       {summary && (summary.total_open > 0 || summary.total_resolved > 0) && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
-          <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4">
+          <div className="bg-white border border-slate-200/50 rounded-xl p-4">
             <div className="flex items-center gap-2 mb-2">
-              <div className="w-8 h-8 bg-amber-400/10 rounded-lg flex items-center justify-center">
-                <Scale className="h-4 w-4 text-amber-400" />
+              <div className="w-8 h-8 bg-amber-100 rounded-lg flex items-center justify-center">
+                <Scale className="h-4 w-4 text-amber-600" />
               </div>
             </div>
-            <p className="text-2xl font-bold text-white">{summary.total_open}</p>
+            <p className="text-2xl font-bold text-slate-900">{summary.total_open}</p>
             <p className="text-slate-500 text-xs mt-0.5">Active Disputes</p>
           </div>
-          <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4">
+          <div className="bg-white border border-slate-200/50 rounded-xl p-4">
             <div className="flex items-center gap-2 mb-2">
               <div className="w-8 h-8 bg-green-500/10 rounded-lg flex items-center justify-center">
                 <CheckCircle className="h-4 w-4 text-green-400" />
               </div>
             </div>
-            <p className="text-2xl font-bold text-white">{summary.total_resolved}</p>
+            <p className="text-2xl font-bold text-slate-900">{summary.total_resolved}</p>
             <p className="text-slate-500 text-xs mt-0.5">Resolved</p>
           </div>
-          <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4">
+          <div className="bg-white border border-slate-200/50 rounded-xl p-4">
             <div className="flex items-center gap-2 mb-2">
-              <div className="w-8 h-8 bg-amber-400/10 rounded-lg flex items-center justify-center">
-                <PoundSterling className="h-4 w-4 text-amber-400" />
+              <div className="w-8 h-8 bg-amber-100 rounded-lg flex items-center justify-center">
+                <PoundSterling className="h-4 w-4 text-amber-600" />
               </div>
             </div>
-            <p className="text-2xl font-bold text-white">
+            <p className="text-2xl font-bold text-slate-900">
               £{summary.total_disputed_amount.toLocaleString('en-GB', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
             </p>
             <p className="text-slate-500 text-xs mt-0.5">Being Disputed</p>
           </div>
-          <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4">
+          <div className="bg-white border border-slate-200/50 rounded-xl p-4">
             <div className="flex items-center gap-2 mb-2">
               <div className="w-8 h-8 bg-green-500/10 rounded-lg flex items-center justify-center">
                 <TrendingUp className="h-4 w-4 text-green-400" />
@@ -2265,36 +2265,36 @@ function DisputesList({ onSelect, onNew }: { onSelect: (id: string) => void; onN
       )}
 
       {/* How it works */}
-      <div id="tour-how" className="bg-navy-900 border border-navy-700/50 rounded-xl p-5 mb-6">
-        <p className="text-xs font-semibold text-mint-400 uppercase tracking-wide mb-3">How it works</p>
+      <div id="tour-how" className="bg-white border border-slate-200/50 rounded-xl p-5 mb-6">
+        <p className="text-xs font-semibold text-emerald-600 uppercase tracking-wide mb-3">How it works</p>
         <div className="grid sm:grid-cols-3 gap-4">
           <div className="flex items-start gap-3">
-            <span className="bg-mint-400 text-navy-950 text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">1</span>
-            <p className="text-slate-300 text-sm">Tell us what happened — in plain English, no legal knowledge needed</p>
+            <span className="bg-emerald-500 text-slate-900 text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">1</span>
+            <p className="text-slate-600 text-sm">Tell us what happened — in plain English, no legal knowledge needed</p>
           </div>
           <div className="flex items-start gap-3">
-            <span className="bg-mint-400 text-navy-950 text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">2</span>
-            <p className="text-slate-300 text-sm">Our AI writes the perfect response citing the exact law that protects you</p>
+            <span className="bg-emerald-500 text-slate-900 text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">2</span>
+            <p className="text-slate-600 text-sm">Our AI writes the perfect response citing the exact law that protects you</p>
           </div>
           <div className="flex items-start gap-3">
-            <span className="bg-mint-400 text-navy-950 text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">3</span>
-            <p className="text-slate-300 text-sm">Add their replies and we write even stronger follow-ups — every response builds your argument</p>
+            <span className="bg-emerald-500 text-slate-900 text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">3</span>
+            <p className="text-slate-600 text-sm">Add their replies and we write even stronger follow-ups — every response builds your argument</p>
           </div>
         </div>
       </div>
 
       {loading ? (
         <div className="flex items-center justify-center py-20">
-          <Loader2 className="h-8 w-8 animate-spin text-mint-400" />
+          <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
         </div>
       ) : disputes.length === 0 ? (
-        <div id="tour-list" className="bg-navy-900 border border-navy-700/50 rounded-2xl p-12 text-center">
+        <div id="tour-list" className="bg-white border border-slate-200/50 rounded-2xl p-12 text-center">
           <FileText className="h-16 w-16 text-slate-600 mx-auto mb-4" />
-          <p className="text-slate-400 mb-2">No disputes yet</p>
+          <p className="text-slate-600 mb-2">No disputes yet</p>
           <p className="text-slate-500 text-sm mb-6">Start your first dispute and we will write the perfect complaint letter</p>
           <button
             onClick={onNew}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold rounded-lg transition-all"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-lg transition-all"
           >
             <Plus className="h-4 w-4" /> Start a dispute
           </button>
@@ -2302,18 +2302,18 @@ function DisputesList({ onSelect, onNew }: { onSelect: (id: string) => void; onN
       ) : (
         <div id="tour-list" className="space-y-3">
           {disputes.map((d, idx) => {
-            const statusConf = STATUS_CONFIG[d.status] || { label: d.status, className: 'bg-slate-500/10 text-slate-400' };
+            const statusConf = STATUS_CONFIG[d.status] || { label: d.status, className: 'bg-slate-100 text-slate-600' };
             return (
               <button
                 key={d.id}
                 id={idx === 0 ? 'tour-card' : undefined}
                 onClick={() => onSelect(d.id)}
-                className="w-full text-left bg-navy-900 border border-navy-700/50 rounded-2xl p-6 hover:border-mint-400/30 transition-all"
+                className="w-full text-left bg-white border border-slate-200/50 rounded-2xl p-6 hover:border-emerald-500/30 transition-all"
               >
                 <div className="flex items-start justify-between">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1 flex-wrap">
-                      <h3 className="text-white font-semibold truncate">{d.provider_name}</h3>
+                      <h3 className="text-slate-900 font-semibold truncate">{d.provider_name}</h3>
                       {(d.unread_reply_count ?? 0) > 0 && (
                         <span className="inline-flex items-center gap-1 text-[10px] bg-brand-400/15 text-brand-400 border border-brand-400/25 px-2 py-0.5 rounded-full font-bold uppercase tracking-wide">
                           <span className="relative flex h-1.5 w-1.5">
@@ -2325,7 +2325,7 @@ function DisputesList({ onSelect, onNew }: { onSelect: (id: string) => void; onN
                         </span>
                       )}
                     </div>
-                    <p className="text-slate-400 text-sm truncate">{d.latest_snippet || d.issue_summary}</p>
+                    <p className="text-slate-600 text-sm truncate">{d.latest_snippet || d.issue_summary}</p>
                     <div className="flex items-center gap-3 mt-2 flex-wrap">
                       <span className="text-slate-500 text-xs">{ISSUE_TYPE_LABELS[d.issue_type] || d.issue_type}</span>
                       <span className="text-slate-600 text-xs flex items-center gap-1">
@@ -2345,7 +2345,7 @@ function DisputesList({ onSelect, onNew }: { onSelect: (id: string) => void; onN
                         £{d.money_recovered.toFixed(2)}
                       </span>
                     ) : d.disputed_amount && d.disputed_amount > 0 ? (
-                      <span className="text-amber-400 font-semibold">£{d.disputed_amount.toFixed(2)}</span>
+                      <span className="text-amber-600 font-semibold">£{d.disputed_amount.toFixed(2)}</span>
                     ) : null}
                     <span className={`text-xs px-2.5 py-1 rounded-full font-medium ${statusConf.className}`}>
                       {statusConf.label}

--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -1029,7 +1029,7 @@ export default function SubscriptionsPage() {
 
   const getSourceBadges = (source?: string) => {
     if (!source || source === 'manual') {
-      return <span className="text-xs bg-navy-700/50 text-slate-400 px-1.5 py-0.5 rounded" title="Manually added">✏️</span>;
+      return <span className="text-xs bg-slate-50/50 text-slate-600 px-1.5 py-0.5 rounded" title="Manually added">✏️</span>;
     }
     return (
       <span className="flex gap-1">
@@ -1048,9 +1048,9 @@ export default function SubscriptionsPage() {
       case 'active':
         return <span className="text-xs bg-green-500/10 text-green-500 px-2 py-1 rounded font-medium">Active</span>;
       case 'pending_cancellation':
-        return <span className="text-xs bg-mint-400/10 text-mint-400 px-2 py-1 rounded font-medium">Cancelling</span>;
+        return <span className="text-xs bg-emerald-500/10 text-emerald-600 px-2 py-1 rounded font-medium">Cancelling</span>;
       case 'cancelled':
-        return <span className="text-xs bg-slate-500/10 text-slate-400 px-2 py-1 rounded font-medium">Cancelled</span>;
+        return <span className="text-xs bg-slate-100 text-slate-600 px-2 py-1 rounded font-medium">Cancelled</span>;
       default:
         return null;
     }
@@ -1063,7 +1063,7 @@ export default function SubscriptionsPage() {
 
     if (daysLeft < 0) {
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-slate-500/10 text-slate-400">
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-600">
           Out of contract
         </span>
       );
@@ -1077,7 +1077,7 @@ export default function SubscriptionsPage() {
     }
     if (daysLeft <= 30) {
       return (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-500/10 text-amber-400">
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-600">
           {daysLeft}d left
         </span>
       );
@@ -1180,7 +1180,7 @@ export default function SubscriptionsPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
+        <Loader2 className="h-8 w-8 text-emerald-600 animate-spin" />
       </div>
     );
   }
@@ -1198,14 +1198,14 @@ export default function SubscriptionsPage() {
 
       {/* Delete Confirmation Modal */}
       {deleteConfirm && (
-        <div className="fixed inset-0 bg-navy-950/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-md p-6 relative">
-            <h3 className="text-xl font-bold text-white mb-2">Delete Subscription</h3>
-            <p className="text-slate-400 text-sm mb-6">Are you sure you want to delete this subscription? This action cannot be undone.</p>
+        <div className="fixed inset-0 bg-white/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+          <div className="bg-white border border-slate-200/50 rounded-2xl w-full max-w-md p-6 relative">
+            <h3 className="text-xl font-bold text-slate-900 mb-2">Delete Subscription</h3>
+            <p className="text-slate-600 text-sm mb-6">Are you sure you want to delete this subscription? This action cannot be undone.</p>
             <div className="flex gap-3 justify-end mt-4">
               <button
                 onClick={() => setDeleteConfirm(null)}
-                className="px-4 py-2 hover:bg-navy-800 text-slate-300 rounded-lg transition-all text-sm font-medium"
+                className="px-4 py-2 hover:bg-white text-slate-600 rounded-lg transition-all text-sm font-medium"
               >
                 Cancel
               </button>
@@ -1216,7 +1216,7 @@ export default function SubscriptionsPage() {
                   }
                   setDeleteConfirm(null);
                 }}
-                className="px-4 py-2 bg-red-500 hover:bg-red-600 text-white font-semibold rounded-lg transition-all text-sm"
+                className="px-4 py-2 bg-red-500 hover:bg-red-600 text-slate-900 font-semibold rounded-lg transition-all text-sm"
               >
                 Delete
               </button>
@@ -1240,18 +1240,18 @@ export default function SubscriptionsPage() {
 
       {/* Bulk Results Modal */}
       {bulkResults && (
-        <div className="fixed inset-0 bg-navy-950/80 backdrop-blur-sm z-50 flex items-center justify-center p-4 overflow-y-auto">
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-4xl max-h-[90vh] overflow-y-auto p-6 lg:p-8">
+        <div className="fixed inset-0 bg-white/80 backdrop-blur-sm z-50 flex items-center justify-center p-4 overflow-y-auto">
+          <div className="bg-white border border-slate-200/50 rounded-2xl w-full max-w-4xl max-h-[90vh] overflow-y-auto p-6 lg:p-8">
             <div className="flex justify-between items-start mb-6">
               <div>
-                <h2 className="text-2xl font-bold text-white mb-2 font-[family-name:var(--font-heading)] flex items-center gap-2">
-                  <Sparkles className="h-6 w-6 text-mint-400" /> Bulk Cancellation Complete
+                <h2 className="text-2xl font-bold text-slate-900 mb-2 font-[family-name:var(--font-heading)] flex items-center gap-2">
+                  <Sparkles className="h-6 w-6 text-emerald-600" /> Bulk Cancellation Complete
                 </h2>
-                <p className="text-slate-400">We've drafted cancellation emails for {bulkResults.length} subscriptions.</p>
+                <p className="text-slate-600">We've drafted cancellation emails for {bulkResults.length} subscriptions.</p>
               </div>
               <button
                 onClick={() => setBulkResults(null)}
-                className="text-slate-400 hover:text-white p-2 rounded-lg transition-colors"
+                className="text-slate-600 hover:text-slate-900 p-2 rounded-lg transition-colors"
               >
                 <X className="h-6 w-6" />
               </button>
@@ -1259,23 +1259,23 @@ export default function SubscriptionsPage() {
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {bulkResults.map((result, i) => (
-                <div key={i} className="bg-navy-950 border border-navy-700/50 rounded-xl p-5">
-                  <h3 className="text-lg font-semibold text-white mb-2">{result.sub.provider_name}</h3>
+                <div key={i} className="bg-white border border-slate-200/50 rounded-xl p-5">
+                  <h3 className="text-lg font-semibold text-slate-900 mb-2">{result.sub.provider_name}</h3>
                   {result.error ? (
                     <div className="text-red-400 text-sm bg-red-400/10 p-3 rounded-lg border border-red-400/20">
                       Error: {result.error}
                     </div>
                   ) : (
                     <>
-                      <p className="text-sm font-medium text-slate-300 mb-2 border-b border-navy-800 pb-2">
+                      <p className="text-sm font-medium text-slate-600 mb-2 border-b border-slate-200 pb-2">
                         Subject: {result.email.subject}
                       </p>
-                      <div className="bg-navy-800/50 rounded-lg p-3 max-h-48 overflow-y-auto text-sm text-slate-300 font-mono text-xs whitespace-pre-wrap">
+                      <div className="bg-white/50 rounded-lg p-3 max-h-48 overflow-y-auto text-sm text-slate-600 font-mono text-xs whitespace-pre-wrap">
                         {result.email.body}
                       </div>
                       <button
                         onClick={() => handleCopy(result.email.body)}
-                        className="mt-3 w-full flex items-center justify-center gap-2 px-4 py-2 bg-navy-800 hover:bg-navy-700 text-slate-300 rounded-lg text-sm transition-all"
+                        className="mt-3 w-full flex items-center justify-center gap-2 px-4 py-2 bg-white hover:bg-slate-50 text-slate-600 rounded-lg text-sm transition-all"
                       >
                         {copied ? <CheckCircle className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
                         {copied ? 'Copied' : 'Copy Email Body'}
@@ -1289,7 +1289,7 @@ export default function SubscriptionsPage() {
             <div className="mt-8 flex justify-end">
               <button
                 onClick={() => setBulkResults(null)}
-                className="px-6 py-3 bg-navy-800 hover:bg-navy-700 text-white rounded-xl transition-all font-semibold"
+                className="px-6 py-3 bg-white hover:bg-slate-50 text-slate-900 rounded-xl transition-all font-semibold"
               >
                 Close
               </button>
@@ -1300,7 +1300,7 @@ export default function SubscriptionsPage() {
 
       {/* Bank toast (success or error) */}
       {bankToast && (
-        <div className={`fixed top-6 right-6 z-50 text-white px-6 py-3 rounded-xl shadow-lg flex items-center gap-2 animate-in fade-in slide-in-from-top-2 ${bankToast.toLowerCase().includes('fail') || bankToast.toLowerCase().includes('error') ? 'bg-red-600' : 'bg-green-500'}`}>
+        <div className={`fixed top-6 right-6 z-50 text-slate-900 px-6 py-3 rounded-xl shadow-lg flex items-center gap-2 animate-in fade-in slide-in-from-top-2 ${bankToast.toLowerCase().includes('fail') || bankToast.toLowerCase().includes('error') ? 'bg-red-600' : 'bg-green-500'}`}>
           <CheckCircle className="h-5 w-5" />
           {bankToast}
         </div>
@@ -1308,7 +1308,7 @@ export default function SubscriptionsPage() {
 
       {/* Bank connections — Compressed */}
       {!bankLoading && (
-        <div className="mb-6 bg-navy-900 border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-4">
+        <div className="mb-6 bg-white border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-4">
           <button
             onClick={() => setConnectionsCollapsed(!connectionsCollapsed)}
             className="flex items-center justify-between w-full text-left"
@@ -1316,8 +1316,8 @@ export default function SubscriptionsPage() {
             <div className="flex items-center gap-3">
               <Building2 className="h-5 w-5 text-blue-400" />
               <div>
-                <h2 className="text-white font-semibold text-sm">Bank Connections</h2>
-                <p className="text-slate-400 text-xs">
+                <h2 className="text-slate-900 font-semibold text-sm">Bank Connections</h2>
+                <p className="text-slate-600 text-xs">
                  {bankConnections.length > 0
                    ? `${bankConnections.length} bank${bankConnections.length === 1 ? '' : 's'} connected`
                    : expiredBanks.length > 0
@@ -1327,15 +1327,15 @@ export default function SubscriptionsPage() {
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <span className="text-xs text-mint-400 font-medium">
+              <span className="text-xs text-emerald-600 font-medium">
                 {connectionsCollapsed ? 'Manage' : 'Hide'}
               </span>
-              {connectionsCollapsed ? <ChevronDown className="h-4 w-4 text-slate-400" /> : <ChevronUp className="h-4 w-4 text-slate-400" />}
+              {connectionsCollapsed ? <ChevronDown className="h-4 w-4 text-slate-600" /> : <ChevronUp className="h-4 w-4 text-slate-600" />}
             </div>
           </button>
 
           {!connectionsCollapsed && (
-            <div className="mt-4 space-y-3 pt-4 border-t border-navy-700/50">
+            <div className="mt-4 space-y-3 pt-4 border-t border-slate-200/50">
               {/* Free-tier stale data banner */}
               {bankTierInfo.tier === 'free' && bankConnections.length > 0 && (() => {
                 const conn = bankConnections[0];
@@ -1343,8 +1343,8 @@ export default function SubscriptionsPage() {
                 const daysSinceSync = Math.floor((Date.now() - new Date(conn.last_synced_at).getTime()) / 86_400_000);
                 if (daysSinceSync < 1) return null;
                 return (
-                  <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3 flex items-start gap-3">
-                    <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
+                  <div className="bg-amber-100 border border-amber-300 rounded-xl px-4 py-3 flex items-start gap-3">
+                    <AlertTriangle className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" />
                     <p className="text-amber-300 text-xs">
                       Your data was last synced {daysSinceSync} day{daysSinceSync !== 1 ? 's' : ''} ago. Essential members get daily updates.{' '}
                       <a href="/dashboard/upgrade" className="underline hover:text-amber-200 transition-colors">Upgrade</a>
@@ -1388,7 +1388,7 @@ export default function SubscriptionsPage() {
                 }
 
                 return (
-                  <div key={conn.id} className="bg-navy-950/50 backdrop-blur-sm border border-green-500/20 rounded-xl p-4">
+                  <div key={conn.id} className="bg-white/50 backdrop-blur-sm border border-green-500/20 rounded-xl p-4">
                     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
                       <div className="flex items-center gap-3">
                         <div className="bg-green-500/10 w-8 h-8 rounded-lg flex items-center justify-center shrink-0">
@@ -1396,7 +1396,7 @@ export default function SubscriptionsPage() {
                         </div>
                         <div>
                           <div className="flex items-center gap-2 mb-0.5">
-                            <span className="text-white font-medium text-sm">
+                            <span className="text-slate-900 font-medium text-sm">
                               {conn.bank_name || 'Bank connected'}
                             </span>
                             <span className="text-[10px] bg-green-500/10 text-green-500 px-1.5 py-0.5 rounded uppercase tracking-wider">Active</span>
@@ -1422,7 +1422,7 @@ export default function SubscriptionsPage() {
                           onClick={() => handleSyncBank(conn.id)}
                           disabled={syncBtnDisabled}
                           title={syncBtnTitle}
-                          className="flex items-center gap-1.5 bg-navy-800 hover:bg-navy-700 text-white font-medium px-3 py-1.5 rounded-lg transition-all text-xs border border-navy-600/50"
+                          className="flex items-center gap-1.5 bg-white hover:bg-slate-50 text-slate-900 font-medium px-3 py-1.5 rounded-lg transition-all text-xs border border-slate-200/50"
                         >
                           <RefreshCw className={`h-3 w-3 ${syncing ? 'animate-spin' : ''}`} />
                           {syncBtnLabel}
@@ -1444,16 +1444,16 @@ export default function SubscriptionsPage() {
               {/* Expired bank connections */}
               {expiredBanks.length > 0 && bankConnections.length === 0 && (
                 expiredBanks.map((conn) => (
-                  <div key={conn.id} className="bg-navy-950/50 backdrop-blur-sm border border-amber-500/20 rounded-xl p-4">
+                  <div key={conn.id} className="bg-white/50 backdrop-blur-sm border border-amber-200 rounded-xl p-4">
                     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
                       <div className="flex items-center gap-3">
-                        <div className="bg-amber-500/10 w-8 h-8 rounded-lg flex items-center justify-center shrink-0">
-                          <WifiOff className="h-4 w-4 text-amber-400" />
+                        <div className="bg-amber-100 w-8 h-8 rounded-lg flex items-center justify-center shrink-0">
+                          <WifiOff className="h-4 w-4 text-amber-600" />
                         </div>
                         <div>
                           <div className="flex items-center gap-2 mb-0.5">
-                            <span className="text-white font-medium text-sm">{conn.bank_name || 'Bank'}</span>
-                            <span className="text-[10px] bg-amber-400/10 text-amber-400 px-1.5 py-0.5 rounded uppercase tracking-wider">Expired</span>
+                            <span className="text-slate-900 font-medium text-sm">{conn.bank_name || 'Bank'}</span>
+                            <span className="text-[10px] bg-amber-100 text-amber-600 px-1.5 py-0.5 rounded uppercase tracking-wider">Expired</span>
                           </div>
                           <p className="text-slate-500 text-xs">
                             Connection expired. Reconnect to resume sync.
@@ -1462,7 +1462,7 @@ export default function SubscriptionsPage() {
                       </div>
                       <button
                         onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }}
-                        className="flex items-center gap-1.5 bg-amber-400 hover:bg-amber-500 text-navy-950 font-semibold px-3 py-1.5 rounded-lg transition-all text-xs"
+                        className="flex items-center gap-1.5 bg-amber-500 hover:bg-orange-600 text-slate-900 font-semibold px-3 py-1.5 rounded-lg transition-all text-xs"
                       >
                         <RefreshCw className="h-3 w-3" />
                         Reconnect
@@ -1479,13 +1479,13 @@ export default function SubscriptionsPage() {
 
                 if (atLimit) {
                   return (
-                    <div className="bg-navy-950/50 backdrop-blur-sm border border-navy-700/50 rounded-xl p-4">
+                    <div className="bg-white/50 backdrop-blur-sm border border-slate-200/50 rounded-xl p-4">
                       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                        <div className="flex text-sm text-slate-400 items-center gap-2">
+                        <div className="flex text-sm text-slate-600 items-center gap-2">
                           <Building2 className="h-4 w-4" />
                           {bankTierInfo.tier === 'free' ? 'Upgrade to connect more accounts.' : 'Upgrade to Pro for unlimited bank connections.'}
                         </div>
-                        <a href="/dashboard/upgrade" className="text-xs bg-amber-400 hover:bg-amber-500 text-navy-950 font-semibold px-3 py-1.5 rounded-lg transition-all">
+                        <a href="/dashboard/upgrade" className="text-xs bg-amber-500 hover:bg-orange-600 text-slate-900 font-semibold px-3 py-1.5 rounded-lg transition-all">
                           Upgrade
                         </a>
                       </div>
@@ -1496,14 +1496,14 @@ export default function SubscriptionsPage() {
                 if (isFirst && bankPromptDismissed) return null;
 
                 return (
-                  <div className="bg-navy-950/50 backdrop-blur-sm border border-blue-500/20 rounded-xl p-4">
+                  <div className="bg-white/50 backdrop-blur-sm border border-blue-500/20 rounded-xl p-4">
                     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
                       <div className="flex items-center gap-3">
                         <div className="bg-blue-500/10 w-8 h-8 rounded-lg flex items-center justify-center shrink-0">
                           <Building2 className="h-4 w-4 text-blue-400" />
                         </div>
                         <div>
-                          <p className="text-white font-medium text-sm">
+                          <p className="text-slate-900 font-medium text-sm">
                             {isFirst ? 'Connect your bank' : 'Add another bank account'}
                           </p>
                           {isFirst && (
@@ -1515,7 +1515,7 @@ export default function SubscriptionsPage() {
                       </div>
                       <button
                         onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }}
-                        className="flex items-center gap-1.5 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-3 py-1.5 rounded-lg transition-all text-xs"
+                        className="flex items-center gap-1.5 bg-blue-600 hover:bg-blue-700 text-slate-900 font-semibold px-3 py-1.5 rounded-lg transition-all text-xs"
                       >
                         <Building2 className="h-3 w-3" />
                         {isFirst ? 'Connect Bank' : 'Add Bank'}
@@ -1542,7 +1542,7 @@ export default function SubscriptionsPage() {
 
       {/* Bill upload toast */}
       {billToast && (
-        <div className={`fixed top-6 right-6 z-50 text-white px-6 py-3 rounded-xl shadow-lg flex items-center gap-2 animate-in fade-in slide-in-from-top-2 ${billToast.toLowerCase().includes('fail') ? 'bg-red-600' : 'bg-green-500'}`}>
+        <div className={`fixed top-6 right-6 z-50 text-slate-900 px-6 py-3 rounded-xl shadow-lg flex items-center gap-2 animate-in fade-in slide-in-from-top-2 ${billToast.toLowerCase().includes('fail') ? 'bg-red-600' : 'bg-green-500'}`}>
           <CheckCircle className="h-5 w-5" />
           {billToast}
         </div>
@@ -1555,14 +1555,14 @@ export default function SubscriptionsPage() {
             const daysLeft = Math.ceil((new Date(alert.contract_end_date).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
             const timeLabel = daysLeft > 0 ? `in ${daysLeft} day${daysLeft !== 1 ? 's' : ''}` : 'has expired';
             return (
-              <div key={alert.id} className="bg-amber-500/5 border border-amber-500/20 rounded-2xl p-4 flex items-start justify-between">
+              <div key={alert.id} className="bg-amber-50 border border-amber-200 rounded-2xl p-4 flex items-start justify-between">
                 <div className="flex items-start gap-3">
-                  <Bell className="h-5 w-5 text-amber-400 mt-0.5 shrink-0" />
+                  <Bell className="h-5 w-5 text-amber-600 mt-0.5 shrink-0" />
                   <div>
-                    <p className="font-medium text-white text-sm">
+                    <p className="font-medium text-slate-900 text-sm">
                       {alert.provider_name} contract ends {timeLabel}
                     </p>
-                    <p className="text-slate-400 text-xs mt-0.5">
+                    <p className="text-slate-600 text-xs mt-0.5">
                       Ends {new Date(alert.contract_end_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
                       {alert.current_amount ? ` · ${formatGBP(alert.current_amount)}/mo` : ''}
                     </p>
@@ -1580,7 +1580,7 @@ export default function SubscriptionsPage() {
                     )}
                   </div>
                 </div>
-                <button onClick={() => handleDismissAlert(alert.id)} className="text-slate-500 hover:text-slate-300 p-1 shrink-0">
+                <button onClick={() => handleDismissAlert(alert.id)} className="text-slate-500 hover:text-slate-700 p-1 shrink-0">
                   <X className="h-4 w-4" />
                 </button>
               </div>
@@ -1593,8 +1593,8 @@ export default function SubscriptionsPage() {
       {!hasAnyContractEndDate && baseSubscriptions.filter(s => s.status === 'active').length > 0 && (
         <div className="bg-blue-500/5 rounded-2xl p-6 text-center border border-blue-500/20 mb-6">
           <CalendarClock className="h-10 w-10 text-blue-400 mx-auto mb-3 opacity-80" />
-          <h3 className="font-semibold text-white text-lg">Never miss a contract end date</h3>
-          <p className="text-slate-400 text-sm mt-1 max-w-md mx-auto">
+          <h3 className="font-semibold text-slate-900 text-lg">Never miss a contract end date</h3>
+          <p className="text-slate-600 text-sm mt-1 max-w-md mx-auto">
             Add your contract end dates and we&apos;ll alert you before they expire —
             so you can switch to a better deal instead of being stuck on expensive out-of-contract rates.
           </p>
@@ -1608,30 +1608,30 @@ export default function SubscriptionsPage() {
       {billUploadSubId && (
         <div className="fixed inset-0 z-50 flex items-start justify-center p-4 pt-8">
           <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={() => { setBillUploadSubId(null); setBillFile(null); }} />
-          <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-md shadow-2xl">
-            <div className="flex items-center justify-between p-6 border-b border-navy-700/50">
-              <h2 className="text-lg font-bold text-white flex items-center gap-2">
-                <Upload className="h-5 w-5 text-mint-400" />
+          <div className="relative bg-white border border-slate-200/50 rounded-2xl w-full max-w-md shadow-2xl">
+            <div className="flex items-center justify-between p-6 border-b border-slate-200/50">
+              <h2 className="text-lg font-bold text-slate-900 flex items-center gap-2">
+                <Upload className="h-5 w-5 text-emerald-600" />
                 Upload Bill / Contract
               </h2>
-              <button onClick={() => { setBillUploadSubId(null); setBillFile(null); }} className="text-slate-400 hover:text-white p-1"><X className="h-5 w-5" /></button>
+              <button onClick={() => { setBillUploadSubId(null); setBillFile(null); }} className="text-slate-600 hover:text-slate-900 p-1"><X className="h-5 w-5" /></button>
             </div>
             <div className="p-6 space-y-4">
-              <p className="text-slate-400 text-sm">
+              <p className="text-slate-600 text-sm">
                 Upload a bill, contract, or letter and we&apos;ll extract the contract end date and key terms automatically.
               </p>
               <div>
                 {billFile ? (
-                  <div className="flex items-center justify-between bg-mint-400/10 border border-mint-400/20 rounded-lg px-3 py-2">
+                  <div className="flex items-center justify-between bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-3 py-2">
                     <div className="flex items-center gap-2">
-                      <Shield className="h-4 w-4 text-mint-400" />
-                      <span className="text-mint-400 text-xs font-medium truncate max-w-[200px]">{billFile.name}</span>
+                      <Shield className="h-4 w-4 text-emerald-600" />
+                      <span className="text-emerald-600 text-xs font-medium truncate max-w-[200px]">{billFile.name}</span>
                     </div>
-                    <button onClick={() => setBillFile(null)} className="text-slate-500 hover:text-white text-xs">Remove</button>
+                    <button onClick={() => setBillFile(null)} className="text-slate-500 hover:text-slate-900 text-xs">Remove</button>
                   </div>
                 ) : (
-                  <label className="flex items-center gap-3 w-full px-4 py-6 bg-navy-950 border-2 border-dashed border-mint-400/30 rounded-lg text-slate-400 hover:border-mint-400/50 hover:text-slate-300 cursor-pointer transition-all text-sm text-center justify-center">
-                    <Upload className="h-6 w-6 text-mint-400" />
+                  <label className="flex items-center gap-3 w-full px-4 py-6 bg-white border-2 border-dashed border-emerald-500/30 rounded-lg text-slate-600 hover:border-emerald-500/50 hover:text-slate-700 cursor-pointer transition-all text-sm text-center justify-center">
+                    <Upload className="h-6 w-6 text-emerald-600" />
                     <span>Drop your bill here or click to browse</span>
                     <input
                       type="file"
@@ -1653,7 +1653,7 @@ export default function SubscriptionsPage() {
               <button
                 onClick={() => billUploadSubId && handleBillUpload(billUploadSubId)}
                 disabled={!billFile || uploadingBill}
-                className="w-full bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
+                className="w-full bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold py-3 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
               >
                 {uploadingBill ? (
                   <><Loader2 className="h-4 w-4 animate-spin" /> Extracting contract details...</>
@@ -1669,14 +1669,14 @@ export default function SubscriptionsPage() {
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-8 gap-4">
         <div>
-          <h1 className="text-3xl md:text-4xl font-bold text-white mb-2 font-[family-name:var(--font-heading)]">Subscriptions</h1>
-          <p className="text-slate-400">Track and cancel subscriptions costing you money</p>
+          <h1 className="text-3xl md:text-4xl font-bold text-slate-900 mb-2 font-[family-name:var(--font-heading)]">Subscriptions</h1>
+          <p className="text-slate-600">Track and cancel subscriptions costing you money</p>
         </div>
         <div className="flex gap-3">
           <button
             onClick={handleDetectFromInbox}
             disabled={detectingFromInbox}
-            className="flex items-center gap-2 bg-navy-800 hover:bg-navy-700 disabled:opacity-50 text-white font-medium px-4 py-3 rounded-lg transition-all text-sm"
+            className="flex items-center gap-2 bg-white hover:bg-slate-50 disabled:opacity-50 text-slate-900 font-medium px-4 py-3 rounded-lg transition-all text-sm"
           >
             {detectingFromInbox
               ? <Loader2 className="h-4 w-4 animate-spin" />
@@ -1685,7 +1685,7 @@ export default function SubscriptionsPage() {
           </button>
           <button
             onClick={() => setShowAddForm(true)}
-            className="flex items-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-4 py-3 rounded-lg transition-all text-sm"
+            className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-4 py-3 rounded-lg transition-all text-sm"
           >
             <Plus className="h-4 w-4" />
             Add
@@ -1695,14 +1695,14 @@ export default function SubscriptionsPage() {
 
       {/* AI Assistant nudge */}
       {subscriptions.length > 0 && (
-        <div className="bg-mint-400/5 border border-mint-400/20 rounded-xl px-4 py-3 mb-6 flex items-center gap-3">
-          <MessageCircle className="h-4 w-4 text-mint-400 shrink-0" />
-          <p className="text-slate-400 text-sm flex-1">
+        <div className="bg-emerald-500/5 border border-emerald-500/20 rounded-xl px-4 py-3 mb-6 flex items-center gap-3">
+          <MessageCircle className="h-4 w-4 text-emerald-600 shrink-0" />
+          <p className="text-slate-600 text-sm flex-1">
             Think a subscription is missing or miscategorised? Ask the AI assistant to find and add it.
           </p>
           <button
             onClick={() => window.dispatchEvent(new CustomEvent('paybacker:open_chat'))}
-            className="text-mint-400 hover:text-mint-300 text-xs font-medium whitespace-nowrap transition-colors"
+            className="text-emerald-600 hover:text-emerald-500 text-xs font-medium whitespace-nowrap transition-colors"
           >
             Ask the AI
           </button>
@@ -1711,30 +1711,30 @@ export default function SubscriptionsPage() {
 
       {/* Detected subscriptions from inbox */}
       {detectedSubs.length > 0 && (
-        <div className="bg-mint-400/5 border border-mint-400/30 rounded-2xl p-6 mb-8">
+        <div className="bg-emerald-500/5 border border-emerald-500/30 rounded-2xl p-6 mb-8">
           <div className="flex items-center gap-2 mb-4">
-            <Sparkles className="h-5 w-5 text-mint-400" />
-            <h2 className="text-white font-semibold">Detected from Inbox Scan ({detectedSubs.length})</h2>
+            <Sparkles className="h-5 w-5 text-emerald-600" />
+            <h2 className="text-slate-900 font-semibold">Detected from Inbox Scan ({detectedSubs.length})</h2>
           </div>
           <div className="space-y-3">
             {detectedSubs.map((s) => (
-              <div key={s.provider_name} className="flex items-center justify-between bg-navy-900 rounded-xl px-4 py-3">
+              <div key={s.provider_name} className="flex items-center justify-between bg-white rounded-xl px-4 py-3">
                 <div>
-                  <p className="text-white font-medium">{normaliseProviderName(s.provider_name)}</p>
-                  <p className="text-slate-400 text-sm capitalize">
+                  <p className="text-slate-900 font-medium">{normaliseProviderName(s.provider_name)}</p>
+                  <p className="text-slate-600 text-sm capitalize">
                     {s.category} · {s.amount > 0 ? formatGBP(s.amount) : '£?'}/{s.billing_cycle}
                   </p>
                 </div>
                 <div className="flex gap-2">
                   <button
                     onClick={() => handleAddDetected(s)}
-                    className="bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
+                    className="bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
                   >
                     Track
                   </button>
                   <button
                     onClick={() => setDetectedSubs((prev) => prev.filter((d) => d.provider_name !== s.provider_name))}
-                    className="text-slate-500 hover:text-slate-300 px-2 py-2 text-sm"
+                    className="text-slate-500 hover:text-slate-700 px-2 py-2 text-sm"
                   >
                     <X className="h-4 w-4" />
                   </button>
@@ -1750,13 +1750,13 @@ export default function SubscriptionsPage() {
         const reviewCount = baseSubscriptions.filter(s => s.needs_review && s.status === 'active').length;
         if (reviewCount === 0) return null;
         return (
-          <div className="bg-amber-500/10 border border-amber-500/30 rounded-2xl p-5 mb-8">
+          <div className="bg-amber-100 border border-amber-300 rounded-2xl p-5 mb-8">
             <div className="flex items-center justify-between gap-4">
               <div className="flex items-center gap-3">
-                <AlertTriangle className="h-5 w-5 text-amber-400 shrink-0" />
+                <AlertTriangle className="h-5 w-5 text-amber-600 shrink-0" />
                 <div>
-                  <h2 className="text-white font-semibold">{reviewCount} subscription{reviewCount > 1 ? 's' : ''} need{reviewCount === 1 ? 's' : ''} your review</h2>
-                  <p className="text-slate-400 text-sm">Auto-detected from your bank transactions. Confirm they&apos;re yours or dismiss.</p>
+                  <h2 className="text-slate-900 font-semibold">{reviewCount} subscription{reviewCount > 1 ? 's' : ''} need{reviewCount === 1 ? 's' : ''} your review</h2>
+                  <p className="text-slate-600 text-sm">Auto-detected from your bank transactions. Confirm they&apos;re yours or dismiss.</p>
                 </div>
               </div>
               <div className="flex items-center gap-2 shrink-0">
@@ -1765,7 +1765,7 @@ export default function SubscriptionsPage() {
                     const el = document.querySelector('[data-needs-review="true"]');
                     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
                   }}
-                  className="bg-amber-500/20 hover:bg-amber-500/30 text-amber-400 font-medium px-4 py-2 rounded-lg text-sm transition-all whitespace-nowrap"
+                  className="bg-amber-200 hover:bg-orange-600/30 text-amber-600 font-medium px-4 py-2 rounded-lg text-sm transition-all whitespace-nowrap"
                 >
                   Review Now
                 </button>
@@ -1794,27 +1794,27 @@ export default function SubscriptionsPage() {
       {/* Summary — from get_subscription_total() RPC (single source of truth) */}
       {rpcTotals && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-          <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-5">
-            <p className="text-slate-400 text-xs mb-1">Subscriptions & Bills</p>
-            <h3 className="text-2xl font-bold text-white">{formatGBP(rpcTotals.subscriptions_monthly)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
+          <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-5">
+            <p className="text-slate-600 text-xs mb-1">Subscriptions & Bills</p>
+            <h3 className="text-2xl font-bold text-slate-900">{formatGBP(rpcTotals.subscriptions_monthly)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
             <p className="text-slate-500 text-xs mt-1">{rpcTotals.subscriptions_count} active</p>
           </div>
 
-          <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-5">
-            <p className="text-slate-400 text-xs mb-1">Mortgages & Loans</p>
-            <h3 className="text-xl font-bold text-slate-300">{formatGBP(rpcTotals.mortgages_monthly + rpcTotals.loans_monthly)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
+          <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-5">
+            <p className="text-slate-600 text-xs mb-1">Mortgages & Loans</p>
+            <h3 className="text-xl font-bold text-slate-600">{formatGBP(rpcTotals.mortgages_monthly + rpcTotals.loans_monthly)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
             <p className="text-slate-500 text-xs mt-1">{rpcTotals.mortgages_count + rpcTotals.loans_count} active</p>
           </div>
 
-          <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-5">
-            <p className="text-slate-400 text-xs mb-1">Council Tax</p>
-            <h3 className="text-xl font-bold text-slate-300">{formatGBP(rpcTotals.council_tax_monthly)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
+          <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-5">
+            <p className="text-slate-600 text-xs mb-1">Council Tax</p>
+            <h3 className="text-xl font-bold text-slate-600">{formatGBP(rpcTotals.council_tax_monthly)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
             <p className="text-slate-500 text-xs mt-1">{rpcTotals.council_tax_count} active</p>
           </div>
 
-          <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-5">
-            <p className="text-slate-400 text-xs mb-1">Total All Commitments</p>
-            <h3 className="text-2xl font-bold text-white">{formatGBP(rpcTotals.monthly_total)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
+          <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-5">
+            <p className="text-slate-600 text-xs mb-1">Total All Commitments</p>
+            <h3 className="text-2xl font-bold text-slate-900">{formatGBP(rpcTotals.monthly_total)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
             <p className="text-slate-500 text-xs mt-1">{formatGBP(rpcTotals.monthly_total * 12)}/year · {rpcTotals.subscriptions_count + rpcTotals.mortgages_count + rpcTotals.loans_count + rpcTotals.council_tax_count} tracked</p>
           </div>
         </div>
@@ -1825,7 +1825,7 @@ export default function SubscriptionsPage() {
         <div className="flex items-center gap-2 overflow-x-auto pb-2 md:pb-0 scrollbar-hide w-full max-w-full">
           <button
             onClick={() => setFilterCategory('All')}
-            className={`whitespace-nowrap px-4 py-2 rounded-full text-sm transition-all ${filterCategory === 'All' ? 'bg-mint-400 text-navy-950 font-semibold' : 'bg-navy-800 text-slate-300 hover:bg-navy-700'}`}
+            className={`whitespace-nowrap px-4 py-2 rounded-full text-sm transition-all ${filterCategory === 'All' ? 'bg-emerald-500 text-slate-900 font-semibold' : 'bg-white text-slate-600 hover:bg-slate-50'}`}
           >
             All
           </button>
@@ -1833,7 +1833,7 @@ export default function SubscriptionsPage() {
             <button
               key={cat.value}
               onClick={() => setFilterCategory(cat.value)}
-              className={`flex items-center gap-1.5 whitespace-nowrap px-4 py-2 rounded-full text-sm transition-all ${filterCategory === cat.value ? 'bg-mint-400 text-navy-950 font-semibold' : 'bg-navy-800 text-slate-300 hover:bg-navy-700'}`}
+              className={`flex items-center gap-1.5 whitespace-nowrap px-4 py-2 rounded-full text-sm transition-all ${filterCategory === cat.value ? 'bg-emerald-500 text-slate-900 font-semibold' : 'bg-white text-slate-600 hover:bg-slate-50'}`}
             >
               {(() => {
                 const Icon = cat.icon;
@@ -1847,7 +1847,7 @@ export default function SubscriptionsPage() {
           <select
             value={sortBy}
             onChange={(e) => setSortBy(e.target.value)}
-            className="bg-navy-900 border border-navy-700/50 text-slate-300 text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-mint-400"
+            className="bg-white border border-slate-200/50 text-slate-600 text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-emerald-500"
           >
             <option value="price_desc">Price: High to Low</option>
             <option value="price_asc">Price: Low to High</option>
@@ -1859,12 +1859,12 @@ export default function SubscriptionsPage() {
 
       {/* Bulk Action Bar */}
       {selectedForBulk.size >= 1 && (
-        <div className="bg-mint-400/10 border border-mint-400/30 rounded-xl p-4 mb-6 flex flex-col sm:flex-row items-center justify-between gap-4 animate-in slide-in-from-bottom-4">
-          <p className="text-mint-400 font-medium ml-2">{selectedForBulk.size} selected</p>
+        <div className="bg-emerald-500/10 border border-emerald-500/30 rounded-xl p-4 mb-6 flex flex-col sm:flex-row items-center justify-between gap-4 animate-in slide-in-from-bottom-4">
+          <p className="text-emerald-600 font-medium ml-2">{selectedForBulk.size} selected</p>
           <div className="flex flex-wrap gap-2 w-full sm:w-auto justify-end">
             <button
               onClick={() => setSelectedForBulk(new Set())}
-              className="text-slate-400 hover:text-white px-3 py-2 text-sm transition-colors"
+              className="text-slate-600 hover:text-slate-900 px-3 py-2 text-sm transition-colors"
             >
               Deselect
             </button>
@@ -1877,7 +1877,7 @@ export default function SubscriptionsPage() {
             </button>
             <button
               onClick={handleBulkMarkCancelled}
-              className="flex items-center gap-1.5 bg-navy-800 hover:bg-navy-700 text-slate-300 px-4 py-2 rounded-lg text-sm transition-all font-medium"
+              className="flex items-center gap-1.5 bg-white hover:bg-slate-50 text-slate-600 px-4 py-2 rounded-lg text-sm transition-all font-medium"
             >
               <CheckCircle className="h-3.5 w-3.5" />
               Mark Cancelled
@@ -1890,7 +1890,7 @@ export default function SubscriptionsPage() {
                   router.push(`/dashboard/complaints?new=1&company=${encodeURIComponent(sub.provider_name)}&type=complaint&issue=${encodeURIComponent(`Unrecognised or disputed charges from ${ids.length > 1 ? `${ids.length} subscriptions` : sub.provider_name}`)}&outcome=${encodeURIComponent('Refund of disputed charges')}`);
                 }
               }}
-              className="flex items-center gap-1.5 bg-navy-800 hover:bg-navy-700 text-slate-300 px-4 py-2 rounded-lg text-sm transition-all font-medium"
+              className="flex items-center gap-1.5 bg-white hover:bg-slate-50 text-slate-600 px-4 py-2 rounded-lg text-sm transition-all font-medium"
             >
               <Shield className="h-3.5 w-3.5" />
               Dispute
@@ -1898,7 +1898,7 @@ export default function SubscriptionsPage() {
             <button
               onClick={handleBulkCancel}
               disabled={bulkGenerating}
-              className="flex items-center gap-1.5 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-4 py-2.5 rounded-lg text-sm transition-all disabled:opacity-50"
+              className="flex items-center gap-1.5 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-4 py-2.5 rounded-lg text-sm transition-all disabled:opacity-50"
             >
               {bulkGenerating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Mail className="h-3.5 w-3.5" />}
               Cancel Emails
@@ -1911,20 +1911,20 @@ export default function SubscriptionsPage() {
         {/* Subscriptions list */}
         <div className="space-y-4 min-w-0 overflow-hidden">
           {activeDuplicateGroups.length > 0 && (
-            <div className="bg-navy-900 border border-amber-500/30 rounded-xl p-4 mb-4">
+            <div className="bg-white border border-amber-300 rounded-xl p-4 mb-4">
               <div className="flex items-center justify-between gap-3 mb-3">
                 <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-amber-500/10 rounded-lg flex items-center justify-center shrink-0">
+                  <div className="w-9 h-9 bg-amber-100 rounded-lg flex items-center justify-center shrink-0">
                     <AlertTriangle className="h-4 w-4 text-amber-500" />
                   </div>
                   <div>
-                    <p className="text-white font-medium text-sm">Possible Duplicate Subscriptions</p>
-                    <p className="text-slate-400 text-xs">{activeDuplicateGroups.length} provider{activeDuplicateGroups.length !== 1 ? 's' : ''} — review before merging</p>
+                    <p className="text-slate-900 font-medium text-sm">Possible Duplicate Subscriptions</p>
+                    <p className="text-slate-600 text-xs">{activeDuplicateGroups.length} provider{activeDuplicateGroups.length !== 1 ? 's' : ''} — review before merging</p>
                   </div>
                 </div>
                 <button
                   onClick={() => setShowDuplicateDetails(v => !v)}
-                  className="text-xs text-amber-400 hover:text-amber-300 underline whitespace-nowrap"
+                  className="text-xs text-amber-600 hover:text-amber-300 underline whitespace-nowrap"
                 >
                   {showDuplicateDetails ? 'Hide details' : 'Review duplicates'}
                 </button>
@@ -1939,13 +1939,13 @@ export default function SubscriptionsPage() {
                     const groupKey = `${cleanMerchantName(group[0].provider_name).toLowerCase()}|${group[0].category}`;
                     const overrideAmt = groupAmountOverrides[groupKey] ?? String(keep.amount);
                     return (
-                      <div key={groupKey} className="bg-navy-950/80 border border-navy-700/50 rounded-lg p-3">
+                      <div key={groupKey} className="bg-white/80 border border-slate-200/50 rounded-lg p-3">
                         <div className="flex items-center justify-between mb-2">
-                          <p className="text-white text-sm font-semibold">{cleanMerchantName(keep.provider_name)}</p>
+                          <p className="text-slate-900 text-sm font-semibold">{cleanMerchantName(keep.provider_name)}</p>
                           <div className="flex gap-2">
                             <button
                               onClick={() => handleDismissGroup(groupKey)}
-                              className="text-xs text-slate-500 hover:text-slate-300 px-2 py-1 rounded transition-colors"
+                              className="text-xs text-slate-500 hover:text-slate-700 px-2 py-1 rounded transition-colors"
                               title="Not a duplicate — dismiss"
                             >
                               Dismiss
@@ -1953,7 +1953,7 @@ export default function SubscriptionsPage() {
                             <button
                               onClick={() => handleMergeDuplicates(group, groupKey)}
                               disabled={mergingDuplicates}
-                              className="text-xs bg-amber-500 hover:bg-amber-600 text-navy-950 font-semibold px-3 py-1 rounded transition-colors disabled:opacity-50"
+                              className="text-xs bg-orange-500 hover:bg-orange-700 text-slate-900 font-semibold px-3 py-1 rounded transition-colors disabled:opacity-50"
                             >
                               Merge
                             </button>
@@ -1962,17 +1962,17 @@ export default function SubscriptionsPage() {
                         <div className="space-y-1.5">
                           <div className="flex items-center gap-2 text-xs flex-wrap">
                             <span className="w-14 text-green-400 font-medium shrink-0">Keep:</span>
-                            <span className="text-slate-200">{keep.provider_name}</span>
+                            <span className="text-slate-700">{keep.provider_name}</span>
                             <span className="text-slate-500">at</span>
                             <span className="inline-flex items-center gap-1">
-                              <span className="text-slate-400">£</span>
+                              <span className="text-slate-600">£</span>
                               <input
                                 type="number"
                                 step="0.01"
                                 min="0"
                                 value={overrideAmt}
                                 onChange={e => setGroupAmountOverrides(prev => ({ ...prev, [groupKey]: e.target.value }))}
-                                className="w-20 bg-navy-800 border border-navy-600 rounded px-1.5 py-0.5 text-white text-xs focus:outline-none focus:border-amber-400"
+                                className="w-20 bg-white border border-slate-200 rounded px-1.5 py-0.5 text-slate-900 text-xs focus:outline-none focus:border-amber-300"
                               />
                               <span className="text-slate-500">/{keep.billing_cycle}</span>
                             </span>
@@ -1981,7 +1981,7 @@ export default function SubscriptionsPage() {
                           {remove.map(r => (
                             <div key={r.id} className="flex items-center gap-2 text-xs">
                               <span className="w-14 text-red-400 font-medium shrink-0">Remove:</span>
-                              <span className="text-slate-400 line-through">{r.provider_name}</span>
+                              <span className="text-slate-600 line-through">{r.provider_name}</span>
                               <span className="text-slate-500">— £{r.amount}/{r.billing_cycle}</span>
                               {r.source && <span className="text-slate-500">({r.source})</span>}
                             </div>
@@ -1995,7 +1995,7 @@ export default function SubscriptionsPage() {
                     <button
                       onClick={() => handleMergeDuplicates()}
                       disabled={mergingDuplicates}
-                      className="w-full bg-amber-500 hover:bg-amber-600 text-navy-950 px-4 py-2 rounded-lg text-sm font-semibold transition-colors disabled:opacity-50"
+                      className="w-full bg-orange-500 hover:bg-orange-700 text-slate-900 px-4 py-2 rounded-lg text-sm font-semibold transition-colors disabled:opacity-50"
                     >
                       {mergingDuplicates ? 'Merging...' : `Merge all ${activeDuplicateGroups.reduce((acc, g) => acc + g.length - 1, 0)} duplicates`}
                     </button>
@@ -2005,18 +2005,18 @@ export default function SubscriptionsPage() {
             </div>
           )}
           {hiddenFinanceCount > 0 && (
-            <div className="bg-navy-900/50 border border-navy-700/30 rounded-lg px-4 py-3 mb-4 flex items-center justify-between">
-              <p className="text-slate-500 text-xs">{hiddenFinanceCount} loan/mortgage/credit card payment{hiddenFinanceCount !== 1 ? 's' : ''} hidden. These are tracked in your <a href="/dashboard/money-hub" className="text-mint-400 hover:text-mint-300">Money Hub</a>.</p>
+            <div className="bg-white/50 border border-slate-200/30 rounded-lg px-4 py-3 mb-4 flex items-center justify-between">
+              <p className="text-slate-500 text-xs">{hiddenFinanceCount} loan/mortgage/credit card payment{hiddenFinanceCount !== 1 ? 's' : ''} hidden. These are tracked in your <a href="/dashboard/money-hub" className="text-emerald-600 hover:text-emerald-500">Money Hub</a>.</p>
             </div>
           )}
 
           {displaySubscriptions.length === 0 ? (
-            <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-12 text-center">
+            <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-12 text-center">
               <CreditCard className="h-16 w-16 text-slate-600 mx-auto mb-4" />
-              <p className="text-slate-400 mb-4">No subscriptions tracked yet</p>
+              <p className="text-slate-600 mb-4">No subscriptions tracked yet</p>
               <button
                 onClick={() => setShowAddForm(true)}
-                className="bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-6 py-3 rounded-lg transition-all"
+                className="bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-6 py-3 rounded-lg transition-all"
               >
                 Add your first subscription
               </button>
@@ -2026,12 +2026,12 @@ export default function SubscriptionsPage() {
               <div
                 key={sub.id}
                 data-needs-review={sub.needs_review ? 'true' : undefined}
-                className={`bg-navy-900 backdrop-blur-sm border rounded-2xl p-6 transition-all cursor-pointer ${
+                className={`bg-white backdrop-blur-sm border rounded-2xl p-6 transition-all cursor-pointer ${
                   selectedSub?.id === sub.id
-                    ? 'border-mint-400/50'
+                    ? 'border-emerald-500/50'
                     : sub.needs_review
                     ? 'border-amber-500/40 hover:border-amber-500/60'
-                    : 'border-navy-700/50 hover:border-navy-700/50'
+                    : 'border-slate-200/50 hover:border-slate-200/50'
                 }`}
                 onClick={() => {
                   setSelectedSub(sub);
@@ -2045,8 +2045,8 @@ export default function SubscriptionsPage() {
               >
                 <div className="flex items-start">
                   <div className="pt-1 pr-4" onClick={(e) => { e.stopPropagation(); handleToggleBulk(sub.id); }}>
-                    <div className={`w-5 h-5 rounded border flex items-center justify-center transition-colors cursor-pointer ${selectedForBulk.has(sub.id) ? 'bg-mint-400 border-mint-400' : 'border-slate-500 hover:border-mint-400'}`}>
-                      {selectedForBulk.has(sub.id) && <svg className="w-3.5 h-3.5 text-navy-950" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>}
+                    <div className={`w-5 h-5 rounded border flex items-center justify-center transition-colors cursor-pointer ${selectedForBulk.has(sub.id) ? 'bg-emerald-500 border-emerald-500' : 'border-slate-500 hover:border-emerald-500'}`}>
+                      {selectedForBulk.has(sub.id) && <svg className="w-3.5 h-3.5 text-slate-900" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>}
                     </div>
                   </div>
                   
@@ -2063,29 +2063,29 @@ export default function SubscriptionsPage() {
                               className="rounded-md shrink-0"
                               onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }}
                             />
-                            <span className="w-6 h-6 rounded-md bg-mint-400/20 text-mint-400 flex items-center justify-center text-xs font-bold shrink-0 hidden">
+                            <span className="w-6 h-6 rounded-md bg-emerald-500/20 text-emerald-600 flex items-center justify-center text-xs font-bold shrink-0 hidden">
                               {normaliseProviderName(sub.provider_name).charAt(0).toUpperCase()}
                             </span>
                           </>
                         ) : (
-                          <span className="w-6 h-6 rounded-md bg-mint-400/20 text-mint-400 flex items-center justify-center text-xs font-bold shrink-0">
+                          <span className="w-6 h-6 rounded-md bg-emerald-500/20 text-emerald-600 flex items-center justify-center text-xs font-bold shrink-0">
                             {normaliseProviderName(sub.provider_name).charAt(0).toUpperCase()}
                           </span>
                         )}
-                        <h3 className="text-lg font-semibold text-white">{normaliseProviderName(sub.provider_name)}</h3>
+                        <h3 className="text-lg font-semibold text-slate-900">{normaliseProviderName(sub.provider_name)}</h3>
                         {getStatusBadge(sub.status)}
                         {getSourceBadges(sub.source)}
                         {sub.needs_review && (
-                          <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-500/20 text-amber-400 border border-amber-500/30">
+                          <span className="px-2 py-0.5 rounded-full text-[10px] font-semibold bg-amber-200 text-amber-600 border border-amber-300">
                             Needs review
                           </span>
                         )}
                       </div>
-                      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-400 mb-2">
+                      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600 mb-2">
                         <div className="relative group inline-block" onClick={e => e.stopPropagation()}>
                           <button
                             onClick={() => setInlineRecatSub(inlineRecatSub === sub.id ? null : sub.id)}
-                            className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors font-medium border ${sub.category ? `${getCategoryColor(sub.category)} ${getCategoryBgColor(sub.category)} border-transparent hover:border-opacity-30` : 'text-slate-400 bg-navy-800 border-navy-700 hover:border-navy-600'}`}
+                            className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors font-medium border ${sub.category ? `${getCategoryColor(sub.category)} ${getCategoryBgColor(sub.category)} border-transparent hover:border-opacity-30` : 'text-slate-600 bg-white border-slate-200 hover:border-slate-200'}`}
                           >
                             {(() => {
                                const Icon = sub.category ? getCategoryIcon(sub.category) : MoreHorizontal;
@@ -2094,12 +2094,12 @@ export default function SubscriptionsPage() {
                             <span>{sub.category ? getCategoryLabel(sub.category) : 'Uncategorised'}</span>
                           </button>
                           {inlineRecatSub === sub.id && (
-                            <div className="absolute top-full left-0 mt-1 w-48 bg-navy-800 border border-navy-700 rounded-lg shadow-xl z-20 max-h-64 overflow-y-auto">
+                            <div className="absolute top-full left-0 mt-1 w-48 bg-white border border-slate-200 rounded-lg shadow-xl z-20 max-h-64 overflow-y-auto">
                               {SORTED_CATEGORIES.map(cat => (
                                 <button
                                   key={cat.value}
                                   onClick={() => handleInlineRecategorise(sub, cat.value)}
-                                  className={`w-full text-left px-3 py-2 text-xs hover:bg-navy-700 flex items-center gap-2 ${sub.category === cat.value ? 'text-mint-400 bg-mint-400/5' : 'text-slate-300'}`}
+                                  className={`w-full text-left px-3 py-2 text-xs hover:bg-slate-50 flex items-center gap-2 ${sub.category === cat.value ? 'text-emerald-600 bg-emerald-500/5' : 'text-slate-600'}`}
                                 >
                                   {(() => {
                                      const Icon = getCategoryIcon(cat.value);
@@ -2118,7 +2118,7 @@ export default function SubscriptionsPage() {
                         )}
                       <ContractBadge contractEndDate={sub.contract_end_date} />
                       {sub.contract_type && sub.contract_type !== 'subscription' && (
-                        <span className="text-xs bg-navy-700/50 text-slate-400 px-1.5 py-0.5 rounded capitalize">{sub.contract_type.replace('_', ' ')}</span>
+                        <span className="text-xs bg-slate-50/50 text-slate-600 px-1.5 py-0.5 rounded capitalize">{sub.contract_type.replace('_', ' ')}</span>
                       )}
                       {sub.auto_renews === false && (
                         <span className="text-xs bg-green-500/10 text-green-400 px-1.5 py-0.5 rounded">No auto-renew</span>
@@ -2149,7 +2149,7 @@ export default function SubscriptionsPage() {
 
                   <div className="flex flex-col items-end gap-2 shrink-0 z-10 relative ml-4">
                     <div className="text-right whitespace-nowrap">
-                      <p className="text-xl font-bold text-white">{formatGBP(sub.amount)}</p>
+                      <p className="text-xl font-bold text-slate-900">{formatGBP(sub.amount)}</p>
                       <p className="text-xs text-slate-500">{sub.billing_cycle}</p>
                     </div>
                     <div className="flex items-center gap-2">
@@ -2168,7 +2168,7 @@ export default function SubscriptionsPage() {
                           e.stopPropagation();
                           openEditModal(sub);
                         }}
-                        className="text-slate-600 hover:text-mint-400 transition-all p-1"
+                        className="text-slate-600 hover:text-emerald-600 transition-all p-1"
                         title="Edit"
                       >
                         <Pencil className="h-4 w-4" />
@@ -2189,7 +2189,7 @@ export default function SubscriptionsPage() {
               </div>
 
               {sub.needs_review && sub.status === 'active' && (
-                <div className="mt-4 pt-4 border-t border-amber-500/30 flex flex-wrap gap-2">
+                <div className="mt-4 pt-4 border-t border-amber-300 flex flex-wrap gap-2">
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
@@ -2222,9 +2222,9 @@ export default function SubscriptionsPage() {
               )}
 
               {!sub.needs_review && sub.status === 'active' && (
-                  <div className="mt-4 pt-4 border-t border-navy-700/50 flex flex-wrap gap-2">
+                  <div className="mt-4 pt-4 border-t border-slate-200/50 flex flex-wrap gap-2">
                     {isStatutoryService(sub.provider_name) ? (
-                      <span className="flex items-center gap-2 bg-slate-500/10 text-slate-400 px-4 py-2 rounded-lg text-sm border border-slate-500/20">
+                      <span className="flex items-center gap-2 bg-slate-100 text-slate-600 px-4 py-2 rounded-lg text-sm border border-slate-200">
                         <AlertTriangle className="h-4 w-4" />
                         Statutory charge
                       </span>
@@ -2235,7 +2235,7 @@ export default function SubscriptionsPage() {
                             e.stopPropagation();
                             handleCancelRequest(sub);
                           }}
-                          className="flex items-center gap-2 bg-navy-800 hover:bg-navy-700 text-white px-4 py-2 rounded-lg transition-all text-sm"
+                          className="flex items-center gap-2 bg-white hover:bg-slate-50 text-slate-900 px-4 py-2 rounded-lg transition-all text-sm"
                         >
                           <Mail className="h-4 w-4" />
                           Generate Cancellation Email
@@ -2281,9 +2281,9 @@ export default function SubscriptionsPage() {
         </div>
 
         {/* Cancellation email panel */}
-        <div className="bg-navy-900 backdrop-blur-sm border border-navy-700/50 rounded-2xl shadow-[--shadow-card] p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto">
-          <h2 className="text-xl font-bold text-white mb-6 flex items-center gap-2">
-            <Mail className="h-5 w-5 text-mint-400" />
+        <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-6 sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto">
+          <h2 className="text-xl font-bold text-slate-900 mb-6 flex items-center gap-2">
+            <Mail className="h-5 w-5 text-emerald-600" />
             Cancellation Email
           </h2>
 
@@ -2295,8 +2295,8 @@ export default function SubscriptionsPage() {
 
           {generating ? (
             <div className="flex flex-col items-center justify-center py-12">
-              <Loader2 className="h-10 w-10 text-mint-400 animate-spin mb-4" />
-              <p className="text-slate-400">Writing your cancellation email...</p>
+              <Loader2 className="h-10 w-10 text-emerald-600 animate-spin mb-4" />
+              <p className="text-slate-600">Writing your cancellation email...</p>
             </div>
           ) : cancellationEmail ? (
             <div className="space-y-4">
@@ -2305,14 +2305,14 @@ export default function SubscriptionsPage() {
                 Saved to your complaint history
               </div>
 
-              <div className="bg-navy-950 rounded-lg p-4 border border-navy-700/50">
+              <div className="bg-white rounded-lg p-4 border border-slate-200/50">
                 <p className="text-xs text-slate-500 mb-1">Subject</p>
-                <p className="text-white font-medium">{cancellationEmail.subject}</p>
+                <p className="text-slate-900 font-medium">{cancellationEmail.subject}</p>
               </div>
 
-              <div className="bg-navy-950 rounded-lg p-4 border border-navy-700/50 max-h-72 overflow-y-auto">
+              <div className="bg-white rounded-lg p-4 border border-slate-200/50 max-h-72 overflow-y-auto">
                 <p className="text-xs text-slate-500 mb-2">Email body</p>
-                <pre className="text-sm text-slate-300 whitespace-pre-wrap font-sans">
+                <pre className="text-sm text-slate-600 whitespace-pre-wrap font-sans">
                   {cancellationEmail.body}
                 </pre>
               </div>
@@ -2324,21 +2324,21 @@ export default function SubscriptionsPage() {
                     value={cancelFeedback}
                     onChange={(e) => setCancelFeedback(e.target.value)}
                     placeholder="Tell the AI what to change (e.g. 'Make it more formal', 'Add reference to my 2 year contract ending', 'Include my account number 12345')"
-                    className="w-full px-3 py-2 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400 text-sm"
+                    className="w-full px-3 py-2 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 text-sm"
                     rows={3}
                   />
                   <div className="flex gap-2">
                     <button
                       onClick={() => selectedSub && handleCancelRequest(selectedSub, cancelFeedback, cancellationEmail.body)}
                       disabled={!cancelFeedback.trim() || regenerating}
-                      className="flex-1 flex items-center justify-center gap-2 bg-mint-400 hover:bg-mint-500 disabled:opacity-50 text-navy-950 font-semibold py-2 rounded-lg transition-all text-sm"
+                      className="flex-1 flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold py-2 rounded-lg transition-all text-sm"
                     >
                       {regenerating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
                       {regenerating ? 'Regenerating...' : 'Regenerate'}
                     </button>
                     <button
                       onClick={() => { setShowCancelFeedback(false); setCancelFeedback(''); }}
-                      className="px-4 py-2 bg-navy-800 hover:bg-navy-700 text-white rounded-lg text-sm"
+                      className="px-4 py-2 bg-white hover:bg-slate-50 text-slate-900 rounded-lg text-sm"
                     >
                       Cancel
                     </button>
@@ -2347,7 +2347,7 @@ export default function SubscriptionsPage() {
               ) : (
                 <button
                   onClick={() => setShowCancelFeedback(true)}
-                  className="w-full flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-slate-300 py-2 rounded-lg transition-all text-sm"
+                  className="w-full flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-600 py-2 rounded-lg transition-all text-sm"
                 >
                   <Pencil className="h-3.5 w-3.5" />
                   Request changes
@@ -2361,7 +2361,7 @@ export default function SubscriptionsPage() {
                       `Subject: ${cancellationEmail.subject}\n\n${cancellationEmail.body}`
                     )
                   }
-                  className="flex-1 flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white py-3 rounded-lg transition-all"
+                  className="flex-1 flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-900 py-3 rounded-lg transition-all"
                 >
                   {copied ? (
                     <>
@@ -2378,7 +2378,7 @@ export default function SubscriptionsPage() {
                 {selectedSub?.account_email && (
                   <a
                     href={`mailto:${selectedSub.account_email}?subject=${encodeURIComponent(cancellationEmail.subject)}&body=${encodeURIComponent(cancellationEmail.body)}`}
-                    className="flex-1 flex items-center justify-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-lg transition-all"
+                    className="flex-1 flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold py-3 rounded-lg transition-all"
                   >
                     <Mail className="h-4 w-4" />
                     Open in Email
@@ -2391,7 +2391,7 @@ export default function SubscriptionsPage() {
               {selectedSub ? (
                 <>
                   {/* Subscription summary */}
-                  <div className="bg-navy-950 rounded-xl p-5 border border-navy-700/50">
+                  <div className="bg-white rounded-xl p-5 border border-slate-200/50">
                     <div className="flex items-center gap-3 mb-3">
                       {selectedSub.logo_url ? (
                         <Image
@@ -2402,13 +2402,13 @@ export default function SubscriptionsPage() {
                           className="rounded-md shrink-0"
                         />
                       ) : (
-                        <span className="w-8 h-8 rounded-md bg-mint-400/20 text-mint-400 flex items-center justify-center text-sm font-bold shrink-0">
+                        <span className="w-8 h-8 rounded-md bg-emerald-500/20 text-emerald-600 flex items-center justify-center text-sm font-bold shrink-0">
                           {normaliseProviderName(selectedSub.provider_name).charAt(0).toUpperCase()}
                         </span>
                       )}
                       <div>
-                        <h4 className="text-base font-semibold text-white">{normaliseProviderName(selectedSub.provider_name)}</h4>
-                        <p className="text-sm text-slate-400">
+                        <h4 className="text-base font-semibold text-slate-900">{normaliseProviderName(selectedSub.provider_name)}</h4>
+                        <p className="text-sm text-slate-600">
                           {selectedSub.billing_cycle === 'one-time'
                             ? `${formatGBP(selectedSub.amount)} one-off`
                             : `${formatGBP(selectedSub.amount)}/${selectedSub.billing_cycle === 'yearly' ? 'year' : selectedSub.billing_cycle === 'quarterly' ? 'quarter' : 'month'}`}
@@ -2417,23 +2417,23 @@ export default function SubscriptionsPage() {
                       </div>
                     </div>
                     {(selectedSub.contract_type || selectedSub.contract_end_date || (selectedSub.early_exit_fee != null && selectedSub.early_exit_fee > 0)) && (
-                      <div className="space-y-1.5 text-xs border-t border-navy-700/50 pt-3 mt-1">
+                      <div className="space-y-1.5 text-xs border-t border-slate-200/50 pt-3 mt-1">
                         {selectedSub.contract_type && (
                           <div className="flex justify-between">
                             <span className="text-slate-500">Contract type</span>
-                            <span className="text-slate-300 capitalize">{selectedSub.contract_type.replace(/_/g, ' ')}</span>
+                            <span className="text-slate-600 capitalize">{selectedSub.contract_type.replace(/_/g, ' ')}</span>
                           </div>
                         )}
                         {selectedSub.contract_end_date && (
                           <div className="flex justify-between">
                             <span className="text-slate-500">Contract ends</span>
-                            <span className="text-slate-300">{new Date(selectedSub.contract_end_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</span>
+                            <span className="text-slate-600">{new Date(selectedSub.contract_end_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}</span>
                           </div>
                         )}
                         {selectedSub.early_exit_fee != null && selectedSub.early_exit_fee > 0 && (
                           <div className="flex justify-between">
                             <span className="text-slate-500">Early exit fee</span>
-                            <span className="text-amber-400">{formatGBP(selectedSub.early_exit_fee)}</span>
+                            <span className="text-amber-600">{formatGBP(selectedSub.early_exit_fee)}</span>
                           </div>
                         )}
                       </div>
@@ -2442,29 +2442,29 @@ export default function SubscriptionsPage() {
 
                   {/* Cancellation method info (when available) */}
                   {cancelInfo && (
-                    <div className="bg-navy-950 rounded-xl p-5 border border-navy-700/50">
-                      <h4 className="text-sm font-semibold text-mint-400 mb-3">How to cancel</h4>
-                      <p className="text-sm text-slate-300 mb-3">{cancelInfo.method}</p>
+                    <div className="bg-white rounded-xl p-5 border border-slate-200/50">
+                      <h4 className="text-sm font-semibold text-emerald-600 mb-3">How to cancel</h4>
+                      <p className="text-sm text-slate-600 mb-3">{cancelInfo.method}</p>
                       {cancelInfo.tips && (
-                        <p className="text-xs text-slate-400 mb-3">{cancelInfo.tips}</p>
+                        <p className="text-xs text-slate-600 mb-3">{cancelInfo.tips}</p>
                       )}
                       <div className="space-y-2">
                         {cancelInfo.email && (
                           <div className="flex items-center gap-2 text-sm">
                             <Mail className="h-3.5 w-3.5 text-slate-500" />
-                            <a href={`mailto:${cancelInfo.email}`} className="text-mint-400 hover:text-mint-300 underline">{cancelInfo.email}</a>
+                            <a href={`mailto:${cancelInfo.email}`} className="text-emerald-600 hover:text-emerald-500 underline">{cancelInfo.email}</a>
                           </div>
                         )}
                         {cancelInfo.phone && (
                           <div className="flex items-center gap-2 text-sm">
                             <span className="text-slate-500 text-xs">Tel</span>
-                            <a href={`tel:${cancelInfo.phone.split('/')[0].trim().replace(/\s/g, '')}`} className="text-mint-400 hover:text-mint-300">{cancelInfo.phone}</a>
+                            <a href={`tel:${cancelInfo.phone.split('/')[0].trim().replace(/\s/g, '')}`} className="text-emerald-600 hover:text-emerald-500">{cancelInfo.phone}</a>
                           </div>
                         )}
                         {cancelInfo.url && (
                           <div className="flex items-center gap-2 text-sm">
                             <span className="text-slate-500 text-xs">Web</span>
-                            <a href={cancelInfo.url} target="_blank" rel="noopener noreferrer" className="text-mint-400 hover:text-mint-300 underline truncate">{cancelInfo.url.replace('https://', '')}</a>
+                            <a href={cancelInfo.url} target="_blank" rel="noopener noreferrer" className="text-emerald-600 hover:text-emerald-500 underline truncate">{cancelInfo.url.replace('https://', '')}</a>
                           </div>
                         )}
                       </div>
@@ -2473,24 +2473,24 @@ export default function SubscriptionsPage() {
 
                   {/* Generate button — same eligibility guards as the card-level button */}
                   {selectedSub.needs_review ? (
-                    <div className="flex items-center gap-2 bg-amber-500/10 border border-amber-500/30 text-amber-400 px-4 py-3 rounded-xl text-sm">
+                    <div className="flex items-center gap-2 bg-amber-100 border border-amber-300 text-amber-600 px-4 py-3 rounded-xl text-sm">
                       <AlertTriangle className="h-4 w-4 shrink-0" />
                       Review this subscription before generating a cancellation letter
                     </div>
                   ) : selectedSub.status !== 'active' ? (
-                    <div className="flex items-center gap-2 bg-slate-500/10 border border-slate-500/20 text-slate-400 px-4 py-3 rounded-xl text-sm">
+                    <div className="flex items-center gap-2 bg-slate-100 border border-slate-200 text-slate-600 px-4 py-3 rounded-xl text-sm">
                       <AlertTriangle className="h-4 w-4 shrink-0" />
                       Cancellation emails are only available for active subscriptions
                     </div>
                   ) : isStatutoryService(selectedSub.provider_name) ? (
-                    <div className="flex items-center gap-2 bg-slate-500/10 border border-slate-500/20 text-slate-400 px-4 py-3 rounded-xl text-sm">
+                    <div className="flex items-center gap-2 bg-slate-100 border border-slate-200 text-slate-600 px-4 py-3 rounded-xl text-sm">
                       <AlertTriangle className="h-4 w-4 shrink-0" />
                       This is a statutory charge and cannot be cancelled via letter
                     </div>
                   ) : (
                     <button
                       onClick={() => handleCancelRequest(selectedSub)}
-                      className="w-full flex items-center justify-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-xl transition-all"
+                      className="w-full flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold py-3 rounded-xl transition-all"
                     >
                       <Sparkles className="h-4 w-4" />
                       Generate Cancellation Email
@@ -2500,7 +2500,7 @@ export default function SubscriptionsPage() {
               ) : (
                 <div className="text-center py-12">
                   <Mail className="h-16 w-16 text-slate-600 mx-auto mb-4" />
-                  <p className="text-slate-400">
+                  <p className="text-slate-600">
                     Select a subscription to see cancellation options and generate a cancellation letter
                   </p>
                 </div>
@@ -2513,26 +2513,26 @@ export default function SubscriptionsPage() {
       {/* "I don't recognise this" modal */}
       {unrecognisedSub && (
         <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-6 w-full max-w-lg">
+          <div className="bg-white border border-slate-200/50 rounded-2xl p-6 w-full max-w-lg">
             {fraudStep === 'initial' ? (
               <>
                 <div className="flex items-start justify-between mb-5">
                   <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 bg-amber-500/10 rounded-xl flex items-center justify-center shrink-0">
-                      <AlertTriangle className="h-5 w-5 text-amber-400" />
+                    <div className="w-10 h-10 bg-amber-100 rounded-xl flex items-center justify-center shrink-0">
+                      <AlertTriangle className="h-5 w-5 text-amber-600" />
                     </div>
                     <div>
-                      <h2 className="text-xl font-bold text-white">Don&apos;t recognise this?</h2>
-                      <p className="text-slate-400 text-sm">{normaliseProviderName(unrecognisedSub.provider_name)} &middot; {formatGBP(unrecognisedSub.amount)}/{unrecognisedSub.billing_cycle}</p>
+                      <h2 className="text-xl font-bold text-slate-900">Don&apos;t recognise this?</h2>
+                      <p className="text-slate-600 text-sm">{normaliseProviderName(unrecognisedSub.provider_name)} &middot; {formatGBP(unrecognisedSub.amount)}/{unrecognisedSub.billing_cycle}</p>
                     </div>
                   </div>
-                  <button onClick={() => setUnrecognisedSub(null)} className="text-slate-400 hover:text-white transition-colors p-1">
+                  <button onClick={() => setUnrecognisedSub(null)} className="text-slate-600 hover:text-slate-900 transition-colors p-1">
                     <X className="h-5 w-5" />
                   </button>
                 </div>
 
-                <div className="bg-navy-950 rounded-xl p-4 border border-navy-700/50 mb-5">
-                  <p className="text-sm text-slate-300 mb-3">Banks often show unfamiliar merchant names on statements. Common examples:</p>
+                <div className="bg-white rounded-xl p-4 border border-slate-200/50 mb-5">
+                  <p className="text-sm text-slate-600 mb-3">Banks often show unfamiliar merchant names on statements. Common examples:</p>
                   <div className="space-y-1.5 text-xs font-mono">
                     {[
                       ['CRV*GOOGLE', 'Google subscription (e.g. Google One, YouTube)'],
@@ -2543,15 +2543,15 @@ export default function SubscriptionsPage() {
                       ['DD*SPOTIFY', 'Spotify subscription'],
                     ].map(([code, desc]) => (
                       <div key={code} className="flex gap-3">
-                        <span className="text-mint-400 shrink-0 w-36">{code}</span>
-                        <span className="text-slate-400">{desc}</span>
+                        <span className="text-emerald-600 shrink-0 w-36">{code}</span>
+                        <span className="text-slate-600">{desc}</span>
                       </div>
                     ))}
                   </div>
                   {unrecognisedSub.bank_description && (
-                    <div className="mt-3 pt-3 border-t border-navy-700/50">
+                    <div className="mt-3 pt-3 border-t border-slate-200/50">
                       <p className="text-xs text-slate-500">Bank description for this payment:</p>
-                      <p className="text-sm text-white font-mono mt-0.5">{unrecognisedSub.bank_description}</p>
+                      <p className="text-sm text-slate-900 font-mono mt-0.5">{unrecognisedSub.bank_description}</p>
                     </div>
                   )}
                 </div>
@@ -2559,7 +2559,7 @@ export default function SubscriptionsPage() {
                 <div className="space-y-2">
                   <button
                     onClick={() => setUnrecognisedSub(null)}
-                    className="w-full bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold py-3 rounded-xl transition-all text-sm"
+                    className="w-full bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold py-3 rounded-xl transition-all text-sm"
                   >
                     Actually, I recognise it now
                   </button>
@@ -2575,7 +2575,7 @@ export default function SubscriptionsPage() {
                         `&outcome=${encodeURIComponent('Full refund of the unrecognised charge')}`
                       );
                     }}
-                    className="w-full bg-navy-800 hover:bg-navy-700 text-white font-medium py-3 rounded-xl transition-all text-sm"
+                    className="w-full bg-white hover:bg-slate-50 text-slate-900 font-medium py-3 rounded-xl transition-all text-sm"
                   >
                     I still don&apos;t recognise it &mdash; dispute this charge
                   </button>
@@ -2595,38 +2595,38 @@ export default function SubscriptionsPage() {
                       <Shield className="h-5 w-5 text-red-400" />
                     </div>
                     <div>
-                      <h2 className="text-xl font-bold text-white">Reporting a fraudulent payment</h2>
-                      <p className="text-slate-400 text-sm">{formatGBP(unrecognisedSub.amount)} &middot; {unrecognisedSub.bank_description || unrecognisedSub.provider_name}</p>
+                      <h2 className="text-xl font-bold text-slate-900">Reporting a fraudulent payment</h2>
+                      <p className="text-slate-600 text-sm">{formatGBP(unrecognisedSub.amount)} &middot; {unrecognisedSub.bank_description || unrecognisedSub.provider_name}</p>
                     </div>
                   </div>
-                  <button onClick={() => setUnrecognisedSub(null)} className="text-slate-400 hover:text-white transition-colors p-1">
+                  <button onClick={() => setUnrecognisedSub(null)} className="text-slate-600 hover:text-slate-900 transition-colors p-1">
                     <X className="h-5 w-5" />
                   </button>
                 </div>
 
                 <div className="space-y-3 mb-5">
                   <div className="bg-red-500/5 border border-red-500/20 rounded-xl p-4">
-                    <p className="text-sm font-semibold text-white mb-1">1. Contact your bank immediately</p>
-                    <p className="text-sm text-slate-300">Call the fraud team using the number on the back of your card or in your banking app. Tell them the payment is unauthorised and ask them to block further transactions from this merchant. They must investigate within 15 business days under the Payment Services Regulations 2017.</p>
+                    <p className="text-sm font-semibold text-slate-900 mb-1">1. Contact your bank immediately</p>
+                    <p className="text-sm text-slate-600">Call the fraud team using the number on the back of your card or in your banking app. Tell them the payment is unauthorised and ask them to block further transactions from this merchant. They must investigate within 15 business days under the Payment Services Regulations 2017.</p>
                   </div>
-                  <div className="bg-navy-950 border border-navy-700/50 rounded-xl p-4">
-                    <p className="text-sm font-semibold text-white mb-2">2. Report to Action Fraud</p>
+                  <div className="bg-white border border-slate-200/50 rounded-xl p-4">
+                    <p className="text-sm font-semibold text-slate-900 mb-2">2. Report to Action Fraud</p>
                     <div className="flex flex-col gap-1.5">
-                      <a href="tel:03001232040" className="flex items-center gap-2 text-sm text-mint-400 hover:text-mint-300">
+                      <a href="tel:03001232040" className="flex items-center gap-2 text-sm text-emerald-600 hover:text-emerald-500">
                         <Phone className="h-4 w-4" />
                         0300 123 2040
                       </a>
-                      <a href="https://www.actionfraud.police.uk" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-sm text-mint-400 hover:text-mint-300">
+                      <a href="https://www.actionfraud.police.uk" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-sm text-emerald-600 hover:text-emerald-500">
                         <Shield className="h-4 w-4" />
                         actionfraud.police.uk
                       </a>
                     </div>
                   </div>
-                  <div className="bg-navy-950 border border-navy-700/50 rounded-xl p-4">
-                    <p className="text-sm font-semibold text-white mb-1">3. Your rights</p>
-                    <div className="space-y-2 text-sm text-slate-300">
-                      <p><span className="text-white font-medium">Credit card:</span> Section 75 of the Consumer Credit Act 1974 gives you the right to claim a refund from your card provider for purchases between £100 and £30,000 where the merchant fails to deliver or commits fraud.</p>
-                      <p><span className="text-white font-medium">Debit card:</span> Ask your bank about chargeback rights. Under Visa/Mastercard rules your bank can reverse the transaction within 120 days.</p>
+                  <div className="bg-white border border-slate-200/50 rounded-xl p-4">
+                    <p className="text-sm font-semibold text-slate-900 mb-1">3. Your rights</p>
+                    <div className="space-y-2 text-sm text-slate-600">
+                      <p><span className="text-slate-900 font-medium">Credit card:</span> Section 75 of the Consumer Credit Act 1974 gives you the right to claim a refund from your card provider for purchases between £100 and £30,000 where the merchant fails to deliver or commits fraud.</p>
+                      <p><span className="text-slate-900 font-medium">Debit card:</span> Ask your bank about chargeback rights. Under Visa/Mastercard rules your bank can reverse the transaction within 120 days.</p>
                     </div>
                   </div>
                 </div>
@@ -2634,13 +2634,13 @@ export default function SubscriptionsPage() {
                 <div className="flex gap-3">
                   <button
                     onClick={() => setFraudStep('initial')}
-                    className="flex-1 bg-navy-800 hover:bg-navy-700 text-white font-medium py-3 rounded-xl transition-all text-sm"
+                    className="flex-1 bg-white hover:bg-slate-50 text-slate-900 font-medium py-3 rounded-xl transition-all text-sm"
                   >
                     Back
                   </button>
                   <button
                     onClick={() => setUnrecognisedSub(null)}
-                    className="flex-1 bg-navy-800 hover:bg-navy-700 text-slate-300 font-medium py-3 rounded-xl transition-all text-sm"
+                    className="flex-1 bg-white hover:bg-slate-50 text-slate-600 font-medium py-3 rounded-xl transition-all text-sm"
                   >
                     Close
                   </button>
@@ -2654,29 +2654,29 @@ export default function SubscriptionsPage() {
       {/* Edit subscription modal */}
       {editSub && (
         <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-slate-900 border border-navy-700/50 rounded-2xl p-8 w-full max-w-lg max-h-[90vh] overflow-y-auto custom-scrollbar">
+          <div className="bg-white border border-slate-200/50 rounded-2xl p-8 w-full max-w-lg max-h-[90vh] overflow-y-auto custom-scrollbar">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-bold text-white">Edit Subscription</h2>
-              <button onClick={() => setEditSub(null)} className="text-slate-400 hover:text-white transition-all">
+              <h2 className="text-2xl font-bold text-slate-900">Edit Subscription</h2>
+              <button onClick={() => setEditSub(null)} className="text-slate-600 hover:text-slate-900 transition-all">
                 <X className="h-6 w-6" />
               </button>
             </div>
 
             <form onSubmit={handleSaveEdit} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">Provider Name *</label>
+                <label className="block text-sm font-medium text-slate-600 mb-2">Provider Name *</label>
                 <input
                   type="text"
                   required
                   value={editForm.provider_name}
                   onChange={(e) => setEditForm({ ...editForm, provider_name: e.target.value })}
-                  className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                  className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                 />
               </div>
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">Amount (£) *</label>
+                  <label className="block text-sm font-medium text-slate-600 mb-2">Amount (£) *</label>
                   <input
                     type="number"
                     step="0.01"
@@ -2685,16 +2685,16 @@ export default function SubscriptionsPage() {
                     required
                     value={editForm.amount}
                     onChange={(e) => setEditForm({ ...editForm, amount: e.target.value })}
-                    className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                    className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                     placeholder="9.99"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">Billing Cycle *</label>
+                  <label className="block text-sm font-medium text-slate-600 mb-2">Billing Cycle *</label>
                   <select
                     value={editForm.billing_cycle}
                     onChange={(e) => setEditForm({ ...editForm, billing_cycle: e.target.value })}
-                    className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                    className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                   >
                     {BILLING_CYCLES.map((c) => <option key={c} value={c}>{c}</option>)}
                   </select>
@@ -2703,11 +2703,11 @@ export default function SubscriptionsPage() {
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">Category</label>
+                  <label className="block text-sm font-medium text-slate-600 mb-2">Category</label>
                   <select
                     value={editForm.category}
                     onChange={(e) => setEditForm({ ...editForm, category: e.target.value })}
-                    className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                    className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                   >
                     {!SORTED_CATEGORIES.some((c) => c.value === editForm.category) && editForm.category && (
                       <option key={editForm.category} value={editForm.category}>{editForm.category}</option>
@@ -2716,30 +2716,30 @@ export default function SubscriptionsPage() {
                   </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">Next Billing Date</label>
+                  <label className="block text-sm font-medium text-slate-600 mb-2">Next Billing Date</label>
                   <input
                     type="date"
                     value={editForm.next_billing_date}
                     onChange={(e) => setEditForm({ ...editForm, next_billing_date: e.target.value })}
-                    className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                    className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                   />
                 </div>
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">Support Email</label>
+                <label className="block text-sm font-medium text-slate-600 mb-2">Support Email</label>
                 <input
                   type="email"
                   value={editForm.account_email}
                   onChange={(e) => setEditForm({ ...editForm, account_email: e.target.value })}
-                  className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                  className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                   placeholder="support@provider.com"
                 />
               </div>
 
               {/* Contract Details Section */}
-              <details className="border border-navy-700/50 rounded-lg" open={!!editForm.contract_end_date}>
-                <summary className="px-4 py-3 text-sm font-medium text-slate-300 cursor-pointer hover:text-white flex items-center gap-2">
+              <details className="border border-slate-200/50 rounded-lg" open={!!editForm.contract_end_date}>
+                <summary className="px-4 py-3 text-sm font-medium text-slate-600 cursor-pointer hover:text-slate-900 flex items-center gap-2">
                   <FileText className="h-4 w-4" />
                   Contract Details
                   <span className="text-xs text-slate-500 font-normal">(enables end-of-contract alerts)</span>
@@ -2747,32 +2747,32 @@ export default function SubscriptionsPage() {
                 <div className="px-4 pb-4 space-y-4">
                   {/* Contract End Date — THE KEY FIELD */}
                   <div>
-                    <label className="block text-sm font-medium text-slate-300 mb-2">Contract End Date</label>
+                    <label className="block text-sm font-medium text-slate-600 mb-2">Contract End Date</label>
                     <input
                       type="date"
                       value={editForm.contract_end_date}
                       onChange={(e) => setEditForm({ ...editForm, contract_end_date: e.target.value })}
-                      className="w-full px-4 py-3 bg-navy-950 border border-mint-400/30 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                      className="w-full px-4 py-3 bg-white border border-emerald-500/30 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                     />
                     <p className="text-xs text-slate-500 mt-1">We&apos;ll alert you before this date so you can switch to a better deal</p>
                   </div>
 
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Contract Start Date</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Contract Start Date</label>
                       <input
                         type="date"
                         value={editForm.contract_start_date}
                         onChange={(e) => setEditForm({ ...editForm, contract_start_date: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Contract Length</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Contract Length</label>
                       <select
                         value={editForm.contract_term_months}
                         onChange={(e) => setEditForm({ ...editForm, contract_term_months: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       >
                         <option value="">Not sure</option>
                         <option value="1">1 month (rolling)</option>
@@ -2786,22 +2786,22 @@ export default function SubscriptionsPage() {
 
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Contract Type</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Contract Type</label>
                       <select
                         value={editForm.contract_type}
                         onChange={(e) => setEditForm({ ...editForm, contract_type: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       >
                         <option value="">Select...</option>
                         {CONTRACT_TYPES.map(t => <option key={t} value={t}>{t.replace('_', ' ')}</option>)}
                       </select>
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Provider Type</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Provider Type</label>
                       <select
                         value={editForm.provider_type}
                         onChange={(e) => setEditForm({ ...editForm, provider_type: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       >
                         <option value="">Select...</option>
                         {PROVIDER_TYPES.map(t => <option key={t} value={t}>{t.replace('_', ' ')}</option>)}
@@ -2811,19 +2811,19 @@ export default function SubscriptionsPage() {
 
                   {/* Current Tariff */}
                   <div>
-                    <label className="block text-sm font-medium text-slate-300 mb-2">Current Plan/Tariff Name</label>
+                    <label className="block text-sm font-medium text-slate-600 mb-2">Current Plan/Tariff Name</label>
                     <input
                       type="text"
                       value={editForm.current_tariff}
                       onChange={(e) => setEditForm({ ...editForm, current_tariff: e.target.value })}
-                      className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                      className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                       placeholder="e.g. Sky Superfast 80Mbps"
                     />
                   </div>
 
                   {/* Early Exit Fee */}
                   <div>
-                    <label className="block text-sm font-medium text-slate-300 mb-2">Early Exit Fee</label>
+                    <label className="block text-sm font-medium text-slate-600 mb-2">Early Exit Fee</label>
                     <div className="relative">
                       <span className="absolute left-3 top-3.5 text-slate-500">£</span>
                       <input
@@ -2832,7 +2832,7 @@ export default function SubscriptionsPage() {
                         min="0"
                         value={editForm.early_exit_fee}
                         onChange={(e) => setEditForm({ ...editForm, early_exit_fee: e.target.value })}
-                        className="w-full pl-7 px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                        className="w-full pl-7 px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                         placeholder="0.00"
                       />
                     </div>
@@ -2841,7 +2841,7 @@ export default function SubscriptionsPage() {
                   {/* Auto-renews */}
                   <div className="flex items-center justify-between py-2">
                     <div>
-                      <label className="text-sm font-medium text-slate-300">Auto-renews?</label>
+                      <label className="text-sm font-medium text-slate-600">Auto-renews?</label>
                       <p className="text-xs text-slate-500">Most UK contracts auto-renew at a higher rate</p>
                     </div>
                     <input
@@ -2849,15 +2849,15 @@ export default function SubscriptionsPage() {
                       id="auto_renews_edit"
                       checked={editForm.auto_renews}
                       onChange={(e) => setEditForm({ ...editForm, auto_renews: e.target.checked })}
-                      className="w-5 h-5 rounded border-navy-700/50 bg-navy-950 text-mint-400 focus:ring-mint-400"
+                      className="w-5 h-5 rounded border-slate-200/50 bg-white text-emerald-600 focus:ring-emerald-500"
                     />
                   </div>
 
                   {/* Alert preferences */}
-                  <div className="border-t border-navy-700/50 pt-3 space-y-3">
+                  <div className="border-t border-slate-200/50 pt-3 space-y-3">
                     <div className="flex items-center justify-between">
                       <div>
-                        <label className="text-sm font-medium text-slate-300">Contract end alerts</label>
+                        <label className="text-sm font-medium text-slate-600">Contract end alerts</label>
                         <p className="text-xs text-slate-500">Email me before this contract ends</p>
                       </div>
                       <input
@@ -2865,15 +2865,15 @@ export default function SubscriptionsPage() {
                         id="alerts_enabled_edit"
                         checked={editForm.alerts_enabled}
                         onChange={(e) => setEditForm({ ...editForm, alerts_enabled: e.target.checked })}
-                        className="w-5 h-5 rounded border-navy-700/50 bg-navy-950 text-mint-400 focus:ring-mint-400"
+                        className="w-5 h-5 rounded border-slate-200/50 bg-white text-emerald-600 focus:ring-emerald-500"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Alert me this many days before</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Alert me this many days before</label>
                       <select
                         value={editForm.alert_before_days}
                         onChange={(e) => setEditForm({ ...editForm, alert_before_days: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       >
                         <option value="14">14 days</option>
                         <option value="30">30 days (recommended)</option>
@@ -2896,7 +2896,7 @@ export default function SubscriptionsPage() {
               <button
                 type="submit"
                 disabled={savingEdit}
-                className="w-full bg-mint-400 hover:bg-mint-500 disabled:opacity-50 text-navy-950 font-semibold py-4 rounded-lg transition-all flex items-center justify-center gap-2"
+                className="w-full bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold py-4 rounded-lg transition-all flex items-center justify-center gap-2"
               >
                 {savingEdit ? <Loader2 className="h-5 w-5 animate-spin" /> : 'Save Changes'}
               </button>
@@ -2908,12 +2908,12 @@ export default function SubscriptionsPage() {
       {/* Add subscription modal */}
       {showAddForm && (
         <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-slate-900 border border-navy-700/50 rounded-2xl p-8 w-full max-w-md max-h-[90vh] overflow-y-auto custom-scrollbar">
+          <div className="bg-white border border-slate-200/50 rounded-2xl p-8 w-full max-w-md max-h-[90vh] overflow-y-auto custom-scrollbar">
             <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-bold text-white">Add Subscription</h2>
+              <h2 className="text-2xl font-bold text-slate-900">Add Subscription</h2>
               <button
                 onClick={() => setShowAddForm(false)}
-                className="text-slate-400 hover:text-white transition-all"
+                className="text-slate-600 hover:text-slate-900 transition-all"
               >
                 <X className="h-6 w-6" />
               </button>
@@ -2921,7 +2921,7 @@ export default function SubscriptionsPage() {
 
             <form onSubmit={handleAddSubscription} className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
+                <label className="block text-sm font-medium text-slate-600 mb-2">
                   Provider Name *
                 </label>
                 <input
@@ -2930,14 +2930,14 @@ export default function SubscriptionsPage() {
                   maxLength={100}
                   value={newSub.provider_name}
                   onChange={(e) => setNewSub({ ...newSub, provider_name: e.target.value })}
-                  className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                  className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                   placeholder="e.g. Netflix, Adobe, Spotify"
                 />
               </div>
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                  <label className="block text-sm font-medium text-slate-600 mb-2">
                     Amount (£) *
                   </label>
                   <input
@@ -2948,19 +2948,19 @@ export default function SubscriptionsPage() {
                     required
                     value={newSub.amount}
                     onChange={(e) => setNewSub({ ...newSub, amount: e.target.value })}
-                    className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                    className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                     placeholder="9.99"
                   />
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                  <label className="block text-sm font-medium text-slate-600 mb-2">
                     Billing Cycle *
                   </label>
                   <select
                     value={newSub.billing_cycle}
                     onChange={(e) => setNewSub({ ...newSub, billing_cycle: e.target.value })}
-                    className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                    className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                   >
                     {BILLING_CYCLES.map((c) => (
                       <option key={c} value={c}>{c}</option>
@@ -2971,13 +2971,13 @@ export default function SubscriptionsPage() {
 
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                  <label className="block text-sm font-medium text-slate-600 mb-2">
                     Category
                   </label>
                   <select
                     value={newSub.category}
                     onChange={(e) => setNewSub({ ...newSub, category: e.target.value })}
-                    className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                    className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                   >
                     {!SORTED_CATEGORIES.some((c) => c.value === newSub.category) && newSub.category && (
                       <option key={newSub.category} value={newSub.category}>{newSub.category}</option>
@@ -2989,13 +2989,13 @@ export default function SubscriptionsPage() {
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-slate-300 mb-2">
+                  <label className="block text-sm font-medium text-slate-600 mb-2">
                     How often used?
                   </label>
                   <select
                     value={newSub.usage_frequency}
                     onChange={(e) => setNewSub({ ...newSub, usage_frequency: e.target.value })}
-                    className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                    className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                   >
                     <option value="never">Never</option>
                     <option value="rarely">Rarely</option>
@@ -3007,33 +3007,33 @@ export default function SubscriptionsPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
+                <label className="block text-sm font-medium text-slate-600 mb-2">
                   Next Billing Date
                 </label>
                 <input
                   type="date"
                   value={newSub.next_billing_date}
                   onChange={(e) => setNewSub({ ...newSub, next_billing_date: e.target.value })}
-                  className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                  className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-slate-300 mb-2">
+                <label className="block text-sm font-medium text-slate-600 mb-2">
                   Support Email (for mailto link)
                 </label>
                 <input
                   type="email"
                   value={newSub.account_email}
                   onChange={(e) => setNewSub({ ...newSub, account_email: e.target.value })}
-                  className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                  className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                   placeholder="support@provider.com"
                 />
               </div>
 
               {/* Contract Details Section */}
-              <details className="border border-navy-700/50 rounded-lg">
-                <summary className="px-4 py-3 text-sm font-medium text-slate-300 cursor-pointer hover:text-white flex items-center gap-2">
+              <details className="border border-slate-200/50 rounded-lg">
+                <summary className="px-4 py-3 text-sm font-medium text-slate-600 cursor-pointer hover:text-slate-900 flex items-center gap-2">
                   <FileText className="h-4 w-4" />
                   Contract Details
                   <span className="text-xs text-slate-500 font-normal">(enables end-of-contract alerts)</span>
@@ -3041,32 +3041,32 @@ export default function SubscriptionsPage() {
                 <div className="px-4 pb-4 space-y-4">
                   {/* Contract End Date — THE KEY FIELD */}
                   <div>
-                    <label className="block text-sm font-medium text-slate-300 mb-2">Contract End Date</label>
+                    <label className="block text-sm font-medium text-slate-600 mb-2">Contract End Date</label>
                     <input
                       type="date"
                       value={newSub.contract_end_date}
                       onChange={(e) => setNewSub({ ...newSub, contract_end_date: e.target.value })}
-                      className="w-full px-4 py-3 bg-navy-950 border border-mint-400/30 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                      className="w-full px-4 py-3 bg-white border border-emerald-500/30 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                     />
                     <p className="text-xs text-slate-500 mt-1">We&apos;ll alert you before this date so you can switch to a better deal</p>
                   </div>
 
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Contract Start Date</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Contract Start Date</label>
                       <input
                         type="date"
                         value={newSub.contract_start_date}
                         onChange={(e) => setNewSub({ ...newSub, contract_start_date: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Contract Length</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Contract Length</label>
                       <select
                         value={newSub.contract_term_months}
                         onChange={(e) => setNewSub({ ...newSub, contract_term_months: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       >
                         <option value="">Not sure</option>
                         <option value="1">1 month (rolling)</option>
@@ -3080,22 +3080,22 @@ export default function SubscriptionsPage() {
 
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Contract Type</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Contract Type</label>
                       <select
                         value={newSub.contract_type}
                         onChange={(e) => setNewSub({ ...newSub, contract_type: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       >
                         <option value="">Select...</option>
                         {CONTRACT_TYPES.map(t => <option key={t} value={t}>{t.replace('_', ' ')}</option>)}
                       </select>
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Provider Type</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Provider Type</label>
                       <select
                         value={newSub.provider_type}
                         onChange={(e) => setNewSub({ ...newSub, provider_type: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       >
                         <option value="">Select...</option>
                         {PROVIDER_TYPES.map(t => <option key={t} value={t}>{t.replace('_', ' ')}</option>)}
@@ -3104,18 +3104,18 @@ export default function SubscriptionsPage() {
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-slate-300 mb-2">Current Plan/Tariff Name</label>
+                    <label className="block text-sm font-medium text-slate-600 mb-2">Current Plan/Tariff Name</label>
                     <input
                       type="text"
                       value={newSub.current_tariff}
                       onChange={(e) => setNewSub({ ...newSub, current_tariff: e.target.value })}
-                      className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                      className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                       placeholder="e.g. Sky Superfast 80Mbps"
                     />
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-slate-300 mb-2">Early Exit Fee</label>
+                    <label className="block text-sm font-medium text-slate-600 mb-2">Early Exit Fee</label>
                     <div className="relative">
                       <span className="absolute left-3 top-3.5 text-slate-500">£</span>
                       <input
@@ -3124,7 +3124,7 @@ export default function SubscriptionsPage() {
                         min="0"
                         value={newSub.early_exit_fee}
                         onChange={(e) => setNewSub({ ...newSub, early_exit_fee: e.target.value })}
-                        className="w-full pl-7 px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                        className="w-full pl-7 px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500"
                         placeholder="0.00"
                       />
                     </div>
@@ -3132,7 +3132,7 @@ export default function SubscriptionsPage() {
 
                   <div className="flex items-center justify-between py-2">
                     <div>
-                      <label className="text-sm font-medium text-slate-300">Auto-renews?</label>
+                      <label className="text-sm font-medium text-slate-600">Auto-renews?</label>
                       <p className="text-xs text-slate-500">Most UK contracts auto-renew at a higher rate</p>
                     </div>
                     <input
@@ -3140,15 +3140,15 @@ export default function SubscriptionsPage() {
                       id="auto_renews_new"
                       checked={newSub.auto_renews}
                       onChange={(e) => setNewSub({ ...newSub, auto_renews: e.target.checked })}
-                      className="w-5 h-5 rounded border-navy-700/50 bg-navy-950 text-mint-400 focus:ring-mint-400"
+                      className="w-5 h-5 rounded border-slate-200/50 bg-white text-emerald-600 focus:ring-emerald-500"
                     />
                   </div>
 
                   {/* Alert preferences */}
-                  <div className="border-t border-navy-700/50 pt-3 space-y-3">
+                  <div className="border-t border-slate-200/50 pt-3 space-y-3">
                     <div className="flex items-center justify-between">
                       <div>
-                        <label className="text-sm font-medium text-slate-300">Contract end alerts</label>
+                        <label className="text-sm font-medium text-slate-600">Contract end alerts</label>
                         <p className="text-xs text-slate-500">Email me before this contract ends</p>
                       </div>
                       <input
@@ -3156,15 +3156,15 @@ export default function SubscriptionsPage() {
                         id="alerts_enabled_new"
                         checked={newSub.alerts_enabled}
                         onChange={(e) => setNewSub({ ...newSub, alerts_enabled: e.target.checked })}
-                        className="w-5 h-5 rounded border-navy-700/50 bg-navy-950 text-mint-400 focus:ring-mint-400"
+                        className="w-5 h-5 rounded border-slate-200/50 bg-white text-emerald-600 focus:ring-emerald-500"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-slate-300 mb-2">Alert me this many days before</label>
+                      <label className="block text-sm font-medium text-slate-600 mb-2">Alert me this many days before</label>
                       <select
                         value={newSub.alert_before_days}
                         onChange={(e) => setNewSub({ ...newSub, alert_before_days: e.target.value })}
-                        className="w-full px-4 py-3 bg-navy-950 border border-navy-700/50 rounded-lg text-white focus:outline-none focus:border-mint-400"
+                        className="w-full px-4 py-3 bg-white border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-emerald-500"
                       >
                         <option value="14">14 days</option>
                         <option value="30">30 days (recommended)</option>
@@ -3178,7 +3178,7 @@ export default function SubscriptionsPage() {
               <button
                 type="submit"
                 disabled={addingSubscription}
-                className="w-full bg-mint-400 hover:bg-mint-500 disabled:opacity-50 text-navy-950 font-semibold py-4 rounded-lg transition-all flex items-center justify-center gap-2"
+                className="w-full bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold py-4 rounded-lg transition-all flex items-center justify-center gap-2"
               >
                 {addingSubscription ? (
                   <Loader2 className="h-5 w-5 animate-spin" />


### PR DESCRIPTION
## Summary
Batch 9 — the three largest remaining dark dashboard pages, re-skinned to match the Paybacker light-theme design system.

| File | Lines | Dark refs translated |
|---|---|---|
| `dashboard/complaints/page.tsx` | 2,413 | 66 |
| `dashboard/subscriptions/page.tsx` | 3,199 | 89 |
| `dashboard/admin/legal-updates/page.tsx` | 551 | 11 |

## Changes
Mechanical Tailwind token translation. **All functionality preserved**: state, handlers, API calls, validation, tier gating, conditional rendering, accessibility attributes, and dynamic className logic are untouched.

Token map:
- `bg-navy-950/900/800` → `bg-white`
- `bg-navy-700/600` + `hover:bg-navy-*` → `bg-slate-50` / `hover:bg-slate-100`
- `border-navy-*` → `border-slate-200`
- `text-white` / `text-navy-950` → `text-slate-900`
- `text-slate-300/400` → `text-slate-600` (re-balanced for light bg)
- `*-mint-400` → `*-emerald-500/600`
- `bg-amber-500` primary → `bg-orange-500` primary; amber tints re-balanced for light surfaces

## Verification
`npx tsc --noEmit` clean — the 4 pre-existing errors (validator.ts, trial-expiry, CareersInterestForm, money-hub selectedMonth prop) are unchanged.

Co-Authored-By: Claude <noreply@anthropic.com>