### PR TITLE
fix(subscriptions): single source of truth for active count

### DIFF
--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -20,6 +20,7 @@ import SpendingPanel from './SpendingPanel';
 import GoalsAndBudgetsPanel from './GoalsAndBudgetsPanel';
 import NetWorthPanel from './NetWorthPanel';
 import ContractsPanel from './ContractsPanel';
+import { filterActiveSubscriptions } from '@/lib/subscriptions/active-count';
 
 // ─── Utilities ──────────────────────────────────────────────────────────────
 
@@ -191,7 +192,12 @@ export default function MoneyHubPage() {
  const res = await fetch('/api/money-hub/fac');
  const d = await res.json();
  if (!d.error) {
- setFacItems(d.items || []);
+ // Align Money Hub's "active subscriptions" list with Dashboard Overview
+ // and the Subscriptions page. filterActiveSubscriptions strips finance
+ // rows (mortgage/loan/credit card — those belong in the Liabilities
+ // section) and dedupes by provider + amount band.
+ const filtered = filterActiveSubscriptions((d.items || []) as FacItem[]);
+ setFacItems(filtered);
  setFacCounts(d.counts || {});
  }
  } catch { /* silent */ }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,6 +18,7 @@ import PriceIncreaseCard from '@/components/alerts/PriceIncreaseCard';
 import SavingsOpportunityWidget from '@/components/dashboard/SavingsOpportunityWidget';
 import SavingsSkeleton from '@/components/dashboard/SavingsSkeleton';
 import { cleanMerchantName } from '@/lib/merchant-utils';
+import { countActiveSubscriptions } from '@/lib/subscriptions/active-count';
 import BankPickerModal, { connectBankDirect } from '@/components/BankPickerModal';
 import { calculateTotalSavings, parseComparisonDeals, isPriceAlertValid, priceAlertAnnualImpact } from '@/lib/savings-utils';
 
@@ -376,26 +377,9 @@ export default function DashboardPage() {
         // potentialSavings will be calculated after all data loads (see below)
 
         const subsList = subs.data || [];
-        // Filter out finance payments and deduplicate — match subscriptions page logic
-        const DEBT_KW = ['mortgage', 'loan', 'finance', 'lendinvest', 'skipton', 'santander loan', 'natwest loan', 'novuna', 'ca auto', 'auto finance', 'funding circle', 'zopa'];
-        const CREDIT_KW = ['barclaycard', 'mbna', 'halifax credit', 'hsbc bank visa', 'virgin money', 'capital one', 'american express', 'amex', 'securepay', 'credit card'];
-        const isFinance = (name: string) => {
-          const l = name.toLowerCase();
-          return DEBT_KW.some(kw => l.includes(kw)) || CREDIT_KW.some(kw => l.includes(kw));
-        };
-        const filteredSubs = subsList.filter(s => !isFinance(s.provider_name));
-        const seenNames = new Map<string, boolean>();
-        const dedupedSubs = filteredSubs.filter(s => {
-          const normName = cleanMerchantName(s.provider_name).toLowerCase();
-          // Include amount band so two separate bills at the same provider but
-          // different amounts (e.g. two council-tax DDs) count as distinct.
-          const band = Math.round(Math.log(Math.max(Math.abs(parseFloat(String(s.amount)) || 0), 0.01)) / Math.log(1.1));
-          const key = `${normName}|${band}`;
-          if (seenNames.has(key)) return false;
-          seenNames.set(key, true);
-          return true;
-        });
-        setSubscriptionCount(dedupedSubs.length);
+        // Single source of truth for "active subscriptions" — dedupe +
+        // finance-strip handled by shared helper so every page agrees.
+        setSubscriptionCount(countActiveSubscriptions(subsList));
         setActiveSubscriptions(subsList);
 
         // Calculate monthly spend via RPC for consistency with subscriptions page
@@ -898,7 +882,7 @@ export default function DashboardPage() {
       <div className="kpi-row c4" style={{ marginBottom: 16 }}>
         <Link href="/dashboard/subscriptions" className="kpi-card" style={{ display: 'block', textDecoration: 'none', color: 'inherit' }}>
           <div className="k-label"><CreditCard className="h-3.5 w-3.5" /> Subscriptions & bills</div>
-          <div className="k-val">{spendBreakdown?.subscriptions_count || subscriptionCount}</div>
+          <div className="k-val">{subscriptionCount}</div>
           <div className="k-delta">{formatGBP(monthlySpend)}/mo</div>
         </Link>
         <Link href="/dashboard/complaints" className="kpi-card" style={{ display: 'block', textDecoration: 'none', color: 'inherit' }}>

--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -15,6 +15,7 @@ import { shouldShowShareModal, hasSharedThisSession } from '@/lib/share-triggers
 import { isCreditProduct } from '@/lib/credit-product-detector';
 import ComparisonCard from '@/components/subscriptions/ComparisonCard';
 import { cleanMerchantName } from '@/lib/merchant-utils';
+import { countActiveSubscriptions } from '@/lib/subscriptions/active-count';
 import { SORTED_CATEGORIES, SUBSCRIPTION_FILTER_CATEGORIES, getCategoryLabel, getCategoryColor, getCategoryBgColor, getCategoryIcon } from '@/lib/category-config';
 import { createClient } from '@/lib/supabase/client';
 import BankPickerModal, { connectBankDirect } from '@/components/BankPickerModal';
@@ -1854,13 +1855,15 @@ export default function SubscriptionsPage() {
         );
       })()}
 
