### PR TITLE
feat(disputes): Variant A compose with live send-to + outcome rail

### DIFF
--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -1873,8 +1873,18 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
     );
   }
 
+  const providerInitials = (formData.provider_name || '?')
+    .split(/\s+/)
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase() || '?';
+  const issueLabel = ISSUE_TYPE_LABELS[formData.issue_type] || formData.issue_type;
+  const disputedAmountNum = parseFloat(formData.disputed_amount || '0') || 0;
+
   return (
-    <div className="max-w-2xl mx-auto">
+    <div>
       <UpgradeModal
         open={upgradeModal.open}
         onClose={() => setUpgradeModal((m) => ({ ...m, open: false }))}
@@ -1895,13 +1905,21 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
         />
       )}
 
-      <button onClick={onCancel} className="flex items-center gap-1 text-slate-600 hover:text-slate-900 mb-4 text-sm transition-all">
-        <ChevronLeft className="h-4 w-4" /> Back
+      <button onClick={onCancel} className="flex items-center gap-1 text-slate-600 hover:text-slate-900 mb-3 text-sm transition-all">
+        <ChevronLeft className="h-4 w-4" /> Back to Disputes
       </button>
 
+      <div style={{marginBottom:14}}>
+        <span className="compose-eyebrow">● Step 2 of 4 · Draft details</span>
+        <h1 className="page-title">Start your dispute.</h1>
+        <p className="page-sub">Give us the facts and we&apos;ll draft a letter in under 30 seconds — citing the exact UK law that protects you.</p>
+      </div>
+
+      <div className="compose-grid">
+      <div>
       <div className="card">
-        <h2 style={{fontSize:18,fontWeight:700,letterSpacing:"-.01em",margin:"0 0 10px"}}>Start a new dispute</h2>
-        <p className="text-slate-600 text-sm mb-6">Tell us what happened and we will write the perfect response</p>
+        <h2 style={{fontSize:18,fontWeight:700,letterSpacing:"-.01em",margin:"0 0 10px"}}>Tell us what happened</h2>
+        <p className="text-slate-600 text-sm mb-6">Every field helps us draft a sharper letter. Required fields are marked *.</p>
 
         <form ref={formRef} onSubmit={handleSubmit} className="space-y-4">
           <div>
@@ -2085,6 +2103,57 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
             </button>
           </div>
         </form>
