### PR TITLE
feat(dashboard): sweep residual dark tokens across 11 dashboard pages (batch 10)

### DIFF
--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -32,14 +32,14 @@ interface LegalRef {
 
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof CheckCircle; className: string }> = {
   current: { label: 'Current', icon: CheckCircle, className: 'text-green-400 bg-green-500/10' },
-  updated: { label: 'Auto-updated', icon: RefreshCw, className: 'text-emerald-600 bg-mint-400/10' },
-  needs_review: { label: 'Needs review', icon: AlertTriangle, className: 'text-amber-400 bg-amber-500/10' },
+  updated: { label: 'Auto-updated', icon: RefreshCw, className: 'text-emerald-600 bg-emerald-500/10' },
+  needs_review: { label: 'Needs review', icon: AlertTriangle, className: 'text-amber-600 bg-amber-100' },
   outdated: { label: 'Outdated', icon: AlertTriangle, className: 'text-red-400 bg-red-500/10' },
 };
 
 const STRENGTH_CONFIG: Record<string, string> = {
   strong: 'text-green-400',
-  moderate: 'text-amber-400',
+  moderate: 'text-amber-600',
   weak: 'text-red-400',
 };
 
@@ -189,7 +189,7 @@ export default function LegalRefsAdminPage() {
           <button
             onClick={runVerification}
             disabled={verifying}
-            className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-white font-semibold px-5 py-2.5 rounded-lg transition-all text-sm shrink-0"
+            className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm shrink-0"
           >
             {verifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
             {verifying ? 'Verifying...' : 'Run Verification'}
@@ -210,8 +210,8 @@ export default function LegalRefsAdminPage() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         {[
           { label: 'Current', count: counts.current, className: 'border-green-500/20 bg-green-500/5', textClass: 'text-green-400' },
-          { label: 'Auto-updated', count: counts.updated, className: 'border-mint-400/20 bg-mint-400/5', textClass: 'text-emerald-600' },
-          { label: 'Needs review', count: counts.needs_review, className: 'border-amber-500/20 bg-amber-500/5', textClass: 'text-amber-400' },
+          { label: 'Auto-updated', count: counts.updated, className: 'border-emerald-500/20 bg-emerald-500/5', textClass: 'text-emerald-600' },
+          { label: 'Needs review', count: counts.needs_review, className: 'border-amber-200 bg-amber-50', textClass: 'text-amber-600' },
           { label: 'Outdated', count: counts.outdated, className: 'border-red-500/20 bg-red-500/5', textClass: 'text-red-400' },
         ].map(card => (
           <button
@@ -234,13 +234,13 @@ export default function LegalRefsAdminPage() {
             value={search}
             onChange={e => setSearch(e.target.value)}
             placeholder="Search references..."
-            className="w-full pl-9 pr-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-900 placeholder-slate-500 text-sm focus:outline-none focus:border-mint-400"
+            className="w-full pl-9 pr-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-900 placeholder-slate-500 text-sm focus:outline-none focus:border-emerald-500"
           />
         </div>
         <select
           value={filterStatus}
           onChange={e => setFilterStatus(e.target.value)}
-          className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm focus:outline-none focus:border-mint-400"
+          className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm focus:outline-none focus:border-emerald-500"
         >
           <option value="all">All statuses</option>
           <option value="current">Current</option>
@@ -251,7 +251,7 @@ export default function LegalRefsAdminPage() {
         <select
           value={filterCategory}
           onChange={e => setFilterCategory(e.target.value)}
-          className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm focus:outline-none focus:border-mint-400"
+          className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm focus:outline-none focus:border-emerald-500"
         >
           <option value="all">All categories</option>
           {categories.map(cat => (
@@ -300,7 +300,7 @@ export default function LegalRefsAdminPage() {
                       )}
                       <p className="text-slate-600 text-xs mt-1 line-clamp-2 max-w-sm">{ref.summary}</p>
                       {ref.verification_notes && (
-                        <p className="text-amber-400/70 text-[11px] mt-1 line-clamp-1">{ref.verification_notes}</p>
+                        <p className="text-amber-600/70 text-[11px] mt-1 line-clamp-1">{ref.verification_notes}</p>
                       )}
                     </td>
                     <td className="px-5 py-4">
@@ -336,7 +336,7 @@ export default function LegalRefsAdminPage() {
                         href={ref.source_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 text-xs text-emerald-600 hover:text-mint-300 transition-colors whitespace-nowrap"
+                        className="inline-flex items-center gap-1.5 text-xs text-emerald-600 hover:text-emerald-500 transition-colors whitespace-nowrap"
                       >
                         <ExternalLink className="h-3.5 w-3.5" />
                         View source

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -217,7 +217,7 @@ export default function AdminPage() {
   const tierColor = (tier: string) => {
     if (tier === 'pro') return 'text-purple-400 bg-purple-500/10';
     if (tier === 'essential') return 'text-emerald-600 bg-emerald-500/10';
-    return 'text-slate-600 bg-navy-500/10';
+    return 'text-slate-600 bg-slate-100';
   };
 
   return (
@@ -232,7 +232,7 @@ export default function AdminPage() {
         </div>
         <button
           onClick={() => setMeetingOpen(true)}
-          className="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-5 py-2.5 rounded-lg flex items-center gap-2 transition-all text-sm shrink-0"
+          className="bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-5 py-2.5 rounded-lg flex items-center gap-2 transition-all text-sm shrink-0"
         >
           <Users className="h-4 w-4" />
           Call a Meeting
@@ -244,23 +244,23 @@ export default function AdminPage() {
       {/* Tabs */}
       <div className="flex gap-2 mb-6">
         <button onClick={() => { setTab('overview'); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${tab === 'overview' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${tab === 'overview' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
           Overview
         </button>
         <button onClick={() => { setTab('members'); loadMembers(); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${tab === 'members' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${tab === 'members' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
           Members
         </button>
         <button onClick={() => { setTab('tickets'); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'tickets' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'tickets' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
           <Ticket className="h-4 w-4" /> Tickets
         </button>
         <button onClick={() => { setTab('leads'); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'leads' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'leads' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
           <Users className="h-4 w-4" /> Leads
         </button>
         <button onClick={() => { setTab('ai_team'); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'ai_team' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'ai_team' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
           <Brain className="h-4 w-4" /> AI Team
         </button>
         <Link
@@ -350,7 +350,7 @@ export default function AdminPage() {
                     setVerifyingDeals(false);
                   }}
                   disabled={verifyingDeals}
-                  className="flex items-center gap-1.5 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-3 py-1.5 rounded-lg transition-all text-xs disabled:opacity-50"
+                  className="flex items-center gap-1.5 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-3 py-1.5 rounded-lg transition-all text-xs disabled:opacity-50"
                 >
                   <RefreshCw className={`h-3.5 w-3.5 ${verifyingDeals ? 'animate-spin' : ''}`} />
                   {verifyingDeals ? 'Verifying...' : 'Verify Deals Now'}
@@ -365,8 +365,8 @@ export default function AdminPage() {
                   <p className="text-2xl font-bold text-red-400">{dealHealth.inactive}</p>
                   <p className="text-slate-500 text-xs">Broken / Inactive</p>
                 </div>
-                <div className="bg-slate-50/50 border border-amber-500/20 rounded-xl p-4">
-                  <p className="text-2xl font-bold text-amber-400">{dealHealth.stale}</p>
+                <div className="bg-slate-50/50 border border-amber-200 rounded-xl p-4">
+                  <p className="text-2xl font-bold text-amber-600">{dealHealth.stale}</p>
                   <p className="text-slate-500 text-xs">Stale (30+ days)</p>
                 </div>
                 <div className="bg-slate-50/50 border border-slate-200/50 rounded-xl p-4">
@@ -413,7 +413,7 @@ export default function AdminPage() {
               <button
                 key={m.id}
                 onClick={() => loadMemberDetail(m.id)}
-                className="w-full flex items-center justify-between bg-slate-50/50 rounded-lg px-4 py-3 border border-slate-200/50 hover:border-mint-400/50 transition-all text-left"
+                className="w-full flex items-center justify-between bg-slate-50/50 rounded-lg px-4 py-3 border border-slate-200/50 hover:border-emerald-500/50 transition-all text-left"
               >
                 <div>
                   <p className="text-slate-900 text-sm font-medium">{m.full_name || m.email}</p>

--- a/src/app/dashboard/contract-vault/page.tsx
+++ b/src/app/dashboard/contract-vault/page.tsx
@@ -244,8 +244,8 @@ export default function ContractVaultPage() {
         <div
           className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors ${
             dragActive
-              ? 'border-amber-400 bg-orange-500/5'
-              : 'border-navy-600 hover:border-navy-500'
+              ? 'border-amber-300 bg-orange-500/5'
+              : 'border-slate-200 hover:border-slate-300'
           }`}
           onDragEnter={handleDrag}
           onDragLeave={handleDrag}
@@ -258,7 +258,7 @@ export default function ContractVaultPage() {
           <button
             onClick={() => fileInputRef.current?.click()}
             disabled={uploading}
-            className="inline-flex items-center gap-1.5 bg-orange-500 hover:bg-amber-600 disabled:bg-slate-600 text-navy-950 font-semibold text-sm px-4 py-2 rounded-lg transition-colors"
+            className="inline-flex items-center gap-1.5 bg-orange-500 hover:bg-orange-700 disabled:bg-slate-600 text-slate-900 font-semibold text-sm px-4 py-2 rounded-lg transition-colors"
           >
             {uploading ? (
               <>
@@ -289,7 +289,7 @@ export default function ContractVaultPage() {
             value={providerName}
             onChange={(e) => setProviderName(e.target.value)}
             placeholder="e.g. British Gas, Virgin Media"
-            className="w-full bg-slate-100 border border-slate-200 rounded-lg px-3 py-2 text-slate-900 text-sm placeholder-slate-500 focus:outline-none focus:border-amber-400"
+            className="w-full bg-slate-100 border border-slate-200 rounded-lg px-3 py-2 text-slate-900 text-sm placeholder-slate-500 focus:outline-none focus:border-amber-300"
           />
         </div>
 
@@ -332,7 +332,7 @@ export default function ContractVaultPage() {
               </p>
               <Link
                 href="/dashboard/subscriptions"
-                className="inline-flex items-center gap-1.5 bg-orange-500 hover:bg-amber-600 text-navy-950 font-semibold text-sm px-4 py-2 rounded-lg transition-colors"
+                className="inline-flex items-center gap-1.5 bg-orange-500 hover:bg-orange-700 text-slate-900 font-semibold text-sm px-4 py-2 rounded-lg transition-colors"
               >
                 <Plus className="h-4 w-4" /> Go to Subscriptions
               </Link>
@@ -430,7 +430,7 @@ function ContractCard({ contract, onDelete }: ContractCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="bg-white border border-slate-200/50 rounded-xl overflow-hidden hover:border-amber-400/40 transition-colors">
+    <div className="bg-white border border-slate-200/50 rounded-xl overflow-hidden hover:border-amber-300/40 transition-colors">
       {/* Collapsed Header */}
       <button
         onClick={() => setExpanded(!expanded)}
@@ -517,31 +517,31 @@ function ContractCard({ contract, onDelete }: ContractCardProps) {
               {contract.cancellation_fee && (
                 <div className="bg-slate-100/50 border border-slate-200 rounded-lg p-3">
                   <p className="text-xs font-semibold text-slate-700 mb-1">Cancellation Fee</p>
-                  <p className="text-sm text-slate-200">{contract.cancellation_fee}</p>
+                  <p className="text-sm text-slate-700">{contract.cancellation_fee}</p>
                 </div>
               )}
               {contract.early_exit_fee && (
                 <div className="bg-slate-100/50 border border-slate-200 rounded-lg p-3">
                   <p className="text-xs font-semibold text-slate-700 mb-1">Early Exit Fee</p>
-                  <p className="text-sm text-slate-200">{contract.early_exit_fee}</p>
+                  <p className="text-sm text-slate-700">{contract.early_exit_fee}</p>
                 </div>
               )}
               {contract.auto_renewal && (
                 <div className="bg-slate-100/50 border border-slate-200 rounded-lg p-3">
                   <p className="text-xs font-semibold text-slate-700 mb-1">Auto-Renewal</p>
-                  <p className="text-sm text-slate-200">{contract.auto_renewal}</p>
+                  <p className="text-sm text-slate-700">{contract.auto_renewal}</p>
                 </div>
               )}
               {contract.price_increase_clause && (
                 <div className="bg-slate-100/50 border border-slate-200 rounded-lg p-3">
                   <p className="text-xs font-semibold text-slate-700 mb-1">Price Increases</p>
-                  <p className="text-sm text-slate-200">{contract.price_increase_clause}</p>
+                  <p className="text-sm text-slate-700">{contract.price_increase_clause}</p>
                 </div>
               )}
               {contract.cooling_off_period && (
                 <div className="bg-slate-100/50 border border-slate-200 rounded-lg p-3">
                   <p className="text-xs font-semibold text-slate-700 mb-1">Cooling Off Period</p>
-                  <p className="text-sm text-slate-200">{contract.cooling_off_period}</p>
+                  <p className="text-sm text-slate-700">{contract.cooling_off_period}</p>
                 </div>
               )}
             </div>
@@ -599,7 +599,7 @@ function SubscriptionRow({ contract: c }: { contract: Subscription }) {
   return (
     <Link
       href={`/dashboard/subscriptions?highlight=${c.id}`}
-      className={`block bg-white border rounded-xl p-4 hover:border-amber-400/40 transition-colors ${
+      className={`block bg-white border rounded-xl p-4 hover:border-amber-300/40 transition-colors ${
         isExpiringSoon ? 'border-orange-200' : 'border-slate-200/50'
       }`}
     >

--- a/src/app/dashboard/contracts/page.tsx
+++ b/src/app/dashboard/contracts/page.tsx
@@ -139,7 +139,7 @@ function SupplierDropdown({
       <button
         type="button"
         onClick={() => { setOpen(!open); setTimeout(() => inputRef.current?.focus(), 50); }}
-        className="w-full flex items-center justify-between px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-left focus:outline-none focus:border-amber-400 transition-all"
+        className="w-full flex items-center justify-between px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-left focus:outline-none focus:border-amber-300 transition-all"
       >
         <span className={value ? 'text-slate-900' : 'text-slate-500'}>
           {value ? selectedLabel : 'Select a supplier...'}
@@ -159,7 +159,7 @@ function SupplierDropdown({
                 placeholder="Search suppliers..."
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="w-full pl-8 pr-3 py-2 bg-slate-50 border border-slate-200/50 rounded text-sm text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-400"
+                className="w-full pl-8 pr-3 py-2 bg-slate-50 border border-slate-200/50 rounded text-sm text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-300"
               />
             </div>
           </div>
@@ -203,7 +203,7 @@ function SupplierDropdown({
           placeholder="Enter supplier name..."
           value={customName}
           onChange={(e) => onCustomNameChange(e.target.value)}
-          className="mt-2 w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-400"
+          className="mt-2 w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-300"
         />
       )}
     </div>
@@ -339,7 +339,7 @@ function ContractDetail({ contract, onBack, onDelete }: {
         )}
         <Link
           href={`/dashboard/complaints?new=1&company=${encodeURIComponent(contract.provider_name || '')}`}
-          className="flex items-center gap-2 px-4 py-2.5 bg-amber-400 hover:bg-orange-500 text-navy-950 font-semibold rounded-lg text-sm transition-all"
+          className="flex items-center gap-2 px-4 py-2.5 bg-amber-500 hover:bg-orange-500 text-slate-900 font-semibold rounded-lg text-sm transition-all"
         >
           <FileText className="h-4 w-4" /> Write a complaint letter
         </Link>
@@ -534,13 +534,13 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
         <div className="flex border-b border-slate-200/50">
           <button
             onClick={() => setTab('upload')}
-            className={`flex-1 py-3 text-sm font-medium transition-all flex items-center justify-center gap-2 ${tab === 'upload' ? 'text-orange-600 border-b-2 border-amber-400' : 'text-slate-600 hover:text-slate-900'}`}
+            className={`flex-1 py-3 text-sm font-medium transition-all flex items-center justify-center gap-2 ${tab === 'upload' ? 'text-orange-600 border-b-2 border-amber-300' : 'text-slate-600 hover:text-slate-900'}`}
           >
             <Upload className="h-4 w-4" /> Upload file
           </button>
           <button
             onClick={() => setTab('manual')}
-            className={`flex-1 py-3 text-sm font-medium transition-all flex items-center justify-center gap-2 ${tab === 'manual' ? 'text-orange-600 border-b-2 border-amber-400' : 'text-slate-600 hover:text-slate-900'}`}
+            className={`flex-1 py-3 text-sm font-medium transition-all flex items-center justify-center gap-2 ${tab === 'manual' ? 'text-orange-600 border-b-2 border-amber-300' : 'text-slate-600 hover:text-slate-900'}`}
           >
             <PenLine className="h-4 w-4" /> Enter manually
           </button>
@@ -576,7 +576,7 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
                   <label
                     className={`flex flex-col items-center gap-2 w-full px-4 py-6 bg-slate-50 border-2 border-dashed rounded-lg cursor-pointer transition-all text-sm text-center ${
                       dragActive
-                        ? 'border-amber-400 bg-amber-400/5'
+                        ? 'border-amber-300 bg-amber-500/5'
                         : 'border-purple-500/30 hover:border-purple-400/50'
                     }`}
                     onDragEnter={handleDrag}
@@ -610,7 +610,7 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
               <button
                 onClick={handleUpload}
                 disabled={!file || !supplierId || (supplierId === 'other' && !customSupplierName.trim()) || uploading}
-                className="w-full bg-amber-400 hover:bg-orange-500 text-navy-950 font-semibold py-3 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
+                className="w-full bg-amber-500 hover:bg-orange-500 text-slate-900 font-semibold py-3 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
               >
                 {uploading ? (
                   <><Loader2 className="h-4 w-4 animate-spin" /> Reading your contract...</>
@@ -629,7 +629,7 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
                 <select
                   value={manualCategory}
                   onChange={(e) => setManualCategory(e.target.value)}
-                  className="w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-amber-400"
+                  className="w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-amber-300"
                 >
                   <option value="">Select category</option>
                   {CATEGORY_OPTIONS.map(c => (
@@ -647,7 +647,7 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
                   placeholder="e.g. 29.99"
                   value={manualMonthlyCost}
                   onChange={(e) => setManualMonthlyCost(e.target.value)}
-                  className="w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-400"
+                  className="w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-300"
                 />
               </div>
 
@@ -658,7 +658,7 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
                     type="date"
                     value={manualStartDate}
                     onChange={(e) => setManualStartDate(e.target.value)}
-                    className="w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-amber-400 [color-scheme:dark]"
+                    className="w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-amber-300 [color-scheme:dark]"
                   />
                 </div>
                 <div>
@@ -667,14 +667,14 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
                     type="date"
                     value={manualEndDate}
                     onChange={(e) => setManualEndDate(e.target.value)}
-                    className="w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-amber-400 [color-scheme:dark]"
+                    className="w-full px-4 py-3 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 focus:outline-none focus:border-amber-300 [color-scheme:dark]"
                   />
                 </div>
               </div>
 
               <label className="flex items-center gap-3 cursor-pointer">
                 <div
-                  className={`relative w-10 h-5 rounded-full transition-all ${manualAutoRenews ? 'bg-amber-400' : 'bg-navy-700'}`}
+                  className={`relative w-10 h-5 rounded-full transition-all ${manualAutoRenews ? 'bg-amber-500' : 'bg-slate-50'}`}
                   onClick={() => setManualAutoRenews(!manualAutoRenews)}
                 >
                   <div className={`absolute top-0.5 w-4 h-4 bg-white rounded-full transition-all ${manualAutoRenews ? 'left-5' : 'left-0.5'}`} />
@@ -685,7 +685,7 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
               <button
                 onClick={handleManualSave}
                 disabled={!supplierId || (supplierId === 'other' && !customSupplierName.trim()) || saving}
-                className="w-full bg-amber-400 hover:bg-orange-500 text-navy-950 font-semibold py-3 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
+                className="w-full bg-amber-500 hover:bg-orange-500 text-slate-900 font-semibold py-3 rounded-lg transition-all disabled:opacity-50 flex items-center justify-center gap-2"
               >
                 {saving ? (
                   <><Loader2 className="h-4 w-4 animate-spin" /> Saving...</>
@@ -798,7 +798,7 @@ export default function ContractsPage() {
         </div>
         <button
           onClick={() => setShowUpload(true)}
-          className="flex items-center gap-2 px-4 py-2.5 bg-amber-400 hover:bg-orange-500 text-navy-950 font-semibold rounded-lg transition-all"
+          className="flex items-center gap-2 px-4 py-2.5 bg-amber-500 hover:bg-orange-500 text-slate-900 font-semibold rounded-lg transition-all"
         >
           <Plus className="h-4 w-4" /> Upload contract
         </button>
@@ -819,7 +819,7 @@ export default function ContractsPage() {
           <div className="flex gap-1.5">
             <button
               onClick={() => setFilterType('all')}
-              className={`text-xs px-3 py-1.5 rounded-full transition-all ${filterType === 'all' ? 'bg-amber-400 text-navy-950 font-semibold' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
+              className={`text-xs px-3 py-1.5 rounded-full transition-all ${filterType === 'all' ? 'bg-amber-500 text-slate-900 font-semibold' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
             >
               All ({contracts.length})
             </button>
@@ -827,7 +827,7 @@ export default function ContractsPage() {
               <button
                 key={t}
                 onClick={() => setFilterType(t)}
-                className={`text-xs px-3 py-1.5 rounded-full transition-all ${filterType === t ? 'bg-amber-400 text-navy-950 font-semibold' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
+                className={`text-xs px-3 py-1.5 rounded-full transition-all ${filterType === t ? 'bg-amber-500 text-slate-900 font-semibold' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
               >
                 {TYPE_LABELS[t] || t}
               </button>
@@ -856,7 +856,7 @@ export default function ContractsPage() {
           <p className="text-slate-600 text-sm mb-6 max-w-md mx-auto">Upload a contract and we will read the key terms, flag anything unfair, and use it to write stronger complaint letters.</p>
           <button
             onClick={() => setShowUpload(true)}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-amber-400 hover:bg-orange-500 text-navy-950 font-semibold rounded-lg transition-all"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-amber-500 hover:bg-orange-500 text-slate-900 font-semibold rounded-lg transition-all"
           >
             <Upload className="h-4 w-4" /> Upload your first contract
           </button>

--- a/src/app/dashboard/deals/page.tsx
+++ b/src/app/dashboard/deals/page.tsx
@@ -216,9 +216,9 @@ function urgencyLabel(days: number): { text: string; color: string; bg: string }
   if (days <= 0) return { text: 'Contract ended', color: 'text-red-400', bg: 'bg-red-500/10 border-red-500/30' };
   if (days <= 7) return { text: `Ends in ${days} days`, color: 'text-red-400', bg: 'bg-red-500/10 border-red-500/30' };
   if (days <= 14) return { text: `Ends in ${days} days`, color: 'text-orange-400', bg: 'bg-orange-500/10 border-orange-500/30' };
-  if (days <= 30) return { text: `Ends in ${days} days`, color: 'text-emerald-600', bg: 'bg-emerald-500/10 border-mint-400/30' };
+  if (days <= 30) return { text: `Ends in ${days} days`, color: 'text-emerald-600', bg: 'bg-emerald-500/10 border-emerald-500/30' };
   if (days <= 90) return { text: `Ends in ${Math.ceil(days / 7)} weeks`, color: 'text-blue-400', bg: 'bg-blue-500/10 border-blue-500/30' };
-  return { text: `Ends in ${Math.ceil(days / 30)} months`, color: 'text-slate-600', bg: 'bg-slate-500/10 border-slate-500/30' };
+  return { text: `Ends in ${Math.ceil(days / 30)} months`, color: 'text-slate-600', bg: 'bg-slate-100 border-slate-500/30' };
 }
 
 // Deals are coming soon. Check if Awin publisher ID is configured.
@@ -246,17 +246,17 @@ function DealCard({ deal, highlight, onDismiss }: { deal: Deal; highlight?: bool
 
   return (
     <div className={`group relative bg-white backdrop-blur-sm border rounded-2xl p-5 transition-all flex flex-col overflow-hidden ${
-      highlight || deal.featured ? 'border-amber-400/40 ring-1 ring-amber-400/20' : 'border-slate-200/50'
-    } ${!DEALS_LIVE ? 'opacity-60' : 'hover:border-navy-600'}`}>
+      highlight || deal.featured ? 'border-amber-300/40 ring-1 ring-amber-400/20' : 'border-slate-200/50'
+    } ${!DEALS_LIVE ? 'opacity-60' : 'hover:border-slate-200'}`}>
       {deal.featured && (
-        <span className="absolute top-3 left-3 text-[10px] font-bold text-navy-950 bg-amber-400 px-2 py-0.5 rounded-full uppercase tracking-wide">
+        <span className="absolute top-3 left-3 text-[10px] font-bold text-slate-900 bg-amber-500 px-2 py-0.5 rounded-full uppercase tracking-wide">
           New Deal
         </span>
       )}
       {onDismiss && (
         <button
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDismiss(); }}
-          className="absolute top-3 right-3 p-1.5 bg-slate-100 hover:bg-navy-700 text-slate-600 hover:text-slate-900 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+          className="absolute top-3 right-3 p-1.5 bg-slate-100 hover:bg-slate-50 text-slate-600 hover:text-slate-900 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
           title="Not interested"
         >
           <X className="h-3.5 w-3.5" />
@@ -281,12 +281,12 @@ function DealCard({ deal, highlight, onDismiss }: { deal: Deal; highlight?: bool
             target="_blank"
             rel="noopener noreferrer"
             onClick={handleClick}
-            className="flex items-center gap-1 bg-emerald-500 hover:bg-emerald-600 text-navy-950 font-semibold px-3 py-1.5 rounded-lg transition-all text-xs whitespace-nowrap flex-shrink-0 ml-auto"
+            className="flex items-center gap-1 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-3 py-1.5 rounded-lg transition-all text-xs whitespace-nowrap flex-shrink-0 ml-auto"
           >
             View Deal →
           </a>
         ) : (
-          <span className="bg-navy-700 text-slate-600 font-medium px-3 py-1.5 rounded-lg text-xs cursor-not-allowed flex-shrink-0 ml-auto">
+          <span className="bg-slate-50 text-slate-600 font-medium px-3 py-1.5 rounded-lg text-xs cursor-not-allowed flex-shrink-0 ml-auto">
             Coming Soon
           </span>
         )}
@@ -389,11 +389,11 @@ function AffiliatePlanCard({ deal, savingsMonthly, savingsYearly, userProvider, 
   const isSaving = hasSavingsData && savingsMonthly! > 0;
 
   return (
-    <div className="group relative bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl p-5 transition-all flex flex-col overflow-hidden hover:border-navy-600">
+    <div className="group relative bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl p-5 transition-all flex flex-col overflow-hidden hover:border-slate-200">
       {onDismiss && (
         <button 
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDismiss(); }}
-          className="absolute top-3 right-3 p-1.5 bg-slate-100 hover:bg-navy-700 text-slate-600 hover:text-slate-900 rounded-full opacity-0 group-hover:opacity-100 transition-opacity z-10"
+          className="absolute top-3 right-3 p-1.5 bg-slate-100 hover:bg-slate-50 text-slate-600 hover:text-slate-900 rounded-full opacity-0 group-hover:opacity-100 transition-opacity z-10"
           title="Not interested"
         >
           <X className="h-3.5 w-3.5" />
@@ -425,7 +425,7 @@ function AffiliatePlanCard({ deal, savingsMonthly, savingsYearly, userProvider, 
           <div className={`mt-2 text-xs px-2 py-1 rounded-lg inline-flex items-center gap-1 ${
             isSaving
               ? 'bg-green-500/10 text-green-400 border border-green-500/20'
-              : 'bg-slate-500/10 text-slate-600 border border-slate-500/20'
+              : 'bg-slate-100 text-slate-600 border border-slate-200'
           }`}>
             {isSaving ? (
               <>Save £{savingsMonthly!.toFixed(2)}/mo <span className="text-[10px] text-green-400/70">(£{savingsYearly!.toFixed(0)}/yr vs your {userProvider} plan)</span></>
@@ -445,7 +445,7 @@ function AffiliatePlanCard({ deal, savingsMonthly, savingsYearly, userProvider, 
           target="_blank"
           rel="noopener noreferrer"
           onClick={handleClick}
-          className="flex items-center gap-1 bg-emerald-500 hover:bg-emerald-600 text-navy-950 font-semibold px-3 py-1.5 rounded-lg transition-all text-xs whitespace-nowrap flex-shrink-0 ml-auto"
+          className="flex items-center gap-1 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-3 py-1.5 rounded-lg transition-all text-xs whitespace-nowrap flex-shrink-0 ml-auto"
         >
           View Deal →
         </a>
@@ -645,8 +645,8 @@ export default function DealsPage() {
           onClick={() => setActiveCategory(null)}
           className={`px-4 py-2 rounded-lg text-sm font-semibold whitespace-nowrap transition-all ${
             activeCategory === null
-              ? 'bg-emerald-500 text-white'
-              : 'bg-slate-100 text-slate-700 hover:bg-navy-700'
+              ? 'bg-emerald-500 text-slate-900'
+              : 'bg-slate-100 text-slate-700 hover:bg-slate-50'
           }`}
         >
           All
@@ -657,8 +657,8 @@ export default function DealsPage() {
             onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
             className={`px-4 py-2 rounded-lg text-sm font-semibold whitespace-nowrap transition-all ${
               activeCategory === cat
-                ? 'bg-emerald-500 text-white'
-                : 'bg-slate-100 text-slate-700 hover:bg-navy-700'
+                ? 'bg-emerald-500 text-slate-900'
+                : 'bg-slate-100 text-slate-700 hover:bg-slate-50'
             }`}
           >
             {cat}
@@ -831,7 +831,7 @@ export default function DealsPage() {
 
               {/* Best Deal For You recommendation */}
               {bestDeal && userSpend && (
-                <div className="bg-gradient-to-r from-emerald-500/10 to-mint-400/5 border border-emerald-500/20 rounded-2xl p-5 mb-4">
+                <div className="bg-gradient-to-r from-emerald-500/10 to-emerald-500/5 border border-emerald-500/20 rounded-2xl p-5 mb-4">
                   <div className="flex items-start gap-3">
                     <Trophy className="h-6 w-6 text-emerald-400 flex-shrink-0 mt-0.5" />
                     <div className="flex-1 min-w-0">
@@ -913,7 +913,7 @@ export default function DealsPage() {
                         <button
                           key={`expand-${provider}`}
                           onClick={() => setExpandedProviders(prev => { const n = new Set(prev); n.add(`${catLower}-${provider}`); return n; })}
-                          className="bg-white border border-dashed border-slate-200/50 rounded-2xl p-5 flex items-center justify-center text-sm text-emerald-600 hover:border-mint-400/30 transition-all"
+                          className="bg-white border border-dashed border-slate-200/50 rounded-2xl p-5 flex items-center justify-center text-sm text-emerald-600 hover:border-emerald-500/30 transition-all"
                         >
                           See all {plans.length} {provider} plans →
                         </button>

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -468,7 +468,7 @@ export default function MoneyHubPage() {
         <div className="bg-red-500/10 border border-red-500/20 rounded-2xl p-8">
           <p className="text-red-400 font-semibold mb-2">Money Hub failed to load</p>
           <p className="text-slate-600 text-sm mb-4">{error}</p>
-          <button onClick={() => { setLoading(true); setError(null); refreshData(); }} className="bg-orange-500 hover:bg-amber-400 text-black font-semibold px-4 py-2 rounded-xl text-sm">Retry</button>
+          <button onClick={() => { setLoading(true); setError(null); refreshData(); }} className="bg-orange-500 hover:bg-amber-300 text-black font-semibold px-4 py-2 rounded-xl text-sm">Retry</button>
         </div>
       </div>
     );
@@ -485,7 +485,7 @@ export default function MoneyHubPage() {
           <p className="text-slate-600 max-w-md mx-auto mb-6">
             We analyse your Open Banking transactions to build a complete financial picture — spending, income, subscriptions, budgets, and savings goals.
           </p>
-          <button onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }} className="inline-flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-6 py-3 rounded-xl transition-all">
+          <button onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }} className="inline-flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-6 py-3 rounded-xl transition-all">
             <Building2 className="h-5 w-5" /> Connect Bank Account
           </button>
           <p className="text-slate-500 text-xs mt-3">FCA regulated via Yapily · Read-only access · Takes 2 minutes</p>
@@ -493,14 +493,14 @@ export default function MoneyHubPage() {
         {/* Demo preview */}
         <p className="text-slate-500 text-xs uppercase tracking-wider mb-3 text-center">Preview — your data will look like this</p>
         <div className="relative rounded-2xl overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-navy-950/60 to-navy-950 z-10 pointer-events-none" />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-white/60 to-white z-10 pointer-events-none" />
           <div className="blur-sm pointer-events-none select-none">
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
               {[
                 { label: 'Monthly income', value: '£3,200', color: 'text-green-400' },
                 { label: 'Monthly outgoings', value: '£2,140', color: 'text-red-400' },
                 { label: 'Savings rate', value: '33.1%', color: 'text-emerald-600' },
-                { label: 'Subscriptions', value: '£127/mo', color: 'text-amber-400' },
+                { label: 'Subscriptions', value: '£127/mo', color: 'text-amber-600' },
               ].map(item => (
                 <div key={item.label} className="bg-white border border-slate-200/50 rounded-2xl p-5">
                   <p className={`text-3xl font-bold ${item.color}`}>{item.value}</p>
@@ -606,7 +606,7 @@ export default function MoneyHubPage() {
           <select
             value={selectedMonth || data.selectedMonth}
             onChange={(e) => { setSelectedMonth(e.target.value); refreshData(e.target.value); fetchExpectedBills(e.target.value); }}
-            className="bg-slate-100 border border-slate-200/50 rounded-lg px-3 py-2 text-sm text-slate-900 focus:outline-none focus:border-mint-400"
+            className="bg-slate-100 border border-slate-200/50 rounded-lg px-3 py-2 text-sm text-slate-900 focus:outline-none focus:border-emerald-500"
           >
             <option value="">This month</option>
             {Array.from({ length: 12 }, (_, i) => {
@@ -658,10 +658,10 @@ export default function MoneyHubPage() {
 
       {/* Expired bank connection warning — per-bank reconnect */}
       {expiredConnections.length > 0 && !bankPromptDismissed && (
-        <div className="bg-orange-500/10 border border-amber-500/20 rounded-xl p-4">
+        <div className="bg-orange-500/10 border border-amber-200 rounded-xl p-4">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-amber-400" />
+              <AlertTriangle className="h-5 w-5 text-amber-600" />
               <p className="text-amber-300 font-semibold text-sm">Bank connection{expiredConnections.length > 1 ? 's' : ''} expired</p>
             </div>
             <button onClick={() => { setBankPromptDismissed(true); localStorage.setItem('bank_prompt_dismissed_at', new Date().toISOString()); }} className="text-slate-500 hover:text-slate-900"><X className="h-4 w-4" /></button>
@@ -670,7 +670,7 @@ export default function MoneyHubPage() {
             {expiredConnections.map((conn) => (
               <div key={conn.id} className="flex items-center justify-between bg-slate-50/40 rounded-lg px-3 py-2">
                 <div className="flex items-center gap-2">
-                  <Building2 className="h-4 w-4 text-amber-400" />
+                  <Building2 className="h-4 w-4 text-amber-600" />
                   <span className="text-slate-900 text-sm font-medium">{conn.bank_name || 'Bank'}</span>
                   <span className="text-slate-500 text-xs">· expired</span>
                 </div>
@@ -728,14 +728,14 @@ export default function MoneyHubPage() {
         <div className="bg-white border border-slate-200/50 rounded-2xl p-5">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-slate-900 font-semibold text-lg flex items-center gap-2">
-              <Clock className="h-5 w-5 text-amber-400" />
+              <Clock className="h-5 w-5 text-amber-600" />
               Expected Bills
               <span className="text-slate-500 text-sm font-normal">£{fmtNum(expectedBillsTotal)} expected</span>
             </h3>
             <div className="flex items-center gap-3 text-xs text-slate-500">
               <span className="flex items-center gap-1"><span className="w-2 h-2 bg-green-400 rounded-full" /> Paid</span>
               <span className="flex items-center gap-1"><span className="w-2 h-2 bg-red-400 rounded-full" /> Past due</span>
-              <span className="flex items-center gap-1"><span className="w-2 h-2 bg-amber-400 rounded-full" /> Upcoming</span>
+              <span className="flex items-center gap-1"><span className="w-2 h-2 bg-amber-500 rounded-full" /> Upcoming</span>
             </div>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
@@ -744,8 +744,8 @@ export default function MoneyHubPage() {
                 ? 'border-green-500/30 bg-green-500/5'
                 : bill.past_due
                   ? 'border-red-500/30 bg-red-500/5'
-                  : 'border-navy-800';
-              const amountColor = bill.paid ? 'text-green-400' : bill.past_due ? 'text-red-400' : 'text-amber-400';
+                  : 'border-slate-200';
+              const amountColor = bill.paid ? 'text-green-400' : bill.past_due ? 'text-red-400' : 'text-amber-600';
               const catLabel = bill.category !== 'other' ? bill.category.replace(/_/g, ' ') : '';
               return (
                 <div key={bill.bill_key || bill.name} className={`rounded-xl p-3 border ${statusColor}`}>
@@ -797,7 +797,7 @@ export default function MoneyHubPage() {
           {expectedBills.length > 12 && (
             <button
               onClick={() => setShowAllBills(v => !v)}
-              className="w-full flex items-center justify-center gap-1.5 text-xs text-slate-400 hover:text-mint-400 py-2 mt-1 transition-colors"
+              className="w-full flex items-center justify-center gap-1.5 text-xs text-slate-600 hover:text-emerald-600 py-2 mt-1 transition-colors"
             >
               {showAllBills
                 ? <><ChevronUp className="h-3.5 w-3.5" /> Show less</>
@@ -816,7 +816,7 @@ export default function MoneyHubPage() {
           </h3>
           <div className="space-y-2">
             {priceIncreasAlerts.slice(0, 5).map((alert: any) => (
-              <div key={alert.id} className="bg-slate-50/50 rounded-xl p-3 border border-navy-800 flex items-center justify-between">
+              <div key={alert.id} className="bg-slate-50/50 rounded-xl p-3 border border-slate-200 flex items-center justify-between">
                 <div className="min-w-0">
                   <p className="text-sm text-slate-900 font-medium">{alert.title || 'Price increase'}</p>
                   <p className="text-xs text-slate-500">{alert.details || alert.description || ''}</p>
@@ -853,7 +853,7 @@ export default function MoneyHubPage() {
           </div>
           <Link
             href={isPro ? '/dashboard/settings/mcp' : '/docs/paybacker-assistant'}
-            className="whitespace-nowrap text-xs bg-mint-500/10 border border-emerald-200 text-emerald-600 hover:bg-emerald-600/20 hover:text-mint-300 px-3 py-1.5 rounded-full transition-colors"
+            className="whitespace-nowrap text-xs bg-emerald-500/10 border border-emerald-200 text-emerald-600 hover:bg-emerald-500/20 hover:text-emerald-500 px-3 py-1.5 rounded-full transition-colors"
           >
             {isPro ? 'Generate token →' : 'Setup guide →'}
           </Link>
@@ -869,7 +869,7 @@ export default function MoneyHubPage() {
           ].map((q) => (
             <div
               key={q}
-              className="bg-slate-50/50 border border-navy-800 rounded-xl px-3 py-2 text-sm text-slate-200"
+              className="bg-slate-50/50 border border-slate-200 rounded-xl px-3 py-2 text-sm text-slate-700"
             >
               &ldquo;{q}&rdquo;
             </div>
@@ -878,7 +878,7 @@ export default function MoneyHubPage() {
         {!isPro && (
           <p className="text-xs text-slate-500 mt-4">
             The Paybacker Assistant is a Pro feature.{' '}
-            <Link href="/pricing" className="text-emerald-600 hover:text-mint-300">
+            <Link href="/pricing" className="text-emerald-600 hover:text-emerald-500">
               Upgrade for £9.99/mo
             </Link>{' '}
             to unlock it.
@@ -891,17 +891,17 @@ export default function MoneyHubPage() {
         <div className="bg-white border border-slate-200/50 rounded-2xl p-5">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-slate-900 font-semibold text-lg flex items-center gap-2">
-              <Zap className="h-5 w-5 text-amber-400" />
+              <Zap className="h-5 w-5 text-amber-600" />
               Financial Action Centre
               {facItems.length > 0 && (
                 <span className="text-xs font-normal text-slate-600 ml-1">
                   {facCounts.overdue > 0 && <span className="text-red-400 font-semibold">{facCounts.overdue} overdue · </span>}
-                  {facCounts.due_soon > 0 && <span className="text-amber-400 font-semibold">{facCounts.due_soon} due soon · </span>}
+                  {facCounts.due_soon > 0 && <span className="text-amber-600 font-semibold">{facCounts.due_soon} due soon · </span>}
                   {facItems.length} tracked
                 </span>
               )}
             </h3>
-            <Link href="/dashboard/deals" className="text-emerald-600 hover:text-mint-300 text-sm font-medium">Browse deals →</Link>
+            <Link href="/dashboard/deals" className="text-emerald-600 hover:text-emerald-500 text-sm font-medium">Browse deals →</Link>
           </div>
 
           {/* Email scan results / alerts */}
@@ -913,7 +913,7 @@ export default function MoneyHubPage() {
               <button
                 onClick={() => scanInbox(false)}
                 disabled={scanning}
-                className="text-xs text-emerald-600 hover:text-mint-300 font-medium disabled:opacity-50"
+                className="text-xs text-emerald-600 hover:text-emerald-500 font-medium disabled:opacity-50"
               >
                 {scanning ? 'Scanning...' : (alerts.length > 0 ? 'Re-scan' : 'Scan Now')}
               </button>
@@ -921,7 +921,7 @@ export default function MoneyHubPage() {
             {alerts.length > 0 ? (
               <div className="space-y-2">
                 {alerts.slice(0, 5).map((a: any) => (
-                  <div key={a.id} className="flex items-center justify-between bg-slate-50/50 rounded-lg p-3 border border-navy-800">
+                  <div key={a.id} className="flex items-center justify-between bg-slate-50/50 rounded-lg p-3 border border-slate-200">
                     <div className="min-w-0">
                       <p className="text-sm text-slate-900 font-medium truncate">{a.title}</p>
                       {a.details && <p className="text-xs text-slate-500 truncate">{a.details}</p>}
@@ -939,11 +939,11 @@ export default function MoneyHubPage() {
           <div className="mb-4">
             <div className="flex items-center justify-between mb-2">
               <p className="text-xs text-slate-600 uppercase tracking-wider font-semibold flex items-center gap-1.5">
-                <Building2 className="h-3.5 w-3.5 text-amber-400" /> Tracked Subscriptions
+                <Building2 className="h-3.5 w-3.5 text-amber-600" /> Tracked Subscriptions
               </p>
               <div className="flex items-center gap-3">
                 {facLoading && <Loader2 className="h-3 w-3 text-slate-500 animate-spin" />}
-                <Link href="/dashboard/subscriptions" className="text-xs text-emerald-600 hover:text-mint-300 font-medium">View all →</Link>
+                <Link href="/dashboard/subscriptions" className="text-xs text-emerald-600 hover:text-emerald-500 font-medium">View all →</Link>
               </div>
             </div>
 
@@ -970,7 +970,7 @@ export default function MoneyHubPage() {
                         </span>
                       );
                       if (item.bankStatus === 'due_soon') return (
-                        <span className="inline-flex items-center gap-1 text-[10px] bg-orange-500/10 text-amber-400 border border-amber-500/20 rounded-full px-2 py-0.5 whitespace-nowrap">
+                        <span className="inline-flex items-center gap-1 text-[10px] bg-orange-500/10 text-amber-600 border border-amber-200 rounded-full px-2 py-0.5 whitespace-nowrap">
                           <Clock className="h-2.5 w-2.5" /> Due soon
                         </span>
                       );
@@ -982,7 +982,7 @@ export default function MoneyHubPage() {
                     })();
 
                     return (
-                      <div key={item.id} className={`rounded-lg border transition-colors ${isEditing ? 'bg-slate-100 border-mint-400/40' : 'bg-slate-50/50 border-navy-800'}`}>
+                      <div key={item.id} className={`rounded-lg border transition-colors ${isEditing ? 'bg-slate-100 border-emerald-500/40' : 'bg-slate-50/50 border-slate-200'}`}>
                         <div className="flex items-center gap-2 p-3">
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2 flex-wrap">
@@ -1001,7 +1001,7 @@ export default function MoneyHubPage() {
                             )}
                           </div>
                           <div className="flex items-center gap-1.5 shrink-0">
-                            <span className={`text-sm font-semibold whitespace-nowrap ${item.bankStatus === 'overdue' ? 'text-red-400' : 'text-amber-400'}`}>
+                            <span className={`text-sm font-semibold whitespace-nowrap ${item.bankStatus === 'overdue' ? 'text-red-400' : 'text-amber-600'}`}>
                               £{fmtNum(item.amount)}/{cycleLabel(item.billing_cycle)}
                             </span>
                             <button
@@ -1033,7 +1033,7 @@ export default function MoneyHubPage() {
                                   min="0"
                                   value={facEditFields.amount}
                                   onChange={e => setFacEditFields(f => ({ ...f, amount: e.target.value }))}
-                                  className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-sm text-slate-900 focus:outline-none focus:border-mint-400"
+                                  className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-sm text-slate-900 focus:outline-none focus:border-emerald-500"
                                 />
                               </div>
                               <div>
@@ -1041,7 +1041,7 @@ export default function MoneyHubPage() {
                                 <select
                                   value={facEditFields.billing_cycle}
                                   onChange={e => setFacEditFields(f => ({ ...f, billing_cycle: e.target.value }))}
-                                  className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-sm text-slate-900 focus:outline-none focus:border-mint-400"
+                                  className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-sm text-slate-900 focus:outline-none focus:border-emerald-500"
                                 >
                                   <option value="weekly">Weekly</option>
                                   <option value="monthly">Monthly</option>
@@ -1055,7 +1055,7 @@ export default function MoneyHubPage() {
                                 <select
                                   value={facEditFields.category}
                                   onChange={e => setFacEditFields(f => ({ ...f, category: e.target.value }))}
-                                  className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-sm text-slate-900 focus:outline-none focus:border-mint-400"
+                                  className="w-full bg-white border border-slate-200 rounded-lg px-2 py-1.5 text-sm text-slate-900 focus:outline-none focus:border-emerald-500"
                                 >
                                   {['streaming', 'software', 'fitness', 'broadband', 'mobile', 'utility', 'insurance', 'loan', 'credit_card', 'mortgage', 'council_tax', 'transport', 'shopping', 'charity', 'other'].map(c => (
                                     <option key={c} value={c}>{c.replace(/_/g, ' ')}</option>
@@ -1081,7 +1081,7 @@ export default function MoneyHubPage() {
                               <button
                                 onClick={() => saveFacEdit(item.id)}
                                 disabled={facSaving}
-                                className="text-xs text-white font-semibold px-3 py-1.5 bg-emerald-500 hover:bg-mint-300 disabled:opacity-50 rounded-lg transition-colors"
+                                className="text-xs text-slate-900 font-semibold px-3 py-1.5 bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 rounded-lg transition-colors"
                               >
                                 {facSaving ? 'Saving...' : 'Save'}
                               </button>
@@ -1145,7 +1145,7 @@ export default function MoneyHubPage() {
                             <div className="text-right shrink-0">
                               <p className="text-green-400 text-sm font-semibold">Save £{fmtNum(deal.annualSaving)}/yr</p>
                               {deal.dealUrl ? (
-                                <a href={deal.dealUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-emerald-600 hover:text-mint-300 font-medium flex items-center gap-1 justify-end mt-1">
+                                <a href={deal.dealUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-emerald-600 hover:text-emerald-500 font-medium flex items-center gap-1 justify-end mt-1">
                                   Switch <ExternalLink className="h-3 w-3" />
                                 </a>
                               ) : null}
@@ -1166,8 +1166,8 @@ export default function MoneyHubPage() {
           })()}
 
           {/* Manage Subscriptions quick link */}
-          <Link href="/dashboard/subscriptions" className="bg-slate-50/50 border border-navy-800 rounded-xl p-3 text-left hover:border-emerald-200 transition-all flex items-center gap-3">
-            <Building2 className="h-5 w-5 text-amber-400 shrink-0" />
+          <Link href="/dashboard/subscriptions" className="bg-slate-50/50 border border-slate-200 rounded-xl p-3 text-left hover:border-emerald-200 transition-all flex items-center gap-3">
+            <Building2 className="h-5 w-5 text-amber-600 shrink-0" />
             <div>
               <p className="text-slate-900 font-medium text-sm">{facItems.length > 0 ? `Manage ${facItems.length} subscriptions` : 'Subscription Audit'}</p>
               <p className="text-slate-500 text-xs">Review, cancel, or switch</p>
@@ -1202,7 +1202,7 @@ export default function MoneyHubPage() {
 
           {chatOpen && (
             <div className="fixed bottom-20 right-6 z-50 w-96 max-w-[calc(100vw-2rem)] bg-white border border-slate-200 rounded-2xl shadow-2xl flex flex-col" style={{ height: '480px' }}>
-              <div className="p-4 border-b border-navy-800 flex items-center justify-between">
+              <div className="p-4 border-b border-slate-200 flex items-center justify-between">
                 <div>
                   <h3 className="text-slate-900 font-semibold text-sm">AI Financial Assistant</h3>
                   <p className="text-slate-500 text-[10px]">Ask about your finances, recategorise transactions, and more</p>
@@ -1223,7 +1223,7 @@ export default function MoneyHubPage() {
                 )}
                 {chatMessages.map((m, i) => (
                   <div key={i} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-                    <div className={`max-w-[85%] px-3 py-2 rounded-xl text-sm whitespace-pre-wrap ${m.role === 'user' ? 'bg-purple-500/20 text-purple-100' : 'bg-slate-100 text-slate-200'}`}>
+                    <div className={`max-w-[85%] px-3 py-2 rounded-xl text-sm whitespace-pre-wrap ${m.role === 'user' ? 'bg-purple-500/20 text-purple-100' : 'bg-slate-100 text-slate-700'}`}>
                       {m.content}
                     </div>
                   </div>
@@ -1235,7 +1235,7 @@ export default function MoneyHubPage() {
                 )}
                 <div ref={chatEndRef} />
               </div>
-              <div className="p-3 border-t border-navy-800">
+              <div className="p-3 border-t border-slate-200">
                 <div className="flex gap-2">
                   <input
                     value={chatInput}

--- a/src/app/dashboard/money-hub/payments/page.tsx
+++ b/src/app/dashboard/money-hub/payments/page.tsx
@@ -208,9 +208,9 @@ function PaymentCard({ payment, type, onCategoryChange, onDelete, onAmountChange
                     onChange={e => setAmountInput(e.target.value)}
                     onKeyDown={e => { if (e.key === 'Enter') handleAmountSave(); if (e.key === 'Escape') setEditingAmount(false); }}
                     autoFocus
-                    className="w-20 bg-slate-100 border border-slate-200 rounded px-1.5 py-0.5 text-slate-900 text-sm text-right focus:outline-none focus:border-mint-400"
+                    className="w-20 bg-slate-100 border border-slate-200 rounded px-1.5 py-0.5 text-slate-900 text-sm text-right focus:outline-none focus:border-emerald-500"
                   />
-                  <button onClick={handleAmountSave} disabled={saving} className="text-emerald-600 hover:text-mint-300 p-0.5">
+                  <button onClick={handleAmountSave} disabled={saving} className="text-emerald-600 hover:text-emerald-500 p-0.5">
                     <Check className="h-3.5 w-3.5" />
                   </button>
                 </div>
@@ -222,13 +222,13 @@ function PaymentCard({ payment, type, onCategoryChange, onDelete, onAmountChange
                 >
                   {hasAmount ? (
                     <>
-                      <p className="text-emerald-600 font-bold group-hover/amt:text-mint-300 transition-colors">
+                      <p className="text-emerald-600 font-bold group-hover/amt:text-emerald-500 transition-colors">
                         £{Math.abs(payment.amount).toFixed(2)}
                       </p>
                       <p className="text-slate-500 text-[10px]">{CYCLE_LABELS[payment.billing_cycle] || payment.billing_cycle}</p>
                     </>
                   ) : (
-                    <p className="text-amber-400/80 text-xs italic hover:text-amber-300">Set amount →</p>
+                    <p className="text-amber-600/80 text-xs italic hover:text-amber-300">Set amount →</p>
                   )}
                 </button>
               )}
@@ -272,7 +272,7 @@ function PaymentCard({ payment, type, onCategoryChange, onDelete, onAmountChange
           </div>
 
           {unusedWarning && (
-            <div className="flex items-center gap-1.5 mt-2 text-xs text-amber-400 bg-orange-500/10 rounded-lg px-2 py-1">
+            <div className="flex items-center gap-1.5 mt-2 text-xs text-amber-600 bg-orange-500/10 rounded-lg px-2 py-1">
               <AlertCircle className="h-3 w-3" />
               Not used in {lastUsedDays}+ days — consider cancelling
             </div>
@@ -455,7 +455,7 @@ export default function PaymentsPage() {
             key={t.key}
             onClick={() => setTab(t.key)}
             className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all whitespace-nowrap ${
-              tab === t.key ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'
+              tab === t.key ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'
             }`}
           >
             <t.icon className="h-4 w-4" />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -557,7 +557,7 @@ export default function DashboardPage() {
             <p className="text-slate-900 font-semibold text-sm">Your free Pro trial has ended</p>
             <p className="text-slate-600 text-xs mt-1">Upgrade to keep unlimited letters, daily bank sync, spending intelligence, and all Pro features. All your data is safe.</p>
           </div>
-          <Link href="/pricing" className="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-5 py-2.5 rounded-xl transition-all text-sm whitespace-nowrap ml-4">
+          <Link href="/pricing" className="bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-5 py-2.5 rounded-xl transition-all text-sm whitespace-nowrap ml-4">
             Upgrade Now
           </Link>
         </div>
@@ -571,7 +571,7 @@ export default function DashboardPage() {
               Pro trial ends in <span className="text-emerald-600 font-semibold">{trialDaysLeft} day{trialDaysLeft !== 1 ? 's' : ''}</span>. Upgrade to keep all features.
             </p>
           </div>
-          <Link href="/pricing" className="text-emerald-600 hover:text-mint-300 text-sm font-medium whitespace-nowrap ml-4">
+          <Link href="/pricing" className="text-emerald-600 hover:text-emerald-500 text-sm font-medium whitespace-nowrap ml-4">
             View Plans
           </Link>
         </div>
@@ -731,7 +731,7 @@ export default function DashboardPage() {
             {(() => {
               const hasActive = bankAccounts.some(b => b.status === 'active');
               const hasExpired = bankConnected && !hasActive;
-              const borderClass = hasActive ? 'border-green-500/30 bg-green-500/5' : hasExpired ? 'border-amber-500/30 bg-orange-500/5' : 'border-amber-500/30 bg-orange-500/5';
+              const borderClass = hasActive ? 'border-green-500/30 bg-green-500/5' : hasExpired ? 'border-amber-300 bg-orange-500/5' : 'border-amber-300 bg-orange-500/5';
               return (
             <div className={`rounded-xl border p-4 ${borderClass}`}>
               <div className="flex items-center gap-2 mb-2">
@@ -746,11 +746,11 @@ export default function DashboardPage() {
                   </>
                 ) : hasExpired ? (
                   <>
-                    <AlertTriangle className="h-4 w-4 text-amber-400" />
-                    <span className="text-amber-400 text-sm">Needs reconnect</span>
+                    <AlertTriangle className="h-4 w-4 text-amber-600" />
+                    <span className="text-amber-600 text-sm">Needs reconnect</span>
                   </>
                 ) : (
-                  <span className="text-amber-400 text-sm">Not connected</span>
+                  <span className="text-amber-600 text-sm">Not connected</span>
                 )}
               </div>
               {hasActive ? (
@@ -781,7 +781,7 @@ export default function DashboardPage() {
             })()}
 
             {/* Email Inbox */}
-            <div className={`rounded-xl border p-4 ${emailConnected ? 'border-green-500/30 bg-green-500/5' : 'border-amber-500/30 bg-orange-500/5'}`}>
+            <div className={`rounded-xl border p-4 ${emailConnected ? 'border-green-500/30 bg-green-500/5' : 'border-amber-300 bg-orange-500/5'}`}>
               <div className="flex items-center gap-2 mb-2">
                 <Mail className="h-5 w-5 text-slate-700" />
                 <span className="text-slate-900 font-medium text-sm">Email Inbox</span>
@@ -793,7 +793,7 @@ export default function DashboardPage() {
                     <span className="text-green-400 text-sm">Connected</span>
                   </>
                 ) : (
-                  <span className="text-amber-400 text-sm">Not connected</span>
+                  <span className="text-amber-600 text-sm">Not connected</span>
                 )}
               </div>
               {emailConnected ? (
@@ -807,7 +807,7 @@ export default function DashboardPage() {
               ) : (
                 <Link
                   href="/dashboard/profile?connect_email=true"
-                  className="flex items-center gap-1.5 font-semibold px-3 py-1.5 rounded-lg transition-all text-sm w-full justify-center bg-emerald-500 hover:bg-emerald-600 text-white"
+                  className="flex items-center gap-1.5 font-semibold px-3 py-1.5 rounded-lg transition-all text-sm w-full justify-center bg-emerald-500 hover:bg-emerald-600 text-slate-900"
                 >
                   Connect Email
                 </Link>
@@ -815,7 +815,7 @@ export default function DashboardPage() {
             </div>
 
             {/* First Letter */}
-            <div className={`rounded-xl border p-4 ${complaintsGenerated > 0 ? 'border-green-500/30 bg-green-500/5' : 'border-amber-500/30 bg-orange-500/5'}`}>
+            <div className={`rounded-xl border p-4 ${complaintsGenerated > 0 ? 'border-green-500/30 bg-green-500/5' : 'border-amber-300 bg-orange-500/5'}`}>
               <div className="flex items-center gap-2 mb-2">
                 <FileText className="h-5 w-5 text-slate-700" />
                 <span className="text-slate-900 font-medium text-sm">First Letter</span>
@@ -827,7 +827,7 @@ export default function DashboardPage() {
                     <span className="text-green-400 text-sm">{complaintsGenerated} written</span>
                   </>
                 ) : (
-                  <span className="text-amber-400 text-sm">None yet</span>
+                  <span className="text-amber-600 text-sm">None yet</span>
                 )}
               </div>
               <Link
@@ -835,7 +835,7 @@ export default function DashboardPage() {
                 className={`flex items-center gap-1.5 font-semibold px-3 py-1.5 rounded-lg transition-all text-sm w-full justify-center ${
                   complaintsGenerated > 0
                     ? 'bg-slate-100 hover:bg-slate-200 text-slate-900 font-medium'
-                    : 'bg-emerald-500 hover:bg-emerald-600 text-white'
+                    : 'bg-emerald-500 hover:bg-emerald-600 text-slate-900'
                 }`}
               >
                 Write Letter
@@ -865,7 +865,7 @@ export default function DashboardPage() {
             bankAccounts.map(b => {
               const isActive = b.status === 'active';
               const statusLabel = isActive ? 'Active' : 'Expired';
-              const statusClass = isActive ? 'text-green-400 bg-green-500/10 border-green-500/20' : 'text-amber-400 bg-orange-500/10 border-amber-500/20';
+              const statusClass = isActive ? 'text-green-400 bg-green-500/10 border-green-500/20' : 'text-amber-600 bg-orange-500/10 border-amber-200';
               return (
               (b.account_display_names && b.account_display_names.length > 0)
                 ? b.account_display_names.map((name, i) => (
@@ -880,7 +880,7 @@ export default function DashboardPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
-                      {!isActive && <button onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }} className="text-xs text-amber-400 hover:text-amber-300 font-medium">Reconnect</button>}
+                      {!isActive && <button onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }} className="text-xs text-amber-600 hover:text-amber-300 font-medium">Reconnect</button>}
                       <span className={`text-xs px-2 py-0.5 rounded-full border ${statusClass}`}>{statusLabel}</span>
                       <button onClick={() => disconnectBank(b.id, b.bank_name || 'Bank')} disabled={disconnectingId === b.id} className="text-slate-500 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ml-1" title="Disconnect this bank">
                         <Trash2 className="h-4 w-4" />
@@ -900,7 +900,7 @@ export default function DashboardPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
-                      {!isActive && <button onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }} className="text-xs text-amber-400 hover:text-amber-300 font-medium">Reconnect</button>}
+                      {!isActive && <button onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }} className="text-xs text-amber-600 hover:text-amber-300 font-medium">Reconnect</button>}
                       <span className={`text-xs px-2 py-0.5 rounded-full border ${statusClass}`}>{statusLabel}</span>
                       <button onClick={() => disconnectBank(b.id, b.bank_name || 'Bank')} disabled={disconnectingId === b.id} className="text-slate-500 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ml-1" title="Disconnect this bank">
                         <Trash2 className="h-4 w-4" />
@@ -978,7 +978,7 @@ export default function DashboardPage() {
               <p className="text-slate-600 text-xs">Review these before they auto-renew at a higher rate</p>
             </div>
           </div>
-          <Link href="/dashboard/contracts" className="text-emerald-600 hover:text-mint-300 text-sm font-medium flex items-center gap-1">
+          <Link href="/dashboard/contracts" className="text-emerald-600 hover:text-emerald-500 text-sm font-medium flex items-center gap-1">
             View <ArrowRight className="h-4 w-4" />
           </Link>
         </div>
@@ -1029,13 +1029,13 @@ export default function DashboardPage() {
                   dispute: { text: 'Dispute', color: 'bg-orange-600 hover:bg-orange-700' },
                   claim_compensation: { text: 'Claim', color: 'bg-green-600 hover:bg-green-700' },
                   claim_refund: { text: 'Claim Refund', color: 'bg-green-600 hover:bg-green-700' },
-                  monitor: { text: 'Monitor', color: 'bg-slate-200 hover:bg-navy-600' },
+                  monitor: { text: 'Monitor', color: 'bg-slate-200 hover:bg-slate-50' },
                 };
                 const action = actionLabel[opp.suggestedAction] || actionLabel.track;
                 // Determine action based on opportunity type for better routing
                 const effectiveAction = (() => {
                   if (opp.suggestedAction === 'switch_deal' || ['utility_bill', 'renewal', 'insurance', 'insurance_renewal', 'deal_expiry', 'bill'].includes(opp.type)) {
-                    return { text: 'Find Deal', color: 'bg-emerald-500 hover:bg-emerald-600 text-white' };
+                    return { text: 'Find Deal', color: 'bg-emerald-500 hover:bg-emerald-600 text-slate-900' };
                   }
                   if (['overcharge', 'price_increase', 'debt_dispute', 'dd_advance_notice'].includes(opp.type) || opp.suggestedAction === 'dispute') {
                     return { text: 'Dispute', color: 'bg-red-500 hover:bg-red-600' };
@@ -1053,7 +1053,7 @@ export default function DashboardPage() {
                 })();
                 const typeColors: Record<string, string> = {
                   subscription: 'text-blue-400 bg-blue-500/10',
-                  renewal: 'text-amber-400 bg-orange-500/10',
+                  renewal: 'text-amber-600 bg-orange-500/10',
                   price_increase: 'text-orange-400 bg-orange-500/10',
                   overcharge: 'text-red-400 bg-red-500/10',
                   utility_bill: 'text-cyan-400 bg-cyan-500/10',
@@ -1064,12 +1064,12 @@ export default function DashboardPage() {
                   insurance_renewal: 'text-emerald-400 bg-emerald-500/10',
                   refund_opportunity: 'text-green-400 bg-green-500/10',
                   loan: 'text-violet-400 bg-violet-500/10',
-                  deal_expiry: 'text-amber-400 bg-orange-500/10',
+                  deal_expiry: 'text-amber-600 bg-orange-500/10',
                   dd_advance_notice: 'text-blue-400 bg-blue-500/10',
                   tax_rebate: 'text-purple-400 bg-purple-500/10',
                   government: 'text-purple-400 bg-purple-500/10',
                 };
-                const typeColor = typeColors[opp.type] || 'text-slate-600 bg-slate-500/10';
+                const typeColor = typeColors[opp.type] || 'text-slate-600 bg-slate-100';
                 return (
                   <div key={opp.id || i} className="bg-white border border-slate-200/50 rounded-xl p-4">
                     <div className="flex items-start justify-between gap-3">
@@ -1255,7 +1255,7 @@ export default function DashboardPage() {
                   <button
                     key={f}
                     onClick={() => setTaskFilter(f)}
-                    className={`text-xs px-3 py-1.5 rounded-full transition-all whitespace-nowrap capitalize ${taskFilter === f ? 'bg-emerald-500 text-white font-semibold' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
+                    className={`text-xs px-3 py-1.5 rounded-full transition-all whitespace-nowrap capitalize ${taskFilter === f ? 'bg-emerald-500 text-slate-900 font-semibold' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
                   >
                     {f}
                   </button>
@@ -1289,13 +1289,13 @@ export default function DashboardPage() {
                   const complaintUrl = `/dashboard/complaints?${complaintParams.toString()}`;
 
                   return (
-                    <div key={task.id} className={`bg-white border rounded-xl p-4 transition-all ${isHighPriority ? 'border-red-500/30 shadow-[0_0_15px_rgba(239,68,68,0.05)]' : isSoon ? 'border-amber-500/30 shadow-[0_0_15px_rgba(245,158,11,0.05)]' : 'border-slate-200/50'}`}>
+                    <div key={task.id} className={`bg-white border rounded-xl p-4 transition-all ${isHighPriority ? 'border-red-500/30 shadow-[0_0_15px_rgba(239,68,68,0.05)]' : isSoon ? 'border-amber-300 shadow-[0_0_15px_rgba(245,158,11,0.05)]' : 'border-slate-200/50'}`}>
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 mb-1 flex-wrap">
                         {task.urgency === 'immediate' && <span className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full bg-red-500/10 text-red-400 font-semibold border border-red-500/20 uppercase tracking-widest"><AlertTriangle className="h-3 w-3" /> Urgent</span>}
-                        {task.urgency === 'soon' && <span className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full bg-orange-500/10 text-amber-400 font-semibold border border-amber-500/20 uppercase tracking-widest"><Clock className="h-3 w-3" /> Soon</span>}
-                        {!task.urgency && isHighPriority && <span className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full bg-orange-500/10 text-amber-500 font-semibold border border-amber-500/20 uppercase tracking-widest"><AlertTriangle className="h-3 w-3" /> Urgent</span>}
+                        {task.urgency === 'soon' && <span className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full bg-orange-500/10 text-amber-600 font-semibold border border-amber-200 uppercase tracking-widest"><Clock className="h-3 w-3" /> Soon</span>}
+                        {!task.urgency && isHighPriority && <span className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded-full bg-orange-500/10 text-amber-500 font-semibold border border-amber-200 uppercase tracking-widest"><AlertTriangle className="h-3 w-3" /> Urgent</span>}
                         <span className={`text-xs px-2 py-0.5 rounded-full ${badge.color}`}>{badge.text}</span>
                         {task.provider && <span className="text-slate-500 text-xs">{cleanMerchantName(task.provider)}</span>}
                         {task.amount && Number(task.amount) > 0 && <span className="text-green-400 text-xs font-medium">{formatGBP(parseFloat(String(task.amount)))}</span>}
@@ -1316,7 +1316,7 @@ export default function DashboardPage() {
                             </span>
                           )}
                           {task.contractEndDate && (
-                            <span className="text-[10px] px-2 py-0.5 rounded bg-orange-500/10 text-amber-400">
+                            <span className="text-[10px] px-2 py-0.5 rounded bg-orange-500/10 text-amber-600">
                               ends {new Date(task.contractEndDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
                             </span>
                           )}
@@ -1415,7 +1415,7 @@ export default function DashboardPage() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
         <Link
           href="/dashboard/complaints"
-          className="bg-white border border-slate-200/50 rounded-2xl p-6 shadow-[--shadow-card] hover:border-mint-400/50 transition-all group"
+          className="bg-white border border-slate-200/50 rounded-2xl p-6 shadow-[--shadow-card] hover:border-emerald-500/50 transition-all group"
         >
           <FileText className="h-8 w-8 text-emerald-600 mb-3" />
           <h3 className="text-slate-900 font-semibold mb-1 group-hover:text-emerald-600 transition-all">Write a Complaint Letter</h3>
@@ -1425,7 +1425,7 @@ export default function DashboardPage() {
 
         <Link
           href="/dashboard/subscriptions"
-          className="bg-white border border-slate-200/50 rounded-2xl p-6 shadow-[--shadow-card] hover:border-mint-400/50 transition-all group"
+          className="bg-white border border-slate-200/50 rounded-2xl p-6 shadow-[--shadow-card] hover:border-emerald-500/50 transition-all group"
         >
           <CreditCard className="h-8 w-8 text-green-500 mb-3" />
           <h3 className="text-slate-900 font-semibold mb-1 group-hover:text-emerald-600 transition-all">Track Subscriptions</h3>
@@ -1435,7 +1435,7 @@ export default function DashboardPage() {
 
         <Link
           href="/dashboard/complaints?new=1"
-          className="bg-white border border-slate-200/50 rounded-2xl p-6 shadow-[--shadow-card] hover:border-mint-400/50 transition-all group"
+          className="bg-white border border-slate-200/50 rounded-2xl p-6 shadow-[--shadow-card] hover:border-emerald-500/50 transition-all group"
         >
           <Building2 className="h-8 w-8 text-purple-500 mb-3" />
           <h3 className="text-slate-900 font-semibold mb-1 group-hover:text-emerald-600 transition-all">Disputes</h3>
@@ -1446,7 +1446,7 @@ export default function DashboardPage() {
         {userTier !== 'free' && (
           <Link
             href="/dashboard/money-hub"
-            className="bg-white border border-slate-200/50 rounded-2xl p-6 shadow-[--shadow-card] hover:border-mint-400/50 transition-all group"
+            className="bg-white border border-slate-200/50 rounded-2xl p-6 shadow-[--shadow-card] hover:border-emerald-500/50 transition-all group"
           >
             <BarChart3 className="h-8 w-8 text-sky-500 mb-3" />
             <h3 className="text-slate-900 font-semibold mb-1 group-hover:text-emerald-600 transition-all">Money Hub</h3>
@@ -1458,7 +1458,7 @@ export default function DashboardPage() {
         {userTier === 'free' && (
           <Link
             href="/pricing"
-            className="bg-white border border-emerald-200 rounded-2xl p-6 hover:border-mint-400/50 transition-all group"
+            className="bg-white border border-emerald-200 rounded-2xl p-6 hover:border-emerald-500/50 transition-all group"
           >
             <Sparkles className="h-8 w-8 text-emerald-600 mb-3" />
             <h3 className="text-slate-900 font-semibold mb-1 group-hover:text-emerald-600 transition-all">Upgrade Your Plan</h3>

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -212,7 +212,7 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
               {emailConns.map(e => (
                 <div key={e.id} className="flex items-center justify-between text-sm pr-2">
                   <div className="flex items-center gap-2 text-sm z-10 w-full min-w-0 pr-4">
-                    <div className={`w-1.5 h-1.5 rounded-full ${e.status === 'active' ? 'bg-green-400' : 'bg-amber-400'}`} />
+                    <div className={`w-1.5 h-1.5 rounded-full ${e.status === 'active' ? 'bg-green-400' : 'bg-amber-500'}`} />
                     <span className="text-slate-700 capitalize">{e.provider_type === 'google' ? 'Gmail' : e.provider_type === 'outlook' ? 'Outlook' : e.provider_type}</span>
                     <span className="text-slate-500 truncate">· {e.email_address}</span>
                   </div>
@@ -304,7 +304,7 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
                 <div className="grid grid-cols-2 gap-2">
                   <button
                      onClick={() => { window.location.href = '/api/auth/google?returnPath=/dashboard/profile'; }}
-                    className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-mint-400/50 rounded-lg px-4 py-3 transition-all text-left"
+                    className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-emerald-500/50 rounded-lg px-4 py-3 transition-all text-left"
                   >
                     <span className="text-xl">📧</span>
                     <div>
@@ -314,7 +314,7 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
                   </button>
                   <button
                      onClick={() => { window.location.href = '/api/outlook/auth?returnPath=/dashboard/profile'; }}
-                    className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-mint-400/50 rounded-lg px-4 py-3 transition-all text-left"
+                    className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-emerald-500/50 rounded-lg px-4 py-3 transition-all text-left"
                   >
                     <span className="text-xl">📬</span>
                     <div>
@@ -322,14 +322,14 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
                       <p className="text-slate-500 text-[10px]">One-click connect</p>
                     </div>
                   </button>
-                  <button onClick={() => { setImapMode(true); setConnectEmail(''); }} className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-mint-400/50 rounded-lg px-4 py-3 transition-all text-left">
+                  <button onClick={() => { setImapMode(true); setConnectEmail(''); }} className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-emerald-500/50 rounded-lg px-4 py-3 transition-all text-left">
                     <span className="text-xl">📨</span>
                     <div>
                       <p className="text-slate-900 text-sm font-medium">Yahoo Mail</p>
                       <p className="text-slate-500 text-[10px]">App password required</p>
                     </div>
                   </button>
-                  <button onClick={() => { setImapMode(true); setConnectEmail(''); }} className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-mint-400/50 rounded-lg px-4 py-3 transition-all text-left">
+                  <button onClick={() => { setImapMode(true); setConnectEmail(''); }} className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-emerald-500/50 rounded-lg px-4 py-3 transition-all text-left">
                     <span className="text-xl">✉️</span>
                     <div>
                       <p className="text-slate-900 text-sm font-medium">Other</p>
@@ -349,7 +349,7 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
                       value={connectEmail}
                       onChange={(e) => setConnectEmail(e.target.value)}
                       placeholder="you@example.com"
-                      className="w-full bg-slate-50 border border-slate-200 rounded-lg px-4 py-2.5 text-slate-900 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-mint-400/50 text-sm"
+                      className="w-full bg-slate-50 border border-slate-200 rounded-lg px-4 py-2.5 text-slate-900 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 text-sm"
                       autoFocus
                     />
                     {detectedProvider && connectEmail.length > 3 && connectEmail.includes('@') && (
@@ -368,7 +368,7 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
                         value={connectPassword}
                         onChange={(e) => setConnectPassword(e.target.value)}
                         placeholder="Your email password"
-                        className="w-full bg-slate-50 border border-slate-200 rounded-lg px-4 py-2.5 pr-10 text-slate-900 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-mint-400/50 text-sm"
+                        className="w-full bg-slate-50 border border-slate-200 rounded-lg px-4 py-2.5 pr-10 text-slate-900 placeholder:text-slate-600 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 text-sm"
                       />
                       <button
                         type="button"
@@ -381,15 +381,15 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
                   </div>
 
                   {detectedProvider?.note && (
-                    <div className="bg-orange-500/10 border border-amber-500/20 rounded-lg px-3 py-2.5">
-                      <p className="text-xs text-amber-400 leading-relaxed">{detectedProvider.note}</p>
+                    <div className="bg-orange-500/10 border border-amber-200 rounded-lg px-3 py-2.5">
+                      <p className="text-xs text-amber-600 leading-relaxed">{detectedProvider.note}</p>
                     </div>
                   )}
 
                   <button
                     onClick={handleConnectEmail}
                     disabled={connecting || !connectEmail || !connectEmail.includes('@') || !connectPassword}
-                    className="w-full flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold px-5 py-2.5 rounded-lg transition-all text-sm"
+                    className="w-full flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed text-slate-900 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm"
                   >
                     {connecting ? (
                       <><Loader2 className="h-4 w-4 animate-spin" /> Connecting...</>
@@ -717,7 +717,7 @@ export default function ProfilePage() {
 
   const subscriptionBadge = () => {
     const colors = {
-      free: 'bg-slate-500/10 text-slate-600 border-slate-500/30',
+      free: 'bg-slate-100 text-slate-600 border-slate-500/30',
       essential: 'bg-emerald-500/10 text-emerald-600 border-emerald-200',
       pro: 'bg-purple-500/10 text-purple-400 border-purple-500/30',
     };
@@ -775,8 +775,8 @@ export default function ProfilePage() {
       <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-8 mb-6">
         <div className="flex items-start justify-between mb-6">
           <div className="flex items-center gap-4">
-            <div className="w-16 h-16 bg-gradient-to-br from-mint-400 to-mint-500 rounded-full flex items-center justify-center">
-              <User className="h-8 w-8 text-white" />
+            <div className="w-16 h-16 bg-gradient-to-br from-emerald-500 to-emerald-500 rounded-full flex items-center justify-center">
+              <User className="h-8 w-8 text-slate-900" />
             </div>
             <div>
               <h2 className="text-2xl font-bold text-slate-900">{profile?.full_name || 'User'}</h2>
@@ -832,7 +832,7 @@ export default function ProfilePage() {
                   type="text"
                   value={editForm.first_name}
                   onChange={(e) => setEditForm({ ...editForm, first_name: e.target.value })}
-                  className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-mint-400 text-sm"
+                  className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 text-sm"
                   placeholder="First name"
                 />
               </div>
@@ -842,7 +842,7 @@ export default function ProfilePage() {
                   type="text"
                   value={editForm.last_name}
                   onChange={(e) => setEditForm({ ...editForm, last_name: e.target.value })}
-                  className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-mint-400 text-sm"
+                  className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 text-sm"
                   placeholder="Last name"
                 />
               </div>
@@ -854,7 +854,7 @@ export default function ProfilePage() {
                 type="tel"
                 value={editForm.phone}
                 onChange={(e) => setEditForm({ ...editForm, phone: e.target.value })}
-                className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-mint-400 text-sm"
+                className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 text-sm"
                 placeholder="07xxx xxxxxx"
               />
             </div>
@@ -865,7 +865,7 @@ export default function ProfilePage() {
                 type="text"
                 value={editForm.address}
                 onChange={(e) => setEditForm({ ...editForm, address: e.target.value })}
-                className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-mint-400 text-sm"
+                className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 text-sm"
                 placeholder="House number, street, city"
               />
             </div>
@@ -876,7 +876,7 @@ export default function ProfilePage() {
                 type="text"
                 value={editForm.postcode}
                 onChange={(e) => setEditForm({ ...editForm, postcode: e.target.value })}
-                className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-mint-400 text-sm uppercase"
+                className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 text-sm uppercase"
                 placeholder="SW1A 1AA"
                 maxLength={8}
               />
@@ -894,7 +894,7 @@ export default function ProfilePage() {
               <button
                 onClick={handleSaveProfile}
                 disabled={saving}
-                className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold rounded-xl transition-all text-sm disabled:opacity-50"
+                className="flex items-center gap-2 px-5 py-2.5 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-xl transition-all text-sm disabled:opacity-50"
               >
                 <Save className="h-4 w-4" />
                 {saving ? 'Saving...' : 'Save Changes'}
@@ -937,7 +937,7 @@ export default function ProfilePage() {
               type="password"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
-              className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-mint-400 text-sm"
+              className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200/50 rounded-lg text-slate-900 placeholder-slate-500 focus:outline-none focus:border-emerald-500 text-sm"
               placeholder="••••••••"
              />
           </div>
@@ -975,7 +975,7 @@ export default function ProfilePage() {
             </div>
             <div className="w-full bg-slate-100 rounded-full h-2 mb-3">
               <div
-                className="bg-gradient-to-r from-mint-400 to-mint-500 h-2 rounded-full transition-all duration-500"
+                className="bg-gradient-to-r from-emerald-500 to-emerald-500 h-2 rounded-full transition-all duration-500"
                 style={{ width: `${percent}%` }}
               />
             </div>
@@ -987,7 +987,7 @@ export default function ProfilePage() {
               {!profile?.postcode && ' Add your postcode.'}
             </p>
             {!editing && (
-              <button onClick={startEditing} className="mt-2 text-xs text-emerald-600 hover:text-mint-300 font-medium transition-all">
+              <button onClick={startEditing} className="mt-2 text-xs text-emerald-600 hover:text-emerald-500 font-medium transition-all">
                 Complete profile
               </button>
             )}
@@ -1013,7 +1013,7 @@ export default function ProfilePage() {
             <div className="flex items-center justify-between">
               <div>
                 <span className={`inline-block text-sm font-semibold px-3 py-1 rounded-full ${
-                  isTrialUser ? 'bg-amber-400/10 text-amber-400' :
+                  isTrialUser ? 'bg-amber-100 text-amber-600' :
                   effectiveTier === 'pro' ? 'bg-brand-400/10 text-brand-400' :
                   effectiveTier === 'essential' ? 'bg-emerald-500/10 text-emerald-600' :
                   'bg-slate-400/10 text-slate-600'
@@ -1031,11 +1031,11 @@ export default function ProfilePage() {
                 </p>
               </div>
               {isTrialUser ? (
-                <Link href="/pricing" className="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-4 py-2 rounded-lg transition-all text-sm whitespace-nowrap">
+                <Link href="/pricing" className="bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-4 py-2 rounded-lg transition-all text-sm whitespace-nowrap">
                   Subscribe to keep Pro
                 </Link>
               ) : effectiveTier === 'free' ? (
-                <Link href="/pricing" className="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-4 py-2 rounded-lg transition-all text-sm whitespace-nowrap">
+                <Link href="/pricing" className="bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-4 py-2 rounded-lg transition-all text-sm whitespace-nowrap">
                   Upgrade Plan
                 </Link>
               ) : (
@@ -1064,7 +1064,7 @@ export default function ProfilePage() {
               <button
                 onClick={() => handleGenerateReport('annual')}
                 disabled={reportLoading}
-                className="flex items-center gap-2 bg-gradient-to-r from-mint-400 to-mint-500 hover:from-mint-500 hover:to-mint-600 text-white font-semibold px-5 py-2.5 rounded-xl transition-all disabled:opacity-50"
+                className="flex items-center gap-2 bg-gradient-to-r from-emerald-500 to-emerald-500 hover:from-emerald-500 hover:to-emerald-600 text-slate-900 font-semibold px-5 py-2.5 rounded-xl transition-all disabled:opacity-50"
               >
                 {reportLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <FileText className="h-4 w-4" />}
                 {reportLoading ? 'Generating...' : 'Generate Annual Report'}
@@ -1162,7 +1162,7 @@ export default function ProfilePage() {
             </p>
             <a
               href="/pricing"
-              className="inline-flex items-center gap-2 bg-gradient-to-r from-mint-400 to-mint-500 hover:from-mint-500 hover:to-mint-600 text-white font-semibold px-6 py-3 rounded-lg transition-all"
+              className="inline-flex items-center gap-2 bg-gradient-to-r from-emerald-500 to-emerald-500 hover:from-emerald-500 hover:to-emerald-600 text-slate-900 font-semibold px-6 py-3 rounded-lg transition-all"
             >
               Upgrade Plan
             </a>
@@ -1247,7 +1247,7 @@ export default function ProfilePage() {
         ) : (
           <Link
             href="/dashboard/pocket-agent"
-            className="inline-flex items-center gap-2 px-4 py-2 bg-orange-500/10 hover:bg-orange-500/20 text-amber-400 rounded-xl text-sm font-medium transition-colors"
+            className="inline-flex items-center gap-2 px-4 py-2 bg-orange-500/10 hover:bg-orange-500/20 text-amber-600 rounded-xl text-sm font-medium transition-colors"
           >
             Set Up Pocket Agent
           </Link>

--- a/src/app/dashboard/profile/report/page.tsx
+++ b/src/app/dashboard/profile/report/page.tsx
@@ -142,7 +142,7 @@ export default function AnnualReportPage() {
             </div>
           </div>
           <div className="flex-1 w-full">
-            <p className={`text-xl font-bold ${data.financialHealth.tier === 'healthy' ? 'text-green-400' : data.financialHealth.tier === 'coping' ? 'text-amber-400' : 'text-red-400'} mb-1`}>
+            <p className={`text-xl font-bold ${data.financialHealth.tier === 'healthy' ? 'text-green-400' : data.financialHealth.tier === 'coping' ? 'text-amber-600' : 'text-red-400'} mb-1`}>
               {data.financialHealth.tier.charAt(0).toUpperCase() + data.financialHealth.tier.slice(1)}
             </p>
             <div className="space-y-2 mt-3">
@@ -313,7 +313,7 @@ export default function AnnualReportPage() {
                   <span className={`text-xs px-2 py-0.5 rounded-full ${
                     d.status === 'resolved' || d.status === 'resolved_success' ? 'bg-green-500/10 text-green-400' :
                     d.status === 'open' || d.status === 'in_progress' ? 'bg-blue-500/10 text-blue-400' :
-                    'bg-slate-500/10 text-slate-600'
+                    'bg-slate-100 text-slate-600'
                   }`}>{d.status.replace(/_/g, ' ')}</span>
                   <p className="text-[10px] text-slate-500 mt-0.5">{d.dateFiled}</p>
                 </div>
@@ -394,7 +394,7 @@ export default function AnnualReportPage() {
       {/* Footer actions */}
       <div className="flex flex-wrap gap-3 justify-center">
         <button onClick={handleDownloadPDF} disabled={pdfLoading}
-          className="flex items-center gap-2 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-mint-500 hover:to-mint-600 text-navy-950 font-semibold px-6 py-3 rounded-xl transition-all disabled:opacity-50">
+          className="flex items-center gap-2 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-500 hover:to-emerald-600 text-slate-900 font-semibold px-6 py-3 rounded-xl transition-all disabled:opacity-50">
           {pdfLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
           Download PDF
         </button>

--- a/src/app/dashboard/rewards/page.tsx
+++ b/src/app/dashboard/rewards/page.tsx
@@ -203,7 +203,7 @@ export default function RewardsPage() {
         <Gift className="h-16 w-16 text-red-400 mx-auto mb-4" />
         <h2 className="text-2xl font-bold text-slate-900 mb-2">Something went wrong</h2>
         <p className="text-slate-600 mb-4">{error}</p>
-        <button onClick={() => { setError(null); setLoading(true); loadData(); }} className="px-4 py-2 bg-emerald-500 text-white rounded-lg font-medium hover:bg-emerald-600 transition-colors">
+        <button onClick={() => { setError(null); setLoading(true); loadData(); }} className="px-4 py-2 bg-emerald-500 text-slate-900 rounded-lg font-medium hover:bg-emerald-600 transition-colors">
           Retry
         </button>
       </div>
@@ -334,7 +334,7 @@ export default function RewardsPage() {
             const isRedeeming = redeemingId === opt.id;
             const pointsNeeded = Math.max(0, opt.points - data.balance);
             return (
-              <div key={opt.id} className={`bg-white border rounded-2xl p-4 text-center transition-all ${isLocked ? 'border-slate-200/50 opacity-60' : 'border-mint-400/30 hover:border-mint-400/60'}`}>
+              <div key={opt.id} className={`bg-white border rounded-2xl p-4 text-center transition-all ${isLocked ? 'border-slate-200/50 opacity-60' : 'border-emerald-500/30 hover:border-emerald-500/60'}`}>
                 <span className="text-3xl block mb-2">{redemptionEmojis[opt.id] || '🎁'}</span>
                 <p className="text-slate-900 font-semibold text-sm mb-1">{opt.label}</p>
                 <p className="text-emerald-600 font-bold text-sm mb-2">{opt.points.toLocaleString()} pts</p>
@@ -351,7 +351,7 @@ export default function RewardsPage() {
                       }
                     }}
                     disabled={isRedeeming}
-                    className="bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-navy-950 font-semibold px-3 py-1.5 rounded-lg text-xs transition-all w-full"
+                    className="bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-3 py-1.5 rounded-lg text-xs transition-all w-full"
                   >
                     {isRedeeming ? <Loader2 className="h-3 w-3 animate-spin mx-auto" /> : 'Redeem'}
                   </button>
@@ -377,7 +377,7 @@ export default function RewardsPage() {
                 key={badge.id}
                 href={earned ? '#' : badge.action}
                 className={`rounded-xl p-3 text-center transition-all border ${earned
-                  ? 'bg-emerald-50 border-emerald-200 hover:border-mint-400/40'
+                  ? 'bg-emerald-50 border-emerald-200 hover:border-emerald-500/40'
                   : 'bg-slate-50/50 border-slate-200/50 hover:border-slate-200/50 opacity-40'
                 }`}
                 title={earned ? `${badge.name} - earned ${earnedData ? new Date(earnedData.earned_at).toLocaleDateString('en-GB') : ''}` : badge.description}
@@ -528,7 +528,7 @@ export default function RewardsPage() {
 
       {/* ═══ SECTION 6: Referrals ═══ */}
       {referrals && (
-        <div id="referrals" className="bg-gradient-to-r from-mint-400/10 to-mint-500/5 border border-emerald-200 rounded-2xl p-6 mb-8">
+        <div id="referrals" className="bg-gradient-to-r from-emerald-500/10 to-emerald-500/5 border border-emerald-200 rounded-2xl p-6 mb-8">
           <h2 className="text-lg font-bold text-slate-900 mb-2 flex items-center gap-2">
             <Share2 className="h-5 w-5 text-emerald-600" /> Invite friends, both get 1 free month
           </h2>
@@ -537,8 +537,8 @@ export default function RewardsPage() {
           <div className="bg-slate-50/50 rounded-xl p-4 border border-slate-200/50 mb-4">
             <p className="text-slate-500 text-xs mb-2">Your referral link</p>
             <div className="flex items-center gap-2">
-              <code className="flex-1 text-emerald-600 text-sm bg-slate-900 rounded-lg px-3 py-2 font-mono truncate">{referrals.joinUrl}</code>
-              <button onClick={handleCopyCode} className="shrink-0 bg-emerald-500 hover:bg-emerald-600 text-navy-950 font-semibold px-3 py-2 rounded-lg text-sm transition-all">
+              <code className="flex-1 text-emerald-600 text-sm bg-white rounded-lg px-3 py-2 font-mono truncate">{referrals.joinUrl}</code>
+              <button onClick={handleCopyCode} className="shrink-0 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-3 py-2 rounded-lg text-sm transition-all">
                 {codeCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
               </button>
               <button onClick={handleWhatsAppShare} className="shrink-0 bg-green-600 hover:bg-green-700 text-slate-900 px-3 py-2 rounded-lg text-sm transition-all">
@@ -643,7 +643,7 @@ export default function RewardsPage() {
               <p className="text-slate-600 text-sm mb-3">Tiers are based on both your membership duration and lifetime points earned. Higher tiers unlock better perks and a points multiplier.</p>
               <div className="space-y-2">
                 {data.allTiers.map((t) => (
-                  <div key={t.key} className={`flex items-center gap-3 rounded-lg px-4 py-3 border ${t.isCurrent ? 'border-mint-400/50 bg-emerald-50' : 'border-slate-200/50 bg-slate-50/50'}`}>
+                  <div key={t.key} className={`flex items-center gap-3 rounded-lg px-4 py-3 border ${t.isCurrent ? 'border-emerald-500/50 bg-emerald-50' : 'border-slate-200/50 bg-slate-50/50'}`}>
                     <span>{tierEmojis[t.key]}</span>
                     <div className="flex-1">
                       <span className="text-slate-900 font-semibold text-sm">{t.label}</span>


### PR DESCRIPTION
Final pass — earlier batches left small residues of navy/mint tokens in gradients and progress bars. This sweep catches all remaining dark-theme tokens across 11 dashboard pages.

`npx tsc --noEmit` clean (4 pre-existing errors unchanged).