### PR TITLE
feat(dashboard): convert remaining Tailwind h1s to design .page-title

### DIFF
--- a/src/app/dashboard/contract-vault/page.tsx
+++ b/src/app/dashboard/contract-vault/page.tsx
@@ -228,7 +228,7 @@ export default function ContractVaultPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 font-[family-name:var(--font-heading)] flex items-center gap-2">
+          <h1 className="page-title flex items-center gap-2">
             <FolderLock className="h-6 w-6 text-orange-600" /> Contract Vault
           </h1>
           <p className="text-slate-600 text-sm mt-1">Upload contracts and track key terms. Get alerts before contracts auto-renew.</p>

--- a/src/app/dashboard/contracts/page.tsx
+++ b/src/app/dashboard/contracts/page.tsx
@@ -256,7 +256,7 @@ function ContractDetail({ contract, onBack, onDelete }: {
       <div className="card mb-6">
         <div className="flex items-start justify-between mb-3">
           <div>
-            <h1 className="text-2xl font-bold text-slate-900 font-[family-name:var(--font-heading)]">
+            <h1 className="page-title ">
               {contract.provider_name ? `Your ${contract.provider_name} contract` : 'Contract details'}
             </h1>
             <div className="flex items-center gap-3 mt-2">

--- a/src/app/dashboard/pocket-agent/page.tsx
+++ b/src/app/dashboard/pocket-agent/page.tsx
@@ -138,7 +138,7 @@ export default function PocketAgentPage() {
       <div className="max-w-2xl mx-auto p-6 space-y-6">
         {/* Header */}
         <div>
-          <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-3">
+          <h1 className="page-title flex items-center gap-3">
             <Bot className="h-7 w-7 text-orange-500" />
             Pocket Agent
           </h1>
@@ -259,7 +259,7 @@ export default function PocketAgentPage() {
     <div className="max-w-2xl mx-auto p-6 space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-3">
+        <h1 className="page-title flex items-center gap-3">
           <Bot className="h-7 w-7 text-orange-500" />
           Pocket Agent
         </h1>

--- a/src/app/dashboard/settings/mcp/page.tsx
+++ b/src/app/dashboard/settings/mcp/page.tsx
@@ -194,7 +194,7 @@ export default function McpSettingsPage() {
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-3">
+        <h1 className="page-title flex items-center gap-3">
           <Terminal className="h-7 w-7 text-emerald-600" />
           Paybacker Assistant (MCP)
         </h1>

--- a/src/app/dashboard/settings/telegram/page.tsx
+++ b/src/app/dashboard/settings/telegram/page.tsx
@@ -134,7 +134,7 @@ export default function TelegramSettingsPage() {
     <div className="max-w-2xl mx-auto p-6 space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-slate-900 flex items-center gap-3">
+        <h1 className="page-title flex items-center gap-3">
           <MessageCircle className="h-7 w-7 text-orange-500" />
           Telegram Bot
         </h1>


### PR DESCRIPTION
Five pages (Contract Vault, Pocket Agent, Settings/Telegram, Settings/MCP, Contracts) had raw Tailwind on their h1 headings. Converted to .page-title for consistent typography across the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)