### PR TITLE
fix(homepage): hardcode £1,000+ in Average potential savings stat card

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -562,10 +562,7 @@ export default function HomepageV2Preview() {
             <div className="stat-card reveal">
               <div className="label">Average potential savings</div>
               <div className="num">
-                {stats && stats.avgSavingsPerUser > 0
-                  ? formatGBP(stats.avgSavingsPerUser)
-                  : '£1,000+'}
-                <span className="unit">/yr</span>
+                £1,000+<span className="unit">/yr</span>
               </div>
               <div className="underline" />
               <div className="blurb">


### PR DESCRIPTION
Replaces the dynamic stats.avgSavingsPerUser lookup with the canonical marketing figure. The stats API was returning £8,029/yr from verified_savings seed rows, but the rest of the page already uses £1,000+ as the headline.