### PR TITLE
feat(dashboard): sweep dark theme from Money Hub panels + 23 more components

### DIFF
--- a/src/app/dashboard/forms/page.tsx
+++ b/src/app/dashboard/forms/page.tsx
@@ -197,13 +197,13 @@ export default function FormsPage() {
       <div className="flex gap-2 mb-6">
         <button
           onClick={() => { setActiveTab('generate'); setResult(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${activeTab === 'generate' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${activeTab === 'generate' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
         >
           <Sparkles className="h-4 w-4" /> Generate
         </button>
         <button
           onClick={() => { setActiveTab('history'); loadHistory(); setSelectedHistoryTask(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${activeTab === 'history' ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
+          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${activeTab === 'history' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}
         >
           <History className="h-4 w-4" /> History ({historyTasks.length})
         </button>
@@ -234,7 +234,7 @@ export default function FormsPage() {
                   >{selectedHistoryTask.letter}</pre>
                   <button
                     onClick={() => { navigator.clipboard.writeText(selectedHistoryTask.letter!); setCopied(true); setTimeout(() => setCopied(false), 2000); }}
-                    className="mt-4 flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-4 py-2 rounded-lg text-sm"
+                    className="mt-4 flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm"
                   >
                     {copied ? <><CheckCircle className="h-4 w-4" /> Copied</> : <><Copy className="h-4 w-4" /> Copy Letter</>}
                   </button>
@@ -245,7 +245,7 @@ export default function FormsPage() {
             </div>
           ) : historyTasks.length === 0 ? (
             <div className="card shadow-sm p-12 text-center">
-              <FileText className="h-12 w-12 text-slate-300 mx-auto mb-3" />
+              <FileText className="h-12 w-12 text-slate-700 mx-auto mb-3" />
               <p className="text-slate-600 mb-2">No letters generated yet</p>
               <button onClick={() => setActiveTab('generate')} className="text-emerald-600 text-sm hover:text-emerald-700">Generate your first letter</button>
             </div>
@@ -360,14 +360,14 @@ export default function FormsPage() {
                 <button
                   onClick={handleGenerate}
                   disabled={generating || !details || !desiredOutcome}
-                  className="w-full bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white font-semibold py-3 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                  className="w-full bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-slate-900 font-semibold py-3 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                 >
                   {generating ? <><Loader2 className="h-4 w-4 animate-spin" /> Generating...</> : <><Sparkles className="h-4 w-4" /> Generate Letter</>}
                 </button>
               </div>
             ) : (
               <div className="text-center py-12">
-                <FileText className="h-16 w-16 text-slate-300 mx-auto mb-4" />
+                <FileText className="h-16 w-16 text-slate-700 mx-auto mb-4" />
                 <p className="text-slate-500">Select a letter type from the left to get started</p>
               </div>
             )}
@@ -437,7 +437,7 @@ export default function FormsPage() {
               {copied ? <><CheckCircle className="h-4 w-4" /> Copied!</> : <><Copy className="h-4 w-4" /> Copy Letter</>}
             </button>
             <button onClick={handlePDF}
-              className="flex-1 flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold py-3 rounded-lg transition-all">
+              className="flex-1 flex items-center justify-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold py-3 rounded-lg transition-all">
               <Download className="h-4 w-4" /> Download PDF
             </button>
           </div>

--- a/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
+++ b/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
@@ -121,8 +121,8 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
     if (isIncomeMode) {
       return (
         <>
-          <div className="p-2 border-b border-navy-700 bg-navy-900/50">
-            <p className="text-xs text-slate-400 font-medium">Change income type</p>
+          <div className="p-2 border-b border-slate-200 bg-white">
+            <p className="text-xs text-slate-500 font-medium">Change income type</p>
           </div>
           <div className="max-h-48 overflow-y-auto custom-scrollbar p-1">
             {INCOME_TYPES.map(t => (
@@ -130,14 +130,14 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                 key={`inc-${t}`}
                 onClick={() => handleRecategorise(pattern, t, 'incomeType')}
                 disabled={recatLoading}
-                className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
+                className="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
               >
                 {t.replace(/_/g, ' ')}
               </button>
             ))}
           </div>
-          <div className="p-2 border-t border-b border-navy-700 bg-navy-900/50">
-            <p className="text-xs text-slate-400 font-medium">Not income — tag as</p>
+          <div className="p-2 border-t border-b border-slate-200 bg-white">
+            <p className="text-xs text-slate-500 font-medium">Not income — tag as</p>
           </div>
           <div className="max-h-32 overflow-y-auto custom-scrollbar p-1">
             {NON_INCOME_CATEGORIES.map(c => (
@@ -145,7 +145,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                 key={`nic-${c}`}
                 onClick={() => handleRecategorise(pattern, c, 'category')}
                 disabled={recatLoading}
-                className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
+                className="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
               >
                 {c.replace(/_/g, ' ')}
               </button>
@@ -156,8 +156,8 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
     }
     return (
       <>
-        <div className="p-2 border-b border-navy-700 bg-navy-900/50">
-          <p className="text-xs text-slate-400 font-medium">Reassign to...</p>
+        <div className="p-2 border-b border-slate-200 bg-white">
+          <p className="text-xs text-slate-500 font-medium">Reassign to...</p>
         </div>
         <div className="max-h-60 overflow-y-auto custom-scrollbar p-1">
           {ALL_CATEGORIES.map(c => (
@@ -165,7 +165,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
               key={c}
               onClick={() => handleRecategorise(pattern, c, 'category')}
               disabled={recatLoading}
-              className="w-full text-left px-3 py-2 text-sm text-slate-300 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
+              className="w-full text-left px-3 py-2 text-sm text-slate-700 hover:bg-purple-500/20 hover:text-purple-300 rounded capitalize disabled:opacity-50"
             >
               {c.replace(/_/g, ' ')}
             </button>
@@ -177,14 +177,14 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-navy-950/80 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border border-navy-700 rounded-2xl w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-navy-800">
+      <div className="absolute inset-0 bg-white backdrop-blur-sm" onClick={onClose} />
+      <div className="relative card w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl">
+        <div className="flex items-center justify-between p-6 border-b border-slate-200">
           <div>
-            <h2 className="text-xl font-bold text-white capitalize">{displayTitle}</h2>
-            <p className="text-slate-400 text-sm mt-1">{selectedMonth ? new Date(`${selectedMonth}-01`).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }) : 'This month'}</p>
+            <h2 className="text-xl font-bold text-slate-900 capitalize">{displayTitle}</h2>
+            <p className="text-slate-500 text-sm mt-1">{selectedMonth ? new Date(`${selectedMonth}-01`).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }) : 'This month'}</p>
           </div>
-          <button onClick={onClose} className="text-slate-500 hover:text-white p-2 rounded-lg hover:bg-navy-800 transition-colors">
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-2 rounded-lg hover:bg-slate-100 transition-colors">
             <X className="h-5 w-5" />
           </button>
         </div>
@@ -196,7 +196,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
             </div>
           ) : !data || data.transactions.length === 0 ? (
             <div className="text-center py-20">
-              <p className="text-slate-400">No transactions found for this category.</p>
+              <p className="text-slate-500">No transactions found for this category.</p>
             </div>
           ) : (
             <div className="space-y-8">
@@ -205,18 +205,18 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                 <p className="text-xs text-slate-500 uppercase tracking-wider mb-4 font-semibold">Top Merchants</p>
                 <div className="space-y-3">
                   {data.merchants.slice(0, 5).map((m, idx) => (
-                    <div key={m.merchant} className="bg-navy-950/50 rounded-xl p-4 flex items-center justify-between group relative">
+                    <div key={m.merchant} className="bg-white rounded-xl p-4 flex items-center justify-between group relative">
                       <div className="flex items-center gap-3">
-                        <div className="h-10 w-10 rounded-full bg-navy-800 flex items-center justify-center border border-navy-700 font-bold text-white uppercase">
+                        <div className="h-10 w-10 rounded-full bg-slate-100 flex items-center justify-center border border-slate-200 font-bold text-slate-900 uppercase">
                           {m.merchant.substring(0, 2)}
                         </div>
                         <div>
-                          <p className="text-white font-medium capitalize">{m.merchant}</p>
+                          <p className="text-slate-900 font-medium capitalize">{m.merchant}</p>
                           <p className="text-slate-500 text-xs">{m.count} transactions</p>
                         </div>
                       </div>
                       <div className="text-right">
-                        <p className="text-white font-bold">£{fmtNum(m.total)}</p>
+                        <p className="text-slate-900 font-bold">£{fmtNum(m.total)}</p>
                         <button 
                           onClick={() => setMerchantRecatIdx(merchantRecatIdx === idx ? null : idx)}
                           className="text-[10px] text-purple-400 hover:text-purple-300 transition-colors"
@@ -226,7 +226,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                       </div>
                       
                       {merchantRecatIdx === idx && (
-                        <div className="absolute top-16 right-0 w-56 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
+                        <div className="absolute top-16 right-0 w-56 bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
                           {renderReassignOptions(m.merchant)}
                         </div>
                       )}
@@ -238,18 +238,18 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
               {/* INDIVIDUAL TRANSACTIONS */}
               <div>
                 <p className="text-xs text-slate-500 uppercase tracking-wider mb-4 font-semibold">Transactions</p>
-                <div className="bg-navy-950/20 rounded-xl border border-navy-800 divide-y divide-navy-800">
+                <div className="bg-white rounded-xl border border-slate-200 divide-y divide-navy-800">
                   {data.transactions.map((txn, idx) => {
                     const dt = new Date(txn.timestamp);
                     const isRecatOpen = recatDropdown === txn.id;
                     return (
                       <div key={txn.id || idx} className="p-4 flex items-center justify-between group relative">
                         <div>
-                          <p className="text-white text-sm font-medium">{txn.merchant_name || txn.description}</p>
+                          <p className="text-slate-900 text-sm font-medium">{txn.merchant_name || txn.description}</p>
                           <p className="text-slate-500 text-xs mt-0.5">{dt.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}</p>
                         </div>
                         <div className="text-right">
-                          <p className="text-white text-sm font-medium">£{fmtNum(Math.abs(txn.amount))}</p>
+                          <p className="text-slate-900 text-sm font-medium">£{fmtNum(Math.abs(txn.amount))}</p>
                           <button 
                             onClick={() => setRecatDropdown(isRecatOpen ? null : txn.id)}
                             className="text-[10px] text-slate-500 hover:text-purple-400 transition-colors"
@@ -259,7 +259,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                         </div>
 
                         {isRecatOpen && (
-                          <div className="absolute top-12 right-4 w-56 bg-navy-800 border border-navy-700 rounded-xl shadow-xl z-20 overflow-hidden">
+                          <div className="absolute top-12 right-4 w-56 bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
                             {renderReassignOptions(cleanMerchantName(txn.description || ''))}
                           </div>
                         )}

--- a/src/app/dashboard/money-hub/ContractsPanel.tsx
+++ b/src/app/dashboard/money-hub/ContractsPanel.tsx
@@ -56,9 +56,9 @@ export default function ContractsPanel({ data, isPro }: { data: any, isPro: bool
   const switchableCount = activeSubs.filter((s: any) => switchableCats.has(s.category)).length;
 
   return (
-    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 flex flex-col h-full">
+    <div className="card p-5 flex flex-col h-full">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-white font-semibold text-lg flex items-center gap-2">
+        <h3 className="text-slate-900 font-semibold text-lg flex items-center gap-2">
           <Calendar className="h-5 w-5 text-amber-400" />
           Regular Payments
         </h3>
@@ -72,7 +72,7 @@ export default function ContractsPanel({ data, isPro }: { data: any, isPro: bool
         <div className="flex items-center gap-4 mb-4 text-xs">
           <div>
             <span className="text-slate-500">Monthly</span>
-            <p className="text-white font-semibold">£{fmtNum(monthlyTotal)}</p>
+            <p className="text-slate-900 font-semibold">£{fmtNum(monthlyTotal)}</p>
           </div>
           <div className="text-slate-700">|</div>
           <div>
@@ -91,15 +91,15 @@ export default function ContractsPanel({ data, isPro }: { data: any, isPro: bool
       )}
       
       {!isPro ? (
-        <div className="bg-navy-950/50 border border-navy-700/50 rounded-xl p-4 relative overflow-hidden flex-1">
-          <div className="absolute inset-0 bg-navy-950/60 backdrop-blur-sm z-10 flex flex-col items-center justify-center">
+        <div className="bg-white border border-slate-200 rounded-xl p-4 relative overflow-hidden flex-1">
+          <div className="absolute inset-0 bg-white backdrop-blur-sm z-10 flex flex-col items-center justify-center">
             <Lock className="h-6 w-6 text-slate-500 mb-2" />
-            <p className="text-white font-semibold text-xs mb-1">Upgrade to track subscriptions</p>
+            <p className="text-slate-900 font-semibold text-xs mb-1">Upgrade to track subscriptions</p>
             <Link href="/pricing" className="text-mint-400 text-[10px] hover:text-mint-300">View plans</Link>
           </div>
           <div className="space-y-3 opacity-30 pointer-events-none">
-            <div className="h-10 bg-navy-800 rounded-lg w-full" />
-            <div className="h-10 bg-navy-800 rounded-lg w-full" />
+            <div className="h-10 bg-slate-100 rounded-lg w-full" />
+            <div className="h-10 bg-slate-100 rounded-lg w-full" />
           </div>
         </div>
       ) : (
@@ -122,9 +122,9 @@ export default function ContractsPanel({ data, isPro }: { data: any, isPro: bool
               const cycleLabel = sub.billing_cycle === 'yearly' ? '/yr' : sub.billing_cycle === 'quarterly' ? '/qtr' : '/mo';
               
               return (
-                <div key={sub.id} className="flex items-center justify-between bg-navy-950/50 rounded-xl p-3 border border-navy-800 hover:border-navy-700 transition-colors">
+                <div key={sub.id} className="flex items-center justify-between bg-white rounded-xl p-3 border border-slate-200 hover:border-slate-200 transition-colors">
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-white capitalize truncate">{sub.provider_name}</p>
+                    <p className="text-sm font-medium text-slate-900 capitalize truncate">{sub.provider_name}</p>
                     {tag}
                   </div>
                   <p className="text-sm font-semibold text-amber-400 whitespace-nowrap ml-2">

--- a/src/app/dashboard/money-hub/GoalsAndBudgetsModal.tsx
+++ b/src/app/dashboard/money-hub/GoalsAndBudgetsModal.tsx
@@ -95,35 +95,35 @@ export default function GoalsAndBudgetsModal({ isOpen, onClose, data, onUpdated 
   return (
     <>
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-navy-950/80 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border border-navy-700 rounded-2xl w-full max-w-xl max-h-[85vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-navy-800">
-          <h2 className="text-xl font-bold text-white flex items-center gap-2 pt-1"><Target className="h-6 w-6 text-green-400" /> Manage Budgets & Goals</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-white p-2 rounded-lg hover:bg-navy-800 transition-colors"><X className="h-5 w-5" /></button>
+      <div className="absolute inset-0 bg-white backdrop-blur-sm" onClick={onClose} />
+      <div className="relative card w-full max-w-xl max-h-[85vh] flex flex-col shadow-2xl">
+        <div className="flex items-center justify-between p-6 border-b border-slate-200">
+          <h2 className="text-xl font-bold text-slate-900 flex items-center gap-2 pt-1"><Target className="h-6 w-6 text-green-400" /> Manage Budgets & Goals</h2>
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-2 rounded-lg hover:bg-slate-100 transition-colors"><X className="h-5 w-5" /></button>
         </div>
 
-        <div className="flex border-b border-navy-800">
-          <button onClick={() => setActiveTab('budgets')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'budgets' ? 'text-green-400 border-b-2 border-green-400' : 'text-slate-500 hover:text-slate-300'}`}>Budgets</button>
-          <button onClick={() => setActiveTab('goals')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'goals' ? 'text-mint-400 border-b-2 border-mint-400' : 'text-slate-500 hover:text-slate-300'}`}>Savings Goals</button>
+        <div className="flex border-b border-slate-200">
+          <button onClick={() => setActiveTab('budgets')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'budgets' ? 'text-green-400 border-b-2 border-green-400' : 'text-slate-500 hover:text-slate-700'}`}>Budgets</button>
+          <button onClick={() => setActiveTab('goals')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'goals' ? 'text-mint-400 border-b-2 border-mint-400' : 'text-slate-500 hover:text-slate-700'}`}>Savings Goals</button>
         </div>
 
         <div className="p-6 overflow-y-auto custom-scrollbar flex-1">
           {activeTab === 'budgets' ? (
             <div className="space-y-6">
-              <div className="bg-navy-950/50 p-4 rounded-xl border border-navy-800">
-                <h3 className="text-white font-semibold mb-3 text-sm flex items-center gap-2">Add New Budget</h3>
+              <div className="bg-white p-4 rounded-xl border border-slate-200">
+                <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2">Add New Budget</h3>
                 <div className="grid grid-cols-2 gap-3 mb-3">
-                  <select value={budgetCategory} onChange={e => setBudgetCategory(e.target.value)} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-green-400 focus:outline-none capitalize">
+                  <select value={budgetCategory} onChange={e => setBudgetCategory(e.target.value)} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none capitalize">
                     {ALL_CATEGORIES.map(c => <option key={c} value={c}>{c.replace(/_/g, ' ')}</option>)}
                   </select>
-                  <input type="number" placeholder="Limit (£)" value={budgetAmount} onChange={e => setBudgetAmount(e.target.value)} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-green-400 focus:outline-none" />
+                  <input type="number" placeholder="Limit (£)" value={budgetAmount} onChange={e => setBudgetAmount(e.target.value)} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none" />
                 </div>
-                <button onClick={handleAddBudget} disabled={loading || !budgetAmount || !budgetCategory} className="w-full bg-green-500 hover:bg-green-600 disabled:opacity-50 text-white font-semibold py-2 rounded-lg text-sm flex justify-center items-center gap-2"><Plus className="h-4 w-4" /> Save Budget</button>
+                <button onClick={handleAddBudget} disabled={loading || !budgetAmount || !budgetCategory} className="w-full bg-green-500 hover:bg-green-600 disabled:opacity-50 text-slate-900 font-semibold py-2 rounded-lg text-sm flex justify-center items-center gap-2"><Plus className="h-4 w-4" /> Save Budget</button>
               </div>
               <div>
                 {budgets.length === 0 ? <p className="text-slate-500 text-sm">No budgets set.</p> : budgets.map((b: any) => (
-                  <div key={b.id} className="flex justify-between items-center py-3 border-b border-navy-800 last:border-0">
-                    <div><p className="text-white text-sm capitalize">{b.category.replace(/_/g, ' ')}</p><p className="text-xs text-slate-500">Target: £{fmtNum(b.monthly_limit)}</p></div>
+                  <div key={b.id} className="flex justify-between items-center py-3 border-b border-slate-200 last:border-0">
+                    <div><p className="text-slate-900 text-sm capitalize">{b.category.replace(/_/g, ' ')}</p><p className="text-xs text-slate-500">Target: £{fmtNum(b.monthly_limit)}</p></div>
                     <button onClick={() => handleDeleteBudget(b.id)} disabled={loading} className="text-slate-500 hover:text-red-400"><Trash2 className="h-4 w-4" /></button>
                   </div>
                 ))}
@@ -131,31 +131,31 @@ export default function GoalsAndBudgetsModal({ isOpen, onClose, data, onUpdated 
             </div>
           ) : (
             <div className="space-y-6">
-              <div className="bg-navy-950/50 p-4 rounded-xl border border-navy-800">
-                <h3 className="text-white font-semibold mb-3 text-sm flex items-center gap-2">Add Savings Goal</h3>
+              <div className="bg-white p-4 rounded-xl border border-slate-200">
+                <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2">Add Savings Goal</h3>
                 <div className="mb-3">
                   <div className="flex gap-2 flex-wrap mb-2">
                     {GOAL_EMOJIS.map(em => (
-                      <button key={em} onClick={() => setGoalForm(prev => ({ ...prev, emoji: em }))} className={`h-8 w-8 rounded-full flex items-center justify-center text-lg ${goalForm.emoji === em ? 'bg-mint-400/20 border border-mint-400/50' : 'hover:bg-navy-800 border border-transparent'}`}>{em}</button>
+                      <button key={em} onClick={() => setGoalForm(prev => ({ ...prev, emoji: em }))} className={`h-8 w-8 rounded-full flex items-center justify-center text-lg ${goalForm.emoji === em ? 'bg-mint-400/20 border border-mint-400/50' : 'hover:bg-slate-100 border border-transparent'}`}>{em}</button>
                     ))}
                   </div>
-                  <input type="text" placeholder="Goal Name (e.g. Holiday)" value={goalForm.name} onChange={e => setGoalForm(prev => ({ ...prev, name: e.target.value }))} className="w-full mb-2 bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-mint-400 focus:outline-none" />
+                  <input type="text" placeholder="Goal Name (e.g. Holiday)" value={goalForm.name} onChange={e => setGoalForm(prev => ({ ...prev, name: e.target.value }))} className="w-full mb-2 bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-mint-400 focus:outline-none" />
                   <div className="grid grid-cols-2 gap-3">
-                    <input type="number" placeholder="Target (£)" value={goalForm.targetAmount} onChange={e => setGoalForm(prev => ({ ...prev, targetAmount: e.target.value }))} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-mint-400 focus:outline-none" />
-                    <input type="number" placeholder="Already saved (£)" value={goalForm.currentAmount} onChange={e => setGoalForm(prev => ({ ...prev, currentAmount: e.target.value }))} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-mint-400 focus:outline-none" />
+                    <input type="number" placeholder="Target (£)" value={goalForm.targetAmount} onChange={e => setGoalForm(prev => ({ ...prev, targetAmount: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-mint-400 focus:outline-none" />
+                    <input type="number" placeholder="Already saved (£)" value={goalForm.currentAmount} onChange={e => setGoalForm(prev => ({ ...prev, currentAmount: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-mint-400 focus:outline-none" />
                   </div>
                 </div>
                 <button onClick={handleAddGoal} disabled={loading || !goalForm.name || !goalForm.targetAmount} className="w-full bg-mint-400 hover:bg-mint-500 disabled:opacity-50 text-navy-950 font-semibold py-2 rounded-lg text-sm flex justify-center items-center gap-2"><Plus className="h-4 w-4" /> Save Goal</button>
               </div>
               <div>
                 {goals.length === 0 ? <p className="text-slate-500 text-sm">No goals set.</p> : goals.map((g: any) => (
-                  <div key={g.id} className="flex justify-between items-center py-3 border-b border-navy-800 last:border-0">
+                  <div key={g.id} className="flex justify-between items-center py-3 border-b border-slate-200 last:border-0">
                     <div>
-                      <p className="text-white text-sm">{g.emoji} {g.goal_name}</p>
+                      <p className="text-slate-900 text-sm">{g.emoji} {g.goal_name}</p>
                       <p className="text-xs text-slate-500">Saved: £{fmtNum(g.current_amount)} / £{fmtNum(g.target_amount)}</p>
                     </div>
                     <div className="flex items-center gap-3">
-                      <button onClick={() => handleAddMoneyToGoal(g.id, g.current_amount)} className="text-mint-400 hover:text-mint-300 transition-colors flex items-center gap-1 text-xs font-semibold bg-mint-400/10 px-2 py-1 rounded-full"><PlusCircle className="h-3 w-3 " /> Add</button>
+                      <button onClick={() => handleAddMoneyToGoal(g.id, g.current_amount)} className="text-mint-400 hover:text-mint-300 transition-colors flex items-center gap-1 text-xs font-semibold bg-mint-400/10 px-2 py-1 rounded-full"><PlusCircle className="h-3 w-3" /> Add</button>
                       <button onClick={() => handleDeleteGoal(g.id)} disabled={loading} className="text-slate-500 hover:text-red-400"><Trash2 className="h-4 w-4" /></button>
                     </div>
                   </div>
@@ -171,20 +171,20 @@ export default function GoalsAndBudgetsModal({ isOpen, onClose, data, onUpdated 
       {addFundGoal && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
           <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setAddFundGoal(null)} />
-          <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-sm p-6 shadow-2xl">
-            <h3 className="text-lg font-bold text-white mb-2">Add Funds to Goal</h3>
-            <p className="text-sm text-slate-400 mb-4">How much would you like to add?</p>
+          <div className="relative card w-full max-w-sm p-6 shadow-2xl">
+            <h3 className="text-lg font-bold text-slate-900 mb-2">Add Funds to Goal</h3>
+            <p className="text-sm text-slate-500 mb-4">How much would you like to add?</p>
             <input 
               type="number" 
               step="0.01"
               value={addFundAmount} 
               onChange={e => setAddFundAmount(e.target.value)} 
-              className="w-full bg-navy-950 border border-navy-700 rounded-lg px-3 py-2 text-white focus:border-mint-400 focus:outline-none mb-4" 
+              className="w-full bg-white border border-slate-200 rounded-lg px-3 py-2 text-slate-900 focus:border-mint-400 focus:outline-none mb-4" 
               placeholder="Amount (£)"
               autoFocus
             />
             <div className="flex gap-2 justify-end">
-              <button disabled={loading} onClick={() => setAddFundGoal(null)} className="px-4 py-2 hover:bg-navy-800 text-slate-300 rounded-lg text-sm transition-colors">Cancel</button>
+              <button disabled={loading} onClick={() => setAddFundGoal(null)} className="px-4 py-2 hover:bg-slate-100 text-slate-700 rounded-lg text-sm transition-colors">Cancel</button>
               <button disabled={loading || !addFundAmount} onClick={submitAddFunds} className="px-4 py-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold rounded-lg text-sm disabled:opacity-50 transition-colors">Add Funds</button>
             </div>
           </div>

--- a/src/app/dashboard/money-hub/GoalsAndBudgetsPanel.tsx
+++ b/src/app/dashboard/money-hub/GoalsAndBudgetsPanel.tsx
@@ -14,29 +14,29 @@ export default function GoalsAndBudgetsPanel({ data, isPro, refreshData, selecte
   const goals = data.goals || [];
 
   return (
-    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 flex flex-col h-full">
+    <div className="card p-5 flex flex-col h-full">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-white font-semibold text-lg flex items-center gap-2">
+        <h3 className="text-slate-900 font-semibold text-lg flex items-center gap-2">
           <Target className="h-5 w-5 text-green-400" />
           Budgets & Goals
         </h3>
         {isPro && (
-          <button onClick={() => setModalOpen(true)} className="text-slate-500 hover:text-white transition-colors" title="Manage Budgets and Goals">
+          <button onClick={() => setModalOpen(true)} className="text-slate-500 hover:text-slate-900 transition-colors" title="Manage Budgets and Goals">
             <Settings className="h-4 w-4" />
           </button>
         )}
       </div>
       
       {!isPro ? (
-        <div className="bg-navy-950/50 border border-navy-700/50 rounded-xl p-4 relative overflow-hidden flex-1">
-          <div className="absolute inset-0 bg-navy-950/60 backdrop-blur-sm z-10 flex flex-col items-center justify-center">
+        <div className="bg-white border border-slate-200 rounded-xl p-4 relative overflow-hidden flex-1">
+          <div className="absolute inset-0 bg-white backdrop-blur-sm z-10 flex flex-col items-center justify-center">
             <Lock className="h-6 w-6 text-slate-500 mb-2" />
-            <p className="text-white font-semibold text-xs mb-1">Upgrade to set Budgets & Goals</p>
+            <p className="text-slate-900 font-semibold text-xs mb-1">Upgrade to set Budgets & Goals</p>
             <Link href="/pricing" className="text-mint-400 text-[10px] hover:text-mint-300">View plans</Link>
           </div>
           <div className="space-y-4 opacity-30 pointer-events-none">
-            <div className="h-2 bg-navy-700 rounded-full w-full" />
-            <div className="h-2 bg-navy-700 rounded-full w-3/4" />
+            <div className="h-2 bg-slate-100 rounded-full w-full" />
+            <div className="h-2 bg-slate-100 rounded-full w-3/4" />
           </div>
         </div>
       ) : (
@@ -44,7 +44,7 @@ export default function GoalsAndBudgetsPanel({ data, isPro, refreshData, selecte
           {/* Budgets */}
           <div>
             <div className="flex items-center justify-between mb-3">
-              <p className="text-xs text-slate-400 uppercase tracking-wider font-semibold">Active Budgets</p>
+              <p className="text-xs text-slate-500 uppercase tracking-wider font-semibold">Active Budgets</p>
               {budgets.length === 0 && (
                 <button onClick={() => setModalOpen(true)} className="text-mint-400 hover:text-mint-300 text-xs flex items-center gap-1">
                   <Plus className="h-3 w-3" /> Add
@@ -58,15 +58,15 @@ export default function GoalsAndBudgetsPanel({ data, isPro, refreshData, selecte
                 <button
                   key={b.id}
                   onClick={() => setDrillCategory(b.category)}
-                  className="mb-3 w-full text-left group hover:bg-navy-800/40 rounded-lg px-2 -mx-2 py-1 transition-colors"
+                  className="mb-3 w-full text-left group hover:bg-slate-100 rounded-lg px-2 -mx-2 py-1 transition-colors"
                 >
                   <div className="flex justify-between text-sm mb-1">
-                    <span className="text-white capitalize group-hover:text-mint-400 transition-colors">{(b.category || '').replace(/_/g, ' ')}</span>
-                    <span className={`text-xs font-medium ${b.status === 'over_budget' ? 'text-red-400' : b.status === 'warning' ? 'text-amber-400' : 'text-slate-400'}`}>
+                    <span className="text-slate-900 capitalize group-hover:text-mint-400 transition-colors">{(b.category || '').replace(/_/g, ' ')}</span>
+                    <span className={`text-xs font-medium ${b.status === 'over_budget' ? 'text-red-400' : b.status === 'warning' ? 'text-amber-400' : 'text-slate-500'}`}>
                       £{fmtNum(b.spent)} / £{fmtNum(b.monthly_limit)}
                     </span>
                   </div>
-                  <div className="w-full bg-navy-800 rounded-full h-1.5">
+                  <div className="w-full bg-slate-100 rounded-full h-1.5">
                     <div
                       className={`h-1.5 rounded-full transition-all ${b.status === 'over_budget' ? 'bg-red-400' : b.status === 'warning' ? 'bg-amber-400' : 'bg-green-400'}`}
                       style={{ width: `${Math.min(b.percentage, 100)}%` }}
@@ -83,7 +83,7 @@ export default function GoalsAndBudgetsPanel({ data, isPro, refreshData, selecte
           {/* Savings Goals */}
           <div>
             <div className="flex items-center justify-between mb-3">
-              <p className="text-xs text-slate-400 uppercase tracking-wider font-semibold flex items-center gap-1">
+              <p className="text-xs text-slate-500 uppercase tracking-wider font-semibold flex items-center gap-1">
                 <PiggyBank className="h-3 w-3" /> Savings Goals
               </p>
               {goals.length === 0 && (
@@ -101,10 +101,10 @@ export default function GoalsAndBudgetsPanel({ data, isPro, refreshData, selecte
                 return (
                   <div key={g.id} className="mb-3">
                     <div className="flex justify-between text-sm mb-1">
-                      <span className="text-white flex items-center gap-1">{g.emoji} {g.goal_name}</span>
-                      <span className="text-slate-400 text-xs">£{fmtNum(g.current_amount)} / £{fmtNum(g.target_amount)}</span>
+                      <span className="text-slate-900 flex items-center gap-1">{g.emoji} {g.goal_name}</span>
+                      <span className="text-slate-500 text-xs">£{fmtNum(g.current_amount)} / £{fmtNum(g.target_amount)}</span>
                     </div>
-                    <div className="w-full bg-navy-800 rounded-full h-1.5">
+                    <div className="w-full bg-slate-100 rounded-full h-1.5">
                       <div className="bg-mint-400 h-1.5 rounded-full transition-all" style={{ width: `${Math.min(pct, 100)}%` }} />
                     </div>
                     {remaining > 0 && g.target_date && (

--- a/src/app/dashboard/money-hub/NetWorthManagementModal.tsx
+++ b/src/app/dashboard/money-hub/NetWorthManagementModal.tsx
@@ -55,36 +55,36 @@ export default function NetWorthManagementModal({ isOpen, onClose, data, onUpdat
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-navy-950/80 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border border-navy-700 rounded-2xl w-full max-w-xl max-h-[85vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-navy-800">
-          <h2 className="text-xl font-bold text-white flex items-center gap-2 pt-1"><PiggyBank className="h-6 w-6 text-mint-400" /> Manage Net Worth</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-white p-2 rounded-lg hover:bg-navy-800 transition-colors"><X className="h-5 w-5" /></button>
+      <div className="absolute inset-0 bg-white backdrop-blur-sm" onClick={onClose} />
+      <div className="relative card w-full max-w-xl max-h-[85vh] flex flex-col shadow-2xl">
+        <div className="flex items-center justify-between p-6 border-b border-slate-200">
+          <h2 className="text-xl font-bold text-slate-900 flex items-center gap-2 pt-1"><PiggyBank className="h-6 w-6 text-mint-400" /> Manage Net Worth</h2>
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-2 rounded-lg hover:bg-slate-100 transition-colors"><X className="h-5 w-5" /></button>
         </div>
 
-        <div className="flex border-b border-navy-800">
-          <button onClick={() => setActiveTab('assets')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'assets' ? 'text-green-400 border-b-2 border-green-400' : 'text-slate-500 hover:text-slate-300'}`}>Assets</button>
-          <button onClick={() => setActiveTab('liabilities')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'liabilities' ? 'text-red-400 border-b-2 border-red-400' : 'text-slate-500 hover:text-slate-300'}`}>Liabilities</button>
+        <div className="flex border-b border-slate-200">
+          <button onClick={() => setActiveTab('assets')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'assets' ? 'text-green-400 border-b-2 border-green-400' : 'text-slate-500 hover:text-slate-700'}`}>Assets</button>
+          <button onClick={() => setActiveTab('liabilities')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'liabilities' ? 'text-red-400 border-b-2 border-red-400' : 'text-slate-500 hover:text-slate-700'}`}>Liabilities</button>
         </div>
 
         <div className="p-6 overflow-y-auto custom-scrollbar flex-1">
           {activeTab === 'assets' ? (
             <div className="space-y-6">
-              <div className="bg-navy-950/50 p-4 rounded-xl border border-navy-800">
-                <h3 className="text-white font-semibold mb-3 text-sm flex items-center gap-2"><Building2 className="h-4 w-4 text-green-400" /> Add Asset</h3>
+              <div className="bg-white p-4 rounded-xl border border-slate-200">
+                <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2"><Building2 className="h-4 w-4 text-green-400" /> Add Asset</h3>
                 <div className="grid grid-cols-2 gap-3 mb-3">
-                  <input type="text" placeholder="Asset Name (e.g. Monzo, House)" value={assetForm.name} onChange={e => setAssetForm(prev => ({ ...prev, name: e.target.value }))} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-green-400 focus:outline-none col-span-2" />
-                  <select value={assetForm.type} onChange={e => setAssetForm(prev => ({ ...prev, type: e.target.value }))} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-green-400 focus:outline-none">
+                  <input type="text" placeholder="Asset Name (e.g. Monzo, House)" value={assetForm.name} onChange={e => setAssetForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none col-span-2" />
+                  <select value={assetForm.type} onChange={e => setAssetForm(prev => ({ ...prev, type: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none">
                     <option value="savings">Savings</option><option value="property">Property</option><option value="investment">Investment</option><option value="vehicle">Vehicle</option><option value="crypto">Crypto</option><option value="business">Business</option><option value="pension">Pension</option><option value="other">Other</option>
                   </select>
-                  <input type="number" placeholder="Value (£)" value={assetForm.value} onChange={e => setAssetForm(prev => ({ ...prev, value: e.target.value }))} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-green-400 focus:outline-none" />
+                  <input type="number" placeholder="Value (£)" value={assetForm.value} onChange={e => setAssetForm(prev => ({ ...prev, value: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none" />
                 </div>
-                <button onClick={handleAddAsset} disabled={loading || !assetForm.name || !assetForm.value} className="w-full bg-green-500 hover:bg-green-600 disabled:opacity-50 text-white font-semibold py-2 rounded-lg text-sm flex justify-center items-center gap-2"><Plus className="h-4 w-4" /> Add Asset</button>
+                <button onClick={handleAddAsset} disabled={loading || !assetForm.name || !assetForm.value} className="w-full bg-green-500 hover:bg-green-600 disabled:opacity-50 text-slate-900 font-semibold py-2 rounded-lg text-sm flex justify-center items-center gap-2"><Plus className="h-4 w-4" /> Add Asset</button>
               </div>
               <div>
                 {assetsList.length === 0 ? <p className="text-slate-500 text-sm">No assets added yet.</p> : assetsList.map((a: any) => (
-                  <div key={a.id} className="flex justify-between items-center py-3 border-b border-navy-800 last:border-0">
-                    <div><p className="text-white text-sm">{a.asset_name}</p><p className="text-xs text-slate-500 capitalize">{a.asset_type}</p></div>
+                  <div key={a.id} className="flex justify-between items-center py-3 border-b border-slate-200 last:border-0">
+                    <div><p className="text-slate-900 text-sm">{a.asset_name}</p><p className="text-xs text-slate-500 capitalize">{a.asset_type}</p></div>
                     <div className="flex items-center gap-4"><p className="text-green-400 font-semibold">£{fmtNum(a.estimated_value)}</p><button onClick={() => handleDelete(a.id, 'asset')} disabled={loading} className="text-slate-500 hover:text-red-400"><Trash2 className="h-4 w-4" /></button></div>
                   </div>
                 ))}
@@ -92,21 +92,21 @@ export default function NetWorthManagementModal({ isOpen, onClose, data, onUpdat
             </div>
           ) : (
             <div className="space-y-6">
-              <div className="bg-navy-950/50 p-4 rounded-xl border border-navy-800">
-                <h3 className="text-white font-semibold mb-3 text-sm flex items-center gap-2"><CreditCard className="h-4 w-4 text-red-400" /> Add Liability</h3>
+              <div className="bg-white p-4 rounded-xl border border-slate-200">
+                <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2"><CreditCard className="h-4 w-4 text-red-400" /> Add Liability</h3>
                 <div className="grid grid-cols-2 gap-3 mb-3">
-                  <input type="text" placeholder="Liability Name (e.g. Loan, Mortgage)" value={liabilityForm.name} onChange={e => setLiabilityForm(prev => ({ ...prev, name: e.target.value }))} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-red-400 focus:outline-none col-span-2" />
-                  <select value={liabilityForm.type} onChange={e => setLiabilityForm(prev => ({ ...prev, type: e.target.value }))} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-red-400 focus:outline-none">
+                  <input type="text" placeholder="Liability Name (e.g. Loan, Mortgage)" value={liabilityForm.name} onChange={e => setLiabilityForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none col-span-2" />
+                  <select value={liabilityForm.type} onChange={e => setLiabilityForm(prev => ({ ...prev, type: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none">
                     <option value="loan">Loan</option><option value="mortgage">Mortgage</option><option value="credit_card">Credit Card</option><option value="car_finance">Car Finance</option><option value="overdraft">Overdraft</option><option value="other">Other</option>
                   </select>
-                  <input type="number" placeholder="Balance (£)" value={liabilityForm.balance} onChange={e => setLiabilityForm(prev => ({ ...prev, balance: e.target.value }))} className="bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:border-red-400 focus:outline-none" />
+                  <input type="number" placeholder="Balance (£)" value={liabilityForm.balance} onChange={e => setLiabilityForm(prev => ({ ...prev, balance: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none" />
                 </div>
-                <button onClick={handleAddLiability} disabled={loading || !liabilityForm.name || !liabilityForm.balance} className="w-full bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white font-semibold py-2 rounded-lg text-sm flex justify-center items-center gap-2"><Plus className="h-4 w-4" /> Add Liability</button>
+                <button onClick={handleAddLiability} disabled={loading || !liabilityForm.name || !liabilityForm.balance} className="w-full bg-red-500 hover:bg-red-600 disabled:opacity-50 text-slate-900 font-semibold py-2 rounded-lg text-sm flex justify-center items-center gap-2"><Plus className="h-4 w-4" /> Add Liability</button>
               </div>
               <div>
                 {liabilitiesList.length === 0 ? <p className="text-slate-500 text-sm">No liabilities added yet.</p> : liabilitiesList.map((l: any) => (
-                  <div key={l.id} className="flex justify-between items-center py-3 border-b border-navy-800 last:border-0">
-                    <div><p className="text-white text-sm">{l.liability_name}</p><p className="text-xs text-slate-500 capitalize">{l.liability_type}</p></div>
+                  <div key={l.id} className="flex justify-between items-center py-3 border-b border-slate-200 last:border-0">
+                    <div><p className="text-slate-900 text-sm">{l.liability_name}</p><p className="text-xs text-slate-500 capitalize">{l.liability_type}</p></div>
                     <div className="flex items-center gap-4"><p className="text-red-400 font-semibold">£{fmtNum(l.outstanding_balance)}</p><button onClick={() => handleDelete(l.id, 'liability')} disabled={loading} className="text-slate-500 hover:text-red-400"><Trash2 className="h-4 w-4" /></button></div>
                   </div>
                 ))}

--- a/src/app/dashboard/money-hub/NetWorthPanel.tsx
+++ b/src/app/dashboard/money-hub/NetWorthPanel.tsx
@@ -11,9 +11,9 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
   const { total, assets, liabilities, assetsList, liabilitiesList } = data.netWorth || { total: 0, assets: 0, liabilities: 0, assetsList: [], liabilitiesList: [] };
 
   return (
-    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 flex flex-col h-full">
+    <div className="card p-5 flex flex-col h-full">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-white font-semibold text-lg flex items-center gap-2">
+        <h3 className="text-slate-900 font-semibold text-lg flex items-center gap-2">
           <PiggyBank className="h-5 w-5 text-mint-400" />
           Net Worth
         </h3>
@@ -22,7 +22,7 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
             {total >= 0 ? '' : '-'}£{fmtNum(Math.abs(total))}
           </span>
           {isPro && (
-            <button onClick={() => setModalOpen(true)} className="text-slate-500 hover:text-white transition-colors" title="Manage Net Worth">
+            <button onClick={() => setModalOpen(true)} className="text-slate-500 hover:text-slate-900 transition-colors" title="Manage Net Worth">
               <Settings className="h-4 w-4" />
             </button>
           )}
@@ -30,28 +30,28 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
       </div>
       
       {!isPro ? (
-        <div className="bg-navy-950/50 border border-navy-700/50 rounded-xl p-4 relative overflow-hidden flex-1">
-          <div className="absolute inset-0 bg-navy-950/60 backdrop-blur-sm z-10 flex flex-col items-center justify-center">
+        <div className="bg-white border border-slate-200 rounded-xl p-4 relative overflow-hidden flex-1">
+          <div className="absolute inset-0 bg-white backdrop-blur-sm z-10 flex flex-col items-center justify-center">
             <Lock className="h-6 w-6 text-slate-500 mb-2" />
-            <p className="text-white font-semibold text-xs mb-1">Upgrade to track Net Worth</p>
+            <p className="text-slate-900 font-semibold text-xs mb-1">Upgrade to track Net Worth</p>
             <Link href="/pricing" className="text-mint-400 text-[10px] hover:text-mint-300">View plans</Link>
           </div>
           <div className="flex justify-between items-center opacity-30 mt-4 pointer-events-none">
-            <div><p className="text-xs text-slate-400">Assets</p><p className="text-lg text-white font-semibold">£---</p></div>
-            <div className="text-right"><p className="text-xs text-slate-400">Liabilities</p><p className="text-lg text-white font-semibold">£---</p></div>
+            <div><p className="text-xs text-slate-500">Assets</p><p className="text-lg text-slate-900 font-semibold">£---</p></div>
+            <div className="text-right"><p className="text-xs text-slate-500">Liabilities</p><p className="text-lg text-slate-900 font-semibold">£---</p></div>
           </div>
         </div>
       ) : (
         <div className="flex-1 flex flex-col">
           {/* Assets vs Liabilities summary */}
-          <div className="flex justify-between items-center bg-navy-950/50 rounded-xl p-4 border border-navy-800 mb-4">
+          <div className="flex justify-between items-center bg-white rounded-xl p-4 border border-slate-200 mb-4">
             <div>
-              <p className="text-xs text-slate-400 mb-1 flex items-center gap-1"><TrendingUp className="h-3 w-3 text-green-400" /> Assets</p>
+              <p className="text-xs text-slate-500 mb-1 flex items-center gap-1"><TrendingUp className="h-3 w-3 text-green-400" /> Assets</p>
               <p className="text-lg text-green-400 font-semibold">£{fmtNum(assets)}</p>
             </div>
             <div className="px-4 text-slate-500 text-lg">−</div>
             <div className="text-right">
-              <p className="text-xs text-slate-400 mb-1 flex items-center gap-1 justify-end"><TrendingDown className="h-3 w-3 text-red-400" /> Liabilities</p>
+              <p className="text-xs text-slate-500 mb-1 flex items-center gap-1 justify-end"><TrendingDown className="h-3 w-3 text-red-400" /> Liabilities</p>
               <p className="text-lg text-red-400 font-semibold">£{fmtNum(liabilities)}</p>
             </div>
           </div>
@@ -59,13 +59,13 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
           <div className="space-y-4">
             {/* Top assets */}
             <div>
-              <p className="text-xs text-slate-400 uppercase tracking-wider mb-2 font-semibold">Assets</p>
+              <p className="text-xs text-slate-500 uppercase tracking-wider mb-2 font-semibold">Assets</p>
               {assetsList.length === 0 ? (
                 <p className="text-xs text-slate-500">Add assets manually to track net worth.</p>
               ) : (
                 assetsList.slice(0, 3).map((a: any) => (
-                  <div key={a.id} className="flex justify-between text-sm py-1.5 border-b border-navy-800/50 last:border-0">
-                    <span className="text-slate-300">{a.asset_name}</span>
+                  <div key={a.id} className="flex justify-between text-sm py-1.5 border-b border-slate-200 last:border-0">
+                    <span className="text-slate-700">{a.asset_name}</span>
                     <span className="text-green-400 font-medium">£{fmtNum(parseFloat(String(a.estimated_value)) || 0)}</span>
                   </div>
                 ))
@@ -74,13 +74,13 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
 
             {/* Top liabilities */}
             <div>
-              <p className="text-xs text-slate-400 uppercase tracking-wider mb-2 font-semibold">Liabilities</p>
+              <p className="text-xs text-slate-500 uppercase tracking-wider mb-2 font-semibold">Liabilities</p>
               {liabilitiesList.length === 0 ? (
                 <p className="text-xs text-slate-500">No liabilities tracked.</p>
               ) : (
                 liabilitiesList.slice(0, 3).map((l: any) => (
-                  <div key={l.id} className="flex justify-between text-sm py-1.5 border-b border-navy-800/50 last:border-0">
-                    <span className="text-slate-300">{l.liability_name}</span>
+                  <div key={l.id} className="flex justify-between text-sm py-1.5 border-b border-slate-200 last:border-0">
+                    <span className="text-slate-700">{l.liability_name}</span>
                     <span className="text-red-400 font-medium">£{fmtNum(parseFloat(String(l.outstanding_balance)) || 0)}</span>
                   </div>
                 ))
@@ -88,7 +88,7 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
             </div>
           </div>
 
-          <p className="text-[10px] text-slate-500 mt-3 pt-2 border-t border-navy-800/30">
+          <p className="text-[10px] text-slate-500 mt-3 pt-2 border-t border-slate-200">
             Auto-sync with bank balances coming soon. Assets must be added manually.
           </p>
         </div>

--- a/src/app/dashboard/money-hub/OverviewPanel.tsx
+++ b/src/app/dashboard/money-hub/OverviewPanel.tsx
@@ -79,46 +79,46 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
     <div className="space-y-4">
       {/* Summary Cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+        <div className="card p-5">
           <div className="flex items-center gap-2 mb-2">
             <TrendingUp className="h-4 w-4 text-green-400" />
-            <span className="text-slate-400 text-xs">Income this month</span>
+            <span className="text-slate-500 text-xs">Income this month</span>
           </div>
           <p className="text-2xl md:text-3xl font-bold text-green-400">£{fmtNum(monthlyIncome)}</p>
         </div>
 
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+        <div className="card p-5">
           <div className="flex items-center gap-2 mb-2">
             <TrendingDown className="h-4 w-4 text-amber-400" />
-            <span className="text-slate-400 text-xs">Spent this month</span>
+            <span className="text-slate-500 text-xs">Spent this month</span>
           </div>
           <p className="text-2xl md:text-3xl font-bold text-amber-400">£{fmtNum(monthlyOutgoings)}</p>
         </div>
 
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+        <div className="card p-5">
           <div className="flex items-center gap-2 mb-2">
             <Wallet className="h-4 w-4 text-mint-400" />
-            <span className="text-slate-400 text-xs">Savings Rate</span>
+            <span className="text-slate-500 text-xs">Savings Rate</span>
           </div>
           <p className={`text-2xl md:text-3xl font-bold ${(savingsRate || 0) >= 0 ? 'text-mint-400' : 'text-red-400'}`}>
             {(savingsRate || 0).toFixed(1)}%
           </p>
         </div>
 
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 relative overflow-hidden group">
+        <div className="card p-5 relative overflow-hidden group">
           <div className="flex items-center gap-2 mb-2">
             <Target className="h-4 w-4 text-purple-400" />
-            <span className="text-slate-400 text-xs">Health Score</span>
+            <span className="text-slate-500 text-xs">Health Score</span>
           </div>
           <p className={`text-2xl md:text-3xl font-bold ${data.score >= 80 ? 'text-green-400' : data.score >= 40 ? 'text-amber-400' : 'text-red-400'}`}>
             {data.score}
           </p>
           {/* Hover detail */}
-          <div className="absolute inset-0 bg-navy-800/95 backdrop-blur opacity-0 group-hover:opacity-100 transition-opacity flex flex-col justify-center px-4 text-xs rounded-2xl">
-            <div className="flex justify-between mb-1"><span className="text-slate-400">Spend</span><span className="text-white">{healthScore?.pillars?.spend?.score || 0}%</span></div>
-            <div className="flex justify-between mb-1"><span className="text-slate-400">Save</span><span className="text-white">{healthScore?.pillars?.save?.score || 0}%</span></div>
-            <div className="flex justify-between mb-1"><span className="text-slate-400">Borrow</span><span className="text-white">{healthScore?.pillars?.borrow?.score || 0}%</span></div>
-            <div className="flex justify-between"><span className="text-slate-400">Plan</span><span className="text-white">{healthScore?.pillars?.plan?.score || 0}%</span></div>
+          <div className="absolute inset-0 bg-slate-100 backdrop-blur opacity-0 group-hover:opacity-100 transition-opacity flex flex-col justify-center px-4 text-xs rounded-2xl">
+            <div className="flex justify-between mb-1"><span className="text-slate-500">Spend</span><span className="text-slate-900">{healthScore?.pillars?.spend?.score || 0}%</span></div>
+            <div className="flex justify-between mb-1"><span className="text-slate-500">Save</span><span className="text-slate-900">{healthScore?.pillars?.save?.score || 0}%</span></div>
+            <div className="flex justify-between mb-1"><span className="text-slate-500">Borrow</span><span className="text-slate-900">{healthScore?.pillars?.borrow?.score || 0}%</span></div>
+            <div className="flex justify-between"><span className="text-slate-500">Plan</span><span className="text-slate-900">{healthScore?.pillars?.plan?.score || 0}%</span></div>
           </div>
         </div>
       </div>
@@ -127,9 +127,9 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
       {(incomeEntries.length > 0 || spendingCategories.length > 0) && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {/* Income Breakdown */}
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+          <div className="card p-5">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-white font-semibold flex items-center gap-2">
+              <h3 className="text-slate-900 font-semibold flex items-center gap-2">
                 <TrendingUp className="h-4 w-4 text-green-400" />
                 Income
               </h3>
@@ -143,18 +143,18 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
                   return (
                     <div
                       key={entry.type}
-                      className="group cursor-pointer hover:bg-navy-800/50 p-2 -mx-2 rounded-lg transition-colors"
+                      className="group cursor-pointer hover:bg-slate-100 p-2 -mx-2 rounded-lg transition-colors"
                       onClick={() => setDrillIncomeType(entry.type)}
                     >
                       <div className="flex items-center justify-between text-sm mb-1">
-                        <span className="text-slate-300 flex items-center gap-2 group-hover:text-green-400 transition-colors">
+                        <span className="text-slate-700 flex items-center gap-2 group-hover:text-green-400 transition-colors">
                           <span>{entry.icon}</span>
                           {entry.label}
                           <span className="text-slate-500 text-xs">{pct.toFixed(1)}%</span>
                         </span>
                         <span className="text-green-400 font-semibold">£{fmtNum(entry.amount)}</span>
                       </div>
-                      <div className="w-full bg-navy-800 rounded-full h-1.5">
+                      <div className="w-full bg-slate-100 rounded-full h-1.5">
                         <div className="h-1.5 rounded-full transition-all" style={{ width: `${pct}%`, backgroundColor: entry.color }} />
                       </div>
                     </div>
@@ -174,17 +174,17 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
             )}
 
             {totalIncomeFromBreakdown > 0 && (
-              <div className="mt-3 pt-3 border-t border-navy-800 flex justify-between text-sm">
-                <span className="text-slate-400">Total</span>
+              <div className="mt-3 pt-3 border-t border-slate-200 flex justify-between text-sm">
+                <span className="text-slate-500">Total</span>
                 <span className="text-green-400 font-bold">£{fmtNum(totalIncomeFromBreakdown)}</span>
               </div>
             )}
           </div>
 
           {/* Spending Breakdown */}
-          <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+          <div className="card p-5">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-white font-semibold flex items-center gap-2">
+              <h3 className="text-slate-900 font-semibold flex items-center gap-2">
                 <TrendingDown className="h-4 w-4 text-amber-400" />
                 Spending
               </h3>
@@ -199,18 +199,18 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
                   return (
                     <div
                       key={c.category}
-                      className="group cursor-pointer hover:bg-navy-800/50 p-2 -mx-2 rounded-lg transition-colors"
+                      className="group cursor-pointer hover:bg-slate-100 p-2 -mx-2 rounded-lg transition-colors"
                       onClick={() => setDrillSpendingCategory(c.category)}
                     >
                       <div className="flex items-center justify-between text-sm mb-1">
-                        <span className="text-slate-300 flex items-center gap-2 group-hover:text-amber-400 transition-colors">
+                        <span className="text-slate-700 flex items-center gap-2 group-hover:text-amber-400 transition-colors">
                           <span>{meta.icon}</span>
                           {meta.label}
                           <span className="text-slate-500 text-xs">{pct.toFixed(1)}%</span>
                         </span>
                         <span className="text-amber-400 font-semibold">£{fmtNum(c.total)}</span>
                       </div>
-                      <div className="w-full bg-navy-800 rounded-full h-1.5">
+                      <div className="w-full bg-slate-100 rounded-full h-1.5">
                         <div className="h-1.5 rounded-full transition-all" style={{ width: `${pct}%`, backgroundColor: meta.color }} />
                       </div>
                     </div>
@@ -230,8 +230,8 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
             )}
 
             {totalSpentFromBreakdown > 0 && (
-              <div className="mt-3 pt-3 border-t border-navy-800 flex justify-between text-sm">
-                <span className="text-slate-400">Total</span>
+              <div className="mt-3 pt-3 border-t border-slate-200 flex justify-between text-sm">
+                <span className="text-slate-500">Total</span>
                 <span className="text-amber-400 font-bold">£{fmtNum(totalSpentFromBreakdown)}</span>
               </div>
             )}
@@ -241,8 +241,8 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
 
       {/* Monthly Trends */}
       {monthlyTrends.length >= 2 && (
-        <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
-          <h3 className="text-white font-semibold text-lg mb-4 flex items-center gap-2">
+        <div className="card p-5">
+          <h3 className="text-slate-900 font-semibold text-lg mb-4 flex items-center gap-2">
             <BarChart3 className="h-5 w-5 text-blue-400" />
             Monthly Trends
           </h3>
@@ -259,10 +259,10 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
                   </div>
                   <span className="text-[10px] text-slate-500">{monthLabel}</span>
                   {/* Hover tooltip */}
-                  <div className="absolute -top-16 left-1/2 -translate-x-1/2 bg-navy-950 border border-navy-700 rounded-lg p-2 text-[10px] opacity-0 group-hover:opacity-100 transition-opacity z-10 whitespace-nowrap pointer-events-none">
+                  <div className="absolute -top-16 left-1/2 -translate-x-1/2 bg-white border border-slate-200 rounded-lg p-2 text-[10px] opacity-0 group-hover:opacity-100 transition-opacity z-10 whitespace-nowrap pointer-events-none">
                     <p className="text-green-400">In: £{fmtNum(t.income)}</p>
                     <p className="text-amber-400">Out: £{fmtNum(t.outgoings)}</p>
-                    <p className="text-slate-300">Net: £{fmtNum(t.income - t.outgoings)}</p>
+                    <p className="text-slate-700">Net: £{fmtNum(t.income - t.outgoings)}</p>
                   </div>
                 </div>
               );

--- a/src/app/dashboard/money-hub/SpendingPanel.tsx
+++ b/src/app/dashboard/money-hub/SpendingPanel.tsx
@@ -56,14 +56,14 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
   const totalSpent = categories.reduce((s: number, c: any) => s + c.total, 0);
 
   return (
-    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5 flex flex-col h-full">
+    <div className="card p-5 flex flex-col h-full">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-white font-semibold text-lg flex items-center gap-2">
+        <h3 className="text-slate-900 font-semibold text-lg flex items-center gap-2">
           <BarChart3 className="h-5 w-5 text-purple-400" />
           Spending Breakdown
         </h3>
         {totalSpent > 0 && (
-          <span className="text-slate-400 text-sm">£{fmtNum(totalSpent)} total</span>
+          <span className="text-slate-500 text-sm">£{fmtNum(totalSpent)} total</span>
         )}
       </div>
 
@@ -81,14 +81,14 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
             }
           }}
           placeholder="Search transactions..."
-          className="w-full bg-navy-950/50 border border-navy-700 rounded-xl pl-10 pr-4 py-2.5 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-purple-500/50 focus:ring-1 focus:ring-purple-500/50 transition-all font-medium"
+          className="w-full bg-white border border-slate-200 rounded-xl pl-10 pr-4 py-2.5 text-sm text-slate-900 placeholder-slate-500 focus:outline-none focus:border-purple-500/50 focus:ring-1 focus:ring-purple-500/50 transition-all font-medium"
         />
       </div>
       
       <div className="space-y-4 flex-1">
         <div>
           <div className="flex items-center justify-between mb-2">
-            <p className="text-xs text-slate-400 uppercase tracking-wider font-semibold">By Category</p>
+            <p className="text-xs text-slate-500 uppercase tracking-wider font-semibold">By Category</p>
             <span className="text-slate-500 text-[10px]">Click row for details</span>
           </div>
           {categories.length === 0 ? (
@@ -100,18 +100,18 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
               return (
                 <div 
                   key={c.category} 
-                  className="mb-2 cursor-pointer hover:bg-navy-800/50 p-2 -mx-2 rounded-lg transition-colors group"
+                  className="mb-2 cursor-pointer hover:bg-slate-100 p-2 -mx-2 rounded-lg transition-colors group"
                   onClick={() => setDrillCategory(c.category)}
                 >
                   <div className="flex justify-between text-sm mb-1">
-                    <span className="text-slate-300 flex items-center gap-2 group-hover:text-mint-400 transition-colors">
+                    <span className="text-slate-700 flex items-center gap-2 group-hover:text-mint-400 transition-colors">
                       <span className="text-base">{meta.icon}</span>
                       {meta.label}
                       <span className="text-slate-500 text-xs">{pct.toFixed(1)}%</span>
                     </span>
-                    <span className="text-white font-medium group-hover:text-mint-400">£{fmtNum(c.total)}</span>
+                    <span className="text-slate-900 font-medium group-hover:text-mint-400">£{fmtNum(c.total)}</span>
                   </div>
-                  <div className="w-full bg-navy-800 rounded-full h-1.5">
+                  <div className="w-full bg-slate-100 rounded-full h-1.5">
                     <div className="h-1.5 rounded-full transition-all" style={{ width: `${pct}%`, backgroundColor: meta.color }} />
                   </div>
                 </div>
@@ -133,13 +133,13 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
         </div>
 
         <div>
-          <p className="text-xs text-slate-400 uppercase tracking-wider mb-2 font-semibold">Top Merchants</p>
+          <p className="text-xs text-slate-500 uppercase tracking-wider mb-2 font-semibold">Top Merchants</p>
           {!isPro ? (
             <LockedSection title="Top Merchants">
               <div className="space-y-2 opacity-30 pointer-events-none">
-                <div className="h-4 bg-navy-700 rounded w-full" />
-                <div className="h-4 bg-navy-700 rounded w-4/5" />
-                <div className="h-4 bg-navy-700 rounded w-3/4" />
+                <div className="h-4 bg-slate-100 rounded w-full" />
+                <div className="h-4 bg-slate-100 rounded w-4/5" />
+                <div className="h-4 bg-slate-100 rounded w-3/4" />
               </div>
             </LockedSection>
           ) : topMerchants.length === 0 ? (
@@ -148,10 +148,10 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
             topMerchants.slice(0, 5).map((m: any) => (
               <div key={m.merchant} className="mb-2">
                 <div className="flex justify-between text-sm mb-1">
-                  <span className="text-slate-300 capitalize">{m.merchant}</span>
-                  <span className="text-white font-medium">£{fmtNum(m.total)}</span>
+                  <span className="text-slate-700 capitalize">{m.merchant}</span>
+                  <span className="text-slate-900 font-medium">£{fmtNum(m.total)}</span>
                 </div>
-                <div className="w-full bg-navy-800 rounded-full h-1.5">
+                <div className="w-full bg-slate-100 rounded-full h-1.5">
                   <div className="bg-blue-400 h-1.5 rounded-full" style={{ width: `${(m.total / (topMerchants[0]?.total || 1)) * 100}%` }} />
                 </div>
               </div>
@@ -174,10 +174,10 @@ export default function SpendingPanel({ data, isPro, refreshData, selectedMonth 
 
 function LockedSection({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="bg-navy-950/50 border border-navy-700/50 rounded-xl p-4 relative overflow-hidden">
-      <div className="absolute inset-0 bg-navy-950/60 backdrop-blur-sm z-10 flex flex-col items-center justify-center">
+    <div className="bg-white border border-slate-200 rounded-xl p-4 relative overflow-hidden">
+      <div className="absolute inset-0 bg-white backdrop-blur-sm z-10 flex flex-col items-center justify-center">
         <Lock className="h-6 w-6 text-slate-500 mb-2" />
-        <p className="text-white font-semibold text-xs mb-1">Upgrade to unlock {title}</p>
+        <p className="text-slate-900 font-semibold text-xs mb-1">Upgrade to unlock {title}</p>
         <Link href="/pricing" className="text-mint-400 text-[10px] hover:text-mint-300">View plans</Link>
       </div>
       {children}

--- a/src/app/dashboard/settings/mcp/page.tsx
+++ b/src/app/dashboard/settings/mcp/page.tsx
@@ -178,7 +178,7 @@ export default function McpSettingsPage() {
           </p>
           <Link
             href="/dashboard/upgrade"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold rounded-xl transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-xl transition-colors"
           >
             <Sparkles className="h-4 w-4" />
             Upgrade to Pro
@@ -256,7 +256,7 @@ export default function McpSettingsPage() {
           <li>Generate a token below and copy it (you only see it once).</li>
           <li>
             In a terminal, run:
-            <pre className="mt-2 bg-slate-900 text-emerald-300 rounded-lg p-3 text-xs overflow-x-auto font-mono">
+            <pre className="mt-2 bg-white text-emerald-300 rounded-lg p-3 text-xs overflow-x-auto font-mono">
               npx @paybacker/mcp setup
             </pre>
           </li>
@@ -289,7 +289,7 @@ export default function McpSettingsPage() {
                 </code>
                 <button
                   onClick={() => handleCopy(justMinted)}
-                  className="inline-flex items-center gap-1.5 px-3 py-2 bg-emerald-500 hover:bg-emerald-600 text-white font-medium rounded-lg text-sm transition-colors"
+                  className="inline-flex items-center gap-1.5 px-3 py-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-medium rounded-lg text-sm transition-colors"
                 >
                   {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
                   {copied ? 'Copied' : 'Copy'}
@@ -321,7 +321,7 @@ export default function McpSettingsPage() {
           <button
             onClick={handleCreate}
             disabled={creating}
-            className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold rounded-lg text-sm transition-colors disabled:opacity-50"
+            className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-lg text-sm transition-colors disabled:opacity-50"
           >
             {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
             Generate token

--- a/src/app/dashboard/settings/telegram/page.tsx
+++ b/src/app/dashboard/settings/telegram/page.tsx
@@ -216,12 +216,12 @@ export default function TelegramSettingsPage() {
           <div className="mt-4 pt-4 border-t border-slate-200 grid grid-cols-2 gap-4 text-sm">
             <div>
               <span className="text-slate-500">Linked</span>
-              <p className="text-slate-300">{formatDate(status.session.linked_at)}</p>
+              <p className="text-slate-700">{formatDate(status.session.linked_at)}</p>
             </div>
             {status.session.last_message_at && (
               <div>
                 <span className="text-slate-500">Last message</span>
-                <p className="text-slate-300">{formatDate(status.session.last_message_at)}</p>
+                <p className="text-slate-700">{formatDate(status.session.last_message_at)}</p>
               </div>
             )}
           </div>
@@ -322,7 +322,7 @@ export default function TelegramSettingsPage() {
               <button
                 onClick={generateCode}
                 disabled={generating}
-                className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-300 transition-colors"
+                className="flex items-center gap-2 text-sm text-slate-600 hover:text-slate-700 transition-colors"
               >
                 {generating ? (
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/app/dashboard/spending/page.tsx
+++ b/src/app/dashboard/spending/page.tsx
@@ -74,10 +74,10 @@ export default function SpendingPage() {
           <p className="text-slate-600">Connect your bank account to see where your money goes</p>
         </div>
         <div className="card shadow-sm p-12 text-center">
-          <BarChart3 className="h-16 w-16 text-slate-300 mx-auto mb-4" />
+          <BarChart3 className="h-16 w-16 text-slate-700 mx-auto mb-4" />
           <h3 className="text-xl font-bold text-slate-900 mb-2">No spending data yet</h3>
           <p className="text-slate-600 mb-6">Connect your bank account to get personalised spending insights.</p>
-          <Link href="/dashboard/subscriptions" className="bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-6 py-3 rounded-lg transition-all">
+          <Link href="/dashboard/subscriptions" className="bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-6 py-3 rounded-lg transition-all">
             Connect Bank Account
           </Link>
         </div>
@@ -258,7 +258,7 @@ export default function SpendingPage() {
             <Lock className="h-6 w-6 text-emerald-600 mx-auto mb-2" />
             <p className="text-slate-900 font-semibold mb-1">See all {category_breakdown.length} categories</p>
             <p className="text-slate-600 text-sm mb-3">Upgrade to Essential to unlock full spending breakdown</p>
-            <Link href="/pricing" className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-5 py-2 rounded-lg text-sm transition-all">
+            <Link href="/pricing" className="inline-block bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-5 py-2 rounded-lg text-sm transition-all">
               Upgrade Plan
             </Link>
           </div>
@@ -302,7 +302,7 @@ export default function SpendingPage() {
                 <Lock className="h-6 w-6 text-emerald-600 mx-auto mb-2" />
                 <p className="text-slate-900 font-semibold mb-1">Pro feature</p>
                 <p className="text-slate-600 text-sm mb-3">See your biggest transactions with Pro</p>
-                <Link href="/pricing" className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-5 py-2 rounded-lg text-sm transition-all">
+                <Link href="/pricing" className="inline-block bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-5 py-2 rounded-lg text-sm transition-all">
                   Upgrade to Pro
                 </Link>
               </div>
@@ -315,7 +315,7 @@ export default function SpendingPage() {
       <div className="bg-gradient-to-r from-emerald-50 to-emerald-100/60 border border-emerald-200 rounded-2xl p-6 text-center">
         <p className="text-emerald-700 font-semibold mb-2">Based on your spending, we can help you save</p>
         <p className="text-slate-600 text-sm mb-4">Check our deals page for alternatives to your most expensive bills</p>
-        <Link href="/dashboard/deals" className="inline-flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-white font-semibold px-6 py-3 rounded-lg transition-all">
+        <Link href="/dashboard/deals" className="inline-flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold px-6 py-3 rounded-lg transition-all">
           View Deals <ArrowRight className="h-4 w-4" />
         </Link>
       </div>

--- a/src/app/dashboard/tutorials/page.tsx
+++ b/src/app/dashboard/tutorials/page.tsx
@@ -168,7 +168,7 @@ function TutorialCard({ tutorial }: { tutorial: Tutorial }) {
           <ol className="space-y-3">
             {tutorial.steps.map((step, i) => (
               <li key={i} className="flex items-start gap-3 text-sm">
-                <span className="bg-emerald-500 text-white text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
+                <span className="bg-emerald-500 text-slate-900 text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
                   {i + 1}
                 </span>
                 <p className="text-slate-700">{step}</p>

--- a/src/components/BankPickerModal.tsx
+++ b/src/components/BankPickerModal.tsx
@@ -76,7 +76,7 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
         <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-        <div className="relative bg-white border border-slate-200 rounded-2xl w-full max-w-lg p-10 text-center shadow-2xl">
+        <div className="relative card w-full max-w-lg p-10 text-center shadow-2xl">
           <Loader2 className="h-8 w-8 text-amber-500 animate-spin mx-auto mb-4" />
           <p className="text-slate-900 font-semibold">Connecting to your bank...</p>
           <p className="text-slate-500 text-sm mt-1">
@@ -117,7 +117,7 @@ export default function BankPickerModal({ isOpen, onClose }: BankPickerModalProp
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-white border border-slate-200 rounded-2xl w-full max-w-lg max-h-[80vh] flex flex-col shadow-2xl">
+      <div className="relative card w-full max-w-lg max-h-[80vh] flex flex-col shadow-2xl">
         {/* Header */}
         <div className="flex items-center justify-between p-5 border-b border-slate-200 flex-shrink-0">
           <div>

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -17,8 +17,8 @@ function InlineChart({ chartJson }: { chartJson: string }) {
 
     if (chart.chart_type === 'pie') {
       return (
-        <div className="my-2 bg-navy-950 rounded-lg p-3">
-          {chart.title && <p className="text-xs text-white font-medium mb-2">{chart.title}</p>}
+        <div className="my-2 bg-white rounded-lg p-3">
+          {chart.title && <p className="text-xs text-slate-900 font-medium mb-2">{chart.title}</p>}
           <ResponsiveContainer width="100%" height={160}>
             <PieChart>
               <Pie data={chart.data} cx="50%" cy="50%" innerRadius={30} outerRadius={55} paddingAngle={2} dataKey="value" nameKey="name">
@@ -29,7 +29,7 @@ function InlineChart({ chartJson }: { chartJson: string }) {
           </ResponsiveContainer>
           <div className="flex flex-wrap gap-2 mt-1">
             {chart.data.map((d: any, i: number) => (
-              <span key={i} className="text-[9px] text-slate-400 flex items-center gap-1">
+              <span key={i} className="text-[9px] text-slate-500 flex items-center gap-1">
                 <span className="w-2 h-2 rounded-full inline-block" style={{ background: CHART_COLORS[i % CHART_COLORS.length] }} />
                 {d.name}: £{d.value}
               </span>
@@ -41,8 +41,8 @@ function InlineChart({ chartJson }: { chartJson: string }) {
 
     if (chart.chart_type === 'bar') {
       return (
-        <div className="my-2 bg-navy-950 rounded-lg p-3">
-          {chart.title && <p className="text-xs text-white font-medium mb-2">{chart.title}</p>}
+        <div className="my-2 bg-white rounded-lg p-3">
+          {chart.title && <p className="text-xs text-slate-900 font-medium mb-2">{chart.title}</p>}
           <ResponsiveContainer width="100%" height={160}>
             <BarChart data={chart.data}>
               <XAxis dataKey="name" tick={{ fill: '#64748b', fontSize: 10 }} axisLine={false} tickLine={false} />
@@ -81,7 +81,7 @@ function renderAssistantMessage(content: string) {
         return <p key={`${i}-${j}`} className="pl-3 before:content-['•'] before:mr-2 before:text-mint-400">{line.replace(/^[-•]\s*/, '')}</p>;
       }
       if (line.startsWith('**') && line.endsWith('**')) {
-        return <p key={`${i}-${j}`} className="font-semibold text-white">{line.replace(/\*\*/g, '')}</p>;
+        return <p key={`${i}-${j}`} className="font-semibold text-slate-900">{line.replace(/\*\*/g, '')}</p>;
       }
       return <p key={`${i}-${j}`}>{line.replace(/\*\*(.*?)\*\*/g, '$1')}</p>;
     });
@@ -256,12 +256,12 @@ export default function ChatWidget() {
                 setShowTeaser(false);
                 sessionStorage.setItem('pb_chat_teaser_dismissed', '1');
               }}
-              className="absolute -top-2 -right-2 bg-navy-700 hover:bg-navy-600 rounded-full w-5 h-5 flex items-center justify-center text-xs text-slate-400"
+              className="absolute -top-2 -right-2 bg-slate-100 hover:bg-navy-600 rounded-full w-5 h-5 flex items-center justify-center text-xs text-slate-500"
             >
               x
             </button>
             <p className="text-sm font-medium mb-2">Been overcharged on a bill?</p>
-            <p className="text-xs text-slate-400 mb-3">I can generate a free complaint letter citing UK law in 30 seconds. Try me.</p>
+            <p className="text-xs text-slate-500 mb-3">I can generate a free complaint letter citing UK law in 30 seconds. Try me.</p>
             <button
               onClick={() => {
                 setShowTeaser(false);
@@ -294,13 +294,13 @@ export default function ChatWidget() {
 
       {/* Chat panel */}
       {open && (
-        <div className="fixed bottom-16 right-4 z-50 w-[380px] max-w-[calc(100vw-2rem)] h-[460px] max-h-[calc(100vh-8rem)] bg-navy-900 border border-navy-700 rounded-2xl shadow-2xl flex flex-col overflow-hidden md:bottom-6 md:right-6 md:h-[520px] md:max-h-[calc(100vh-6rem)]">
+        <div className="fixed bottom-16 right-4 z-50 w-[380px] max-w-[calc(100vw-2rem)] h-[460px] max-h-[calc(100vh-8rem)] card shadow-2xl flex flex-col overflow-hidden md:bottom-6 md:right-6 md:h-[520px] md:max-h-[calc(100vh-6rem)]">
           {/* Header */}
-          <div className="flex items-center justify-between px-4 py-3 bg-navy-800 border-b border-navy-700">
+          <div className="flex items-center justify-between px-4 py-3 bg-slate-100 border-b border-slate-200">
             <div className="flex items-center gap-2">
               <Image src="/logo.png" alt="Paybacker" width={24} height={24} className="rounded-lg" />
               <div>
-                <p className="text-white text-sm font-semibold">Paybacker Support</p>
+                <p className="text-slate-900 text-sm font-semibold">Paybacker Support</p>
                 <p className="text-green-400 text-xs">Online</p>
               </div>
             </div>
@@ -308,7 +308,7 @@ export default function ChatWidget() {
               {messages.length > 0 && (
                 <button
                   onClick={() => { setMessages([]); setEscalatedTicket(null); sessionStorage.removeItem('pb_chat_history'); }}
-                  className="text-slate-400 hover:text-white transition-all text-xs px-2 py-1 rounded hover:bg-navy-700"
+                  className="text-slate-500 hover:text-slate-900 transition-all text-xs px-2 py-1 rounded hover:bg-slate-100"
                   title="Start new chat"
                 >
                   New Chat
@@ -316,7 +316,7 @@ export default function ChatWidget() {
               )}
               <button
                 onClick={() => setOpen(false)}
-                className="text-slate-400 hover:text-white transition-all p-1"
+                className="text-slate-500 hover:text-slate-900 transition-all p-1"
               >
                 <X className="h-5 w-5" />
               </button>
@@ -328,8 +328,8 @@ export default function ChatWidget() {
             {messages.length === 0 && (
               <div className="text-center py-6">
                 <Image src="/logo.png" alt="Paybacker" width={40} height={40} className="rounded-lg mx-auto mb-3" />
-                <p className="text-white font-medium mb-1">Hi there!</p>
-                <p className="text-slate-400 text-sm mb-3">I can help you organise your finances through conversation. Try asking me to recategorise transactions, find missing subscriptions, check your spending, or dispute a bill.</p>
+                <p className="text-slate-900 font-medium mb-1">Hi there!</p>
+                <p className="text-slate-500 text-sm mb-3">I can help you organise your finances through conversation. Try asking me to recategorise transactions, find missing subscriptions, check your spending, or dispute a bill.</p>
                 <div className="space-y-2">
                   {((userTier === 'essential' || userTier === 'pro')
                     ? [
@@ -366,7 +366,7 @@ export default function ChatWidget() {
                   className={`max-w-[80%] rounded-2xl px-4 py-2.5 text-sm ${
                     msg.role === 'user'
                       ? 'bg-mint-400 text-navy-950'
-                      : 'bg-navy-800 text-slate-200'
+                      : 'bg-slate-100 text-slate-700'
                   }`}
                 >
                   {msg.role === 'user' ? (
@@ -382,10 +382,10 @@ export default function ChatWidget() {
 
             {loading && (
               <div className="flex justify-start">
-                <div className="bg-navy-800 rounded-2xl px-4 py-2.5 flex items-center gap-2">
-                  <Loader2 className="h-4 w-4 text-slate-400 animate-spin" />
+                <div className="bg-slate-100 rounded-2xl px-4 py-2.5 flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 text-slate-500 animate-spin" />
                   {loadingMessage && (
-                    <span className="text-xs text-slate-400">{loadingMessage}</span>
+                    <span className="text-xs text-slate-500">{loadingMessage}</span>
                   )}
                 </div>
               </div>
@@ -432,7 +432,7 @@ export default function ChatWidget() {
                     setLoading(false);
                   }
                 }}
-                className="w-full text-xs text-slate-400 hover:text-mint-400 py-1.5 transition-all"
+                className="w-full text-xs text-slate-500 hover:text-mint-400 py-1.5 transition-all"
               >
                 Talk to a human instead
               </button>
@@ -440,7 +440,7 @@ export default function ChatWidget() {
           )}
 
           {/* Input */}
-          <div className="p-3 border-t border-navy-700">
+          <div className="p-3 border-t border-slate-200">
             <div className="flex items-center gap-2">
               <input
                 type="text"
@@ -448,7 +448,7 @@ export default function ChatWidget() {
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder="Type a message..."
-                className="flex-1 bg-navy-800 border border-navy-700 rounded-xl px-4 py-2.5 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-mint-400"
+                className="flex-1 bg-slate-100 border border-slate-200 rounded-xl px-4 py-2.5 text-sm text-slate-900 placeholder-slate-500 focus:outline-none focus:border-mint-400"
                 disabled={loading}
               />
               <button

--- a/src/components/ConsentRenewalBanner.tsx
+++ b/src/components/ConsentRenewalBanner.tsx
@@ -62,8 +62,8 @@ export default function ConsentRenewalBanner({
       <div className="flex items-start gap-3 flex-1">
         <AlertCircle className="h-5 w-5 text-amber-400 shrink-0 mt-0.5" />
         <div className="flex-1">
-          <p className="text-sm text-slate-200">
-            Your <span className="font-medium text-white">{bankName}</span> connection
+          <p className="text-sm text-slate-700">
+            Your <span className="font-medium text-slate-900">{bankName}</span> connection
             {daysLeft > 0
               ? ` expires in ${daysLeft} day${daysLeft !== 1 ? 's' : ''}`
               : ' has expired'}

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -57,10 +57,10 @@ export default function CookieConsentBanner() {
 
   return (
     <div className="fixed bottom-0 inset-x-0 z-[9999] p-4">
-      <div className="max-w-2xl mx-auto bg-navy-900 border border-navy-700 rounded-2xl shadow-2xl p-6">
+      <div className="max-w-2xl mx-auto card shadow-2xl p-6">
         {!showPreferences ? (
           <>
-            <p className="text-sm text-slate-300 mb-4">
+            <p className="text-sm text-slate-700 mb-4">
               We use cookies to improve your experience and analyse how our site is used.
               You can accept all cookies, reject non-essential ones, or manage your preferences.
               See our <Link href="/cookie-policy" className="text-mint-400 underline hover:text-mint-300">Cookie Policy</Link> for details.
@@ -74,13 +74,13 @@ export default function CookieConsentBanner() {
               </button>
               <button
                 onClick={handleRejectAll}
-                className="bg-navy-800 hover:bg-navy-700 text-slate-300 text-sm font-medium px-5 py-2.5 rounded-xl border border-navy-600 transition-all"
+                className="bg-slate-100 hover:bg-slate-100 text-slate-700 text-sm font-medium px-5 py-2.5 rounded-xl border border-navy-600 transition-all"
               >
                 Reject All
               </button>
               <button
                 onClick={() => setShowPreferences(true)}
-                className="text-slate-400 hover:text-white text-sm font-medium px-5 py-2.5 transition-all"
+                className="text-slate-500 hover:text-slate-900 text-sm font-medium px-5 py-2.5 transition-all"
               >
                 Manage Preferences
               </button>
@@ -88,19 +88,19 @@ export default function CookieConsentBanner() {
           </>
         ) : (
           <>
-            <h3 className="text-white font-semibold mb-4">Cookie Preferences</h3>
+            <h3 className="text-slate-900 font-semibold mb-4">Cookie Preferences</h3>
             <div className="space-y-3 mb-5">
-              <label className="flex items-center justify-between p-3 bg-navy-800 rounded-xl">
+              <label className="flex items-center justify-between p-3 bg-slate-100 rounded-xl">
                 <div>
-                  <span className="text-sm text-white font-medium">Essential</span>
-                  <p className="text-xs text-slate-400 mt-0.5">Required for login and basic functionality. Cannot be disabled.</p>
+                  <span className="text-sm text-slate-900 font-medium">Essential</span>
+                  <p className="text-xs text-slate-500 mt-0.5">Required for login and basic functionality. Cannot be disabled.</p>
                 </div>
                 <input type="checkbox" checked disabled className="accent-mint-400 w-4 h-4" />
               </label>
-              <label className="flex items-center justify-between p-3 bg-navy-800 rounded-xl cursor-pointer">
+              <label className="flex items-center justify-between p-3 bg-slate-100 rounded-xl cursor-pointer">
                 <div>
-                  <span className="text-sm text-white font-medium">Analytics</span>
-                  <p className="text-xs text-slate-400 mt-0.5">Help us understand how you use Paybacker (PostHog, Google Analytics).</p>
+                  <span className="text-sm text-slate-900 font-medium">Analytics</span>
+                  <p className="text-xs text-slate-500 mt-0.5">Help us understand how you use Paybacker (PostHog, Google Analytics).</p>
                 </div>
                 <input
                   type="checkbox"
@@ -109,10 +109,10 @@ export default function CookieConsentBanner() {
                   className="accent-mint-400 w-4 h-4"
                 />
               </label>
-              <label className="flex items-center justify-between p-3 bg-navy-800 rounded-xl cursor-pointer">
+              <label className="flex items-center justify-between p-3 bg-slate-100 rounded-xl cursor-pointer">
                 <div>
-                  <span className="text-sm text-white font-medium">Marketing</span>
-                  <p className="text-xs text-slate-400 mt-0.5">Used for ads and referral tracking (Meta Pixel, Awin).</p>
+                  <span className="text-sm text-slate-900 font-medium">Marketing</span>
+                  <p className="text-xs text-slate-500 mt-0.5">Used for ads and referral tracking (Meta Pixel, Awin).</p>
                 </div>
                 <input
                   type="checkbox"
@@ -121,10 +121,10 @@ export default function CookieConsentBanner() {
                   className="accent-mint-400 w-4 h-4"
                 />
               </label>
-              <label className="flex items-center justify-between p-3 bg-navy-800 rounded-xl cursor-pointer">
+              <label className="flex items-center justify-between p-3 bg-slate-100 rounded-xl cursor-pointer">
                 <div>
-                  <span className="text-sm text-white font-medium">Functional</span>
-                  <p className="text-xs text-slate-400 mt-0.5">Enhanced features like chat and personalisation.</p>
+                  <span className="text-sm text-slate-900 font-medium">Functional</span>
+                  <p className="text-xs text-slate-500 mt-0.5">Enhanced features like chat and personalisation.</p>
                 </div>
                 <input
                   type="checkbox"
@@ -143,7 +143,7 @@ export default function CookieConsentBanner() {
               </button>
               <button
                 onClick={handleAcceptAll}
-                className="bg-navy-800 hover:bg-navy-700 text-slate-300 text-sm font-medium px-5 py-2.5 rounded-xl border border-navy-600 transition-all"
+                className="bg-slate-100 hover:bg-slate-100 text-slate-700 text-sm font-medium px-5 py-2.5 rounded-xl border border-navy-600 transition-all"
               >
                 Accept All
               </button>

--- a/src/components/CookieSettingsButton.tsx
+++ b/src/components/CookieSettingsButton.tsx
@@ -4,7 +4,7 @@ export default function CookieSettingsButton() {
   return (
     <button
       onClick={() => window.dispatchEvent(new Event('open-cookie-settings'))}
-      className="hover:text-white transition-all"
+      className="hover:text-slate-900 transition-all"
     >
       Cookie Settings
     </button>

--- a/src/components/DataExportCard.tsx
+++ b/src/components/DataExportCard.tsx
@@ -99,11 +99,11 @@ export default function DataExportCard() {
         <button
           onClick={() => handleDownload('xlsx')}
           disabled={downloading !== null}
-          className="flex-1 inline-flex items-center justify-center gap-2 text-sm font-medium text-white bg-[#0F7B6C] hover:bg-[#0b6357] transition-colors rounded-lg py-2.5 shadow-sm disabled:opacity-60 disabled:cursor-not-allowed"
+          className="flex-1 inline-flex items-center justify-center gap-2 text-sm font-medium text-slate-900 bg-[#0F7B6C] hover:bg-[#0b6357] transition-colors rounded-lg py-2.5 shadow-sm disabled:opacity-60 disabled:cursor-not-allowed"
         >
           {downloading === 'xlsx' ? (
             <>
-              <svg className="animate-spin h-4 w-4 text-white" viewBox="0 0 24 24" fill="none">
+              <svg className="animate-spin h-4 w-4 text-slate-900" viewBox="0 0 24 24" fill="none">
                 <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" strokeDasharray="42" strokeDashoffset="0" />
               </svg>
               Preparing…

--- a/src/components/GoogleSheetsConnect.tsx
+++ b/src/components/GoogleSheetsConnect.tsx
@@ -117,15 +117,15 @@ export default function GoogleSheetsConnect() {
 
   if (loading) {
     return (
-      <div className="rounded-2xl border border-navy-700/50 bg-navy-900 p-5 animate-pulse">
-        <div className="h-5 w-40 bg-navy-800 rounded mb-2" />
-        <div className="h-4 w-64 bg-navy-800 rounded" />
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 animate-pulse">
+        <div className="h-5 w-40 bg-slate-100 rounded mb-2" />
+        <div className="h-4 w-64 bg-slate-100 rounded" />
       </div>
     )
   }
 
   return (
-    <div className="rounded-2xl border border-navy-700/50 bg-navy-900 p-5 shadow-sm">
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
       {/* Header */}
       <div className="flex items-center gap-3 mb-4">
         <div className="w-10 h-10 rounded-lg bg-green-500/10 flex items-center justify-center flex-shrink-0">
@@ -137,8 +137,8 @@ export default function GoogleSheetsConnect() {
           </svg>
         </div>
         <div className="min-w-0">
-          <h3 className="font-semibold text-white text-sm">Google Sheets</h3>
-          <p className="text-xs text-slate-400 truncate">
+          <h3 className="font-semibold text-slate-900 text-sm">Google Sheets</h3>
+          <p className="text-xs text-slate-500 truncate">
             {connection
               ? `Connected as ${connection.email}`
               : 'Sync every account to a Google Sheet, updated daily'}
@@ -155,10 +155,10 @@ export default function GoogleSheetsConnect() {
       {connection ? (
         /* Connected state */
         <div className="space-y-3">
-          <div className="rounded-lg bg-navy-800/60 p-3 text-sm space-y-1.5">
+          <div className="rounded-lg bg-slate-100 p-3 text-sm space-y-1.5">
             <div className="flex justify-between">
-              <span className="text-slate-400 text-xs">Last synced</span>
-              <span className="font-medium text-white text-xs">
+              <span className="text-slate-500 text-xs">Last synced</span>
+              <span className="font-medium text-slate-900 text-xs">
                 {connection.last_synced_at
                   ? new Date(connection.last_synced_at).toLocaleString('en-GB', {
                       day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
@@ -167,8 +167,8 @@ export default function GoogleSheetsConnect() {
               </span>
             </div>
             <div className="flex justify-between">
-              <span className="text-slate-400 text-xs">Newest transaction</span>
-              <span className="font-medium text-white text-xs">
+              <span className="text-slate-500 text-xs">Newest transaction</span>
+              <span className="font-medium text-slate-900 text-xs">
                 {connection.last_synced_timestamp
                   ? new Date(connection.last_synced_timestamp).toLocaleDateString('en-GB', {
                       day: 'numeric', month: 'short', year: 'numeric',
@@ -218,7 +218,7 @@ export default function GoogleSheetsConnect() {
                 href={connection.spreadsheet_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex-1 min-w-[140px] text-center text-sm font-semibold text-white bg-green-600 hover:bg-green-500 transition-colors rounded-lg py-2.5"
+                className="flex-1 min-w-[140px] text-center text-sm font-semibold text-slate-900 bg-green-600 hover:bg-green-500 transition-colors rounded-lg py-2.5"
               >
                 Open Sheet ↗
               </a>
@@ -226,7 +226,7 @@ export default function GoogleSheetsConnect() {
             <button
               onClick={handleDisconnect}
               disabled={disconnecting || syncing}
-              className="text-sm text-slate-400 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors px-3 py-2 rounded-lg border border-navy-700 hover:border-red-400/50"
+              className="text-sm text-slate-500 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors px-3 py-2 rounded-lg border border-slate-200 hover:border-red-400/50"
             >
               {disconnecting ? 'Disconnecting…' : 'Disconnect'}
             </button>
@@ -235,7 +235,7 @@ export default function GoogleSheetsConnect() {
       ) : (
         /* Not connected state */
         <div className="space-y-3">
-          <ul className="text-xs text-slate-400 space-y-1.5 pl-1">
+          <ul className="text-xs text-slate-500 space-y-1.5 pl-1">
             <li className="flex items-center gap-2">
               <span className="text-green-400">✓</span> One tab per bank account
             </li>

--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -155,7 +155,7 @@ export default function NotificationBell() {
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-2 w-[340px] max-w-[calc(100vw-2rem)] bg-white border border-slate-200 rounded-2xl shadow-2xl z-50 overflow-hidden">
+        <div className="absolute right-0 mt-2 w-[340px] max-w-[calc(100vw-2rem)] card shadow-2xl z-50 overflow-hidden">
           <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200">
             <h3 className="text-sm font-semibold text-slate-900">Notifications</h3>
             <div className="flex items-center gap-2">

--- a/src/components/RotatingCaptionsLoader.tsx
+++ b/src/components/RotatingCaptionsLoader.tsx
@@ -93,15 +93,15 @@ export default function RotatingCaptionsLoader({
     return (
       <div
         className={
-          'rounded-xl border border-white/10 bg-navy-800/50 p-5 flex flex-col items-center text-center gap-3 ' +
+          'rounded-xl border border-white/10 bg-slate-100 p-5 flex flex-col items-center text-center gap-3 ' +
           (className || '')
         }
       >
         <Loader2 className="h-6 w-6 text-mint-400 animate-spin" />
         {heading && (
-          <p className="text-white font-semibold text-sm">{heading}</p>
+          <p className="text-slate-900 font-semibold text-sm">{heading}</p>
         )}
-        <p className="text-white/80 text-sm flex items-center gap-2">
+        <p className="text-slate-900/80 text-sm flex items-center gap-2">
           <span className="text-base" aria-hidden>
             {current.icon}
           </span>
@@ -115,7 +115,7 @@ export default function RotatingCaptionsLoader({
   return (
     <div
       className={
-        'flex items-center gap-2 text-sm text-white/80 ' + (className || '')
+        'flex items-center gap-2 text-sm text-slate-900/80 ' + (className || '')
       }
       role="status"
       aria-live="polite"

--- a/src/components/UpgradeModal.tsx
+++ b/src/components/UpgradeModal.tsx
@@ -25,9 +25,9 @@ export default function UpgradeModal({ open, onClose, used, limit, tier }: Upgra
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
           </div>
-          <h2 className="text-2xl font-bold text-white mb-2">Monthly Limit Reached</h2>
+          <h2 className="text-2xl font-bold text-slate-900 mb-2">Monthly Limit Reached</h2>
           <p className="text-gray-400">
-            You&apos;ve used <span className="text-white font-semibold">{used} of {limit}</span> complaint{limit !== 1 ? 's' : ''} this month on the{' '}
+            You&apos;ve used <span className="text-slate-900 font-semibold">{used} of {limit}</span> complaint{limit !== 1 ? 's' : ''} this month on the{' '}
             <span className="text-yellow-400 capitalize">{tier}</span> plan.
           </p>
         </div>
@@ -59,7 +59,7 @@ export default function UpgradeModal({ open, onClose, used, limit, tier }: Upgra
           </button>
           <button
             onClick={onClose}
-            className="w-full py-3 px-6 text-gray-400 hover:text-white transition-colors text-sm"
+            className="w-full py-3 px-6 text-gray-400 hover:text-slate-900 transition-colors text-sm"
           >
             Maybe later
           </button>

--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -45,7 +45,7 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
         <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={handleClose} />
-        <div className="relative bg-white border border-slate-200 rounded-2xl p-8 max-w-md w-full shadow-2xl">
+        <div className="relative card p-8 max-w-md w-full shadow-2xl">
           <div className="text-center mb-6">
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-mint-400/10 border border-mint-400/30 mb-4">
               <Sparkles className="h-8 w-8 text-mint-400" />

--- a/src/components/admin/LeadsList.tsx
+++ b/src/components/admin/LeadsList.tsx
@@ -95,23 +95,23 @@ export default function LeadsList() {
     <div>
       {/* Stats row */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4">
-          <p className="text-2xl font-bold text-white">{leads.length}</p>
-          <p className="text-slate-400 text-xs">Total leads</p>
+        <div className="bg-white border border-slate-200 rounded-xl p-4">
+          <p className="text-2xl font-bold text-slate-900">{leads.length}</p>
+          <p className="text-slate-500 text-xs">Total leads</p>
         </div>
-        <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4">
+        <div className="bg-white border border-slate-200 rounded-xl p-4">
           <p className="text-2xl font-bold text-mint-400">{newCount}</p>
-          <p className="text-slate-400 text-xs">New (uncontacted)</p>
+          <p className="text-slate-500 text-xs">New (uncontacted)</p>
         </div>
-        <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4">
+        <div className="bg-white border border-slate-200 rounded-xl p-4">
           <p className="text-2xl font-bold text-green-400">{convertedCount}</p>
-          <p className="text-slate-400 text-xs">Converted</p>
+          <p className="text-slate-500 text-xs">Converted</p>
         </div>
-        <div className="bg-navy-900 border border-navy-700/50 rounded-xl p-4">
-          <p className="text-2xl font-bold text-white">
+        <div className="bg-white border border-slate-200 rounded-xl p-4">
+          <p className="text-2xl font-bold text-slate-900">
             {leads.length > 0 ? `${((convertedCount / leads.length) * 100).toFixed(0)}%` : '0%'}
           </p>
-          <p className="text-slate-400 text-xs">Conversion rate</p>
+          <p className="text-slate-500 text-xs">Conversion rate</p>
         </div>
       </div>
 
@@ -122,7 +122,7 @@ export default function LeadsList() {
           <select
             value={filterPlatform}
             onChange={(e) => setFilterPlatform(e.target.value)}
-            className="bg-navy-800 border border-navy-700/50 text-white text-sm rounded-lg px-3 py-1.5 focus:outline-none focus:border-mint-400"
+            className="bg-slate-100 border border-slate-200 text-slate-900 text-sm rounded-lg px-3 py-1.5 focus:outline-none focus:border-mint-400"
           >
             <option value="all">All platforms</option>
             <option value="facebook_dm">Facebook DMs</option>
@@ -136,7 +136,7 @@ export default function LeadsList() {
         <select
           value={filterStatus}
           onChange={(e) => setFilterStatus(e.target.value)}
-          className="bg-navy-800 border border-navy-700/50 text-white text-sm rounded-lg px-3 py-1.5 focus:outline-none focus:border-mint-400"
+          className="bg-slate-100 border border-slate-200 text-slate-900 text-sm rounded-lg px-3 py-1.5 focus:outline-none focus:border-mint-400"
         >
           <option value="all">All statuses</option>
           {STATUS_OPTIONS.map(s => (
@@ -146,7 +146,7 @@ export default function LeadsList() {
 
         <button
           onClick={fetchLeads}
-          className="flex items-center gap-1.5 bg-navy-800 hover:bg-navy-700 text-slate-400 hover:text-white text-sm px-3 py-1.5 rounded-lg transition-all"
+          className="flex items-center gap-1.5 bg-slate-100 hover:bg-slate-100 text-slate-500 hover:text-slate-900 text-sm px-3 py-1.5 rounded-lg transition-all"
         >
           <RefreshCw className="h-3.5 w-3.5" />
           Refresh
@@ -161,14 +161,14 @@ export default function LeadsList() {
       ) : leads.length === 0 ? (
         <div className="text-center py-12">
           <MessageCircle className="h-12 w-12 text-slate-600 mx-auto mb-3" />
-          <p className="text-slate-400">No leads found</p>
+          <p className="text-slate-500">No leads found</p>
           <p className="text-slate-500 text-sm mt-1">Leads are captured from Facebook DMs, Instagram comments, and social engagement.</p>
         </div>
       ) : (
         <div className="space-y-2">
           {leads.map(lead => {
-            const platform = PLATFORM_LABELS[lead.platform] || { label: lead.platform, color: 'bg-slate-500/20 text-slate-400' };
-            const statusColor = STATUS_COLORS[lead.status] || 'bg-slate-500/20 text-slate-400';
+            const platform = PLATFORM_LABELS[lead.platform] || { label: lead.platform, color: 'bg-slate-500/20 text-slate-500' };
+            const statusColor = STATUS_COLORS[lead.status] || 'bg-slate-500/20 text-slate-500';
             const isExpanded = expandedId === lead.id;
             const timeAgo = (() => {
               const diff = Date.now() - new Date(lead.created_at).getTime();
@@ -180,10 +180,10 @@ export default function LeadsList() {
             })();
 
             return (
-              <div key={lead.id} className="bg-navy-900 border border-navy-700/50 rounded-xl overflow-hidden">
+              <div key={lead.id} className="bg-white border border-slate-200 rounded-xl overflow-hidden">
                 {/* Main row */}
                 <div
-                  className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-navy-800/50 transition-all"
+                  className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-slate-100 transition-all"
                   onClick={() => {
                     setExpandedId(isExpanded ? null : lead.id);
                     setEditingNotes(lead.notes || '');
@@ -191,7 +191,7 @@ export default function LeadsList() {
                 >
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-0.5">
-                      <p className="text-white text-sm font-medium truncate">{lead.name || lead.platform_user_id || 'Unknown'}</p>
+                      <p className="text-slate-900 text-sm font-medium truncate">{lead.name || lead.platform_user_id || 'Unknown'}</p>
                       <span className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${platform.color}`}>{platform.label}</span>
                       <span className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${statusColor}`}>{lead.status}</span>
                     </div>
@@ -205,33 +205,33 @@ export default function LeadsList() {
 
                 {/* Expanded detail */}
                 {isExpanded && (
-                  <div className="px-4 pb-4 border-t border-navy-700/50 pt-3 space-y-3">
+                  <div className="px-4 pb-4 border-t border-slate-200 pt-3 space-y-3">
                     {lead.first_message && (
                       <div>
                         <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">First message</p>
-                        <p className="text-slate-300 text-sm bg-navy-800 rounded-lg p-3">{lead.first_message}</p>
+                        <p className="text-slate-700 text-sm bg-slate-100 rounded-lg p-3">{lead.first_message}</p>
                       </div>
                     )}
 
                     <div className="grid grid-cols-2 gap-3 text-sm">
                       <div>
                         <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Email</p>
-                        <p className="text-white">{lead.email || 'Not captured'}</p>
+                        <p className="text-slate-900">{lead.email || 'Not captured'}</p>
                       </div>
                       <div>
                         <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Platform ID</p>
-                        <p className="text-white text-xs font-mono">{lead.platform_user_id || 'N/A'}</p>
+                        <p className="text-slate-900 text-xs font-mono">{lead.platform_user_id || 'N/A'}</p>
                       </div>
                       <div>
                         <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Captured</p>
-                        <p className="text-white">{new Date(lead.created_at).toLocaleString('en-GB')}</p>
+                        <p className="text-slate-900">{new Date(lead.created_at).toLocaleString('en-GB')}</p>
                       </div>
                       <div>
                         <p className="text-[10px] text-slate-500 uppercase tracking-wider mb-1">Status</p>
                         <select
                           value={lead.status}
                           onChange={(e) => updateLead(lead.id, { status: e.target.value })}
-                          className="bg-navy-800 border border-navy-700/50 text-white text-sm rounded-lg px-2 py-1 focus:outline-none focus:border-mint-400 w-full"
+                          className="bg-slate-100 border border-slate-200 text-slate-900 text-sm rounded-lg px-2 py-1 focus:outline-none focus:border-mint-400 w-full"
                         >
                           {STATUS_OPTIONS.map(s => (
                             <option key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</option>
@@ -247,7 +247,7 @@ export default function LeadsList() {
                         value={editingNotes}
                         onChange={(e) => setEditingNotes(e.target.value)}
                         rows={2}
-                        className="w-full bg-navy-800 border border-navy-700/50 text-white text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-mint-400 resize-none"
+                        className="w-full bg-slate-100 border border-slate-200 text-slate-900 text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-mint-400 resize-none"
                         placeholder="Add internal notes..."
                       />
                       {editingNotes !== (lead.notes || '') && (

--- a/src/components/admin/TicketList.tsx
+++ b/src/components/admin/TicketList.tsx
@@ -37,14 +37,14 @@ const statusColors: Record<string, string> = {
   in_progress: 'bg-blue-500/20 text-blue-400',
   awaiting_reply: 'bg-purple-500/20 text-purple-400',
   resolved: 'bg-green-500/20 text-green-400',
-  closed: 'bg-slate-500/20 text-slate-400',
+  closed: 'bg-slate-500/20 text-slate-500',
 };
 
 const priorityColors: Record<string, string> = {
   urgent: 'bg-red-500/20 text-red-400',
   high: 'bg-orange-500/20 text-orange-400',
   medium: 'bg-amber-500/20 text-amber-400',
-  low: 'bg-slate-500/20 text-slate-400',
+  low: 'bg-slate-500/20 text-slate-500',
 };
 
 const CRON_SECRET = '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
@@ -132,16 +132,16 @@ export default function TicketList() {
   if (selectedTicket) {
     return (
       <div>
-        <button onClick={() => { setSelectedTicket(null); loadTickets(); }} className="flex items-center gap-2 text-slate-400 hover:text-white mb-4 text-sm">
+        <button onClick={() => { setSelectedTicket(null); loadTickets(); }} className="flex items-center gap-2 text-slate-500 hover:text-slate-900 mb-4 text-sm">
           <ArrowLeft className="h-4 w-4" /> Back to tickets
         </button>
 
         {/* Ticket Header */}
-        <div className="bg-slate-900/50 border border-slate-800 rounded-2xl p-5 mb-4">
+        <div className="bg-slate-900/50 border border-slate-200 rounded-2xl p-5 mb-4">
           <div className="flex items-start justify-between mb-3">
             <div>
               <p className="text-slate-500 text-xs font-mono">{selectedTicket.ticket_number}</p>
-              <h3 className="text-white text-lg font-semibold">{selectedTicket.subject}</h3>
+              <h3 className="text-slate-900 text-lg font-semibold">{selectedTicket.subject}</h3>
               <p className="text-slate-500 text-xs mt-1">
                 via {selectedTicket.source} · {new Date(selectedTicket.created_at).toLocaleString('en-GB')}
               </p>
@@ -156,7 +156,7 @@ export default function TicketList() {
             <select
               value={selectedTicket.status}
               onChange={(e) => updateTicket('status', e.target.value)}
-              className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-xs text-white"
+              className="bg-slate-100 border border-slate-200 rounded-lg px-3 py-1.5 text-xs text-slate-900"
             >
               <option value="open">New & Unassigned (open)</option>
               <option value="in_progress">Escalated / In Progress (in_progress)</option>
@@ -167,7 +167,7 @@ export default function TicketList() {
             <select
               value={selectedTicket.priority}
               onChange={(e) => updateTicket('priority', e.target.value)}
-              className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-xs text-white"
+              className="bg-slate-100 border border-slate-200 rounded-lg px-3 py-1.5 text-xs text-slate-900"
             >
               {['low', 'medium', 'high', 'urgent'].map(p => (
                 <option key={p} value={p}>{p}</option>
@@ -176,7 +176,7 @@ export default function TicketList() {
             <select
               value={selectedTicket.category}
               onChange={(e) => updateTicket('category', e.target.value)}
-              className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-xs text-white"
+              className="bg-slate-100 border border-slate-200 rounded-lg px-3 py-1.5 text-xs text-slate-900"
             >
               {['general', 'billing', 'technical', 'complaint', 'account'].map(c => (
                 <option key={c} value={c}>{c}</option>
@@ -186,8 +186,8 @@ export default function TicketList() {
         </div>
 
         {/* Messages */}
-        <div className="bg-slate-900/50 border border-slate-800 rounded-2xl p-5 mb-4">
-          <h4 className="text-white font-semibold mb-3 flex items-center gap-2">
+        <div className="bg-slate-900/50 border border-slate-200 rounded-2xl p-5 mb-4">
+          <h4 className="text-slate-900 font-semibold mb-3 flex items-center gap-2">
             <MessageSquare className="h-4 w-4 text-amber-500" /> Conversation
           </h4>
           <div className="space-y-3 max-h-96 overflow-y-auto">
@@ -198,7 +198,7 @@ export default function TicketList() {
                     ? 'bg-amber-500 text-slate-950'
                     : msg.sender_type === 'system'
                     ? 'bg-slate-800/50 text-slate-500 text-xs italic'
-                    : 'bg-slate-800 text-slate-200'
+                    : 'bg-slate-100 text-slate-700'
                 }`}>
                   <p className="text-xs opacity-60 mb-1">{msg.sender_name} · {new Date(msg.created_at).toLocaleString('en-GB')}</p>
                   <p className="whitespace-pre-wrap">{msg.message}</p>
@@ -209,19 +209,19 @@ export default function TicketList() {
         </div>
 
         {/* Reply */}
-        <div className="bg-slate-900/50 border border-slate-800 rounded-2xl p-5">
+        <div className="bg-slate-900/50 border border-slate-200 rounded-2xl p-5">
           <textarea
             value={replyText}
             onChange={(e) => setReplyText(e.target.value)}
             placeholder="Type your reply..."
             rows={3}
-            className="w-full bg-slate-800 border border-slate-700 rounded-xl px-4 py-3 text-sm text-white placeholder-slate-500 focus:outline-none focus:border-amber-500 resize-none"
+            className="w-full bg-slate-100 border border-slate-200 rounded-xl px-4 py-3 text-sm text-slate-900 placeholder-slate-500 focus:outline-none focus:border-amber-500 resize-none"
           />
           <div className="flex justify-end mt-2 gap-2">
             <button
               onClick={sendReply}
               disabled={!replyText.trim() || sending}
-              className="bg-slate-700 hover:bg-slate-600 disabled:opacity-50 text-white font-semibold px-5 py-2 rounded-lg flex items-center gap-2 text-sm"
+              className="bg-slate-700 hover:bg-slate-600 disabled:opacity-50 text-slate-900 font-semibold px-5 py-2 rounded-lg flex items-center gap-2 text-sm"
             >
               {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
               Send Reply
@@ -249,28 +249,28 @@ export default function TicketList() {
       <div className="grid grid-cols-3 gap-4 mb-6">
         <div className="bg-slate-900/50 border border-amber-500/30 rounded-xl p-4">
           <AlertTriangle className="h-5 w-5 text-amber-500 mb-1" />
-          <p className="text-2xl font-bold text-white">{openCount}</p>
+          <p className="text-2xl font-bold text-slate-900">{openCount}</p>
           <p className="text-slate-500 text-xs">Open tickets</p>
         </div>
         <div className="bg-slate-900/50 border border-red-500/30 rounded-xl p-4">
           <Clock className="h-5 w-5 text-red-500 mb-1" />
-          <p className="text-2xl font-bold text-white">{urgentCount}</p>
+          <p className="text-2xl font-bold text-slate-900">{urgentCount}</p>
           <p className="text-slate-500 text-xs">Urgent</p>
         </div>
         <div className="bg-slate-900/50 border border-green-500/30 rounded-xl p-4">
           <CheckCircle className="h-5 w-5 text-green-500 mb-1" />
-          <p className="text-2xl font-bold text-white">{resolvedCount}</p>
+          <p className="text-2xl font-bold text-slate-900">{resolvedCount}</p>
           <p className="text-slate-500 text-xs">Resolved</p>
         </div>
       </div>
 
       {/* Filters */}
       <div className="flex items-center gap-3 mb-4">
-        <Filter className="h-4 w-4 text-slate-400" />
+        <Filter className="h-4 w-4 text-slate-500" />
         <select
           value={filterStatus}
           onChange={(e) => setFilterStatus(e.target.value)}
-          className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-xs text-white"
+          className="bg-slate-100 border border-slate-200 rounded-lg px-3 py-1.5 text-xs text-slate-900"
         >
           <option value="">All tickets</option>
           <option value="active">Needs Action (Open/Escalated)</option>
@@ -283,14 +283,14 @@ export default function TicketList() {
         <select
           value={filterPriority}
           onChange={(e) => setFilterPriority(e.target.value)}
-          className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-1.5 text-xs text-white"
+          className="bg-slate-100 border border-slate-200 rounded-lg px-3 py-1.5 text-xs text-slate-900"
         >
           <option value="">All priorities</option>
           {['urgent', 'high', 'medium', 'low'].map(p => (
             <option key={p} value={p}>{p}</option>
           ))}
         </select>
-        <button onClick={loadTickets} className="text-slate-400 hover:text-white">
+        <button onClick={loadTickets} className="text-slate-500 hover:text-slate-900">
           <RefreshCw className="h-4 w-4" />
         </button>
       </div>
@@ -303,7 +303,7 @@ export default function TicketList() {
       ) : tickets.length === 0 ? (
         <div className="text-center py-12">
           <Ticket className="h-12 w-12 text-slate-600 mx-auto mb-3" />
-          <p className="text-slate-400">No tickets found</p>
+          <p className="text-slate-500">No tickets found</p>
         </div>
       ) : (
         <div className="space-y-2">
@@ -311,16 +311,16 @@ export default function TicketList() {
             <button
               key={t.id}
               onClick={() => loadTicketDetail(t)}
-              className="w-full flex items-center justify-between bg-slate-900/50 border border-slate-800 hover:border-amber-500/50 rounded-xl px-4 py-3 transition-all text-left"
+              className="w-full flex items-center justify-between bg-slate-900/50 border border-slate-200 hover:border-amber-500/50 rounded-xl px-4 py-3 transition-all text-left"
             >
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1">
                   <span className="text-slate-500 text-xs font-mono">{t.ticket_number}</span>
                   <span className={`px-1.5 py-0.5 rounded text-[10px] font-semibold ${statusColors[t.status]}`}>{t.status}</span>
                   <span className={`px-1.5 py-0.5 rounded text-[10px] font-semibold ${priorityColors[t.priority]}`}>{t.priority}</span>
-                  <span className="px-1.5 py-0.5 rounded text-[10px] bg-slate-700 text-slate-300">{t.category}</span>
+                  <span className="px-1.5 py-0.5 rounded text-[10px] bg-slate-700 text-slate-700">{t.category}</span>
                 </div>
-                <p className="text-white text-sm font-medium truncate">{t.subject}</p>
+                <p className="text-slate-900 text-sm font-medium truncate">{t.subject}</p>
                 <p className="text-slate-500 text-xs">via {t.source} · {t.assigned_to || 'unassigned'}</p>
               </div>
               <div className="flex items-center gap-3 ml-4 shrink-0">

--- a/src/components/dispute/WatchdogCard.tsx
+++ b/src/components/dispute/WatchdogCard.tsx
@@ -264,7 +264,7 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
   };
 
   return (
-    <div className="bg-white border border-slate-200 rounded-2xl p-5 mb-6">
+    <div className="card p-5 mb-6">
       <div className="flex items-start justify-between gap-3 mb-3">
         <div>
           <div className="flex items-center gap-2">

--- a/src/components/rewards/ChallengeCard.tsx
+++ b/src/components/rewards/ChallengeCard.tsx
@@ -71,17 +71,17 @@ export default function ChallengeCard({ challenge, mode, onStart, onAbandon, onC
     challenge.progressInfo?.message?.includes('mark as complete');
 
   return (
-    <div className={`bg-navy-900 border rounded-2xl p-5 transition-all ${
+    <div className={`bg-white border rounded-2xl p-5 transition-all ${
       mode === 'active' ? 'border-mint-400/30' :
       mode === 'completed' ? 'border-green-500/20' :
-      'border-navy-700/50 hover:border-navy-600/50'
+      'border-slate-200 hover:border-navy-600/50'
     }`}>
       {/* Header: icon + name + badge */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-3">
           <span className="text-2xl">{challenge.icon || '🎯'}</span>
           <div>
-            <h3 className="text-white font-semibold text-sm leading-tight">{challenge.name}</h3>
+            <h3 className="text-slate-900 font-semibold text-sm leading-tight">{challenge.name}</h3>
             {challenge.difficulty && mode === 'available' && (
               <span className={`inline-block text-[10px] font-medium px-1.5 py-0.5 rounded border mt-1 ${difficultyColors[challenge.difficulty]}`}>
                 {challenge.difficulty}
@@ -94,7 +94,7 @@ export default function ChallengeCard({ challenge, mode, onStart, onAbandon, onC
 
       {/* Description */}
       {challenge.description && (
-        <p className="text-slate-400 text-xs mb-3 leading-relaxed">{challenge.description}</p>
+        <p className="text-slate-500 text-xs mb-3 leading-relaxed">{challenge.description}</p>
       )}
 
       {/* Active spending challenge: progress bar */}
@@ -109,7 +109,7 @@ export default function ChallengeCard({ challenge, mode, onStart, onAbandon, onC
               </span>
             )}
           </div>
-          <div className="h-1.5 bg-navy-800 rounded-full overflow-hidden">
+          <div className="h-1.5 bg-slate-100 rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full transition-all duration-500 ${
                 challenge.progressInfo?.status === 'failed' ? 'bg-red-400' : 'bg-mint-400'
@@ -165,7 +165,7 @@ export default function ChallengeCard({ challenge, mode, onStart, onAbandon, onC
           <button
             onClick={() => handleAction(() => onComplete(challenge.id))}
             disabled={loading}
-            className="flex-1 bg-green-500 hover:bg-green-600 disabled:opacity-50 text-white font-semibold px-4 py-2 rounded-lg text-xs transition-all flex items-center justify-center gap-1"
+            className="flex-1 bg-green-500 hover:bg-green-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-xs transition-all flex items-center justify-center gap-1"
           >
             {loading ? <Loader2 className="h-3 w-3 animate-spin" /> : <><Check className="h-3 w-3" /> Mark Complete</>}
           </button>

--- a/src/components/scanner/ReceiptResults.tsx
+++ b/src/components/scanner/ReceiptResults.tsx
@@ -79,13 +79,13 @@ export default function ReceiptResults({ receipt, onAction }: ReceiptResultsProp
   };
 
   return (
-    <div className="bg-navy-900 border border-navy-700/50 rounded-2xl p-5">
+    <div className="card p-5">
       <div className="flex flex-col sm:flex-row gap-4">
         {/* Thumbnail */}
         <div className="shrink-0">
           {receipt.image_url ? (
             <a href={receipt.image_url} target="_blank" rel="noopener noreferrer" className="block">
-              <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-xl overflow-hidden bg-navy-800 border border-navy-700/50 relative group">
+              <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-xl overflow-hidden bg-slate-100 border border-slate-200 relative group">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={receipt.image_url}
@@ -93,12 +93,12 @@ export default function ReceiptResults({ receipt, onAction }: ReceiptResultsProp
                   className="w-full h-full object-cover"
                 />
                 <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                  <ExternalLink className="h-4 w-4 text-white" />
+                  <ExternalLink className="h-4 w-4 text-slate-900" />
                 </div>
               </div>
             </a>
           ) : (
-            <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-xl bg-navy-800 border border-navy-700/50 flex items-center justify-center">
+            <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-xl bg-slate-100 border border-slate-200 flex items-center justify-center">
               <FileText className="h-8 w-8 text-slate-600" />
             </div>
           )}
@@ -113,11 +113,11 @@ export default function ReceiptResults({ receipt, onAction }: ReceiptResultsProp
                   type="text"
                   value={provider}
                   onChange={(e) => setProvider(e.target.value)}
-                  className="bg-navy-950 border border-navy-600 rounded-lg px-2 py-1 text-white text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-mint-400/50 w-48"
+                  className="bg-white border border-navy-600 rounded-lg px-2 py-1 text-slate-900 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-mint-400/50 w-48"
                   placeholder="Provider name"
                 />
               ) : (
-                <h3 className="text-white font-semibold text-sm truncate">
+                <h3 className="text-slate-900 font-semibold text-sm truncate">
                   {provider || 'Unknown Provider'}
                 </h3>
               )}
@@ -143,10 +143,10 @@ export default function ReceiptResults({ receipt, onAction }: ReceiptResultsProp
                   step="0.01"
                   value={amount}
                   onChange={(e) => setAmount(e.target.value)}
-                  className="bg-navy-950 border border-navy-600 rounded px-2 py-0.5 text-white text-sm w-full focus:outline-none focus:ring-2 focus:ring-mint-400/50"
+                  className="bg-white border border-navy-600 rounded px-2 py-0.5 text-slate-900 text-sm w-full focus:outline-none focus:ring-2 focus:ring-mint-400/50"
                 />
               ) : (
-                <p className="text-white text-sm font-medium">
+                <p className="text-slate-900 text-sm font-medium">
                   {amount ? `£${parseFloat(amount).toFixed(2)}` : 'N/A'}
                 </p>
               )}
@@ -158,10 +158,10 @@ export default function ReceiptResults({ receipt, onAction }: ReceiptResultsProp
                   type="date"
                   value={date}
                   onChange={(e) => setDate(e.target.value)}
-                  className="bg-navy-950 border border-navy-600 rounded px-2 py-0.5 text-white text-sm w-full focus:outline-none focus:ring-2 focus:ring-mint-400/50"
+                  className="bg-white border border-navy-600 rounded px-2 py-0.5 text-slate-900 text-sm w-full focus:outline-none focus:ring-2 focus:ring-mint-400/50"
                 />
               ) : (
-                <p className="text-white text-sm">
+                <p className="text-slate-900 text-sm">
                   {date ? new Date(date + 'T00:00:00').toLocaleDateString('en-GB') : 'N/A'}
                 </p>
               )}
@@ -169,7 +169,7 @@ export default function ReceiptResults({ receipt, onAction }: ReceiptResultsProp
             {referenceNumber && (
               <div>
                 <p className="text-slate-500 text-xs mb-0.5">Reference</p>
-                <p className="text-white text-sm truncate">{referenceNumber}</p>
+                <p className="text-slate-900 text-sm truncate">{referenceNumber}</p>
               </div>
             )}
           </div>
@@ -180,9 +180,9 @@ export default function ReceiptResults({ receipt, onAction }: ReceiptResultsProp
               <p className="text-slate-500 text-xs mb-1.5">Line Items</p>
               <div className="space-y-1 max-h-32 overflow-y-auto">
                 {lineItems.map((item, i) => (
-                  <div key={i} className="flex items-center justify-between bg-navy-950/50 rounded px-2.5 py-1.5 text-xs">
-                    <span className="text-slate-300 truncate mr-2">{item.description}</span>
-                    <span className="text-white font-medium shrink-0">
+                  <div key={i} className="flex items-center justify-between bg-white rounded px-2.5 py-1.5 text-xs">
+                    <span className="text-slate-700 truncate mr-2">{item.description}</span>
+                    <span className="text-slate-900 font-medium shrink-0">
                       £{typeof item.amount === 'number' ? item.amount.toFixed(2) : item.amount}
                     </span>
                   </div>
@@ -195,21 +195,21 @@ export default function ReceiptResults({ receipt, onAction }: ReceiptResultsProp
           <div className="flex flex-wrap gap-2">
             <button
               onClick={handleComplaint}
-              className="flex items-center gap-1.5 bg-orange-600 hover:bg-orange-700 text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-all"
+              className="flex items-center gap-1.5 bg-orange-600 hover:bg-orange-700 text-slate-900 text-xs font-medium px-3 py-1.5 rounded-lg transition-all"
             >
               <AlertTriangle className="h-3.5 w-3.5" />
               Write Complaint About This Bill
             </button>
             <button
               onClick={handleAddSubscription}
-              className="flex items-center gap-1.5 bg-blue-600 hover:bg-blue-700 text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-all"
+              className="flex items-center gap-1.5 bg-blue-600 hover:bg-blue-700 text-slate-900 text-xs font-medium px-3 py-1.5 rounded-lg transition-all"
             >
               <CreditCard className="h-3.5 w-3.5" />
               Add to Subscriptions
             </button>
             <button
               onClick={() => onAction('saved')}
-              className="flex items-center gap-1.5 bg-navy-700 hover:bg-navy-600 text-white text-xs font-medium px-3 py-1.5 rounded-lg transition-all"
+              className="flex items-center gap-1.5 bg-slate-100 hover:bg-navy-600 text-slate-900 text-xs font-medium px-3 py-1.5 rounded-lg transition-all"
             >
               <Save className="h-3.5 w-3.5" />
               Save Receipt

--- a/src/components/scanner/ReceiptScanner.tsx
+++ b/src/components/scanner/ReceiptScanner.tsx
@@ -125,10 +125,10 @@ export default function ReceiptScanner({ open, onClose, onScanComplete }: Receip
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div className="bg-navy-900 border border-navy-700 rounded-2xl shadow-2xl w-full max-w-md p-6 relative">
+      <div className="card shadow-2xl w-full max-w-md p-6 relative">
         <button
           onClick={() => { if (!scanning) onClose(); }}
-          className="absolute top-4 right-4 text-slate-500 hover:text-white transition-all"
+          className="absolute top-4 right-4 text-slate-500 hover:text-slate-900 transition-all"
           disabled={scanning}
         >
           <X className="h-5 w-5" />
@@ -139,16 +139,16 @@ export default function ReceiptScanner({ open, onClose, onScanComplete }: Receip
             <Camera className="h-5 w-5 text-mint-400" />
           </div>
           <div>
-            <h3 className="text-lg font-bold text-white">Scan Receipt or Bill</h3>
-            <p className="text-slate-400 text-sm">Upload or take a photo to extract details</p>
+            <h3 className="text-lg font-bold text-slate-900">Scan Receipt or Bill</h3>
+            <p className="text-slate-500 text-sm">Upload or take a photo to extract details</p>
           </div>
         </div>
 
         {scanning ? (
           <div className="text-center py-12">
             <Loader2 className="h-12 w-12 text-mint-400 animate-spin mx-auto mb-4" />
-            <p className="text-white font-semibold mb-2">Scanning your receipt...</p>
-            <p className="text-slate-400 text-sm transition-opacity duration-500">
+            <p className="text-slate-900 font-semibold mb-2">Scanning your receipt...</p>
+            <p className="text-slate-500 text-sm transition-opacity duration-500">
               {SCANNING_TIPS[tipIndex]}
             </p>
           </div>
@@ -163,11 +163,11 @@ export default function ReceiptScanner({ open, onClose, onScanComplete }: Receip
               className={`border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-all ${
                 dragActive
                   ? 'border-mint-400 bg-mint-400/5'
-                  : 'border-navy-600 hover:border-mint-400/50 hover:bg-navy-800/50'
+                  : 'border-navy-600 hover:border-mint-400/50 hover:bg-slate-100'
               }`}
             >
               <Upload className="h-10 w-10 text-slate-500 mx-auto mb-3" />
-              <p className="text-white font-medium mb-1">
+              <p className="text-slate-900 font-medium mb-1">
                 Drop your receipt here or click to browse
               </p>
               <p className="text-slate-500 text-sm">
@@ -177,7 +177,7 @@ export default function ReceiptScanner({ open, onClose, onScanComplete }: Receip
 
             {/* Camera input for mobile */}
             <div className="mt-3">
-              <label className="flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white font-medium px-4 py-3 rounded-xl transition-all text-sm cursor-pointer w-full">
+              <label className="flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-100 text-slate-900 font-medium px-4 py-3 rounded-xl transition-all text-sm cursor-pointer w-full">
                 <Camera className="h-4 w-4" />
                 Take Photo
                 <input
@@ -208,7 +208,7 @@ export default function ReceiptScanner({ open, onClose, onScanComplete }: Receip
           </div>
         )}
 
-        <div className="flex items-start gap-2 mt-4 bg-navy-950/30 rounded-lg px-3 py-2">
+        <div className="flex items-start gap-2 mt-4 bg-white rounded-lg px-3 py-2">
           <FileText className="h-3.5 w-3.5 text-mint-400 shrink-0 mt-0.5" />
           <p className="text-xs text-slate-500">
             Our AI reads your receipt and extracts the provider, amount, date, and line items. Your image is stored securely.

--- a/src/components/share/ShareWinModal.tsx
+++ b/src/components/share/ShareWinModal.tsx
@@ -61,11 +61,11 @@ export default function ShareWinModal({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      <div className="relative bg-navy-900 border border-navy-700/50 rounded-2xl w-full max-w-md shadow-2xl">
+      <div className="relative card w-full max-w-md shadow-2xl">
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 text-slate-400 hover:text-white transition-all"
+          className="absolute top-4 right-4 text-slate-500 hover:text-slate-900 transition-all"
         >
           <X className="h-5 w-5" />
         </button>
@@ -76,7 +76,7 @@ export default function ShareWinModal({
             <div className="bg-mint-400/10 w-10 h-10 rounded-xl flex items-center justify-center">
               <Share2 className="h-5 w-5 text-mint-400" />
             </div>
-            <h2 className="text-xl font-bold text-white">Share your win</h2>
+            <h2 className="text-xl font-bold text-slate-900">Share your win</h2>
           </div>
 
           {/* Card preview */}
@@ -84,10 +84,10 @@ export default function ShareWinModal({
             <p className="text-mint-400 text-xs font-semibold uppercase tracking-wide mb-2">
               Paybacker
             </p>
-            <p className="text-2xl font-bold text-white mb-1">
+            <p className="text-2xl font-bold text-slate-900 mb-1">
               I just saved {'\u00a3'}{amount}
             </p>
-            <p className="text-slate-400 text-sm">
+            <p className="text-slate-500 text-sm">
               {type === 'complaint' && `Got money back from ${providerName}`}
               {type === 'cancellation' && `Cancelled ${providerName} -- saving ${'\u00a3'}${amount}/year`}
               {type === 'deal' && `Switched ${providerName} -- saving ${'\u00a3'}${amount}/year`}
@@ -98,7 +98,7 @@ export default function ShareWinModal({
           <div className="grid grid-cols-2 gap-3">
             <button
               onClick={() => handleShare('twitter')}
-              className="flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white py-3 rounded-lg transition-all text-sm font-medium"
+              className="flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-100 text-slate-900 py-3 rounded-lg transition-all text-sm font-medium"
             >
               <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
@@ -107,7 +107,7 @@ export default function ShareWinModal({
             </button>
             <button
               onClick={() => handleShare('facebook')}
-              className="flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white py-3 rounded-lg transition-all text-sm font-medium"
+              className="flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-100 text-slate-900 py-3 rounded-lg transition-all text-sm font-medium"
             >
               <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
@@ -116,7 +116,7 @@ export default function ShareWinModal({
             </button>
             <button
               onClick={() => handleShare('whatsapp')}
-              className="flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white py-3 rounded-lg transition-all text-sm font-medium"
+              className="flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-100 text-slate-900 py-3 rounded-lg transition-all text-sm font-medium"
             >
               <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
@@ -125,7 +125,7 @@ export default function ShareWinModal({
             </button>
             <button
               onClick={() => handleShare('clipboard')}
-              className="flex items-center justify-center gap-2 bg-navy-800 hover:bg-navy-700 text-white py-3 rounded-lg transition-all text-sm font-medium"
+              className="flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-100 text-slate-900 py-3 rounded-lg transition-all text-sm font-medium"
             >
               {shared ? (
                 <Check className="h-4 w-4 text-mint-400" />


### PR DESCRIPTION
## Summary
Extends the Phase 4 token-sweep pattern across **31 files** flagged by a \`grep -c "bg-navy-|text-white|..."\` pass. Most impactful: Money Hub's inner panels (OverviewPanel, SpendingPanel, NetWorthPanel, GoalsAndBudgetsPanel, ContractsPanel + three modals). These are what made the Money Hub screenshot still look mostly dark after Phase 3.

## Rules (same as #155)
- \`bg-navy-{700,800,900,950}\` / \`bg-slate-{800,900,950}\` → \`bg-white\` or \`bg-slate-100\`
- \`text-white\` / \`text-slate-{200,300}\` / \`text-slate-400\` → \`text-slate-{900,700,500}\`
- \`border-{navy,slate}-{700,800,900}\` → \`border-slate-200\`
- Tailwind container idioms → \`.card\`
- Collapse any duplicate class artefacts (\`bg-white bg-white\`, etc.)

## Skipped by design
- \`PublicNavbar\` — marketing pages redone separately
- \`FinancialReport\` — PDF/print, intentional contrast
- \`admin/MeetingRoom\`, \`admin/AITeamPanel\` — admin-only, low priority

## Test plan
- [x] \`npx tsc --noEmit\` — zero errors.
- [x] Dev server compiles; every dashboard route 307s (auth gate, confirms compile).
- [ ] Visual: open Money Hub, confirm OverviewPanel / SpendingPanel / NetWorthPanel / GoalsAndBudgetsPanel / ContractsPanel and their modals (CategoryDrillDown, GoalsAndBudgetsModal, NetWorthManagement) all render light.
- [ ] Interactions still work: drill-down modals, goal editor, contracts list, category filter pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)