-      {/* Summary — from get_subscription_total() RPC (single source of truth) */}
+      {/* Summary — monthly totals from get_subscription_total() RPC;
+          active-count computed locally via countActiveSubscriptions so
+          every page agrees on "how many subs are active". */}
       {rpcTotals && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
           <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-5">
             <p className="text-slate-600 text-xs mb-1">Subscriptions & Bills</p>
             <h3 className="text-2xl font-bold text-slate-900">{formatGBP(rpcTotals.subscriptions_monthly)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
-            <p className="text-slate-500 text-xs mt-1">{rpcTotals.subscriptions_count} active</p>
+            <p className="text-slate-500 text-xs mt-1">{countActiveSubscriptions(subscriptions)} active</p>
           </div>
 
           <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-5">
@@ -1878,7 +1881,7 @@ export default function SubscriptionsPage() {
           <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl shadow-[--shadow-card] p-5">
             <p className="text-slate-600 text-xs mb-1">Total All Commitments</p>
             <h3 className="text-2xl font-bold text-slate-900">{formatGBP(rpcTotals.monthly_total)}<span className="text-sm text-slate-500 font-normal">/mo</span></h3>
-            <p className="text-slate-500 text-xs mt-1">{formatGBP(rpcTotals.monthly_total * 12)}/year · {rpcTotals.subscriptions_count + rpcTotals.mortgages_count + rpcTotals.loans_count + rpcTotals.council_tax_count} tracked</p>
+            <p className="text-slate-500 text-xs mt-1">{formatGBP(rpcTotals.monthly_total * 12)}/year · {countActiveSubscriptions(subscriptions) + rpcTotals.mortgages_count + rpcTotals.loans_count + rpcTotals.council_tax_count} tracked</p>
           </div>
         </div>
       )}

--- a/src/lib/subscriptions/active-count.ts
+++ b/src/lib/subscriptions/active-count.ts
@@ -1,0 +1,90 @@
+// src/lib/subscriptions/active-count.ts
+// Single source of truth for "how many active subscriptions does this user
+// have." Before this helper existed, Money Hub, Dashboard Overview, and the
+// Subscriptions page each counted differently (raw query vs client-dedup vs
+// an unmigrated `get_subscription_total` RPC), so users saw three different
+// numbers for the same thing.
+//
+// Rules:
+//  - Only active, non-dismissed rows
+//  - Exclude finance-category rows (mortgage / loan / credit card) — those
+//    are liabilities, tracked separately on Money Hub
+//  - Dedupe by normalised provider name + log-amount band so a Netflix row
+//    that was imported twice doesn't inflate the count
+
+import { cleanMerchantName } from '@/lib/merchant-utils';
+
+export interface ActiveSubscriptionLike {
+  provider_name?: string | null;
+  amount?: number | string | null;
+  status?: string | null;
+  dismissed_at?: string | null;
+  category?: string | null;
+}
+
+const DEBT_KEYWORDS = [
+  'mortgage',
+  'loan',
+  'finance',
+  'lendinvest',
+  'skipton',
+  'santander loan',
+  'natwest loan',
+  'novuna',
+  'ca auto',
+  'auto finance',
+  'funding circle',
+  'zopa',
+];
+
+const CREDIT_KEYWORDS = [
+  'barclaycard',
+  'mbna',
+  'halifax credit',
+  'hsbc bank visa',
+  'virgin money',
+  'capital one',
+  'american express',
+  'amex',
+  'securepay',
+  'credit card',
+];
+
+function isFinanceProvider(name: string | null | undefined): boolean {
+  if (!name) return false;
+  const lower = name.toLowerCase();
+  return DEBT_KEYWORDS.some((k) => lower.includes(k)) || CREDIT_KEYWORDS.some((k) => lower.includes(k));
+}
+
+function amountBand(raw: number | string | null | undefined): number {
+  const amt = Math.abs(parseFloat(String(raw ?? 0)) || 0);
+  if (amt < 0.01) return 0;
+  return Math.round(Math.log(amt) / Math.log(1.1));
+}
+
+/**
+ * Filter a list of subscription rows down to the canonical "active
+ * subscriptions" set: active status, not dismissed, finance stripped,
+ * duplicates merged.
+ */
+export function filterActiveSubscriptions<T extends ActiveSubscriptionLike>(subs: T[]): T[] {
+  const active = subs.filter(
+    (s) => (s.status || 'active') === 'active' && !s.dismissed_at && !isFinanceProvider(s.provider_name),
+  );
+
+  const seen = new Map<string, boolean>();
+  const deduped: T[] = [];
+  for (const s of active) {
+    const name = cleanMerchantName(s.provider_name || '').toLowerCase();
+    if (!name) continue;
+    const key = `${name}|${amountBand(s.amount)}`;
+    if (seen.has(key)) continue;
+    seen.set(key, true);
+    deduped.push(s);
+  }
+  return deduped;
+}
+
+export function countActiveSubscriptions(subs: ActiveSubscriptionLike[]): number {
+  return filterActiveSubscriptions(subs).length;
+}


### PR DESCRIPTION
## Summary
Dashboard, Money Hub, and Subscriptions page were counting active subs three different ways — user saw three different numbers for the same thing.

Introduce \`src/lib/subscriptions/active-count.ts\`:
- \`filterActiveSubscriptions(subs)\` — active + not dismissed, finance keywords stripped (mortgages/loans/credit cards live on Liabilities), deduped by normalised provider name + log-amount band
- \`countActiveSubscriptions(subs)\` — convenience wrapper

Wire it everywhere:
- **Dashboard Overview**: replace inline dedup + keyword lists with the helper, drop the RPC override on the KPI tile
- **Subscriptions page**: keep the RPC for monetary totals but override \"N active\" / \"N tracked\" with the helper
- **Money Hub**: filter the Financial Action Centre list so the 3 places that show \"N subscriptions\" all line up

## Test plan
- [ ] Dashboard KPI \"Subscriptions\" matches Subscriptions page \"N active\" matches Money Hub FAC tracked count
- [ ] Finance rows (mortgage/loan/credit card) don't appear in Money Hub FAC or inflate the Dashboard KPI
- [ ] A double-imported Netflix row collapses to 1 in all three counts
- [ ] Subscriptions page monetary totals unchanged (still come from the RPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)