### PR TITLE
fix(money-hub): recategorise to 'income' no longer silently excluded

### DIFF
--- a/src/app/api/money-hub/recategorise/route.ts
+++ b/src/app/api/money-hub/recategorise/route.ts
@@ -152,15 +152,23 @@ export async function POST(request: NextRequest) {
 
         if (matching && matching.length > 0) {
           // Split into positive-amount (income side) and negative-amount (spending side).
-          // For positive amounts, also exclude from income totals by setting
-          // income_type = 'credit_loan' (which isExcludedIncomeType treats as non-income).
+          // For positive amounts re-tagged as a NON-income category, also stamp
+          // income_type='credit_loan' so Money Hub excludes them from monthly
+          // income (isExcludedIncomeType). But if the user is reclassifying TO
+          // 'income', clear income_type so the classifier can re-detect
+          // income_type naturally from the transaction's own signals.
           const positiveIds = matching.filter(t => Number(t.amount) > 0).map(t => t.id);
           const negativeIds = matching.filter(t => Number(t.amount) <= 0).map(t => t.id);
+
+          const isIncomeRecat = newCategory === 'income';
+          const positivePatch = isIncomeRecat
+            ? { user_category: newCategory, income_type: null }
+            : { user_category: newCategory, income_type: 'credit_loan' };
 
           for (let i = 0; i < positiveIds.length; i += 50) {
             const batch = positiveIds.slice(i, i + 50);
             const { count } = await admin.from('bank_transactions')
-              .update({ user_category: newCategory, income_type: 'credit_loan' })
+              .update(positivePatch)
               .in('id', batch);
             if (count) updated += count;
           }
@@ -199,9 +207,14 @@ export async function POST(request: NextRequest) {
         .single();
 
       const txnPatch: Record<string, any> = { user_category: newCategory };
-      // For positive-amount transactions, also exclude from income by flagging credit_loan
-      if (txnData && Number(txnData.amount) > 0 && newCategory !== 'income') {
-        txnPatch.income_type = 'credit_loan';
+      // For positive-amount transactions:
+      // - re-tagged as a non-income category → stamp 'credit_loan' so Money Hub
+      //   excludes it from monthly income
+      // - re-tagged TO 'income' → clear any stale income_type so the classifier
+      //   can re-detect it (was previously left untouched, which occasionally
+      //   left a credit_loan flag in place that still suppressed income)
+      if (txnData && Number(txnData.amount) > 0) {
+        txnPatch.income_type = newCategory === 'income' ? null : 'credit_loan';
       }
 
       await admin.from('bank_transactions')


### PR DESCRIPTION
## Summary
- When a user recategorised a positive-amount transaction from the Money Hub drill-down, the server unconditionally stamped \`income_type='credit_loan'\` on the row — **even when the new category was 'income'**
- \`isExcludedIncomeType\` treats \`credit_loan\` as non-income, so \"recategorise as income\" wrote the label but left the row hidden from the monthly total on the next read

## Fix
- Merchant-pattern batch update: only stamp \`income_type='credit_loan'\` on positive rows when the new category is NOT \`'income'\`. If it is, null out \`income_type\` so the classifier re-detects naturally
- Single-transaction branch: same rule, plus explicitly null \`income_type\` on income recats (was previously left untouched — could leave a stale credit_loan flag)

This matches what users were hitting when they reported \"recategorisation isn't working\" — the UI refetch fired correctly; the server was writing a value that suppressed the row on the very next read.

## Test plan
- [ ] Recategorise a salary-looking row that was previously classified as spending → now shows up in monthly income on next refresh
- [ ] Recategorise a legitimate refund or rebate as a spending category → still excluded from income (credit_loan preserved)
- [ ] Negative-amount (spend) recategorisation unchanged — no income_type stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)