### PR TITLE
feat(dashboard): wrap page headers in page-title-row (Deals, Profile, Spending)

### DIFF
--- a/src/app/dashboard/deals/page.tsx
+++ b/src/app/dashboard/deals/page.tsx
@@ -634,9 +634,11 @@ export default function DealsPage() {
   return (
     <div className="max-w-7xl">
       {/* Hero */}
-      <div className="mb-8">
-        <h1 className="page-title">Find Better Deals</h1>
-        <p className="page-sub">Personalised savings based on your contracts and bills.</p>
+      <div className="page-title-row">
+        <div>
+          <h1 className="page-title">Find Better Deals</h1>
+          <p className="page-sub">Personalised savings based on your contracts and bills.</p>
+        </div>
       </div>
 
       {/* Category filter tabs */}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -766,9 +766,11 @@ export default function ProfilePage() {
       )}
 
       {/* Header */}
-      <div className="mb-8">
-        <h1 className="page-title">Profile</h1>
-        <p className="page-sub">Manage your account and view your stats</p>
+      <div className="page-title-row">
+        <div>
+          <h1 className="page-title">Profile</h1>
+          <p className="page-sub">Manage your account and view your stats</p>
+        </div>
       </div>
 
       {/* Account Info */}

--- a/src/app/dashboard/spending/page.tsx
+++ b/src/app/dashboard/spending/page.tsx
@@ -69,10 +69,12 @@ export default function SpendingPage() {
   if (!data?.hasData) {
     return (
       <div className="max-w-5xl">
-        <div className="mb-8">
+        <div className="page-title-row">
+        <div>
           <h1 className="page-title">Spending Insights</h1>
-        <p className="page-sub">Connect your bank account to see where your money goes</p>
+          <p className="page-sub">Connect your bank account to see where your money goes</p>
         </div>
+      </div>
         <div className="card shadow-sm p-12 text-center">
           <BarChart3 className="h-16 w-16 text-slate-700 mx-auto mb-4" />
           <h3 className="text-xl font-bold text-slate-900 mb-2">No spending data yet</h3>
@@ -90,11 +92,13 @@ export default function SpendingPage() {
 
   return (
     <div className="max-w-5xl">
-      <div className="mb-8">
-        <h1 className="page-title">Spending Insights</h1>
-        <p className="page-sub">
+      <div className="page-title-row">
+        <div>
+          <h1 className="page-title">Spending Insights</h1>
+          <p className="page-sub">
           Based on {summary.months_analysed} months of bank data · {summary.total_transactions.toLocaleString()} transactions
         </p>
+        </div>
       </div>
 
       {/* Summary Cards — Monthly Averages */}


### PR DESCRIPTION
Adds design's `.page-title-row` flex wrapper around h1+subtitle on Deals, Profile, Spending pages. Aligns heading rhythm with Overview/Subscriptions/Disputes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)