### PR TITLE
fix(dashboard): mobile KPI collapse + sweep dark child components

### DIFF
--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -277,3 +277,42 @@
 @media (max-width: 1100px) {
   .shell-v2 .overview-grid { grid-template-columns: 1fr; }
 }
+
+/* ─── KPI row responsive: c4 collapses 4→2→1 on narrower viewports ─── */
+@media (max-width: 1100px) {
+  .shell-v2 .kpi-row.c4 { grid-template-columns: repeat(2, 1fr); }
+  .shell-v2 .kpi-row.c3 { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .shell-v2 .kpi-row.c4,
+  .shell-v2 .kpi-row.c3 {
+    grid-template-columns: 1fr;
+  }
+  /* Page-title row stacks the CTA cluster below the heading on phones */
+  .shell-v2 .page-title-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .shell-v2 .page-title { font-size: 22px; }
+  .shell-v2 .page-sub { font-size: 13px; }
+  /* Hero Action Centre + embedded cards breathe on narrow screens */
+  .shell-v2 .main-inner { padding: 18px 14px 32px; }
+  .shell-v2 .card { padding: 14px; }
+}
+
+/* Danger variant of .cta used by PriceIncreaseCard */
+.shell-v2 .cta-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--rose-wash);
+  color: var(--rose-deep);
+  border: 1px solid #FCA5A5;
+  padding: 8px 12px;
+  font-size: 12.5px;
+  font-weight: 700;
+  border-radius: 9px;
+  text-decoration: none;
+  cursor: pointer;
+}
+.shell-v2 .cta-danger:hover { background: #FEE2E2; }

--- a/src/components/BankPickerModal.tsx
+++ b/src/components/BankPickerModal.tsx
@@ -76,10 +76,10 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
         <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-        <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-lg p-10 text-center shadow-2xl">
+        <div className="relative bg-white border border-slate-200 rounded-2xl w-full max-w-lg p-10 text-center shadow-2xl">
           <Loader2 className="h-8 w-8 text-amber-500 animate-spin mx-auto mb-4" />
-          <p className="text-white font-semibold">Connecting to your bank...</p>
-          <p className="text-slate-400 text-sm mt-1">
+          <p className="text-slate-900 font-semibold">Connecting to your bank...</p>
+          <p className="text-slate-500 text-sm mt-1">
             You&apos;ll be redirected to TrueLayer to select your bank securely.
           </p>
         </div>
@@ -117,20 +117,20 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-lg max-h-[80vh] flex flex-col shadow-2xl">
+      <div className="relative bg-white border border-slate-200 rounded-2xl w-full max-w-lg max-h-[80vh] flex flex-col shadow-2xl">
         {/* Header */}
-        <div className="flex items-center justify-between p-5 border-b border-navy-700/50 flex-shrink-0">
+        <div className="flex items-center justify-between p-5 border-b border-slate-200 flex-shrink-0">
           <div>
-            <h2 className="text-lg font-bold text-white">Connect Your Bank</h2>
-            <p className="text-slate-400 text-sm mt-0.5">Select your bank to connect securely via Open Banking</p>
+            <h2 className="text-lg font-bold text-slate-900">Connect Your Bank</h2>
+            <p className="text-slate-500 text-sm mt-0.5">Select your bank to connect securely via Open Banking</p>
           </div>
-          <button onClick={onClose} className="text-slate-400 hover:text-white p-1">
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-1">
             <X className="h-5 w-5" />
           </button>
         </div>
 
         {/* Search */}
-        <div className="px-5 py-3 border-b border-navy-700/50 flex-shrink-0">
+        <div className="px-5 py-3 border-b border-slate-200 flex-shrink-0">
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
             <input
@@ -138,7 +138,7 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
               placeholder="Search banks..."
               value={search}
               onChange={e => setSearch(e.target.value)}
-              className="w-full bg-navy-800 border border-navy-700/50 rounded-xl pl-10 pr-4 py-2.5 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-amber-500/50"
+              className="w-full bg-slate-100 border border-slate-200 rounded-xl pl-10 pr-4 py-2.5 text-sm text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-500/50"
               autoFocus
             />
           </div>
@@ -169,17 +169,17 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
               key={inst.id}
               onClick={() => handleSelect(inst)}
               disabled={connecting !== null}
-              className="w-full flex items-center gap-3 p-3 rounded-xl hover:bg-navy-800 transition-colors text-left disabled:opacity-50"
+              className="w-full flex items-center gap-3 p-3 rounded-xl hover:bg-slate-100 transition-colors text-left disabled:opacity-50"
             >
               {inst.logoUrl ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img src={inst.logoUrl} alt="" className="w-8 h-8 rounded-lg object-contain bg-white p-0.5" />
               ) : (
-                <div className="w-8 h-8 rounded-lg bg-navy-700 flex items-center justify-center">
-                  <Building2 className="h-4 w-4 text-slate-400" />
+                <div className="w-8 h-8 rounded-lg bg-slate-100 flex items-center justify-center">
+                  <Building2 className="h-4 w-4 text-slate-500" />
                 </div>
               )}
-              <span className="text-white text-sm font-medium flex-1">{inst.name}</span>
+              <span className="text-slate-900 text-sm font-medium flex-1">{inst.name}</span>
               {connecting === inst.id && (
                 <Loader2 className="h-4 w-4 text-amber-500 animate-spin" />
               )}
@@ -188,7 +188,7 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
         </div>
 
         {/* Footer */}
