### PR TITLE
feat(tiers): Emma-matched tier structure + promote-only Stripe sync

### DIFF
--- a/src/app/api/stripe/sync/route.ts
+++ b/src/app/api/stripe/sync/route.ts
@@ -55,12 +55,16 @@ export async function POST() {
 
     const { data: profile } = await supabase
       .from('profiles')
-      .select('stripe_customer_id, subscription_tier, founding_member')
+      .select('stripe_customer_id, subscription_tier')
       .eq('id', user.id)
       .single();
 
     if (!profile?.stripe_customer_id) {
-      return NextResponse.json({ synced: false, tier: 'free', reason: 'No Stripe customer' });
+      return NextResponse.json({
+        synced: true,
+        tier: profile?.subscription_tier || 'free',
+        reason: 'No Stripe customer — stored tier is authoritative',
+      });
     }
 
     // Fetch active/trialing subs
@@ -71,29 +75,24 @@ export async function POST() {
 
     const allSubs = [...(activeSubs.data || []), ...(trialingSubs.data || [])];
 
+    // IMPORTANT: this route is PROMOTE-ONLY. We never downgrade a user
+    // here — that was the root cause of the April 2026 founder
+    // downgrade incident. Demotion is now webhook-driven only:
+    // customer.subscription.deleted / .updated with status=canceled
+    // in /api/stripe/webhooks explicitly writes subscription_tier='free'.
+    //
+    // If the user has no active Stripe sub but the profile still says
+    // essential/pro, we leave it alone. Either:
+    //   (a) their webhook just hasn't landed yet (race condition — retry);
+    //   (b) they were granted a tier manually (admin grant, comped);
+    //   (c) they're on an onboarding trial (trial_ends_at still in future).
+    // None of these justify a silent tier wipe on every dashboard mount.
     if (allSubs.length === 0) {
-      // Founding members were granted Essential/Pro manually and typically have
-      // no Stripe subscription at all. Never downgrade them here — the profile
-      // tier is authoritative for this cohort. See also commit 35ee3d1 which
-      // added a similar guard to the webhook-triggered path; this closes the
-      // matching hole on the dashboard-mount sync path.
-      if (profile.founding_member === true) {
-        return NextResponse.json({
-          synced: true,
-          tier: profile.subscription_tier || 'free',
-          reason: 'founding_member',
-        });
-      }
-      if (profile.subscription_tier !== 'free') {
-        const admin = createAdmin(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
-        await admin.from('profiles').update({
-          subscription_tier: 'free',
-          subscription_status: null,
-          stripe_subscription_id: null,
-          updated_at: new Date().toISOString(),
-        }).eq('id', user.id);
-      }
-      return NextResponse.json({ synced: true, tier: 'free' });
+      return NextResponse.json({
+        synced: true,
+        tier: profile.subscription_tier || 'free',
+        reason: 'No active Stripe sub — stored tier preserved (promote-only policy)',
+      });
     }
 
     // Get full subscription details directly

--- a/src/lib/plan-limits.ts
+++ b/src/lib/plan-limits.ts
@@ -5,6 +5,10 @@ export type PlanTier = 'free' | 'essential' | 'pro';
 export interface PlanLimits {
   complaintsPerMonth: number | null; // null = unlimited
   scanRunsPerMonth: number | null;
+  /** Maximum number of connected bank accounts. null = unlimited. */
+  maxBanks: number | null;
+  /** Maximum number of connected email accounts. null = unlimited. */
+  maxEmails: number | null;
   /**
    * Max number of active dispute→email-thread links (Watchdog feature).
    * null = unlimited. A "link" is one row in dispute_watchdog_links with
@@ -13,33 +17,115 @@ export interface PlanLimits {
   disputeThreadLinks: number | null;
   /**
    * Minimum minutes between automatic background syncs of a linked thread.
-   * Free tier has no background sync (manual only) — represented by null.
+   * Every paying tier and Free now share the same 30-min cadence — Emma and
+   * other competitors don't cap this, and the cost of a Gmail poll is
+   * negligible. Differentiation between tiers is on scope (bank / email
+   * count, unlocked features), not polling frequency.
    */
   watchdogSyncIntervalMinutes: number | null;
   features: string[];
 }
 
+/**
+ * TIER MATRIX — confirmed with founder 2026-04-22.
+ *
+ *                               Free    Essential   Pro
+ * Bank connections              2       3           ∞
+ * Email connections             1       3           ∞
+ * AI letters / month            3       ∞           ∞
+ * Dispute-reply watchdog        30m auto (all tiers)
+ * Dispute thread links          ∞       ∞           ∞
+ * Renewal reminders             —       ✓           ✓
+ * AI cancellation emails        —       ✓           ✓
+ * Money Hub full categories     top 5   full        full
+ * Money Hub budgets / goals     —       ✓           ✓
+ * Money Hub top merchants       —       —           ✓
+ * Price-increase alerts         in-app  in-app+     in-app + email +
+ *                                       email       Telegram instant
+ * Export (CSV / PDF)            —       —           ✓
+ * Paybacker Assistant (MCP)     —       —           ✓
+ * Pocket Agent (Telegram)       ✓       ✓           ✓
+ * Priority support              —       —           ✓
+ *
+ * Rules for the system:
+ * 1. Paid tiers are NEVER auto-demoted. `/api/stripe/sync` promotes only.
+ *    Demotion is webhook-driven (customer.subscription.deleted).
+ * 2. No 14-day free Pro trial — the silent downgrade it caused was
+ *    producing worse UX than having no trial at all.
+ * 3. getEffectiveTier trusts `profile.subscription_tier` as source of truth.
+ *    Onboarding-trial override kept only where `trial_ends_at > now()`.
+ */
 export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
   free: {
     complaintsPerMonth: 3,
-    scanRunsPerMonth: 1, // one-time bank scan, email scan, opportunity scan
-    disputeThreadLinks: 1,
-    watchdogSyncIntervalMinutes: null, // manual only
-    features: ['complaints', 'basic_scanner', 'one_time_email_scan', 'one_time_opportunity_scan', 'watchdog_manual', 'pocket_agent'],
+    scanRunsPerMonth: null, // scanning is free; gating is on account counts + features
+    maxBanks: 2,
+    maxEmails: 1,
+    disputeThreadLinks: null, // unlimited email-thread monitoring for disputes
+    watchdogSyncIntervalMinutes: 30,
+    features: [
+      'complaints',
+      'scanner',
+      'email_scanner',
+      'opportunity_scanner',
+      'subscriptions',
+      'watchdog_auto',
+      'pocket_agent',
+    ],
   },
   essential: {
     complaintsPerMonth: null,
-    scanRunsPerMonth: 4, // monthly re-scans (bank daily auto, email/opportunity monthly)
-    disputeThreadLinks: 5,
-    watchdogSyncIntervalMinutes: 60,
-    features: ['complaints', 'scanner', 'email_scanner', 'opportunity_scanner', 'subscriptions', 'cancellation_emails', 'renewal_reminders', 'full_spending', 'watchdog_auto', 'pocket_agent'],
+    scanRunsPerMonth: null,
+    maxBanks: 3,
+    maxEmails: 3,
+    disputeThreadLinks: null,
+    watchdogSyncIntervalMinutes: 30,
+    features: [
+      'complaints',
+      'scanner',
+      'email_scanner',
+      'opportunity_scanner',
+      'subscriptions',
+      'cancellation_emails',
+      'renewal_reminders',
+      'full_spending',
+      'budgets_goals',
+      'price_alert_email',
+      'watchdog_auto',
+      'pocket_agent',
+    ],
   },
   pro: {
     complaintsPerMonth: null,
-    scanRunsPerMonth: null, // unlimited everything
+    scanRunsPerMonth: null,
+    maxBanks: null,
+    maxEmails: null,
     disputeThreadLinks: null,
     watchdogSyncIntervalMinutes: 30,
-    features: ['complaints', 'scanner', 'email_scanner', 'opportunity_scanner', 'subscriptions', 'cancellation_emails', 'renewal_reminders', 'full_spending', 'open_banking', 'unlimited_banks', 'transaction_analysis', 'priority_support', 'pocket_agent', 'watchdog_auto', 'watchdog_telegram_instant'],
+    features: [
+      'complaints',
+      'scanner',
+      'email_scanner',
+      'opportunity_scanner',
+      'subscriptions',
+      'cancellation_emails',
+      'renewal_reminders',
+      'full_spending',
+      'budgets_goals',
+      'top_merchants',
+      'open_banking',
+      'unlimited_banks',
+      'unlimited_emails',
+      'transaction_analysis',
+      'priority_support',
+      'pocket_agent',
+      'watchdog_auto',
+      'watchdog_telegram_instant',
+      'price_alert_email',
+      'price_alert_telegram',
+      'export',
+      'mcp',
+    ],
   },
 };
 
@@ -69,40 +155,24 @@ export async function checkUsageLimit(
 ): Promise<UsageCheckResult> {
   const admin = getAdmin();
 
-  // Fetch user's current tier and Stripe subscription info
+  // Fetch user's current tier (and any active onboarding trial window).
+  // getEffectiveTier handles the trial override so we use the same source
+  // of truth here without duplicating logic.
   const { data: profile } = await admin
     .from('profiles')
-    .select('subscription_tier, subscription_status, stripe_subscription_id, trial_ends_at, trial_converted_at, trial_expired_at')
+    .select('subscription_tier, trial_ends_at, trial_converted_at, trial_expired_at')
     .eq('id', userId)
     .single();
 
-  const tier = (profile?.subscription_tier as PlanTier) ?? 'free';
+  const storedTier = (profile?.subscription_tier as PlanTier) ?? 'free';
+  const onboardingTrialActive = !!profile?.trial_ends_at
+    && new Date(profile.trial_ends_at) > new Date()
+    && !profile?.trial_converted_at
+    && !profile?.trial_expired_at;
 
-  // Verify paid tier has an active Stripe subscription or trial
-  const isPaid = tier !== 'free';
-  const hasActiveStripe = profile?.stripe_subscription_id &&
-    ['active', 'trialing'].includes(profile?.subscription_status ?? '');
-
-  // Onboarding trial (any tier): trial_ends_at in the future, not yet converted or expired
-  const isOnboardingTrial = profile?.trial_ends_at &&
-    new Date(profile.trial_ends_at) > new Date() &&
-    !profile?.trial_converted_at &&
-    !profile?.trial_expired_at;
-
-  // Founding member trial: paid tier, trialing, no Stripe, valid trial_ends_at
-  const isFoundingTrial = isPaid && !profile?.stripe_subscription_id &&
-    profile?.subscription_status === 'trialing' &&
-    profile?.trial_ends_at && new Date(profile.trial_ends_at) > new Date();
-
-  // Active onboarding trial always grants pro-level access regardless of stored tier
-  if (!hasActiveStripe && isOnboardingTrial) {
-    return { allowed: true, used: 0, limit: null, tier: 'pro', upgradeRequired: false };
-  }
-
-  const effectiveTier: PlanTier = (isPaid && !hasActiveStripe && !isFoundingTrial) ? 'free' : tier;
-  if (isPaid && !hasActiveStripe && !isFoundingTrial) {
-    console.warn(`[plan-limits] User ${userId} has tier=${tier} but no active Stripe subscription. Treating as free.`);
-  }
+  // Trial grants pro. Otherwise trust the stored tier verbatim —
+  // demotion is webhook-driven (see /api/stripe/webhooks).
+  const effectiveTier: PlanTier = onboardingTrialActive ? 'pro' : storedTier;
 
   const limits = PLAN_LIMITS[effectiveTier];
 
@@ -159,36 +229,24 @@ export async function getEffectiveTier(userId: string): Promise<PlanTier> {
   const admin = getAdmin();
   const { data: profile } = await admin
     .from('profiles')
-    .select('subscription_tier, subscription_status, stripe_subscription_id, trial_ends_at, trial_converted_at, trial_expired_at, founding_member')
+    .select('subscription_tier, trial_ends_at, trial_converted_at, trial_expired_at')
     .eq('id', userId)
     .single();
 
   const tier = (profile?.subscription_tier as PlanTier) ?? 'free';
-  const isPaid = tier !== 'free';
-  const hasActiveStripe = profile?.stripe_subscription_id &&
-    ['active', 'trialing'].includes(profile?.subscription_status ?? '');
 
-  // Onboarding trial grants pro access regardless of stored tier
-  const isOnboardingTrial = profile?.trial_ends_at &&
-    new Date(profile.trial_ends_at) > new Date() &&
-    !profile?.trial_converted_at &&
-    !profile?.trial_expired_at;
+  // Onboarding trial still grants Pro access while the trial window is open.
+  // Founder / Stripe / founding-member gymnastics removed — the profile row
+  // is now the source of truth. Demotion is webhook-driven only
+  // (customer.subscription.deleted writes 'free' to subscription_tier) so if
+  // the stored tier says 'pro', we trust it.
+  const onboardingTrialActive = !!profile?.trial_ends_at
+    && new Date(profile.trial_ends_at) > new Date()
+    && !profile?.trial_converted_at
+    && !profile?.trial_expired_at;
+  if (onboardingTrialActive) return 'pro';
 
-  if (!hasActiveStripe && isOnboardingTrial) return 'pro';
-
-  const isFoundingTrial = isPaid && !profile?.stripe_subscription_id &&
-    profile?.subscription_status === 'trialing' &&
-    profile?.trial_ends_at && new Date(profile.trial_ends_at) > new Date();
-
-  // Founding members were granted Essential/Pro manually and by design have
-  // no Stripe subscription. The profile tier is authoritative for them.
-  // Mirrors the guard PR #151 added to /api/stripe/sync — without this, the
-  // Watchdog cron (and every other caller of getEffectiveTier) degrades
-  // founders to 'free' and skips their linked threads entirely, which is
-  // exactly what was hiding Paul's OneStream reply for 18h.
-  if (profile?.founding_member === true && isPaid) return tier;
-
-  return (isPaid && !hasActiveStripe && !isFoundingTrial) ? 'free' : tier;
+  return tier;
 }
 
 /**


### PR DESCRIPTION
Rewrite of the tier model per founder's 2026-04-22 pricing review. Free matches Emma (2 banks, auto watchdog). Essential £4.99 = 3 banks + 3 emails + reminders + budgets. Pro £9.99 = unlimited + Top Merchants + Telegram instant + Export + MCP. Demotion is webhook-driven only — `/api/stripe/sync` is promote-only now. `getEffectiveTier` simplified: trusts `profile.subscription_tier`, keeps onboarding-trial override only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)