### PR TITLE
feat(auth,404): forgot-password + batch8 light 404

### DIFF
--- a/shared-context/active-sessions.md
+++ b/shared-context/active-sessions.md
@@ -1,4 +1,15 @@
-# Active Sessions — Last Updated 20 Apr 2026 18:00 UTC
+# Active Sessions — Last Updated 22 Apr 2026 18:00 UTC
+
+## Latest: Business Monitor — 22 Apr 2026 (evening)
+- 5 PRs merged to production today:
+  - #150: fix(watchdog): fail loudly on OAuth refresh failures + tighten price alerts
+  - #149: feat(dashboard): Claude Design shell chrome — Phase 1 foundation
+  - #148: fix(homepage): restore demos + competitor matrix lost in 10e4614
+  - #146: fix(homepage): remove "Preview · Homepage v2" badge from production
+  - #145: docs: Open Banking source-of-truth audit
+- 3 new PRs opened today: #147 (bank dedup Faster Payments), #122 (email targeted savings alert), #120 (Codex P1/P2 bundle)
+- 30 open PRs in queue — review backlog building
+- Evening Telegram check-in sent to Paul
 
 ## Latest: Business Monitor — 20 Apr 2026 (evening)
 - 4 PRs merged to production today:

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'edge';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { createClient } from '@/lib/supabase/client';
+import { MarkNav } from '@/app/blog/_shared';
+import '../../(marketing)/styles.css';
+import '../auth.css';
+
+export default function ResetPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const supabase = createClient();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!email.includes('@')) {
+      setError('Enter the email you signed up with.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const origin = typeof window !== 'undefined' ? window.location.origin : 'https://paybacker.co.uk';
+      const { error: supaErr } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${origin}/auth/update-password`,
+      });
+      if (supaErr) {
+        setError(supaErr.message || 'Could not send reset email. Try again shortly.');
+      } else {
+        setSent(true);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="m-land-root">
+      <MarkNav />
+      <main className="auth-shell">
+        <div className="auth-wrap" style={{ maxWidth: 440, textAlign: 'center' }}>
+          <div
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 14,
+              background: 'var(--accent-mint-wash, #DCFCE7)',
+              margin: '0 auto 20px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 24,
+            }}
+          >
+            🔑
+          </div>
+
+          <div className="auth-head">
+            <h1>Forgot your password?</h1>
+            <p>
+              {sent
+                ? 'Check your inbox — we\'ve sent a reset link. It expires in 60 minutes.'
+                : 'Type the email you signed up with. We\'ll send a reset link valid for 60 minutes.'}
+            </p>
+          </div>
+
+          {!sent && (
+            <div className="auth-card" style={{ textAlign: 'left' }}>
+              <form onSubmit={handleSubmit}>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: 12.5,
+                    fontWeight: 600,
+                    color: 'var(--text-secondary)',
+                    marginBottom: 6,
+                  }}
+                >
+                  Email
+                </label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="email"
+                  placeholder="you@email.com"
+                  style={{
+                    width: '100%',
+                    padding: '12px 14px',
+                    fontSize: 14,
+                    border: '1px solid var(--divider)',
+                    borderRadius: 10,
+                    fontFamily: 'inherit',
+                    boxSizing: 'border-box',
+                    background: '#fff',
+                    marginBottom: 14,
+                  }}
+                  required
+                />
+                {error && <div className="form-error" style={{ marginBottom: 10 }}>{error}</div>}
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="auth-submit"
+                  style={{
+                    width: '100%',
+                    padding: '13px',
+                    fontSize: 14,
+                    fontWeight: 700,
+                    borderRadius: 10,
+                  }}
+                >
+                  {loading ? 'Sending…' : 'Send reset link →'}
+                </button>
+              </form>
+            </div>
+          )}
+
+          {sent && (
+            <div
+              className="auth-card"
+              style={{
+                textAlign: 'left',
+                background: 'var(--accent-mint-wash, #DCFCE7)',
+                borderColor: '#86EFAC',
+              }}
+            >
+              <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                <div style={{ fontSize: 24 }}>📬</div>
+                <div style={{ fontSize: 13.5, lineHeight: 1.55, color: '#065F46' }}>
+                  <strong>Reset email sent to {email}.</strong>
+                  <br />
+                  Didn't arrive? Check your spam folder, or{' '}
+                  <button
+                    onClick={() => setSent(false)}
+                    style={{
+                      background: 'transparent',
+                      border: 'none',
+                      color: '#065F46',
+                      textDecoration: 'underline',
+                      padding: 0,
+                      font: 'inherit',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    try a different email
+                  </button>
+                  .
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div
+            style={{
+              marginTop: 24,
+              display: 'flex',
+              gap: 24,
+              justifyContent: 'center',
+              fontSize: 13,
+              flexWrap: 'wrap',
+            }}
+          >
+            <Link href="/auth/login" style={{ color: 'var(--accent-mint-deep)', fontWeight: 600, textDecoration: 'none' }}>
+              ← Back to sign in
+            </Link>
+            <span style={{ color: 'var(--text-tertiary)' }}>·</span>
+            <a
+              href="mailto:support@paybacker.co.uk"
+              style={{ color: 'var(--text-secondary)', fontWeight: 500, textDecoration: 'none' }}
+            >
+              Contact support
+            </a>
+          </div>
+
+          <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 40, lineHeight: 1.6 }}>
+            Can't remember which email you used? Email{' '}
+            <a href="mailto:support@paybacker.co.uk" style={{ color: 'var(--text-secondary)' }}>
+              support@paybacker.co.uk
+            </a>{' '}
+            and we'll help you back in.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,37 +1,175 @@
 import Link from 'next/link';
-import Image from 'next/image';
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-navy-950 flex items-center justify-center">
-      <div className="text-center px-6 max-w-md">
-        <Link href="/" className="inline-flex items-center gap-2 mb-8">
-          <Image src="/logo.png" alt="Paybacker" width={36} height={36} className="rounded-lg" />
-          <span className="text-2xl font-bold text-white">Pay<span className="bg-gradient-to-r from-mint-400 to-brand-400 bg-clip-text text-transparent">backer</span></span>
+    <div
+      style={{
+        minHeight: '100vh',
+        background: '#F9FAFB',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <header style={{ padding: '28px 32px' }}>
+        <Link href="/" style={{ display: 'inline-flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
+          <div
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 8,
+              background: '#0B1220',
+              color: '#fff',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontWeight: 700,
+            }}
+          >
+            P
+          </div>
+          <span style={{ fontWeight: 700, fontSize: 18, letterSpacing: '-0.01em', color: '#0B1220' }}>
+            Pay<span style={{ color: '#059669' }}>backer</span>
+          </span>
         </Link>
+      </header>
 
-        <h1 className="text-6xl font-bold text-mint-400 mb-4 font-[family-name:var(--font-heading)]">404</h1>
-        <p className="text-xl text-white mb-2">Page not found</p>
-        <p className="text-slate-400 mb-8">The page you are looking for does not exist or has been moved.</p>
+      <main
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '0 24px 64px',
+        }}
+      >
+        <div
+          style={{
+            maxWidth: 560,
+            width: '100%',
+            background: '#fff',
+            border: '1px solid #E5E7EB',
+            borderRadius: 16,
+            overflow: 'hidden',
+          }}
+        >
+          <div style={{ background: '#FEF3C7', padding: '44px 36px 32px', textAlign: 'center' }}>
+            <div
+              style={{
+                width: 72,
+                height: 72,
+                borderRadius: 18,
+                background: '#fff',
+                margin: '0 auto 18px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 34,
+                boxShadow: '0 4px 16px -4px rgba(0,0,0,.08)',
+              }}
+            >
+              🔍
+            </div>
+            <div
+              style={{
+                fontSize: 10.5,
+                fontWeight: 700,
+                letterSpacing: '.12em',
+                textTransform: 'uppercase',
+                color: '#78350F',
+                marginBottom: 10,
+              }}
+            >
+              404
+            </div>
+            <h1
+              style={{
+                fontSize: 24,
+                fontWeight: 700,
+                letterSpacing: '-0.015em',
+                margin: '0 0 10px',
+                color: '#0B1220',
+                lineHeight: 1.25,
+              }}
+            >
+              We can't find that page.
+            </h1>
+            <p
+              style={{
+                fontSize: 14,
+                color: '#4B5563',
+                margin: 0,
+                maxWidth: 420,
+                marginLeft: 'auto',
+                marginRight: 'auto',
+                lineHeight: 1.55,
+              }}
+            >
+              The link might be broken, or the page might have moved. Try the dashboard or head back home.
+            </p>
+          </div>
 
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <Link href="/" className="bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold px-6 py-3 rounded-xl transition-all">
-            Go Home
-          </Link>
-          <Link href="/auth/signup" className="bg-navy-900 hover:bg-navy-800 text-white font-semibold px-6 py-3 rounded-xl transition-all border border-navy-700/50">
-            Generate Free Letter
-          </Link>
+          <div
+            style={{
+              padding: '20px 32px',
+              borderTop: '1px solid #E5E7EB',
+              display: 'flex',
+              gap: 10,
+              justifyContent: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            <Link
+              href="/"
+              style={{
+                padding: '10px 18px',
+                fontSize: 13.5,
+                fontWeight: 600,
+                background: '#0B1220',
+                color: '#fff',
+                borderRadius: 8,
+                textDecoration: 'none',
+              }}
+            >
+              Back home
+            </Link>
+            <Link
+              href="/dashboard"
+              style={{
+                padding: '10px 18px',
+                fontSize: 13.5,
+                fontWeight: 600,
+                background: 'transparent',
+                color: '#4B5563',
+                border: '1px solid #E5E7EB',
+                borderRadius: 8,
+                textDecoration: 'none',
+              }}
+            >
+              Go to dashboard
+            </Link>
+          </div>
         </div>
+      </main>
 
-        <div className="mt-8 flex flex-wrap gap-4 justify-center text-sm text-slate-500">
-          <Link href="/pricing" className="hover:text-white transition-all">Pricing</Link>
-          <Link href="/deals" className="hover:text-white transition-all">Deals</Link>
-          <Link href="/blog" className="hover:text-white transition-all">Blog</Link>
-          <Link href="/about" className="hover:text-white transition-all">About</Link>
-          <Link href="/privacy-policy" className="hover:text-white transition-all">Privacy Policy</Link>
-          <Link href="/terms-of-service" className="hover:text-white transition-all">Terms of Service</Link>
-        </div>
-      </div>
+      <footer
+        style={{
+          padding: '24px 32px',
+          display: 'flex',
+          gap: 18,
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          fontSize: 12.5,
+          color: '#9CA3AF',
+        }}
+      >
+        <Link href="/pricing" style={{ color: '#6B7280', textDecoration: 'none' }}>Pricing</Link>
+        <Link href="/deals" style={{ color: '#6B7280', textDecoration: 'none' }}>Deals</Link>
+        <Link href="/blog" style={{ color: '#6B7280', textDecoration: 'none' }}>Blog</Link>
+        <Link href="/about" style={{ color: '#6B7280', textDecoration: 'none' }}>About</Link>
+        <Link href="/privacy-policy" style={{ color: '#6B7280', textDecoration: 'none' }}>Privacy</Link>
+        <Link href="/terms-of-service" style={{ color: '#6B7280', textDecoration: 'none' }}>Terms</Link>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- New \`/auth/reset-password\` page wired to \`supabase.auth.resetPasswordForEmail\`; success state invites the user to check their inbox, with a 'try a different email' escape hatch
- Fixes the dead \"Forgot password?\" link on \`/auth/login\`
- Replaces the navy-950 404 page with a light-theme port from batch8 EmptyStatesGallery (amber hero, clear headline, dual CTA, light marketing footer) so it matches the rest of the redesigned surfaces

## Test plan
- [ ] \`/auth/reset-password\` sends a reset email via Supabase to the typed address
- [ ] Redirect target is \`\${origin}/auth/update-password\` (matches Supabase reset flow expectations)
- [ ] Success state renders inside a mint-washed panel; 'try a different email' resets the form
- [ ] Link from \`/auth/login\` lands on the page without 404
- [ ] Unknown route renders the new 404 with amber hero; CTAs route home + to dashboard
- [ ] 404 remains accessible both logged-in and logged-out

Content consistency:
- [x] Read CONTENT_SOURCES_OF_TRUTH.md at start of session
- [x] Three-tier pricing respected
- [x] 0% success fee claim unchanged
- [x] March 2026 launch date only
- [x] No fabricated customers, member counts, or revenue figures

🤖 Generated with [Claude Code](https://claude.com/claude-code)