-        <div className="p-4 border-t border-navy-700/50 flex-shrink-0">
+        <div className="p-4 border-t border-slate-200 flex-shrink-0">
           <p className="text-xs text-slate-500 text-center">
             FCA regulated via {providerLabel}. Read-only access. We never store your bank credentials.
           </p>

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -142,7 +142,7 @@ export default function NotificationBell() {
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="relative p-2 rounded-lg text-slate-400 hover:text-white hover:bg-navy-800 transition-colors min-h-[40px] min-w-[40px] flex items-center justify-center"
+        className="relative p-2 rounded-lg text-slate-500 hover:text-slate-900 hover:bg-slate-100 transition-colors min-h-[40px] min-w-[40px] flex items-center justify-center"
         aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ''}`}
       >
         <Bell className="h-5 w-5" />
@@ -155,15 +155,15 @@ export default function NotificationBell() {
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-2 w-[340px] max-w-[calc(100vw-2rem)] bg-navy-900 border border-navy-700/70 rounded-2xl shadow-2xl z-50 overflow-hidden">
-          <div className="flex items-center justify-between px-4 py-3 border-b border-navy-700/50">
-            <h3 className="text-sm font-semibold text-white">Notifications</h3>
+        <div className="absolute right-0 mt-2 w-[340px] max-w-[calc(100vw-2rem)] bg-white border border-slate-200 rounded-2xl shadow-2xl z-50 overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200">
+            <h3 className="text-sm font-semibold text-slate-900">Notifications</h3>
             <div className="flex items-center gap-2">
               {items.some((i) => !i.read_at) && (
                 <button
                   type="button"
                   onClick={handleMarkAllRead}
-                  className="text-xs text-slate-400 hover:text-mint-400 transition-colors"
+                  className="text-xs text-slate-500 hover:text-mint-400 transition-colors"
                 >
                   Mark all read
                 </button>
@@ -171,7 +171,7 @@ export default function NotificationBell() {
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="text-slate-500 hover:text-white p-0.5"
+                className="text-slate-500 hover:text-slate-900 p-0.5"
                 aria-label="Close notifications"
               >
                 <X className="h-4 w-4" />
@@ -197,7 +197,7 @@ export default function NotificationBell() {
                       <button
                         type="button"
                         onClick={() => handleNotificationClick(n)}
-                        className={`w-full text-left px-4 py-3 hover:bg-navy-800/70 transition-colors flex gap-3 ${
+                        className={`w-full text-left px-4 py-3 hover:bg-slate-100 transition-colors flex gap-3 ${
                           unread ? 'bg-mint-400/[0.03]' : ''
                         }`}
                       >
@@ -205,7 +205,7 @@ export default function NotificationBell() {
                           className={`flex-shrink-0 h-8 w-8 rounded-lg flex items-center justify-center ${
                             unread
                               ? 'bg-mint-400/10 text-mint-400'
-                              : 'bg-navy-800 text-slate-500'
+                              : 'bg-slate-100 text-slate-500'
                           }`}
                         >
                           <Icon className="h-4 w-4" />
@@ -214,7 +214,7 @@ export default function NotificationBell() {
                           <div className="flex items-center gap-2">
                             <p
                               className={`text-sm truncate ${
-                                unread ? 'text-white font-semibold' : 'text-slate-400'
+                                unread ? 'text-slate-900 font-semibold' : 'text-slate-500'
                               }`}
                             >
                               {n.title}

--- a/src/components/TrialBanner.tsx
+++ b/src/components/TrialBanner.tsx
@@ -16,7 +16,7 @@ export default function TrialBanner({ daysLeft, trialExpired }: TrialBannerProps
       <div className="bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-3 mb-6 flex items-center justify-between gap-3">
         <div className="flex items-center gap-3">
           <XCircle className="h-5 w-5 text-red-400 flex-shrink-0" />
-          <p className="text-sm text-white">Your Pro trial has ended. Subscribe to continue using Pro features.</p>
+          <p className="text-sm text-slate-900">Your Pro trial has ended. Subscribe to continue using Pro features.</p>
         </div>
         <Link href="/pricing" className="bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold text-xs px-3 py-1.5 rounded-lg transition-all whitespace-nowrap">
           Subscribe Now
@@ -30,7 +30,7 @@ export default function TrialBanner({ daysLeft, trialExpired }: TrialBannerProps
       <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl px-4 py-3 mb-6 flex items-center justify-between gap-3">
         <div className="flex items-center gap-3">
           <AlertTriangle className="h-5 w-5 text-amber-400 flex-shrink-0" />
-          <p className="text-sm text-white">Your Pro trial ends in <strong>{daysLeft}</strong> {daysLeft === 1 ? 'day' : 'days'} — subscribe now to keep your features</p>
+          <p className="text-sm text-slate-900">Your Pro trial ends in <strong>{daysLeft}</strong> {daysLeft === 1 ? 'day' : 'days'} — subscribe now to keep your features</p>
         </div>
         <Link href="/pricing" className="bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold text-xs px-3 py-1.5 rounded-lg transition-all whitespace-nowrap">
           Subscribe
@@ -43,9 +43,9 @@ export default function TrialBanner({ daysLeft, trialExpired }: TrialBannerProps
     <div className="bg-mint-400/5 border border-mint-400/20 rounded-xl px-4 py-3 mb-6 flex items-center justify-between gap-3">
       <div className="flex items-center gap-3">
         <Clock className="h-5 w-5 text-mint-400 flex-shrink-0" />
-        <p className="text-sm text-slate-300">You&apos;re on a free Pro trial — <strong className="text-white">{daysLeft} days remaining</strong></p>
+        <p className="text-sm text-slate-700">You&apos;re on a free Pro trial — <strong className="text-slate-900">{daysLeft} days remaining</strong></p>
       </div>
-      <Link href="/pricing" className="bg-navy-800 hover:bg-navy-700 text-white text-xs px-3 py-1.5 rounded-lg transition-all whitespace-nowrap">
+      <Link href="/pricing" className="bg-slate-100 hover:bg-slate-100 text-slate-900 text-xs px-3 py-1.5 rounded-lg transition-all whitespace-nowrap">
         Subscribe to keep Pro
       </Link>
     </div>

--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -25,15 +25,15 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
         <div className="flex items-center gap-3 min-w-0">
           <Sparkles className="h-5 w-5 text-mint-400 flex-shrink-0" />
           <div className="min-w-0">
-            <p className="text-sm text-white font-medium">Unlock unlimited letters, daily bank sync, and full spending intelligence</p>
-            <p className="text-xs text-slate-400">Essential from £4.99/month</p>
+            <p className="text-sm text-slate-900 font-medium">Unlock unlimited letters, daily bank sync, and full spending intelligence</p>
+            <p className="text-xs text-slate-500">Essential from £4.99/month</p>
           </div>
         </div>
         <div className="flex items-center gap-2 flex-shrink-0">
           <Link href="/pricing" className="bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold text-xs px-3 py-1.5 rounded-lg transition-all whitespace-nowrap">
             Upgrade
           </Link>
-          <button onClick={handleClose} className="text-slate-500 hover:text-white p-1">
+          <button onClick={handleClose} className="text-slate-500 hover:text-slate-900 p-1">
             <X className="h-4 w-4" />
           </button>
         </div>
@@ -45,16 +45,16 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
         <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={handleClose} />
-        <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl p-8 max-w-md w-full shadow-2xl">
+        <div className="relative bg-white border border-slate-200 rounded-2xl p-8 max-w-md w-full shadow-2xl">
           <div className="text-center mb-6">
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-mint-400/10 border border-mint-400/30 mb-4">
               <Sparkles className="h-8 w-8 text-mint-400" />
             </div>
-            <h2 className="text-2xl font-bold text-white mb-2">Upgrade to Keep Scanning</h2>
-            <p className="text-slate-400">Free users get one email scan. Upgrade to Essential for unlimited scans, daily bank sync, and full spending intelligence.</p>
+            <h2 className="text-2xl font-bold text-slate-900 mb-2">Upgrade to Keep Scanning</h2>
+            <p className="text-slate-500">Free users get one email scan. Upgrade to Essential for unlimited scans, daily bank sync, and full spending intelligence.</p>
           </div>
-          <div className="bg-navy-950 rounded-xl p-4 mb-6 border border-navy-700/50">
-            <ul className="space-y-2 text-sm text-slate-300">
+          <div className="bg-white rounded-xl p-4 mb-6 border border-slate-200">
+            <ul className="space-y-2 text-sm text-slate-700">
               <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Unlimited email scans</li>
               <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Unlimited complaint letters</li>
               <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Daily bank sync</li>
@@ -66,7 +66,7 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
             <Link href="/pricing" className="w-full py-3 bg-mint-400 hover:bg-mint-500 text-navy-950 font-bold rounded-xl transition-all text-center">
               Upgrade — from £4.99/mo
             </Link>
-            <button onClick={handleClose} className="text-slate-500 hover:text-white text-sm transition-colors">Maybe later</button>
+            <button onClick={handleClose} className="text-slate-500 hover:text-slate-900 text-sm transition-colors">Maybe later</button>
           </div>
         </div>
       </div>
@@ -75,12 +75,12 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
 
   // inline
   return (
-    <div className="bg-navy-900 border border-mint-400/20 rounded-xl p-4">
+    <div className="bg-white border border-mint-400/20 rounded-xl p-4">
       <div className="flex items-center gap-2 mb-2">
         <Sparkles className="h-4 w-4 text-mint-400" />
-        <p className="text-sm text-white font-medium">Upgrade your plan</p>
+        <p className="text-sm text-slate-900 font-medium">Upgrade your plan</p>
       </div>
-      <p className="text-xs text-slate-400 mb-3">Get unlimited letters, bank sync, and full financial insights.</p>
+      <p className="text-xs text-slate-500 mb-3">Get unlimited letters, bank sync, and full financial insights.</p>
       <Link href="/pricing" className="inline-flex items-center gap-1 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold text-xs px-3 py-1.5 rounded-lg transition-all">
         View plans <ArrowRight className="h-3 w-3" />
       </Link>

--- a/src/components/UpgradeTrigger.tsx
+++ b/src/components/UpgradeTrigger.tsx
@@ -102,7 +102,7 @@ export default function UpgradeTrigger({
       title: `We found ${subscriptionCount} subscription${subscriptionCount !== 1 ? 's' : ''} totalling £${monthlyCost.toFixed(0)}/month`,
       body: 'Upgrade to Essential to track these daily, get renewal reminders, and get alerted to price increases.',
       cta: 'Track daily — from £4.99/mo',
-      ctaClass: 'bg-emerald-500 hover:bg-emerald-600 text-white',
+      ctaClass: 'bg-emerald-500 hover:bg-emerald-600 text-slate-900',
     },
     letter_limit: {
       icon: <Sparkles className="h-5 w-5 text-amber-400" />,
@@ -124,7 +124,7 @@ export default function UpgradeTrigger({
       title: `Your email scan found ${opportunitiesFound} potential saving${opportunitiesFound !== 1 ? 's' : ''}`,
       body: 'Upgrade to Essential to scan your inbox every month automatically.',
       cta: 'Scan monthly — £4.99/mo',
-      ctaClass: 'bg-purple-500 hover:bg-purple-600 text-white',
+      ctaClass: 'bg-purple-500 hover:bg-purple-600 text-slate-900',
     },
     price_increase: {
       icon: <TrendingUp className="h-5 w-5 text-red-400" />,
@@ -134,7 +134,7 @@ export default function UpgradeTrigger({
       title: `${priceIncreaseCount} price increase${priceIncreaseCount !== 1 ? 's' : ''} detected — costing you £${priceIncreaseAnnual.toFixed(0)}/year extra`,
       body: 'Upgrade to get automatic alerts whenever your bills go up so you can act immediately.',
       cta: 'Get price alerts — £4.99/mo',
-      ctaClass: 'bg-red-500 hover:bg-red-600 text-white',
+      ctaClass: 'bg-red-500 hover:bg-red-600 text-slate-900',
     },
   };
 
@@ -144,7 +144,7 @@ export default function UpgradeTrigger({
     <div className={`bg-gradient-to-r ${c.gradient} border ${c.border} rounded-2xl p-5 relative ${className}`}>
       <button
         onClick={handleDismiss}
-        className="absolute top-3 right-3 text-slate-500 hover:text-white p-1 transition-colors"
+        className="absolute top-3 right-3 text-slate-500 hover:text-slate-900 p-1 transition-colors"
         aria-label="Dismiss"
       >
         <X className="h-4 w-4" />
@@ -155,8 +155,8 @@ export default function UpgradeTrigger({
           {c.icon}
         </div>
         <div>
-          <p className="text-white font-semibold text-sm leading-snug">{c.title}</p>
-          <p className="text-slate-400 text-xs mt-0.5">{c.body}</p>
+          <p className="text-slate-900 font-semibold text-sm leading-snug">{c.title}</p>
+          <p className="text-slate-500 text-xs mt-0.5">{c.body}</p>
         </div>
       </div>
 

--- a/src/components/alerts/PriceIncreaseCard.tsx
+++ b/src/components/alerts/PriceIncreaseCard.tsx
@@ -46,75 +46,146 @@ export default function PriceIncreaseCard({ alert, onDismiss, onAction }: PriceI
 
   const complaintUrl = `/dashboard/complaints?new=1&company=${encodeURIComponent(cleanName)}&issue=${encodeURIComponent(`price increase from £${alert.old_amount.toFixed(2)} to £${alert.new_amount.toFixed(2)}`)}&alertId=${alert.id}`;
 
-  const dealCategory = ENERGY_KEYWORDS.some(kw => cleanName.toLowerCase().includes(kw)) ? 'energy' : 
-                       BROADBAND_MOBILE_KEYWORDS.some(kw => cleanName.toLowerCase().includes(kw)) ? 'broadband' : 
+  const dealCategory = ENERGY_KEYWORDS.some(kw => cleanName.toLowerCase().includes(kw)) ? 'energy' :
+                       BROADBAND_MOBILE_KEYWORDS.some(kw => cleanName.toLowerCase().includes(kw)) ? 'broadband' :
                        cleanName.toLowerCase().includes('card') ? 'credit' : 'all';
 
   return (
-    <div className="bg-navy-900 border border-red-500/20 rounded-xl p-5">
+    <div className="card" style={{ borderColor: '#FCA5A5' }}>
       <div className="flex items-start justify-between gap-3 mb-4">
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 bg-red-500/10 rounded-xl flex items-center justify-center">
-            <TrendingUp className="h-5 w-5 text-red-400" />
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              background: 'var(--rose-wash)',
+              borderRadius: 12,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'var(--rose-deep)',
+              flexShrink: 0,
+            }}
+          >
+            <TrendingUp className="h-5 w-5" />
           </div>
           <div>
-            <h3 className="text-white font-semibold text-sm">{cleanName}</h3>
-            <p className="text-slate-500 text-xs">
+            <h3 style={{ margin: 0, fontSize: 14, fontWeight: 700, color: 'var(--text)' }}>
+              {cleanName}
+            </h3>
+            <p style={{ margin: '2px 0 0', fontSize: 12, color: 'var(--text-3)' }}>
               {new Date(alert.old_date).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}
               {' '}&rarr;{' '}
               {new Date(alert.new_date).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}
             </p>
           </div>
         </div>
-        <span className="bg-red-500/10 text-red-400 text-xs font-semibold px-2.5 py-1 rounded-full whitespace-nowrap">
+        <span
+          className="pill red"
+          style={{ padding: '4px 10px', fontSize: 11, whiteSpace: 'nowrap' }}
+        >
           +{alert.increase_pct}%
         </span>
       </div>
 
       {/* Price comparison */}
       <div className="flex items-center gap-3 mb-3">
-        <div className="bg-navy-800 rounded-lg px-4 py-2 text-center flex-1">
-          <p className="text-slate-500 text-xs mb-0.5">Was</p>
-          <p className="text-white font-semibold">&pound;{alert.old_amount.toFixed(2)}</p>
+        <div
+          style={{
+            background: 'var(--paper)',
+            border: '1px solid var(--divider)',
+            borderRadius: 10,
+            padding: '8px 14px',
+            textAlign: 'center',
+            flex: 1,
+          }}
+        >
+          <p style={{ margin: 0, fontSize: 11, color: 'var(--text-3)' }}>Was</p>
+          <p style={{ margin: '2px 0 0', fontSize: 15, fontWeight: 700, color: 'var(--text)' }}>
+            &pound;{alert.old_amount.toFixed(2)}
+          </p>
         </div>
-        <ArrowRight className="h-4 w-4 text-red-400 flex-shrink-0" />
-        <div className="bg-red-500/5 border border-red-500/20 rounded-lg px-4 py-2 text-center flex-1">
-          <p className="text-slate-500 text-xs mb-0.5">Now</p>
-          <p className="text-red-400 font-bold">&pound;{alert.new_amount.toFixed(2)}</p>
+        <ArrowRight className="h-4 w-4" style={{ color: 'var(--rose-deep)', flexShrink: 0 }} />
+        <div
+          style={{
+            background: 'var(--rose-wash)',
+            border: '1px solid #FCA5A5',
+            borderRadius: 10,
+            padding: '8px 14px',
+            textAlign: 'center',
+            flex: 1,
+          }}
+        >
+          <p style={{ margin: 0, fontSize: 11, color: 'var(--text-3)' }}>Now</p>
+          <p style={{ margin: '2px 0 0', fontSize: 15, fontWeight: 800, color: 'var(--rose-deep)' }}>
+            &pound;{alert.new_amount.toFixed(2)}
+          </p>
         </div>
       </div>
 
       {/* Annual impact */}
-      <p className="text-sm text-slate-300 mb-3">
-        This costs you <span className="text-amber-400 font-semibold">&pound;{alert.annual_impact.toFixed(2)} more per year</span>
+      <p style={{ fontSize: 13, color: 'var(--text-2)', margin: '0 0 10px' }}>
+        This costs you{' '}
+        <span style={{ color: 'var(--orange-deep)', fontWeight: 700 }}>
+          &pound;{alert.annual_impact.toFixed(2)} more per year
+        </span>
       </p>
 
       {/* Regulation hint */}
       {regulationHint && (
-        <div className="bg-blue-500/5 border border-blue-500/20 rounded-lg px-3 py-2 mb-4">
-          <p className="text-blue-400 text-xs">{regulationHint}</p>
+        <div
+          style={{
+            background: 'var(--blue-wash)',
+            border: '1px solid #BFDBFE',
+            borderRadius: 10,
+            padding: '8px 12px',
+            marginBottom: 12,
+          }}
+        >
+          <p style={{ margin: 0, fontSize: 12, color: 'var(--blue-deep)' }}>{regulationHint}</p>
         </div>
       )}
 
       {/* Actions */}
-      <div className="flex items-center gap-2 pt-3 border-t border-navy-700/50 flex-wrap">
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          paddingTop: 12,
+          borderTop: '1px solid var(--divider-2)',
+          flexWrap: 'wrap',
+        }}
+      >
         <Link
           href={complaintUrl}
           onClick={() => onAction(alert.id)}
-          className="bg-red-500/10 hover:bg-red-500/20 text-red-400 px-3 py-1.5 rounded-lg text-xs font-medium transition-all flex items-center gap-1"
+          className="cta-danger"
+          style={{ fontSize: 12, padding: '7px 11px' }}
         >
-          <FileText className="h-3 w-3" /> Start Dispute
+          <FileText className="h-3 w-3" /> Start dispute
         </Link>
         <Link
           href={`/dashboard/deals?category=${dealCategory}`}
-          className="bg-mint-400/10 hover:bg-mint-400/20 text-mint-400 px-3 py-1.5 rounded-lg text-xs font-medium transition-all flex items-center gap-1"
+          className="cta-ghost"
+          style={{ fontSize: 12, padding: '7px 11px' }}
         >
-          <ArrowRight className="h-3 w-3" /> Find Better Deal
+          <ArrowRight className="h-3 w-3" /> Find better deal
         </Link>
-        <div className="flex-1" />
+        <div style={{ flex: 1 }} />
         <button
           onClick={() => onDismiss(alert.id)}
-          className="text-slate-500 hover:text-slate-400 text-xs transition-all px-2 py-1.5 flex items-center gap-1"
+          style={{
+            background: 'transparent',
+            border: 0,
+            color: 'var(--text-3)',
+            fontSize: 11.5,
+            cursor: 'pointer',
+            padding: '6px 8px',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+          }}
         >
           <X className="h-3 w-3" /> Dismiss
         </button>

--- a/src/components/dashboard/SavingsOpportunityWidget.tsx
+++ b/src/components/dashboard/SavingsOpportunityWidget.tsx
@@ -34,46 +34,118 @@ export default function SavingsOpportunityWidget({ totalSaving, count, deals }: 
   const topDeals = filteredDeals.sort((a, b) => b.annualSaving - a.annualSaving).slice(0, 3);
 
   return (
-    <div className="bg-gradient-to-r from-green-500/10 to-green-600/5 border border-green-500/20 rounded-2xl p-6 mb-8">
-      <div className="flex items-center gap-4 mb-4">
-        <div className="w-12 h-12 bg-green-500/20 rounded-xl flex items-center justify-center flex-shrink-0">
-          <TrendingDown className="h-6 w-6 text-green-400" />
+    <div
+      className="card"
+      style={{
+        background: 'linear-gradient(135deg, var(--mint-wash) 0%, #fff 100%)',
+        borderColor: '#BBF7D0',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14, marginBottom: 14, flexWrap: 'wrap' }}>
+        <div
+          style={{
+            width: 44,
+            height: 44,
+            background: 'var(--mint-wash)',
+            borderRadius: 12,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'var(--mint-deep)',
+            flexShrink: 0,
+          }}
+        >
+          <TrendingDown className="h-5 w-5" />
         </div>
-        <div>
-          <p className="text-sm text-green-400 font-semibold uppercase tracking-wider mb-0.5">
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <p
+            style={{
+              margin: 0,
+              fontSize: 11,
+              color: 'var(--mint-deep)',
+              fontWeight: 700,
+              letterSpacing: '.1em',
+              textTransform: 'uppercase',
+            }}
+          >
             Better deals found
           </p>
-          <p className="text-2xl md:text-3xl font-bold text-white font-[family-name:var(--font-heading)]">
-            Save {formatGBP(filteredTotal)}<span className="text-lg font-normal text-slate-400">/year</span>
+          <p
+            style={{
+              margin: '4px 0 0',
+              fontSize: 24,
+              fontWeight: 800,
+              color: 'var(--text)',
+              letterSpacing: '-.02em',
+              lineHeight: 1.1,
+            }}
+          >
+            Save {formatGBP(filteredTotal)}
+            <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--text-3)' }}>/year</span>
           </p>
-          <p className="text-sm text-slate-400 mt-0.5">
+          <p style={{ margin: '4px 0 0', fontSize: 12.5, color: 'var(--text-2)' }}>
             {filteredCount} subscription{filteredCount !== 1 ? 's' : ''} with cheaper alternatives
           </p>
         </div>
       </div>
 
       {topDeals.length > 0 && (
-        <div className="space-y-2 mb-4">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 14 }}>
           {topDeals.map((deal, i) => (
-            <div key={i} className="flex items-center justify-between bg-navy-950/50 rounded-lg px-4 py-3">
-              <div className="min-w-0 flex-1">
-                <p className="text-white text-sm font-medium truncate">{deal.subscriptionName}</p>
-                <p className="text-slate-500 text-xs">
-                  {formatGBP(deal.currentPrice)}/mo → <span className="text-green-400 font-medium">{formatGBP(deal.dealPrice)}/mo</span> with {deal.dealProvider}
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                background: '#fff',
+                border: '1px solid var(--divider)',
+                borderRadius: 10,
+                padding: '10px 14px',
+                gap: 12,
+                flexWrap: 'wrap',
+              }}
+            >
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <p style={{ margin: 0, fontSize: 13, fontWeight: 600, color: 'var(--text)' }}>
+                  {deal.subscriptionName}
+                </p>
+                <p style={{ margin: '2px 0 0', fontSize: 11.5, color: 'var(--text-3)' }}>
+                  {formatGBP(deal.currentPrice)}/mo →{' '}
+                  <span style={{ color: 'var(--mint-deep)', fontWeight: 600 }}>
+                    {formatGBP(deal.dealPrice)}/mo
+                  </span>{' '}
+                  with {deal.dealProvider}
                 </p>
               </div>
-              <div className="flex items-center gap-3 flex-shrink-0 ml-3">
-                <span className="text-green-400 text-sm font-semibold whitespace-nowrap">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
+                <span
+                  style={{
+                    fontSize: 12.5,
+                    fontWeight: 700,
+                    color: 'var(--mint-deep)',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
                   Save {formatGBP(deal.annualSaving)}/yr
                 </span>
                 <a
                   href={deal.dealUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="bg-green-500/20 hover:bg-green-500/30 text-green-400 p-2 rounded-lg transition-all"
+                  style={{
+                    background: 'var(--mint-wash)',
+                    color: 'var(--mint-deep)',
+                    padding: 7,
+                    borderRadius: 8,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    textDecoration: 'none',
+                  }}
                   title={`Switch to ${deal.dealProvider}`}
                 >
-                  <ExternalLink className="h-4 w-4" />
+                  <ExternalLink className="h-3.5 w-3.5" />
                 </a>
               </div>
             </div>
@@ -83,7 +155,15 @@ export default function SavingsOpportunityWidget({ totalSaving, count, deals }: 
 
       <Link
         href="/dashboard/subscriptions"
-        className="inline-flex items-center gap-1.5 text-green-400 hover:text-green-300 text-sm font-medium transition-all"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          color: 'var(--mint-deep)',
+          fontSize: 13,
+          fontWeight: 600,
+          textDecoration: 'none',
+        }}
       >
         View all comparisons <ArrowRight className="h-4 w-4" />
       </Link>

--- a/src/components/dashboard/SavingsSkeleton.tsx
+++ b/src/components/dashboard/SavingsSkeleton.tsx
@@ -16,10 +16,10 @@ export default function SavingsSkeleton() {
 
       <div className="space-y-2 mb-4">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="flex items-center justify-between bg-navy-950/30 rounded-lg px-4 py-3">
+          <div key={i} className="flex items-center justify-between bg-white rounded-lg px-4 py-3">
             <div className="min-w-0 flex-1 space-y-2">
               <div className="h-4 bg-slate-700 rounded w-1/3"></div>
-              <div className="h-3 bg-slate-800 rounded w-1/2"></div>
+              <div className="h-3 bg-slate-100 rounded w-1/2"></div>
             </div>
             <div className="flex items-center gap-3 flex-shrink-0 ml-3">
               <div className="h-4 bg-green-500/20 rounded w-24"></div>

--- a/src/components/dispute/WatchdogCard.tsx
+++ b/src/components/dispute/WatchdogCard.tsx
@@ -264,14 +264,14 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
   };
 
   return (
-    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 mb-6">
+    <div className="bg-white border border-slate-200 rounded-2xl p-5 mb-6">
       <div className="flex items-start justify-between gap-3 mb-3">
         <div>
           <div className="flex items-center gap-2">
             <div className="h-7 w-7 rounded-lg bg-mint-400/10 text-mint-400 flex items-center justify-center">
               <Mail className="h-4 w-4" />
             </div>
-            <h3 className="text-sm font-semibold text-white">
+            <h3 className="text-sm font-semibold text-slate-900">
               Watchdog <span className="text-slate-500">— email reply sync</span>
             </h3>
           </div>
@@ -299,7 +299,7 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
                     : 'Email'}{' '}
                   needs reconnecting
                 </p>
-                <p className="text-xs text-slate-400 mt-0.5">
+                <p className="text-xs text-slate-500 mt-0.5">
                   We can't fetch new replies until the connection is restored. Replies sent since then will import automatically once you reconnect.
                 </p>
                 <a
@@ -311,7 +311,7 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
               </div>
             </div>
           )}
-          <div className="bg-navy-950 rounded-lg p-3 mb-3">
+          <div className="bg-white rounded-lg p-3 mb-3">
             <div className="flex items-center justify-between gap-2 mb-1">
               <span className="text-xs uppercase tracking-wide text-mint-400 font-semibold">
                 Linked thread
@@ -320,7 +320,7 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
                 {linked.provider}
               </span>
             </div>
-            <p className="text-sm text-white truncate" title={linked.subject ?? ''}>
+            <p className="text-sm text-slate-900 truncate" title={linked.subject ?? ''}>
               {linked.subject || '(no subject)'}
             </p>
             {linked.sender_address && (
@@ -350,7 +350,7 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
             <button
               type="button"
               onClick={openPicker}
-              className="flex items-center gap-2 px-3 py-2 bg-navy-800 hover:bg-navy-700 text-slate-300 rounded-lg text-sm transition-all"
+              className="flex items-center gap-2 px-3 py-2 bg-slate-100 hover:bg-slate-100 text-slate-700 rounded-lg text-sm transition-all"
             >
               <Link2 className="h-4 w-4" /> Relink different thread
             </button>
@@ -364,11 +364,11 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
           </div>
         </>
       ) : (
-        <div className="bg-navy-950 rounded-lg p-4">
+        <div className="bg-white rounded-lg p-4">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
             <div className="flex items-start gap-2">
               <Sparkles className="h-4 w-4 text-mint-400 flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-slate-300">
+              <p className="text-sm text-slate-700">
                 Link an email thread so we can auto-import {providerName}'s replies.
               </p>
             </div>
@@ -426,12 +426,12 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
 
       {pickerOpen && (
         <div className="fixed inset-0 bg-black/70 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
-          <div className="bg-navy-900 border border-navy-700/60 w-full sm:max-w-lg rounded-t-2xl sm:rounded-2xl max-h-[85vh] overflow-hidden flex flex-col">
-            <div className="flex items-center justify-between px-5 py-4 border-b border-navy-700/50">
-              <h4 className="text-base font-semibold text-white">Pick the thread to watch</h4>
+          <div className="bg-white border border-slate-200 w-full sm:max-w-lg rounded-t-2xl sm:rounded-2xl max-h-[85vh] overflow-hidden flex flex-col">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-slate-200">
+              <h4 className="text-base font-semibold text-slate-900">Pick the thread to watch</h4>
               <button
                 onClick={() => setPickerOpen(false)}
-                className="text-slate-400 hover:text-white p-1"
+                className="text-slate-500 hover:text-slate-900 p-1"
                 aria-label="Close"
               >
                 <X className="h-5 w-5" />
@@ -448,8 +448,8 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
                     <div className="flex items-start gap-2 mb-3">
                       <Mail className="h-4 w-4 text-mint-400 flex-shrink-0 mt-0.5" />
                       <div>
-                        <p className="font-semibold text-white mb-1">Connect an email first</p>
-                        <p className="text-slate-400">
+                        <p className="font-semibold text-slate-900 mb-1">Connect an email first</p>
+                        <p className="text-slate-500">
                           Watchdog needs to read your inbox to find replies from {providerName}. Connect Gmail or Outlook in your Profile — takes about 30 seconds.
                         </p>
                       </div>
@@ -470,7 +470,7 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
               ) : !candidates || candidates.length === 0 ? (
                 <div className="text-center py-10">
                   <Mail className="h-10 w-10 text-slate-700 mx-auto mb-3" />
-                  <p className="text-slate-300 font-semibold mb-1">No matching threads found</p>
+                  <p className="text-slate-700 font-semibold mb-1">No matching threads found</p>
                   <p className="text-slate-500 text-sm">
                     We searched the last 365 days for mail mentioning {providerName}. If the thread
                     is older, forward the most recent message to yourself first, then try again.
@@ -505,17 +505,17 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
                         type="button"
                         disabled={linking}
                         onClick={() => pickCandidate(c)}
-                        className="w-full text-left bg-navy-950 hover:bg-navy-800 border border-navy-700/50 hover:border-mint-400/40 rounded-xl p-3 transition-all disabled:opacity-50 disabled:cursor-wait"
+                        className="w-full text-left bg-white hover:bg-slate-100 border border-slate-200 hover:border-mint-400/40 rounded-xl p-3 transition-all disabled:opacity-50 disabled:cursor-wait"
                       >
                         <div className="flex items-center justify-between gap-2 mb-1">
-                          <p className="text-sm font-semibold text-white truncate" title={c.subject}>
+                          <p className="text-sm font-semibold text-slate-900 truncate" title={c.subject}>
                             {c.subject || '(no subject)'}
                           </p>
                           <span className="text-[10px] uppercase tracking-wide text-mint-400 font-semibold flex-shrink-0">
                             {Math.round(c.confidence * 100)}%
                           </span>
                         </div>
-                        <p className="text-xs text-slate-400 truncate">from {c.senderAddress}</p>
+                        <p className="text-xs text-slate-500 truncate">from {c.senderAddress}</p>
                         <p className="text-xs text-slate-500 mt-1 line-clamp-2">{c.snippet}</p>
                         <div className="flex items-center gap-2 mt-2 flex-wrap">
                           <span className="text-[10px] text-slate-500">
@@ -533,7 +533,7 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
               )}
             </div>
             {linking && (
-              <div className="px-5 py-3 border-t border-navy-700/50 bg-navy-950">
+              <div className="px-5 py-3 border-t border-slate-200 bg-white">
                 <div className="flex items-center gap-2 text-mint-400 text-sm">
                   <Loader2 className="h-4 w-4 animate-spin" />
                   Importing history… this can take a few seconds.

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -57,13 +57,13 @@ export default function OnboardingFlow({
             <CheckCircle2 className="h-5 w-5 text-emerald-400" />
           </div>
           <div>
-            <p className="text-white font-semibold text-sm">You&apos;re all set!</p>
-            <p className="text-slate-400 text-sm">
+            <p className="text-slate-900 font-semibold text-sm">You&apos;re all set!</p>
+            <p className="text-slate-500 text-sm">
               Tracking {subscriptionCount} subscription{subscriptionCount !== 1 ? 's' : ''} and ready to fight unfair bills.
             </p>
           </div>
         </div>
-        <button onClick={handleDismiss} className="text-slate-500 hover:text-white p-1 flex-shrink-0">
+        <button onClick={handleDismiss} className="text-slate-500 hover:text-slate-900 p-1 flex-shrink-0">
           <X className="h-5 w-5" />
         </button>
       </div>
@@ -74,7 +74,7 @@ export default function OnboardingFlow({
   if (!hasLetter) {
     return (
       <div className="bg-gradient-to-br from-amber-500/10 via-amber-600/5 to-transparent border border-amber-500/20 rounded-2xl p-6 mb-8 relative">
-        <button onClick={handleDismiss} className="absolute top-4 right-4 text-slate-500 hover:text-white p-1">
+        <button onClick={handleDismiss} className="absolute top-4 right-4 text-slate-500 hover:text-slate-900 p-1">
           <X className="h-4 w-4" />
         </button>
 
@@ -84,8 +84,8 @@ export default function OnboardingFlow({
           </div>
           <div>
             <p className="text-xs font-semibold text-amber-400 uppercase tracking-wider mb-1">Quick win — 30 seconds</p>
-            <h3 className="text-white font-bold text-lg leading-snug">Generate your first complaint letter</h3>
-            <p className="text-slate-400 text-sm mt-1">
+            <h3 className="text-slate-900 font-bold text-lg leading-snug">Generate your first complaint letter</h3>
+            <p className="text-slate-500 text-sm mt-1">
               AI-powered letters citing exact UK law. Free, no card needed.
             </p>
           </div>
@@ -97,10 +97,10 @@ export default function OnboardingFlow({
               key={issue.category}
               href={`/dashboard/complaints?category=${issue.category}`}
               onClick={() => capture('onboarding_issue_click', { category: issue.category })}
-              className="flex items-center gap-2 bg-navy-800/60 hover:bg-amber-500/10 border border-navy-700/50 hover:border-amber-500/30 rounded-xl px-3 py-2.5 transition-all"
+              className="flex items-center gap-2 bg-slate-100 hover:bg-amber-500/10 border border-slate-200 hover:border-amber-500/30 rounded-xl px-3 py-2.5 transition-all"
             >
               <span className="text-base leading-none">{issue.icon}</span>
-              <span className="text-sm text-slate-300 leading-tight">{issue.label}</span>
+              <span className="text-sm text-slate-700 leading-tight">{issue.label}</span>
             </Link>
           ))}
         </div>
@@ -124,7 +124,7 @@ export default function OnboardingFlow({
   // Step 2 — Has letter but no bank: connect bank
   return (
     <div className="bg-gradient-to-br from-blue-500/10 via-blue-600/5 to-transparent border border-blue-500/20 rounded-2xl p-6 mb-8 relative">
-      <button onClick={handleDismiss} className="absolute top-4 right-4 text-slate-500 hover:text-white p-1">
+      <button onClick={handleDismiss} className="absolute top-4 right-4 text-slate-500 hover:text-slate-900 p-1">
         <X className="h-4 w-4" />
       </button>
 
@@ -134,9 +134,9 @@ export default function OnboardingFlow({
         </div>
         <div>
           <p className="text-xs font-semibold text-blue-400 uppercase tracking-wider mb-1">Next step</p>
-          <h3 className="text-white font-bold text-lg leading-snug">Connect your bank — find hidden costs</h3>
-          <p className="text-slate-400 text-sm mt-1">
-            We typically find <span className="text-white font-semibold">£47/month</span> in forgotten subscriptions. Takes 2 minutes.
+          <h3 className="text-slate-900 font-bold text-lg leading-snug">Connect your bank — find hidden costs</h3>
+          <p className="text-slate-500 text-sm mt-1">
+            We typically find <span className="text-slate-900 font-semibold">£47/month</span> in forgotten subscriptions. Takes 2 minutes.
           </p>
         </div>
       </div>
@@ -147,10 +147,10 @@ export default function OnboardingFlow({
           { icon: '📊', title: 'Spending breakdown', desc: '20+ categories analysed in seconds' },
           { icon: '🔔', title: 'Price increase alerts', desc: 'Get notified when your bills go up' },
         ].map(item => (
-          <div key={item.title} className="bg-navy-800/40 rounded-xl p-3 border border-navy-700/30">
+          <div key={item.title} className="bg-slate-100 rounded-xl p-3 border border-slate-200">
             <span className="text-xl">{item.icon}</span>
-            <p className="text-white text-sm font-semibold mt-1">{item.title}</p>
-            <p className="text-slate-400 text-xs mt-0.5">{item.desc}</p>
+            <p className="text-slate-900 text-sm font-semibold mt-1">{item.title}</p>
+            <p className="text-slate-500 text-xs mt-0.5">{item.desc}</p>
           </div>
         ))}
       </div>
@@ -158,7 +158,7 @@ export default function OnboardingFlow({
       <div className="flex items-center gap-3">
         <button
           onClick={() => { capture('onboarding_cta_click', { step: 'bank' }); if (!connectBankDirect()) setShowBankPicker(true); }}
-          className="inline-flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold px-5 py-2.5 rounded-xl transition-all text-sm"
+          className="inline-flex items-center gap-2 bg-blue-500 hover:bg-blue-600 text-slate-900 font-semibold px-5 py-2.5 rounded-xl transition-all text-sm"
         >
           <Building2 className="h-4 w-4" />
           Connect bank (2 minutes)

--- a/src/components/subscriptions/ComparisonCard.tsx
+++ b/src/components/subscriptions/ComparisonCard.tsx
@@ -49,7 +49,7 @@ export default function ComparisonCard({ subscription, comparisons, category }: 
           <TrendingDown className="h-3 w-3" />
           {isComparisonOnly ? 'Compare deals' : `Save ${formatGBP(best.annualSaving)}/year`}
         </span>
-        <span className="text-xs text-slate-500 group-hover:text-slate-400 transition-colors">
+        <span className="text-xs text-slate-500 group-hover:text-slate-500 transition-colors">
           {expanded ? 'Hide' : 'Show'} alternatives
         </span>
         {expanded
@@ -67,8 +67,8 @@ export default function ComparisonCard({ subscription, comparisons, category }: 
               <div className="flex-1 grid grid-cols-2 gap-4">
                 <div>
                   <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Your plan</p>
-                  <p className="text-sm font-medium text-white">{subscription.provider_name}</p>
-                  <p className="text-sm text-slate-400">
+                  <p className="text-sm font-medium text-slate-900">{subscription.provider_name}</p>
+                  <p className="text-sm text-slate-500">
                     {formatGBP(subscription.amount)}/{subscription.billing_cycle === 'one-time' ? 'once' : 'mo'}
                   </p>
                 </div>
@@ -95,7 +95,7 @@ export default function ComparisonCard({ subscription, comparisons, category }: 
             <div className="flex flex-wrap gap-2 mt-3">
               <a
                 href={`/deals/${dealsPageCategory}`}
-                className="inline-flex items-center gap-1.5 bg-navy-800 hover:bg-navy-700 text-white px-3 py-1.5 rounded-lg text-xs font-medium transition-all"
+                className="inline-flex items-center gap-1.5 bg-slate-100 hover:bg-slate-100 text-slate-900 px-3 py-1.5 rounded-lg text-xs font-medium transition-all"
               >
                 Compare Deals <ArrowRight className="h-3 w-3" />
               </a>
@@ -114,9 +114,9 @@ export default function ComparisonCard({ subscription, comparisons, category }: 
           {others.length > 0 && (
             <div className="space-y-1.5">
               {others.map((alt, i) => (
-                <div key={i} className="flex items-center justify-between bg-navy-800/50 rounded-lg px-3 py-2">
+                <div key={i} className="flex items-center justify-between bg-slate-100 rounded-lg px-3 py-2">
                   <div className="flex-1 min-w-0">
-                    <p className="text-xs font-medium text-white truncate">{alt.dealProvider}</p>
+                    <p className="text-xs font-medium text-slate-900 truncate">{alt.dealProvider}</p>
                     <p className="text-xs text-slate-500 truncate">{alt.dealName}</p>
                   </div>
                   <div className="flex items-center gap-3 ml-3 flex-shrink-0">
@@ -124,7 +124,7 @@ export default function ComparisonCard({ subscription, comparisons, category }: 
                       <span className="text-xs text-green-400 font-medium">Save {formatGBP(alt.annualSaving)}/yr</span>
                     )}
                     {!isComparisonOnly && alt.dealPrice > 0 && (
-                      <span className="text-xs text-slate-400">{formatGBP(alt.dealPrice)}/mo</span>
+                      <span className="text-xs text-slate-500">{formatGBP(alt.dealPrice)}/mo</span>
                     )}
                     <a
                       href={alt.dealUrl}

--- a/src/components/subscriptions/CreditScoreWarning.tsx
+++ b/src/components/subscriptions/CreditScoreWarning.tsx
@@ -24,11 +24,11 @@ export default function CreditScoreWarning({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border-2 border-amber-500/50 rounded-2xl w-full max-w-md shadow-2xl">
+      <div className="relative bg-white border-2 border-amber-500/50 rounded-2xl w-full max-w-md shadow-2xl">
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-slate-400 hover:text-white transition-all"
+          className="absolute top-4 right-4 text-slate-500 hover:text-slate-900 transition-all"
         >
           <X className="h-5 w-5" />
         </button>
@@ -40,20 +40,20 @@ export default function CreditScoreWarning({
               <AlertTriangle className="h-5 w-5 text-amber-400" />
             </div>
             <div>
-              <h2 className="text-lg font-bold text-white">Credit Score Warning</h2>
+              <h2 className="text-lg font-bold text-slate-900">Credit Score Warning</h2>
               <p className="text-amber-400 text-sm font-medium">{productType}</p>
             </div>
           </div>
 
           {/* Provider name */}
-          <div className="bg-navy-950 rounded-lg px-4 py-3 mb-4 border border-navy-700/50">
-            <p className="text-slate-400 text-xs mb-0.5">Provider</p>
-            <p className="text-white font-semibold">{providerName}</p>
+          <div className="bg-white rounded-lg px-4 py-3 mb-4 border border-slate-200">
+            <p className="text-slate-500 text-xs mb-0.5">Provider</p>
+            <p className="text-slate-900 font-semibold">{providerName}</p>
           </div>
 
           {/* Warning content */}
           <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-4 mb-4">
-            <p className="text-slate-300 text-sm leading-relaxed">{warningContent}</p>
+            <p className="text-slate-700 text-sm leading-relaxed">{warningContent}</p>
           </div>
 
           {/* FCA disclaimer */}
@@ -65,7 +65,7 @@ export default function CreditScoreWarning({
           <div className="flex gap-3">
             <button
               onClick={onClose}
-              className="flex-1 flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white py-3 rounded-lg transition-all font-medium text-sm"
+              className="flex-1 flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-100 text-slate-900 py-3 rounded-lg transition-all font-medium text-sm"
             >
               Keep Subscription
             </button>


### PR DESCRIPTION
## Two regressions from the screenshot review

1. **KPI row clipping on iPhone** — \`.kpi-row.c4\` stayed 4-column, so only ~3 of 4 cards were visible at 375px width.
2. **Dark cards still rendering** inside restyled parents — \`PriceIncreaseCard\` and \`SavingsOpportunityWidget\` kept their navy backgrounds and white text, producing the dark blocks visible under "Price increase alerts" and inside "BETTER DEALS FOUND".

## Responsive fixes (\`shell-v2.css\`)
- \`.kpi-row.c4\` / \`.c3\` → 2 cols at ≤1100px, 1 col at ≤640px.
- \`.page-title-row\` stacks vertically at ≤640px (CTA cluster drops under heading).
- Page title font 26px → 22px at ≤640px.
- \`.main-inner\` and \`.card\` paddings tighten on phones.
- New \`.cta-danger\` variant for red-washed dispute CTAs.

## Sub-components restyled
- \`PriceIncreaseCard\` — rewritten in design tokens: \`.card\` container with rose-washed merchant tile, paper "Was" + rose "Now" boxes, amber "costs you" copy, blue-washed regulatory hint, \`.cta-danger\` + \`.cta-ghost\` actions.
- \`SavingsOpportunityWidget\` — rewritten: mint-wash gradient \`.card\`, mint \`TrendingDown\` tile, white per-deal rows with mint-wash external-link buttons.
- Scripted dark→light sweep on 8 more: \`UpgradePrompt\`, \`UpgradeTrigger\`, \`TrialBanner\`, \`SavingsSkeleton\`, \`WatchdogCard\`, \`BankPickerModal\`, \`ComparisonCard\`, \`CreditScoreWarning\`, \`NotificationBell\`, \`OnboardingFlow\`. Mapping: \`bg-navy-*\` → \`bg-white\`/\`bg-slate-100\`, \`text-white\` → \`text-slate-900\`, \`text-slate-300/400\` → \`text-slate-700/500\`, \`border-navy-*\` → \`border-slate-200\`.

## Test plan
- [x] \`npx tsc --noEmit\` — zero errors.
- [x] Dev server compiles clean.
- [ ] iPhone (~375px): KPI cards stack 1-col; page-title row stacks vertical; Price-Increase Cards + Savings Widget render light.
- [ ] Tablet (~900px): KPI cards 2-col.
- [ ] Desktop (>1100px): unchanged — 4-col KPI row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)