### PR TITLE
fix(homepage): remove "Preview · Homepage v2" badge from production

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -227,10 +227,6 @@ export default function HomepageV2Preview() {
 
   return (
     <div className="m-v2-root" ref={revealContainerRef}>
-      <div className="preview-badge" aria-label="Preview page">
-        Preview · Homepage v2
-      </div>
-
       {/* Floating pill nav ------------------------------------------ */}
       <div className={`nav-shell${navScrolled ? ' scrolled' : ''}`} id="navShell">
         <nav className="nav-pill" aria-label="Primary">


### PR DESCRIPTION
PR #116 stripped the .preview-badge CSS rule, leaving the dev marker rendering as unstyled text at the top of paybacker.co.uk. Removing the markup entirely since it has no place on the live homepage.