### PR TITLE
fix(watchdog): await Telegram dispute-reply alert so serverless doesn't kill it mid-send

### DIFF
--- a/src/lib/dispute-sync/sync-runner.ts
+++ b/src/lib/dispute-sync/sync-runner.ts
@@ -220,17 +220,24 @@ export async function syncLinkedThread(
         },
       });
 
-      // Telegram alert — fire-and-forget. Import lazily so the module graph stays light.
-      sendTelegramSafely({
-        userId: link.user_id,
-        disputeId: link.dispute_id,
-        correspondenceId: inserted.id,
-        providerName,
-        subject: m.subject,
-        snippet: m.snippet,
-        linkUrl,
-        classification,
-      }).catch(async (err) => {
+      // Telegram alert — MUST be awaited. In Vercel serverless the function
+      // instance can terminate the moment the handler returns, which means a
+      // fire-and-forget Telegram call gets killed mid-HTTPS and the user never
+      // receives the alert (confirmed by empty telegram_message_log rows for
+      // dispute replies that did produce in-app notifications). Import lazily
+      // so the module graph stays light.
+      try {
+        await sendTelegramSafely({
+          userId: link.user_id,
+          disputeId: link.dispute_id,
+          correspondenceId: inserted.id,
+          providerName,
+          subject: m.subject,
+          snippet: m.snippet,
+          linkUrl,
+          classification,
+        });
+      } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn('[watchdog] telegram send failed:', msg);
         try {
@@ -248,7 +255,8 @@ export async function syncLinkedThread(
             logErr instanceof Error ? logErr.message : logErr,
           );
         }
-      });
+        // Swallow — a failed Telegram alert must never abort the sync loop.
+      }
     }
   }
 


### PR DESCRIPTION
## Confirmed regression

Dispute-reply Telegram alerts have been silently dropping for paid users on Vercel. Confirmed against live data from Paul's OneStream reply imported at 18:11 UTC today:

| Check | Result |
|---|---|
| user_notifications (in-app bell) | ✅ row inserted |
| telegram_message_log (outbound TG) | ❌ no row |
| business_log (telegram_error) | ❌ no row |
| telegram_alert_preferences | null → default-ON, not blocked |
| telegram_sessions | active chat_id on file |

## Cause

\`sendTelegramSafely(...).catch(...)\` is fire-and-forget. In Vercel Lambda-style runtime the function instance can be terminated the moment the handler returns its HTTP response, cutting off any in-flight HTTPS call to \`api.telegram.org\`. The \`.catch()\` handler never runs either, so there's no breadcrumb.

## Fix

\`await\` the send and wrap in try/catch. On failure, still write to \`business_log\` and swallow — a flaky Telegram API must never abort the dispute-sync loop. Net latency: ~200–400ms per imported reply, comfortably inside the 5-minute cron budget.

## Test plan
- [x] \`npx tsc --noEmit\` — zero errors.
- [ ] After deploy: simulate a new supplier reply → cron imports → verify both \`user_notifications\` and \`telegram_message_log\` get rows, and the user actually sees the alert in Telegram.
- [ ] If Telegram API fails, verify \`business_log\` gets a \`telegram_error\` row and the dispute-sync still completes for all other links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)