### PR TITLE
fix(watchdog): fail loudly on OAuth refresh failures + tighten price alerts

### DIFF
--- a/src/app/api/disputes/[id]/link-email-thread/route.ts
+++ b/src/app/api/disputes/[id]/link-email-thread/route.ts
@@ -42,7 +42,7 @@ export async function GET(
 
   const { data, error } = await supabase
     .from('dispute_watchdog_links')
-    .select('id, provider, thread_id, subject, sender_domain, sender_address, last_synced_at, last_message_date, sync_enabled, created_at')
+    .select('id, email_connection_id, provider, thread_id, subject, sender_domain, sender_address, last_synced_at, last_message_date, sync_enabled, created_at')
     .eq('dispute_id', disputeId)
     .eq('user_id', user.id)
     .eq('sync_enabled', true)

--- a/src/components/dispute/WatchdogCard.tsx
+++ b/src/components/dispute/WatchdogCard.tsx
@@ -21,6 +21,7 @@ import { Loader2, Mail, Link2, RefreshCw, CheckCircle2, AlertCircle, X, Search, 
 
 interface LinkedThread {
   id: string;
+  email_connection_id: string | null;
   provider: 'gmail' | 'outlook' | 'imap';
   thread_id: string;
   subject: string | null;
@@ -129,6 +130,18 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
   const hasStaleEmail =
     emailConnections !== null &&
     emailConnections.some((c) => c.status === 'needs_reauth' || c.status === 'expired');
+
+  // When a thread is linked, find the specific connection backing it so we can
+  // surface a reconnect CTA if that connection's tokens have died. Falls back
+  // to any same-provider connection when the link is older than the
+  // email_connection_id column (best-effort for older rows).
+  const linkedConnection =
+    linked && emailConnections
+      ? emailConnections.find((c) => c.id === linked.email_connection_id) ??
+        emailConnections.find((c) => c.provider_type === linked.provider)
+      : null;
+  const linkedConnectionStale =
+    !!linkedConnection && linkedConnection.status !== 'active';
 
   const openPicker = async () => {
     setPickerOpen(true);
@@ -274,6 +287,30 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
         </div>
       ) : linked ? (
         <>
+          {linkedConnectionStale && (
+            <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 mb-3 flex items-start gap-3">
+              <AlertCircle className="h-4 w-4 text-red-400 flex-shrink-0 mt-0.5" />
+              <div className="flex-1">
+                <p className="text-sm font-semibold text-red-300">
+                  {linked.provider === 'gmail'
+                    ? 'Gmail'
+                    : linked.provider === 'outlook'
+                    ? 'Outlook'
+                    : 'Email'}{' '}
+                  needs reconnecting
+                </p>
+                <p className="text-xs text-slate-400 mt-0.5">
+                  We can't fetch new replies until the connection is restored. Replies sent since then will import automatically once you reconnect.
+                </p>
+                <a
+                  href="/dashboard/profile"
+                  className="inline-flex items-center gap-1.5 mt-2 px-3 py-1.5 bg-red-500/20 hover:bg-red-500/30 text-red-300 font-semibold rounded-md text-xs transition-colors"
+                >
+                  <Link2 className="h-3.5 w-3.5" /> Reconnect in Profile
+                </a>
+              </div>
+            </div>
+          )}
           <div className="bg-navy-950 rounded-lg p-3 mb-3">
             <div className="flex items-center justify-between gap-2 mb-1">
               <span className="text-xs uppercase tracking-wide text-mint-400 font-semibold">

--- a/src/lib/dispute-sync/fetchers.ts
+++ b/src/lib/dispute-sync/fetchers.ts
@@ -10,6 +10,7 @@
  * Plan ref: docs/DISPUTE_EMAIL_SYNC_PLAN.md §6
  */
 
+import { createClient } from '@supabase/supabase-js';
 import { refreshAccessToken as refreshGmailToken } from '../gmail';
 import { refreshMicrosoftToken } from '../outlook';
 import type {
@@ -18,6 +19,29 @@ import type {
   EmailProvider,
 } from './types';
 import { providerFromConnection } from './types';
+
+function admin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+/**
+ * Thrown when an OAuth refresh attempt fails and the connection needs a
+ * human to reconnect. The caller should stop retrying and surface this via
+ * the UI / business_log rather than keep polling on a dead token.
+ */
+export class EmailConnectionAuthError extends Error {
+  constructor(
+    message: string,
+    readonly connectionId: string,
+    readonly provider: EmailProvider,
+  ) {
+    super(message);
+    this.name = 'EmailConnectionAuthError';
+  }
+}
 
 // Local type mirroring the shape Microsoft Graph /me/messages returns with
 // the $select we request. Kept inline so the outlook.ts public surface
@@ -73,24 +97,87 @@ function makeSnippet(body: string, n = 150): string {
   return body.length > n ? body.slice(0, n).trim() + '…' : body.trim();
 }
 
+async function markConnectionNeedsReauth(
+  connectionId: string,
+  provider: EmailProvider,
+  message: string,
+): Promise<void> {
+  const db = admin();
+  try {
+    await db
+      .from('email_connections')
+      .update({
+        status: 'needs_reauth',
+        last_error: message.slice(0, 500),
+        last_error_at: new Date().toISOString(),
+      })
+      .eq('id', connectionId);
+
+    await db.from('business_log').insert({
+      category: 'watchdog_error',
+      title: `${provider} connection needs reauth`,
+      content:
+        `Email connection ${connectionId} (${provider}) failed to refresh its access token. ` +
+        `User must reconnect via Profile. Error: ${message}`,
+      created_by: 'dispute-sync-fetchers',
+    });
+  } catch {
+    // Never let bookkeeping failures mask the real auth error.
+  }
+}
+
+async function persistRefreshedToken(
+  connectionId: string,
+  accessToken: string,
+  expiresInSeconds: number,
+): Promise<void> {
+  const db = admin();
+  try {
+    const expiry = new Date(Date.now() + expiresInSeconds * 1000).toISOString();
+    await db
+      .from('email_connections')
+      .update({
+        access_token: accessToken,
+        token_expiry: expiry,
+        // If we were previously flagged, a successful refresh clears the flag.
+        status: 'active',
+        last_error: null,
+        last_error_at: null,
+      })
+      .eq('id', connectionId);
+  } catch {
+    // Non-fatal — the in-memory token still works for this request.
+  }
+}
+
 async function ensureFreshToken(conn: EmailConnection, provider: EmailProvider): Promise<string> {
   const expiresAt = conn.token_expiry ? new Date(conn.token_expiry).getTime() : 0;
   const now = Date.now();
   if (conn.access_token && expiresAt - now > 60_000) return conn.access_token;
 
   if (!conn.refresh_token) {
-    throw new Error(`No refresh token for connection ${conn.id}; user must reconnect ${provider}.`);
+    const msg = `No refresh token on file — user must reconnect ${provider}.`;
+    await markConnectionNeedsReauth(conn.id, provider, msg);
+    throw new EmailConnectionAuthError(msg, conn.id, provider);
   }
 
-  if (provider === 'gmail') {
-    const refreshed = await refreshGmailToken(conn.refresh_token);
-    return refreshed.access_token;
+  try {
+    if (provider === 'gmail') {
+      const refreshed = await refreshGmailToken(conn.refresh_token);
+      await persistRefreshedToken(conn.id, refreshed.access_token, refreshed.expires_in);
+      return refreshed.access_token;
+    }
+    if (provider === 'outlook') {
+      const refreshed = await refreshMicrosoftToken(conn.refresh_token);
+      await persistRefreshedToken(conn.id, refreshed.access_token, refreshed.expires_in);
+      return refreshed.access_token;
+    }
+    throw new Error(`ensureFreshToken called for non-OAuth provider: ${provider}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Token refresh failed';
+    await markConnectionNeedsReauth(conn.id, provider, message);
+    throw new EmailConnectionAuthError(message, conn.id, provider);
   }
-  if (provider === 'outlook') {
-    const refreshed = await refreshMicrosoftToken(conn.refresh_token);
-    return refreshed.access_token;
-  }
-  throw new Error(`ensureFreshToken called for non-OAuth provider: ${provider}`);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/lib/price-increase-detector.ts
+++ b/src/lib/price-increase-detector.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { normaliseMerchantName } from '@/lib/merchant-normalise';
+import { EXCLUDED_SAVINGS_CATEGORIES } from '@/lib/savings-utils';
 
 function getAdmin() {
   return createClient(
@@ -19,7 +20,9 @@ export interface PriceIncrease {
   newDate: string;
 }
 
-// Categories where amounts vary naturally -- skip these
+// Categories where amounts vary naturally — skip outright. Loans/mortgage/
+// council_tax/credit etc. are handled via EXCLUDED_SAVINGS_CATEGORIES (shared
+// with the Money Hub deals detector) so the two stay in lockstep.
 const VARIABLE_CATEGORIES = new Set([
   'groceries', 'fuel', 'eating_out', 'shopping', 'cash', 'transfers',
   'income', 'other', 'transport', 'gambling',
@@ -28,14 +31,49 @@ const VARIABLE_CATEGORIES = new Set([
   'CREDIT', 'INTEREST', 'OTHER',
 ]);
 
-// Only these transaction categories can be recurring bills
+// Only these transaction categories can be recurring bills. Loans / mortgages
+// / council tax / credit were removed Apr 2026 — their amounts fluctuate with
+// repayment schedules or billing cycles, which the std-dev filter wasn't
+// catching (see Funding Circle + Winchester Council in real user data).
 const RECURRING_CATEGORIES = new Set([
   'DIRECT_DEBIT', 'STANDING_ORDER',
   // Mapped internal categories
   'energy', 'broadband', 'mobile', 'streaming', 'insurance',
-  'mortgage', 'loans', 'credit', 'council_tax', 'water',
-  'fitness', 'software', 'bills',
+  'water', 'fitness', 'software', 'bills',
 ]);
+
+function looksLikeTransferToSelf(
+  description: string,
+  merchantName: string | null,
+  userNameTokens: string[],
+): boolean {
+  if (userNameTokens.length === 0) return false;
+  const haystack = `${merchantName ?? ''} ${description}`.toLowerCase();
+  // Require at least two user-name tokens to appear — a single common first
+  // name would false-positive on any retailer that happens to share it.
+  const matches = userNameTokens.filter((t) => haystack.includes(t));
+  return matches.length >= 2;
+}
+
+async function loadUserNameTokens(userId: string): Promise<string[]> {
+  const db = getAdmin();
+  try {
+    const { data } = await db
+      .from('profiles')
+      .select('first_name, last_name, full_name')
+      .eq('id', userId)
+      .maybeSingle();
+    if (!data) return [];
+    const raw = [data.first_name, data.last_name, data.full_name]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+    const tokens = Array.from(new Set(raw.split(/\s+/).filter((t) => t.length >= 3)));
+    return tokens;
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Detect price increases in recurring payments for a user.
@@ -44,6 +82,7 @@ const RECURRING_CATEGORIES = new Set([
  */
 export async function detectPriceIncreases(userId: string): Promise<PriceIncrease[]> {
   const supabase = getAdmin();
+  const userNameTokens = await loadUserNameTokens(userId);
 
   // Fetch last 6 months of debit transactions
   const sixMonthsAgo = new Date();
@@ -78,9 +117,14 @@ export async function detectPriceIncreases(userId: string): Promise<PriceIncreas
 
     // Use user_category if set, otherwise category
     const cat = tx.user_category || tx.category || '';
-    if (VARIABLE_CATEGORIES.has(cat)) continue;
+    const catLower = cat.toLowerCase();
+    if (VARIABLE_CATEGORIES.has(cat) || EXCLUDED_SAVINGS_CATEGORIES.has(catLower)) continue;
     // Only track categories that represent recurring bills
     if (!RECURRING_CATEGORIES.has(cat)) continue;
+
+    // Transfers to self (e.g. "PAUL AIREY … HALIFAX VIA MOBILE — PYMT") can
+    // otherwise look like huge price rises when amounts vary. Skip them.
+    if (looksLikeTransferToSelf(tx.description || '', tx.merchant_name, userNameTokens)) continue;
 
     const normalised = normaliseMerchantName(tx.description || tx.merchant_name || '');
     if (normalised === 'Unknown') continue;
@@ -116,8 +160,9 @@ export async function detectPriceIncreases(userId: string): Promise<PriceIncreas
       (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
     );
 
-    // Need at least 2 months of data
-    if (monthlyPayments.length < 2) continue;
+    // Need at least 3 months of data — a single comparison against one
+    // previous month turned out to be too noisy in real user data.
+    if (monthlyPayments.length < 3) continue;
 
     const latest = monthlyPayments[monthlyPayments.length - 1];
     const previous = monthlyPayments.slice(0, -1);
@@ -128,17 +173,17 @@ export async function detectPriceIncreases(userId: string): Promise<PriceIncreas
     // Calculate average of previous payments
     const avgPrevious = previous.reduce((sum, p) => sum + p.amount, 0) / previous.length;
 
-    // Check previous payments were roughly consistent (std dev < 20% of mean)
-    // This ensures we're comparing recurring payments, not random purchases
+    // Require previous payments to be tight (std dev < 15% of mean). Loan /
+    // council-tax style schedules used to slip through at 20%.
     const variance = previous.reduce((sum, p) => sum + Math.pow(p.amount - avgPrevious, 2), 0) / previous.length;
     const stdDev = Math.sqrt(variance);
-    if (avgPrevious > 0 && stdDev / avgPrevious > 0.20) continue;
+    if (avgPrevious > 0 && stdDev / avgPrevious > 0.15) continue;
 
     // Calculate increase
     const increasePct = ((latest.amount - avgPrevious) / avgPrevious) * 100;
 
-    // Flag if increase > 2%
-    if (increasePct <= 2) continue;
+    // Require ≥5% increase (old 2% was catching rounding noise)
+    if (increasePct < 5) continue;
 
     const annualImpact = (latest.amount - avgPrevious) * 12;
 


### PR DESCRIPTION
## What broke

**Watchdog silently died** when a user's Gmail/Outlook refresh_token expired. The cron tried every 30 min, got 401, the fetcher threw, \`syncLinkedThread\` caught it and returned without updating \`last_synced_at\`. No log, no connection flip, no UI warning. Paul's OneStream dispute card showed "Last checked 17h ago" while a real supplier reply sat unimported in his inbox.

**Price-increase detector false-positive flood** produced £34,355/yr in bogus alerts on Paul's Overview, built from three rows that should never have been flagged: a £595→£2,097 self-transfer via Halifax Mobile, Winchester City Council tax (£233→£1,083), and a Funding Circle loan repayment (£1,427→£1,895).

## What changed

### Watchdog OAuth
- \`fetchers.ts:ensureFreshToken\` now persists the refreshed \`access_token\` + \`token_expiry\` to \`email_connections\` on success. The old code kept them only in-memory, so every cron did a redundant refresh and the DB always looked expired.
- On refresh failure it flips \`email_connections.status\` → \`needs_reauth\`, writes \`last_error\` + \`last_error_at\`, and logs \`watchdog_error\` to \`business_log\`. Raises \`EmailConnectionAuthError\` so callers stop retrying.
- \`WatchdogCard.tsx\` cross-references the linked thread's \`email_connection_id\` against \`/api/email/connections\`. When the backing connection is \`needs_reauth\` / \`expired\`, renders a red **"Reconnect in Profile"** banner above the thread card instead of the silent "Last checked Nh ago" text.
- \`/api/disputes/[id]/link-email-thread\` GET now returns \`email_connection_id\` so the UI can match the specific connection (not just the provider, which couldn't disambiguate multiple Gmail accounts).

### Price-increase detector
- Honours \`EXCLUDED_SAVINGS_CATEGORIES\` from \`savings-utils.ts\` (loan / mortgage / council_tax / credit / tax / fees / parking / car_finance) — same list Money Hub's deals detector uses, so they stay in lockstep.
- Dropped \`mortgage\`, \`loans\`, \`credit\`, \`council_tax\` from \`RECURRING_CATEGORIES\`.
- Transfer-to-self filter: skips transactions where the description contains ≥2 tokens of the user's own name (from \`profiles.first_name / last_name / full_name\`).
- Tightened filters: ≥3 months of prior history (was 2), previous-month std-dev ≤15% of mean (was 20%), ≥5% increase (was 2%).

## Not in this PR (follow-ups)

1. **User action:** Paul needs to reconnect Gmail in Profile to pick up the pending OneStream reply.
2. **Founder action:** Publish the OAuth consent screen in Google Cloud Console. Testing-mode apps have refresh tokens invalidated every 7 days — this is Google policy, not our code. Publishing lifts that limit.
3. **DB cleanup:** Existing false-positive rows in \`price_increase_alerts\` will be dismissed via a one-off query post-merge — the detector fix only prevents new ones.

## Test plan

- [x] \`npx tsc --noEmit\` — zero errors.
- [ ] **After merge:** Paul reconnects Gmail, opens the OneStream dispute, sees the today's reply import within ~30 min (next cron) or instantly via "Check for replies now".
- [ ] After a simulated refresh failure, the Watchdog card shows the red "Reconnect in Profile" banner instead of "Last checked 17h ago".
- [ ] Overview page total "Potential savings" drops from £36k to a realistic figure after the bogus rows are dismissed.
- [ ] New syncs on a Pro account correctly persist the refreshed token — \`email_connections.token_expiry\` advances ~1h per sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)