### PR TITLE
fix(money-hub): honour user overrides on positive-amount txns + allow income-type reassignment

### DIFF
--- a/src/app/api/money-hub/recategorise/route.ts
+++ b/src/app/api/money-hub/recategorise/route.ts
@@ -40,11 +40,24 @@ export async function POST(request: NextRequest) {
 
     // ─── Income type recategorisation ──────────────────────────────────────
     if (newIncomeType) {
+      // When the user reclassifies to a real income type, clear any conflicting
+      // user_category spending override (e.g. if they'd previously marked it 'loans').
+      const incomePatch: Record<string, any> = { income_type: newIncomeType, user_category: null };
+
       if (transactionId) {
         await admin.from('bank_transactions')
-          .update({ income_type: newIncomeType })
+          .update(incomePatch)
           .eq('id', transactionId)
           .eq('user_id', user.id);
+
+        // Also clear any per-transaction override row (best-effort)
+        try {
+          await admin.from('money_hub_category_overrides')
+            .delete()
+            .eq('user_id', user.id)
+            .eq('transaction_id', transactionId);
+        } catch { /* silent */ }
+
         return NextResponse.json({ success: true, updated: 1, transactionId, incomeType: newIncomeType });
       }
 
@@ -64,11 +77,20 @@ export async function POST(request: NextRequest) {
           for (let i = 0; i < ids.length; i += 50) {
             const batch = ids.slice(i, i + 50);
             const { count } = await admin.from('bank_transactions')
-              .update({ income_type: newIncomeType })
+              .update(incomePatch)
               .in('id', batch);
             if (count) updated += count;
           }
         }
+
+        // Remove any stale merchant-level override that would force back to a spending category (best-effort)
+        const corePattern = merchantPattern.toLowerCase().trim();
+        try {
+          await admin.from('money_hub_category_overrides')
+            .delete()
+            .eq('user_id', user.id)
+            .eq('merchant_pattern', corePattern);
+        } catch { /* silent */ }
 
         await learnFromCorrection({
           rawName: merchantPattern,
@@ -122,16 +144,28 @@ export async function POST(request: NextRequest) {
       if (applyToAll !== false) {
         const ilikePattern = `%${overridePattern}%`;
         const { data: matching } = await admin.from('bank_transactions')
-          .select('id')
+          .select('id, amount')
           .eq('user_id', user.id)
           .gte('timestamp', sixMonthsAgo.toISOString())
           .or(`merchant_name.ilike.${ilikePattern},description.ilike.${ilikePattern}`)
           .limit(500);
 
         if (matching && matching.length > 0) {
-          const ids = matching.map(t => t.id);
-          for (let i = 0; i < ids.length; i += 50) {
-            const batch = ids.slice(i, i + 50);
+          // Split into positive-amount (income side) and negative-amount (spending side).
+          // For positive amounts, also exclude from income totals by setting
+          // income_type = 'credit_loan' (which isExcludedIncomeType treats as non-income).
+          const positiveIds = matching.filter(t => Number(t.amount) > 0).map(t => t.id);
+          const negativeIds = matching.filter(t => Number(t.amount) <= 0).map(t => t.id);
+
+          for (let i = 0; i < positiveIds.length; i += 50) {
+            const batch = positiveIds.slice(i, i + 50);
+            const { count } = await admin.from('bank_transactions')
+              .update({ user_category: newCategory, income_type: 'credit_loan' })
+              .in('id', batch);
+            if (count) updated += count;
+          }
+          for (let i = 0; i < negativeIds.length; i += 50) {
+            const batch = negativeIds.slice(i, i + 50);
             const { count } = await admin.from('bank_transactions')
               .update({ user_category: newCategory })
               .in('id', batch);
@@ -158,14 +192,20 @@ export async function POST(request: NextRequest) {
 
     // Single transaction override
     if (transactionId) {
-      // Need metadata for learning engine
+      // Need metadata for learning engine and to decide whether to exclude from income
       const { data: txnData } = await admin.from('bank_transactions')
         .select('amount, description, merchant_name')
         .eq('id', transactionId)
         .single();
-        
+
+      const txnPatch: Record<string, any> = { user_category: newCategory };
+      // For positive-amount transactions, also exclude from income by flagging credit_loan
+      if (txnData && Number(txnData.amount) > 0 && newCategory !== 'income') {
+        txnPatch.income_type = 'credit_loan';
+      }
+
       await admin.from('bank_transactions')
-        .update({ user_category: newCategory })
+        .update(txnPatch)
         .eq('id', transactionId)
         .eq('user_id', user.id);
 

--- a/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
+++ b/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
@@ -22,6 +22,17 @@ const ALL_CATEGORIES = [
   'transfers', 'travel', 'utility', 'water',
 ];
 
+// Income types the user can pick from when drilling into income.
+// Must match the CHECK constraint on bank_transactions.income_type and REAL_INCOME_TYPES in money-hub-classification.
+const INCOME_TYPES = [
+  'salary', 'freelance', 'benefits', 'rental', 'investment',
+  'refund', 'loan_repayment', 'gift', 'other',
+];
+
+// "This isn't income" escape hatch — picking one of these marks the txn as
+// non-income (income_type = 'credit_loan') and labels it on the spending side.
+const NON_INCOME_CATEGORIES = ['transfers', 'loans', 'mortgage', 'credit'];
+
 export default function CategoryDrillDownModal({ isOpen, onClose, category, incomeType, searchQuery, selectedMonth, onRecategorised }: CategoryDrillDownModalProps) {
   const [data, setData] = useState<{ transactions: any[]; merchants: any[]; totalSpent: number } | null>(null);
   const [loading, setLoading] = useState(false);
@@ -55,19 +66,37 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
     setLoading(false);
   };
 
-  const handleRecategorise = async (merchantPattern: string, newCategory: string) => {
+  // Unified recategorise handler.
+  // `mode` decides whether we POST { newIncomeType } (income-type change) or
+  // { newCategory } (spending-category / non-income label).
+  const handleRecategorise = async (
+    merchantPattern: string,
+    newValue: string,
+    mode: 'incomeType' | 'category' = 'category',
+  ) => {
     setRecatLoading(true);
     try {
+      const body: Record<string, any> =
+        mode === 'incomeType'
+          ? { merchantPattern, newIncomeType: newValue, applyToAll: true }
+          : { merchantPattern, newCategory: newValue, applyToAll: true };
+
       await fetch('/api/money-hub/recategorise', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ merchantPattern, newCategory, applyToAll: true }),
+        body: JSON.stringify(body),
       });
+
+      // Teach the learning engine with the matching signal
+      const learnBody: Record<string, any> = { rawName: merchantPattern };
+      if (mode === 'incomeType') learnBody.incomeType = newValue;
+      else learnBody.category = newValue;
       await fetch('/api/learn', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rawName: merchantPattern, category: newCategory }),
+        body: JSON.stringify(learnBody),
       });
+
       await loadData();
       onRecategorised();
     } catch {
@@ -83,6 +112,68 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
   let displayTitle = '';
   if (searchQuery) displayTitle = `Search: "${searchQuery}"`;
   else displayTitle = (incomeType || category!).replace(/_/g, ' ');
+
+  // When the modal is opened in income context, the dropdown offers income types
+  // plus a "Not income" escape hatch. Otherwise we fall back to spending categories.
+  const isIncomeMode = !!incomeType;
+
+  const renderReassignOptions = (pattern: string) => {
+    if (isIncomeMode) {
+      return (
+        <>
+          <div className="p-2 border-b border-navy-700 bg-navy-900/50">
+            <p className="text-xs text-slate-400 font-medium">Change income type</p>
+          </div>
+          <div className="max-h-48 overflow-y-auto custom-scrollbar p-1">
+            {INCOME_TYPES.map(t => (
+              <button
+                key={`inc-${t}`}
+                onClick={() => handleRecategorise(pattern, t, 'incomeType')}
+                disabled={recatLoading}
+                className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
+              >
+                {t.replace(/_/g, ' ')}
+              </button>
+            ))}
+          </div>
+          <div className="p-2 border-t border-b border-navy-700 bg-navy-900/50">
+            <p className="text-xs text-slate-400 font-medium">Not income — tag as</p>
+          </div>
+          <div className="max-h-32 overflow-y-auto custom-scrollbar p-1">
+            {NON_INCOME_CATEGORIES.map(c => (
+              <button
+                key={`nic-${c}`}
+                onClick={() => handleRecategorise(pattern, c, 'category')}
+                disabled={recatLoading}
+                className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
+              >
+                {c.replace(/_/g, ' ')}
+              </button>
+            ))}
+          </div>
+        </>
+      );
+    }
+    return (
+      <>
+        <div className="p-2 border-b border-navy-700 bg-navy-900/50">
+          <p className="text-xs text-slate-400 font-medium">Reassign to...</p>
+        </div>
+        <div className="max-h-60 overflow-y-auto custom-scrollbar p-1">
+          {ALL_CATEGORIES.map(c => (
+            <button
+              key={c}
+              onClick={() => handleRecategorise(pattern, c, 'category')}
+              disabled={recatLoading}
+              className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
+            >
+              {c.replace(/_/g, ' ')}
+            </button>
+          ))}
+        </div>
+      </>
+    );
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -135,22 +226,8 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                       </div>
                       
                       {merchantRecatIdx === idx && (
-                        <div className="absolute top-16 right-0 w-48 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
-                          <div className="p-2 border-b border-navy-700 bg-navy-900/50">
-                            <p className="text-xs text-slate-400 font-medium">Reassign to...</p>
-                          </div>
-                          <div className="max-h-60 overflow-y-auto custom-scrollbar p-1">
-                            {ALL_CATEGORIES.map(c => (
-                              <button
-                                key={c}
-                                onClick={() => handleRecategorise(m.merchant, c)}
-                                disabled={recatLoading}
-                                className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
-                              >
-                                {c.replace(/_/g, ' ')}
-                              </button>
-                            ))}
-                          </div>
+                        <div className="absolute top-16 right-0 w-56 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
+                          {renderReassignOptions(m.merchant)}
                         </div>
                       )}
                     </div>
@@ -182,19 +259,8 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                         </div>
 
                         {isRecatOpen && (
-                          <div className="absolute top-12 right-4 w-48 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
-                            <div className="max-h-60 overflow-y-auto custom-scrollbar p-1">
-                              {ALL_CATEGORIES.map(c => (
-                                <button
-                                  key={c}
-                                  onClick={() => handleRecategorise(cleanMerchantName(txn.description || ''), c)}
-                                  disabled={recatLoading}
-                                  className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
-                                >
-                                  {c.replace(/_/g, ' ')}
-                                </button>
-                              ))}
-                            </div>
+                          <div className="absolute top-12 right-4 w-56 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
+                            {renderReassignOptions(cleanMerchantName(txn.description || ''))}
                           </div>
                         )}
                       </div>

--- a/src/lib/money-hub-classification.ts
+++ b/src/lib/money-hub-classification.ts
@@ -21,6 +21,11 @@ const SPENDING_CATEGORY_ALIASES: Record<string, string> = {
   loan: 'loans',
   utility: 'energy',
   transport: 'travel',
+  // Bank-provided "BILL_PAYMENT" raw category should collapse into 'bills'
+  // so the spending breakdown doesn't show two separate rows.
+  bill_payment: 'bills',
+  billpayment: 'bills',
+  'bill-payment': 'bills',
 };
 
 type OverrideMap = Map<string, string>;
@@ -159,6 +164,34 @@ export function resolveMoneyHubTransaction(
   if (amount > 0) {
     if (resolvedOverride === 'transfers' || isTransferLikeTransaction(txn, effectiveIncomeType)) {
       return { amount, kind: 'transfer', spendingCategory: 'transfers', incomeType: 'transfer' };
+    }
+
+    // User override wins for positive-amount transactions too.
+    // If the user has explicitly tagged this as a non-income category
+    // (e.g. 'loans', 'mortgage', 'credit'), respect it — exclude from income totals.
+    // We mirror the spending-branch logic: resolvedOverride (from the overrides
+    // table — strong signal) is honoured outright, while storedCategory (which
+    // migrations can also set) is honoured only for non-soft categories.
+    if (resolvedOverride && resolvedOverride !== 'income') {
+      return {
+        amount,
+        kind: 'transfer',
+        spendingCategory: resolvedOverride,
+        incomeType: null,
+      };
+    }
+    if (
+      storedCategory &&
+      storedCategory !== 'income' &&
+      storedCategory !== 'transfers' &&
+      !SOFT_SPENDING_CATEGORIES.has(storedCategory)
+    ) {
+      return {
+        amount,
+        kind: 'transfer',
+        spendingCategory: storedCategory,
+        incomeType: null,
+      };
     }
 
     const hasRealIncomeType = !!effectiveIncomeType && !isExcludedIncomeType(effectiveIncomeType);


### PR DESCRIPTION
## Summary
Fixes the bug where recategorising a transaction in Money Hub has no visible effect in two common cases:

- **Other → Salary.** API only updated `income_type`, leaving a stale `user_category` override to win on the next render.
- **Salary → Loan.** No UI path existed, and the classifier ignored user overrides on positive-amount rows.

## What changed
- **Server** (`/api/money-hub/recategorise`): when the user sets a new income type, also null out the conflicting `user_category` and best-effort delete any override rows. When a positive-amount txn is tagged as a non-income spending category (e.g. 'loans'), also set `income_type = 'credit_loan'` so the classifier excludes it from income totals.
- **Classifier** (`src/lib/money-hub-classification.ts`): in the positive-amount / income branch, consult `resolvedOverride` and `storedCategory` first. If the user has tagged the row as non-income (loans, mortgage, credit, transfers…), respect it and exclude from income totals.
- **UI** (`CategoryDrillDownModal`): drilldown in income context now offers the 9 canonical income types + a "Not income — tag as" escape hatch (transfers, loans, mortgage, credit). Learning engine is taught with either `{ incomeType }` or `{ category }` depending on the mode.

## Scope
Three files only. Every other change from the exploratory branch (worktree gitlinks, binary office files, research docs, canonical-taxonomy bits already on master) is intentionally left out.

## Test plan
- [x] `npx tsc --noEmit` — zero errors in the touched files (two pre-existing errors in `dashboard/page.tsx` are fixed by #140).
- [ ] Once #140 lands: Other → Salary reassign persists on reload and moves the txn into income totals.
- [ ] Salary → Loan reassign (via "Not income — tag as" in the income drilldown) removes the txn from income totals and shows it under Loans on the spending side.
- [ ] Merchant-pattern reassign ("Apply to all matching") propagates to the last 6 months of rows.

Depends on #140 for a clean production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)