### PR TITLE
feat(tiers): enforce bank + email caps from the new PLAN_LIMITS matrix

### DIFF
--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getGoogleAuthUrl } from '@/lib/gmail';
+import { PLAN_LIMITS, getEffectiveTier } from '@/lib/plan-limits';
 
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
@@ -8,6 +9,33 @@ export async function GET(request: NextRequest) {
 
   if (!user) {
     return NextResponse.redirect(new URL('/auth/login', request.url));
+  }
+
+  // Enforce tier email-connection cap (Free=1, Essential=3, Pro=∞).
+  // Counts active email_connections across Gmail + Outlook/IMAP.
+  const tier = await getEffectiveTier(user.id);
+  const maxEmails = PLAN_LIMITS[tier].maxEmails;
+  if (maxEmails !== null) {
+    const { data: existing } = await supabase
+      .from('email_connections')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('status', 'active');
+    const count = existing?.length ?? 0;
+    if (count >= maxEmails) {
+      const errorCopy =
+        tier === 'free'
+          ? `Free plan allows ${maxEmails} email connection. Upgrade to Essential for 3, or Pro for unlimited.`
+          : `Essential plan allows ${maxEmails} email connections. Upgrade to Pro for unlimited.`;
+      // Redirect back to profile with a flag the page can read to show an
+      // upgrade prompt — avoids dropping the user on a JSON error.
+      const back = new URL('/dashboard/profile', request.url);
+      back.searchParams.set('email_limit_reached', '1');
+      back.searchParams.set('tier', tier);
+      back.searchParams.set('max_emails', String(maxEmails));
+      console.log(`[google-auth] email cap reached for tier=${tier}: ${errorCopy}`);
+      return NextResponse.redirect(back);
+    }
   }
 
   // State = base64(userId:timestamp) — verified in callback to prevent CSRF

--- a/src/app/api/auth/microsoft/route.ts
+++ b/src/app/api/auth/microsoft/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getMicrosoftAuthUrl } from '@/lib/outlook';
+import { PLAN_LIMITS, getEffectiveTier } from '@/lib/plan-limits';
 
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
@@ -14,6 +15,24 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(
       new URL('/dashboard/profile?error=outlook_not_configured', request.url)
     );
+  }
+
+  // Same tier cap as Gmail — counts active email_connections across providers.
+  const tier = await getEffectiveTier(user.id);
+  const maxEmails = PLAN_LIMITS[tier].maxEmails;
+  if (maxEmails !== null) {
+    const { data: existing } = await supabase
+      .from('email_connections')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('status', 'active');
+    if ((existing?.length ?? 0) >= maxEmails) {
+      const back = new URL('/dashboard/profile', request.url);
+      back.searchParams.set('email_limit_reached', '1');
+      back.searchParams.set('tier', tier);
+      back.searchParams.set('max_emails', String(maxEmails));
+      return NextResponse.redirect(back);
+    }
   }
 
   const state = Buffer.from(`${user.id}:${Date.now()}`).toString('base64');

--- a/src/app/api/auth/truelayer/route.ts
+++ b/src/app/api/auth/truelayer/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { PLAN_LIMITS, getEffectiveTier } from '@/lib/plan-limits';
 
 const TRUELAYER_AUTH_URL = process.env.TRUELAYER_AUTH_URL || 'https://auth.truelayer.com';
 
@@ -11,14 +12,11 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Check bank connection limits by tier
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('subscription_tier')
-    .eq('id', user.id)
-    .single();
-
-  const tier = profile?.subscription_tier || 'free';
+  // Bank-connection cap per tier comes from the single PLAN_LIMITS source
+  // of truth now (Free=2, Essential=3, Pro=∞). Previously hard-coded to
+  // 1/2/∞ here — that stayed stale during the April 2026 matrix rewrite.
+  const tier = await getEffectiveTier(user.id);
+  const maxBanks = PLAN_LIMITS[tier].maxBanks;
 
   const { data: existingConnections } = await supabase
     .from('bank_connections')
@@ -28,16 +26,14 @@ export async function GET(request: Request) {
 
   const connectionCount = existingConnections?.length || 0;
 
-  // Tier connection limits: Free=1, Essential=2, Pro=unlimited
-  const maxConnections = tier === 'pro' ? Infinity : tier === 'essential' ? 2 : 1;
-  if (connectionCount >= maxConnections) {
+  if (maxBanks !== null && connectionCount >= maxBanks) {
     return NextResponse.json({
       error: tier === 'free'
-        ? 'Free plan allows 1 bank connection. Upgrade to Essential for 2, or Pro for unlimited.'
-        : 'Essential plan allows 2 bank connections. Upgrade to Pro for unlimited banks.',
+        ? `Free plan allows ${maxBanks} bank connections. Upgrade to Essential for 3, or Pro for unlimited.`
+        : `Essential plan allows ${maxBanks} bank connections. Upgrade to Pro for unlimited banks.`,
       upgradeRequired: true,
       tier,
-      maxConnections,
+      maxConnections: maxBanks,
     }, { status: 403 });
   }
 

--- a/src/lib/bank-tier-config.ts
+++ b/src/lib/bank-tier-config.ts
@@ -7,24 +7,28 @@ export type SyncTrigger = 'cron' | 'manual' | 'initial';
 export type SyncStatus = 'success' | 'failed' | 'skipped';
 export type BankTier = 'free' | 'essential' | 'pro';
 
+// Updated April 2026 to match PLAN_LIMITS (see src/lib/plan-limits.ts).
+// Free now gets daily auto-sync and 2 banks (Emma-parity on Free so we don't
+// lose the head-to-head at £0). Essential gets 3 banks. Pro unlimited.
+// Manual on-demand sync stays Pro-only (cost protection).
 export const TIER_CONFIG = {
   free: {
-    maxConnections: 1,
-    dailyCron: false,     // Only syncs on Mondays via cron
-    weeklyCron: true,
-    manualSyncAllowed: false,
-    manualSyncCooldownHours: 0,
-    manualSyncDailyLimit: 0,
-    upgradeMessage: 'Upgrade to Essential for daily auto-sync.',
-  },
-  essential: {
     maxConnections: 2,
     dailyCron: true,
     weeklyCron: false,
     manualSyncAllowed: false,
     manualSyncCooldownHours: 0,
     manualSyncDailyLimit: 0,
-    upgradeMessage: 'Upgrade to Pro for on-demand sync.',
+    upgradeMessage: 'Upgrade to Essential for 3 banks, or Pro for unlimited + on-demand sync.',
+  },
+  essential: {
+    maxConnections: 3,
+    dailyCron: true,
+    weeklyCron: false,
+    manualSyncAllowed: false,
+    manualSyncCooldownHours: 0,
+    manualSyncDailyLimit: 0,
+    upgradeMessage: 'Upgrade to Pro for unlimited banks + on-demand sync.',
   },
   pro: {
     maxConnections: Infinity,


### PR DESCRIPTION
Follow-up to #164. The new tier matrix (Free=2 banks/1 email, Essential=3/3, Pro=∞/∞) is now enforced at the connect endpoints. Two out-of-sync sources of truth (plan-limits.ts + bank-tier-config.ts) realigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)