### PR TITLE
hotfix: export missing savings-utils helpers (unblocks prod deploys)

### DIFF
--- a/src/lib/savings-utils.ts
+++ b/src/lib/savings-utils.ts
@@ -21,15 +21,22 @@ export function isDealValid(deal: { category?: string | null; currentPrice?: num
   return true;
 }
 
+export function priceAlertAnnualImpact(a: any): number {
+  const diff = (parseFloat(a?.new_amount) || 0) - (parseFloat(a?.old_amount) || 0);
+  if (diff > 0) return diff * 12;
+  return parseFloat(a?.annual_impact) || 0;
+}
+
+export function isPriceAlertValid(a: any): boolean {
+  return priceAlertAnnualImpact(a) > 0;
+}
+
 export function calculateTotalSavings(deals: any[], priceAlerts: any[]): number {
   const validDeals = (deals || []).filter(isDealValid);
   const dealsTotal = validDeals.reduce((sum, d) => sum + (d.annualSaving || 0), 0);
-  
-  const alertTotal = (priceAlerts || []).reduce((sum, a) => {
-    const diff = (parseFloat(a.new_amount) || 0) - (parseFloat(a.old_amount) || 0);
-    return sum + (diff > 0 ? diff * 12 : (parseFloat(a.annual_impact) || 0));
-  }, 0);
-  
+
+  const alertTotal = (priceAlerts || []).reduce((sum, a) => sum + priceAlertAnnualImpact(a), 0);
+
   return dealsTotal + alertTotal;
 }
 


### PR DESCRIPTION
## Summary
- Adds the two exports that PR #136 (batch 8e re-skin) imports but never defined: `isPriceAlertValid` and `priceAlertAnnualImpact`.
- Production deploys have been erroring since ~14:28 UTC today with:
  > Export `priceAlertAnnualImpact` doesn't exist in target module
- That single missing export is blocking the homepage link fixes (PR #137), the Telegram Pocket Agent Pro-gate fixes, and every dashboard light-theme re-skin from reaching paybacker.co.uk.

## What changed
- `src/lib/savings-utils.ts` — extracted `priceAlertAnnualImpact` and `isPriceAlertValid` as named exports. Logic is lifted verbatim from the inline reducer already in `calculateTotalSavings`, so behaviour is identical.
- `calculateTotalSavings` now reuses `priceAlertAnnualImpact` internally rather than inlining the same rule twice.

## Test plan
- [x] `npx tsc --noEmit` — zero errors.
- [ ] Once merged, confirm the next Vercel production build succeeds (`vercel ls` → Ready).
- [ ] Load `https://paybacker.co.uk/` and confirm the new homepage (Sign in / Start Free in the nav, `/privacy-policy` in the footer) is live.
- [ ] Confirm Telegram Pocket Agent no longer prompts free users to upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)