### PR TITLE
feat(export): batch5 ExportHub layout

### DIFF
--- a/src/app/dashboard/export/page.tsx
+++ b/src/app/dashboard/export/page.tsx
@@ -53,73 +53,111 @@ const comingSoon: ComingSoonDestination[] = [
 
 export default function ExportPage() {
   return (
-    <div className="max-w-4xl mx-auto space-y-6">
-      {/* Header */}
-      <div>
-        <div className="page-title-row">
+    <div className="max-w-5xl">
+      {/* Variant A header (batch5 ExportHub) */}
+      <div className="page-title-row" style={{ marginBottom: 14 }}>
         <div>
           <h1 className="page-title">Export</h1>
+          <p className="page-sub">
+            Send your Paybacker data to the tools you already use. Connect once and we keep it in sync automatically. You always own your data — revoke anytime.
+          </p>
         </div>
-      </div>
-        <p className="mt-2 text-sm text-slate-600 max-w-2xl">
-          Send your Paybacker data to the tools you already use. Connect a destination once and
-          we&rsquo;ll keep it in sync automatically.
-        </p>
+        <Link
+          href="mailto:hello@paybacker.co.uk?subject=Destination%20request"
+          className="cta-ghost"
+        >
+          Request a destination →
+        </Link>
       </div>
 
       {/* Live destinations */}
-      <section>
-        <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">
-          Available now
-        </h2>
-        <div className="grid grid-cols-1 gap-4">
-          <GoogleSheetsConnect />
-          <DataExportCard />
-        </div>
-      </section>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '.1em',
+          textTransform: 'uppercase',
+          color: 'var(--text-3)',
+          marginBottom: 8,
+        }}
+      >
+        Available now
+      </div>
+      <div className="grid grid-cols-1 gap-3 mb-6">
+        <GoogleSheetsConnect />
+        <DataExportCard />
+      </div>
 
       {/* Coming soon */}
-      <section>
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-500">
-            Coming soon
-          </h2>
-          <Link
-            href="mailto:hello@paybacker.co.uk?subject=Destination%20request"
-            className="text-xs text-emerald-600 hover:text-emerald-700 transition-colors"
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 700,
+          letterSpacing: '.1em',
+          textTransform: 'uppercase',
+          color: 'var(--text-3)',
+          marginBottom: 8,
+        }}
+      >
+        Coming soon
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {comingSoon.map((d) => (
+          <div
+            key={d.name}
+            className="card"
+            style={{ padding: 14, opacity: 0.75 }}
           >
-            Request a destination →
-          </Link>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {comingSoon.map((d) => (
-            <div
-              key={d.name}
-              className="rounded-2xl border border-slate-200 bg-white shadow-sm p-5 opacity-80"
-            >
-              <div className="flex items-center gap-3">
-                <div className={`w-10 h-10 rounded-lg ${d.iconBg} flex items-center justify-center flex-shrink-0`}>
-                  {d.icon}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <h3 className="font-semibold text-slate-900 text-sm">{d.name}</h3>
-                    <span className="text-[10px] font-medium uppercase tracking-wider px-2 py-0.5 rounded-full text-slate-600 bg-slate-100">
-                      Soon
-                    </span>
-                  </div>
-                  <p className="text-xs text-slate-600 mt-0.5">{d.blurb}</p>
-                </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+              <div
+                className={`w-10 h-10 rounded-lg ${d.iconBg} flex items-center justify-center flex-shrink-0`}
+              >
+                {d.icon}
               </div>
+              <div style={{ fontSize: 13.5, fontWeight: 700 }}>{d.name}</div>
+              <span
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  padding: '2px 6px',
+                  borderRadius: 4,
+                  letterSpacing: '.04em',
+                  background: '#F3F4F6',
+                  color: 'var(--text-2)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                Soon
+              </span>
             </div>
-          ))}
-        </div>
-      </section>
+            <div style={{ fontSize: 11.5, color: 'var(--text-2)', lineHeight: 1.4, marginBottom: 10, minHeight: 32 }}>
+              {d.blurb}
+            </div>
+            <Link
+              href={`mailto:hello@paybacker.co.uk?subject=Notify%20me%20about%20${encodeURIComponent(d.name)}`}
+              className="cta-ghost"
+              style={{ padding: '5px 10px', fontSize: 11.5, width: '100%', justifyContent: 'center', display: 'inline-flex' }}
+            >
+              Notify me
+            </Link>
+          </div>
+        ))}
+      </div>
 
       {/* Privacy footer */}
-      <div className="text-xs text-slate-500 pt-2">
+      <div
+        style={{
+          marginTop: 18,
+          padding: '10px 14px',
+          background: '#F9FAFB',
+          border: '1px solid var(--divider)',
+          borderRadius: 10,
+          fontSize: 11.5,
+          color: 'var(--text-3)',
+        }}
+      >
         Paybacker only writes to destinations you connect yourself. You can disconnect any time
-        — your existing sheets and exports aren&rsquo;t deleted.
+        — your existing sheets, exports and Notion databases aren&rsquo;t deleted.
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
Ports batch5 ExportHub onto \`/dashboard/export\`. Keeps the real \`GoogleSheetsConnect\` + \`DataExportCard\` components intact — purely structural + design-token port.

- page-title-row headline + full subtitle copy
- \"Request a destination\" cta-ghost CTA top-right
- Small-caps \"Available now\" / \"Coming soon\" section headers
- Coming-soon cards: Soon pill, min-height on body for row alignment, \"Notify me\" ghost CTA wired to subject-prefilled mailto
- Privacy footer re-tokenised to card gray

## Test plan
- [ ] Page renders for Pro users with working Google Sheets connect + CSV/Excel/PDF export
- [ ] \"Request a destination\" mailto opens correctly
- [ ] \"Notify me\" on each coming-soon card opens mailto with correct subject
- [ ] Mobile stacks to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)