### PR TITLE
fix(homepage): FAQ privacy/terms links point at real routes

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -1533,8 +1533,8 @@ export default function HomepageV2Preview() {
                   Your data is <strong>never sold</strong>, never shared with third-party
                   advertisers, and never used to train AI models outside your own account. Full
                   detail in our{' '}
-                  <a href="/privacy">Privacy Policy</a> and{' '}
-                  <a href="/terms">Terms of Service</a>.
+                  <a href="/privacy-policy">Privacy Policy</a> and{' '}
+                  <a href="/terms-of-service">Terms of Service</a>.
                 </p>
               </div>
             </details>


### PR DESCRIPTION
## Summary
Two links inside the data-privacy FAQ still pointed at `/privacy` and `/terms`, which 404 on paybacker.co.uk. Swapped them to the canonical `/privacy-policy` and `/terms-of-service` (already used in the page footer and already 200-ing).

## Test plan
- [x] Confirmed the two targets return 200 in production (`/privacy-policy`, `/terms-of-service`).
- [ ] After deploy, open the homepage, expand the data-privacy FAQ, click both links — should load the policy pages rather than 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)