### PR TITLE
fix(mobile): stop horizontal overflow across dashboard

### DIFF
--- a/src/app/dashboard/deals/page.tsx
+++ b/src/app/dashboard/deals/page.tsx
@@ -679,7 +679,7 @@ export default function DealsPage() {
           flexWrap: 'wrap',
         }}
       >
-        <div style={{ flex: 1, minWidth: 280 }}>
+        <div style={{ flex: '1 1 240px', minWidth: 0 }}>
           <span
             style={{
               fontSize: 11,
@@ -691,7 +691,7 @@ export default function DealsPage() {
           >
             Deals · updated weekly
           </span>
-          <h2 style={{ fontSize: 26, fontWeight: 700, letterSpacing: '-.015em', margin: '8px 0 6px', color: '#fff' }}>
+          <h2 style={{ fontSize: 'clamp(20px, 5vw, 26px)', fontWeight: 700, letterSpacing: '-.015em', margin: '8px 0 6px', color: '#fff' }}>
             {dealsCount} verified deals
             {potentialAnnualSaving > 0 && <>, £{potentialAnnualSaving.toLocaleString()} in potential savings.</>}
             {potentialAnnualSaving === 0 && ' tailored to your subscriptions.'}
@@ -711,7 +711,7 @@ export default function DealsPage() {
             color: '#059669',
             borderRadius: 12,
             textDecoration: 'none',
-            whiteSpace: 'nowrap',
+            flexShrink: 0,
           }}
         >
           Match against my bills →

--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -317,6 +317,39 @@
 }
 .shell-v2 .cta-danger:hover { background: #FEE2E2; }
 
+/* ─── Mobile overflow safeguards ──────────────────────────────────────────
+   Pages were rendering with horizontal scroll on iPhone-class viewports
+   because:
+   - `.shell-v2 .shell` is a CSS grid; without `min-width:0` on its column
+     track, a long unbreakable string (or an inline grid that doesn't
+     stack on its own) expands the track past the viewport
+   - `.page-title-row` is `flex-wrap:wrap` but its first child <div>
+     has default `min-width:auto` so a long page-sub forces the row wider
+   - several hero strips use `flex` with `whiteSpace:nowrap` CTAs that
+     refused to wrap on narrow widths
+
+   This block hard-stops overflow at the shell-v2 root + adds the
+   required min-width:0 to the columns + makes the inline-style grids
+   that didn't ship their own media queries stack below 760px. */
+.shell-v2 { overflow-x: hidden; }
+.shell-v2 > .shell > * { min-width: 0; }
+.shell-v2 .main-inner { min-width: 0; max-width: 100vw; }
+.shell-v2 .page-title-row > * { min-width: 0; }
+.shell-v2 .page-title { overflow-wrap: anywhere; word-break: break-word; }
+
+/* The deals hero CTA had whiteSpace:nowrap which refused to wrap on a
+   ~390px viewport. Same for the rewards / billing tier grids etc. */
+@media (max-width: 760px) {
+  .shell-v2 .compose-grid,
+  .shell-v2 .rewards-hero-grid,
+  .shell-v2 .deal-grid,
+  .shell-v2 .notif-grid,
+  .shell-v2 .tier-grid,
+  .shell-v2 .onboarding-grid {
+    grid-template-columns: 1fr !important;
+  }
+}
+
 /* ─── Dispute compose: 2-col grid with right rail (batch7 DisputeCompose) ─── */
 .shell-v2 .compose-grid{display:grid;grid-template-columns:1fr 360px;gap:24px;align-items:start}
 .shell-v2 .compose-eyebrow{font-size:12px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--mint-deep);display:inline-block;margin-bottom:10px}


### PR DESCRIPTION
## Summary
User reported subscriptions, money hub, deals, rewards and profile pages were rendering with content cut off at the right edge on iPhone (text wrapping but the page itself scrolling sideways).

## Root causes
1. \`.shell-v2 .shell\` is a CSS grid; without \`min-width:0\` on the main column track, a long inline-grid expanded the track past the viewport.
2. \`.page-title-row\` is \`flex-wrap:wrap\` but its first child \`<div>\` defaults to \`min-width:auto\`, so a long page-sub forced the row wider than the screen.
3. Several inline-style grids (compose, rewards-hero, deal, notif, tier, onboarding) had their own media queries inside \`<style jsx>\` which scope to component instance and didn't always apply across navigations.
4. Deals hero CTA had \`whiteSpace:nowrap\` and inner column had \`minWidth:280\` — both prevented \`flexWrap:wrap\` from kicking in on a 390px viewport.

## Fix
- \`overflow-x:hidden\` on \`.shell-v2\` root
- \`min-width:0\` + \`max-width:100vw\` on \`.main-inner\` and on grid track
- \`min-width:0\` + \`overflow-wrap:anywhere\` on page-title-row children
- Global \`@media (max-width:760px)\` fallback that forces named inline-style grids to a single column
- Deals hero: \`flex:'1 1 240px'\` + clamp() headline + \`flexShrink:0\` on CTA

## Test plan
- [ ] iPhone-width Subscriptions: subtitle wraps, no horizontal scroll
- [ ] Money Hub: income breakdown amounts visible, total not cut off
- [ ] Disputes: KPIs visible (4 cards stack as 2x2 then 1-col)
- [ ] Deals hero: CTA wraps below text on narrow screens, headline doesn't wrap to 4 lines
- [ ] Rewards: tier gradient + KPI stack collapse to single column
- [ ] Profile: section tabs scroll horizontally as before, content fits

🤖 Generated with [Claude Code](https://claude.com/claude-code)