+      </div>
+      </div>
+
+      {/* Right rail — live preview of send-to + expected outcome */}
+      <aside className="compose-rail">
+        <div className="card" style={{marginBottom:14}}>
+          <div className="rail-label">Send to</div>
+          {formData.provider_name ? (
+            <>
+              <div className="provider-chip">
+                <div className="avatar">{providerInitials}</div>
+                <div style={{flex:1,minWidth:0}}>
+                  <div style={{fontSize:14,fontWeight:600,color:'var(--text)',overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap'}}>{formData.provider_name}</div>
+                  <div style={{fontSize:12,color:'var(--text-3)'}}>{issueLabel}</div>
+                </div>
+              </div>
+              <div style={{fontSize:11.5,color:'var(--text-3)',lineHeight:1.55,marginTop:12}}>
+                We&apos;ll look up the provider&apos;s complaints inbox when you send. If we can&apos;t find one, you can paste an address.
+              </div>
+            </>
+          ) : (
+            <div style={{fontSize:13,color:'var(--text-3)',padding:'14px 4px'}}>Enter the company name on the left to preview where we&apos;ll send this.</div>
+          )}
+        </div>
+
+        <div className="card" style={{marginBottom:14}}>
+          <div className="rail-label">Expected outcome</div>
+          {disputedAmountNum > 0 ? (
+            <>
+              <div className="outcome-amount">£{disputedAmountNum.toLocaleString('en-GB',{maximumFractionDigits:2})}</div>
+              <div style={{fontSize:12,color:'var(--text-3)',marginBottom:8}}>{formData.desired_outcome || 'refund / compensation target'}</div>
+            </>
+          ) : (
+            <div style={{fontSize:13,color:'var(--text-3)',marginBottom:10}}>Add an amount on the left to show your refund target.</div>
+          )}
+          <div className="rail-row" style={{borderTop:'1px solid var(--divider)',paddingTop:10}}>
+            <span>AI draft time</span><strong>~28s</strong>
+          </div>
+          <div className="rail-row">
+            <span>Cites UK law</span><strong>Yes</strong>
+          </div>
+          <div className="rail-row">
+            <span>Letter limit</span>
+            <strong>{usageInfo?.limit === null ? 'Unlimited' : usageInfo ? `${usageInfo.used}/${usageInfo.limit}` : '—'}</strong>
+          </div>
+        </div>
+
+        <div className="compose-disclaimer">
+          <strong>Please review before sending.</strong> AI-generated letters are for guidance only and do not constitute legal advice. You remain responsible for the accuracy of claims and details.
+        </div>
+      </aside>
       </div>
     </div>
   );

--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -316,3 +316,16 @@
   cursor: pointer;
 }
 .shell-v2 .cta-danger:hover { background: #FEE2E2; }
+
+/* ─── Dispute compose: 2-col grid with right rail (batch7 DisputeCompose) ─── */
+.shell-v2 .compose-grid{display:grid;grid-template-columns:1fr 360px;gap:24px;align-items:start}
+.shell-v2 .compose-eyebrow{font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--mint-deep);display:inline-block;margin-bottom:10px}
+.shell-v2 .compose-rail .rail-label{font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--text-3);margin-bottom:14px}
+.shell-v2 .compose-rail .provider-chip{display:flex;align-items:center;gap:12px;padding:12px 14px;background:#F3F4F6;border-radius:10px}
+.shell-v2 .compose-rail .provider-chip .avatar{width:36px;height:36px;border-radius:8px;background:var(--mint-deep);color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:14px;flex-shrink:0}
+.shell-v2 .compose-rail .outcome-amount{font-size:32px;font-weight:700;letter-spacing:-.02em;color:var(--mint-deep);margin-bottom:4px}
+.shell-v2 .compose-rail .rail-row{display:flex;justify-content:space-between;font-size:12px;color:var(--text-2);margin-top:8px}
+.shell-v2 .compose-disclaimer{padding:14px 18px;background:#FEF3C7;border:1px solid #F59E0B;border-radius:10px;font-size:12.5px;color:#78350F;line-height:1.5}
+@media (max-width: 1100px) {
+  .shell-v2 .compose-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- Wraps `NewDisputeForm` in a 2-col compose grid (1fr / 360px) with an eyebrow pill (\"● Step 2 of 4 · Draft details\") and a proper `.page-title-row` headline
- Right rail live-previews Send to (provider initials + issue label) and Expected outcome (disputed amount + desired outcome) as the user types — no more empty aside, data-first preview
- Keeps every existing handler intact: bill upload, validation, Preview & Confirm modal, letter-generation spinner, upgrade modal — this is a structural + token port, not a rebuild

## Test plan
- [ ] \"Start a new dispute\" renders at `/dashboard/complaints?new=1`: eyebrow pill, Step 2 of 4 copy, two-col grid above 1100px
- [ ] Provider name typed on the left shows a live chip on the right with correct initials
- [ ] Disputed amount keys into the rail's green £ figure; desired outcome copy follows
- [ ] Bill upload still prefills provider/amount and rail updates
- [ ] Preview & Confirm modal still opens and submits
- [ ] Mobile ≤1100px collapses rail below form; all inputs readable

Content consistency:
- [x] Read CONTENT_SOURCES_OF_TRUTH.md at start of session
- [x] Three-tier pricing respected (Free / £4.99 / £9.99)
- [x] 0% success fee claim unchanged
- [x] March 2026 launch date only
- [x] No fabricated customers, member counts, or revenue figures

🤖 Generated with [Claude Code](https://claude.com/claude-code)