### PR TITLE
fix(stripe/sync): never downgrade founding members to free

### DIFF
--- a/src/app/api/stripe/sync/route.ts
+++ b/src/app/api/stripe/sync/route.ts
@@ -55,7 +55,7 @@ export async function POST() {
 
     const { data: profile } = await supabase
       .from('profiles')
-      .select('stripe_customer_id, subscription_tier')
+      .select('stripe_customer_id, subscription_tier, founding_member')
       .eq('id', user.id)
       .single();
 
@@ -72,6 +72,18 @@ export async function POST() {
     const allSubs = [...(activeSubs.data || []), ...(trialingSubs.data || [])];
 
     if (allSubs.length === 0) {
+      // Founding members were granted Essential/Pro manually and typically have
+      // no Stripe subscription at all. Never downgrade them here — the profile
+      // tier is authoritative for this cohort. See also commit 35ee3d1 which
+      // added a similar guard to the webhook-triggered path; this closes the
+      // matching hole on the dashboard-mount sync path.
+      if (profile.founding_member === true) {
+        return NextResponse.json({
+          synced: true,
+          tier: profile.subscription_tier || 'free',
+          reason: 'founding_member',
+        });
+      }
       if (profile.subscription_tier !== 'free') {
         const admin = createAdmin(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
         await admin.from('profiles').update({


### PR DESCRIPTION
## The real root cause behind the "why does OAuth keep disconnecting" thread

OAuth isn't the problem. The sync cron was correctly returning 200 every 30 min but **skipping** the dispute's linked thread because \`getEffectiveTier\` was returning \`'free'\` for a user whose profile flipped to \`subscription_tier='free'\` less than an hour ago — triggered by the dashboard-mount call to \`/api/stripe/sync\`.

Commit \`35ee3d1\` ("guard founding_member users from Stripe-triggered tier downgrades") patched the webhook path. It missed this one. \`src/app/api/stripe/sync/route.ts:74-85\` still writes \`subscription_tier: 'free'\` whenever a Stripe customer has no active subscription — which is exactly the state of every founding member, because they were granted Essential/Pro manually and never had a Stripe sub to begin with.

## Evidence

\`\`\`
profiles row for aireypaul@googlemail.com (pre-fix):
  founding_member        true
  stripe_customer_id     cus_UBuYXbcHO1S4LG
  stripe_subscription_id null
  subscription_tier      free     ← flipped by /api/stripe/sync
  updated_at             2026-04-22 16:16:56   (less than 1h ago)
\`\`\`

Cron invocation returned:
\`\`\`json
{ "success": true, "processed": 0, "imported": 0, "skipped": 1, "elapsedMs": 1517 }
\`\`\`

Skipped because: \`PLAN_LIMITS.free.watchdogSyncIntervalMinutes === null\` — free tier is manual-only for the Watchdog, by design. So the cron saw Paul, checked his tier, saw 'free', and moved on. That's the 17-hour "Last checked" reading you saw on the dispute page, and the "Upgrade to unlock Top Merchants" gates on Money Hub.

## What changed
- In the no-Stripe-subs branch: if \`profile.founding_member === true\`, return the current tier verbatim instead of writing 'free'.
- Pulled \`founding_member\` into the profiles SELECT so the guard can read it.

13 lines, one file.

## Already applied in production DB
- Restored aireypaul@googlemail.com to \`subscription_tier='pro'\`, \`subscription_status='active'\`. Without this PR, the next dashboard load would reset it.

## Not in this PR
- A full audit of other founder-user profiles to confirm none of them are sitting on a silently-downgraded tier is a good follow-up.
- The \`/api/stripe/sync\` route is long (~150 lines) and has *other* branches that write to profiles — I only touched the one branch that was definitively firing for founders. Happy to sweep the rest in a follow-up if you want.

## Test plan
- [x] \`npx tsc --noEmit\` — zero errors.
- [ ] After deploy: Paul reloads dashboard, \`profiles.subscription_tier\` stays 'pro' (doesn't revert).
- [ ] "Upgrade to unlock Top Merchants" and "Upgrade to set Budgets & Goals" gates disappear on Money Hub.
- [ ] Next Watchdog cron (~30 min) processes Paul's link and imports the OneStream reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)