### PR TITLE
fix(homepage): mobile menu, demo scaling, duplicated trust strip, stat copy

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -205,6 +205,28 @@ function Nav() {
     };
   }, []);
 
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Close drawer on route change / anchor click / esc
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setMenuOpen(false); };
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', onKey);
+    return () => {
+      document.body.style.overflow = '';
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [menuOpen]);
+
+  const navLinks: ReadonlyArray<readonly [string, string]> = [
+    ['How it works', '#how'],
+    ['Product', '#features'],
+    ['Deals', '#deals'],
+    ['Pricing', '#pricing'],
+    ['Stories', '#testimonials'],
+  ];
+
   return (
     <>
       <div className={`nav-shell${scrolled ? ' scrolled' : ''}`}>
@@ -214,11 +236,9 @@ function Nav() {
             <span className="backer">backer</span>
           </Link>
           <div className="nav-links">
-            <a href="#how">How it works</a>
-            <a href="#pillars">Product</a>
-            <a href="#deals">Deals</a>
-            <a href="#pricing">Pricing</a>
-            <a href="#testimonials">Stories</a>
+            {navLinks.map(([label, href]) => (
+              <a key={href} href={href}>{label}</a>
+            ))}
           </div>
           <div className="nav-cta-row">
             <Link className="nav-signin" href="/auth/login">
@@ -227,6 +247,16 @@ function Nav() {
             <Link className="nav-start" href="/auth/signup">
               Start free
             </Link>
+            <button
+              type="button"
+              className="nav-burger"
+              aria-label="Open menu"
+              aria-expanded={menuOpen}
+              aria-controls="m-v2-mob-menu"
+              onClick={() => setMenuOpen(true)}
+            >
+              <span /><span /><span />
+            </button>
           </div>
         </nav>
       </div>
@@ -235,6 +265,42 @@ function Nav() {
         aria-hidden="true"
         style={{ ['--progress' as string]: 'var(--m-v2-progress, 0)' } as CSSVarProperties}
       />
+
+      {/* Mobile drawer — full-screen sheet that covers the page while open. */}
+      {menuOpen && (
+        <>
+          <div className="nav-drawer-backdrop" onClick={() => setMenuOpen(false)} />
+          <div id="m-v2-mob-menu" className="nav-drawer" role="dialog" aria-modal="true" aria-label="Site navigation">
+            <div className="nav-drawer-head">
+              <Link className="nav-logo" href="/" onClick={() => setMenuOpen(false)}>
+                <span className="pay">Pay</span>
+                <span className="backer">backer</span>
+              </Link>
+              <button
+                type="button"
+                className="nav-drawer-close"
+                aria-label="Close menu"
+                onClick={() => setMenuOpen(false)}
+              >
+                ×
+              </button>
+            </div>
+            <div className="nav-drawer-links">
+              {navLinks.map(([label, href]) => (
+                <a key={href} href={href} onClick={() => setMenuOpen(false)}>{label}</a>
+              ))}
+            </div>
+            <div className="nav-drawer-ctas">
+              <Link className="btn btn-ghost" href="/auth/login" onClick={() => setMenuOpen(false)}>
+                Sign in
+              </Link>
+              <Link className="btn btn-mint" href="/auth/signup" onClick={() => setMenuOpen(false)}>
+                Start free 14-day trial
+              </Link>
+            </div>
+          </div>
+        </>
+      )}
     </>
   );
 }
@@ -669,18 +735,9 @@ export default function HomepageV3PreviewPage() {
         </div>
       </section>
 
-      {/* ========== Trust strip ========== */}
-      <section className="trust-strip section-light">
-        <div className="wrap">
-          <div className="trust-row">
-            <div className="trust-item"><div className="ring">ICO</div>Registered data controller</div>
-            <div className="trust-item"><div className="ring">FCA</div>Open Banking via Yapily</div>
-            <div className="trust-item"><div className="ring">GDPR</div>UK data residency</div>
-            <div className="trust-item"><div className="ring">£</div>Stripe-secured payments</div>
-            <div className="trust-item"><div className="ring">UK</div>Paybacker LTD · 15289174</div>
-          </div>
-        </div>
-      </section>
+      {/* Trust strip removed — same credentials already appear in the
+          compact `.trust-bar` above the hero so the lower block was
+          pure duplication pushing real content further down. */}
 
       {/* ========== Stats (mint wash) ========== */}
       <section className="stats-section section-mint" id="stats">
@@ -726,15 +783,16 @@ export default function HomepageV3PreviewPage() {
             </Reveal>
 
             <Reveal className="stat-card" delay={160}>
-              <div className="label">Paybacker success fee</div>
+              <div className="label">Of your refund you keep</div>
               <div className="num">
-                <Counter to={0} />
+                <Counter to={100} />
                 <span className="unit">%</span>
               </div>
               <div className="underline" />
               <div className="blurb">
-                Competitors take 15–30% of what you recover. We charge a flat monthly
-                subscription — every £ you get back is yours.
+                Paybacker takes 0% of your refund. Competitors take 15–30% of what
+                you recover — we just charge a flat monthly subscription, so every
+                £ you get back stays yours.
               </div>
             </Reveal>
           </div>
@@ -1347,9 +1405,9 @@ export default function HomepageV3PreviewPage() {
             </div>
             <div className="footer-col">
               <h5>Product</h5>
-              <a href="#pillars">Disputes Centre</a>
-              <a href="#pillars">Money Hub</a>
-              <a href="#pillars">Pocket Agent</a>
+              <a href="#features">Disputes Centre</a>
+              <a href="#features">Money Hub</a>
+              <a href="#features">Pocket Agent</a>
               <a href="#deals">Deals</a>
               <Link href="/pricing">Pricing</Link>
             </div>

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1909,4 +1909,150 @@
 
   /* Pricing card CTA buttons */
   .m-v2-root .price-card .btn { width: 100%; justify-content: center; }
+
+  /* "Generate letter" button inside the demo form — previously 10px
+     horizontal padding made the label feel cramped on mobile. */
+  .m-v2-root .mini-form button { padding: 12px 16px; font-size: 14px; }
+}
+
+/* ============================================================
+   Mobile nav drawer — shown when Nav's hamburger is active.
+   Desktop hides .nav-burger and drawer; mobile hides .nav-links
+   and shows .nav-burger via the existing 980px breakpoint.
+   ============================================================ */
+.m-v2-root .nav-burger {
+  display: none;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--divider, #E5E7EB);
+  border-radius: 10px;
+  background: #fff;
+  cursor: pointer;
+  padding: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  margin-left: 4px;
+}
+.m-v2-root .nav-burger span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--text-primary, #0B1220);
+  border-radius: 2px;
+}
+
+@media (max-width: 980px) {
+  .m-v2-root .nav-burger { display: inline-flex; }
+  /* Replace "Start free" button with the burger on very narrow viewports
+     so the pill doesn't fight for space. Keep Start free visible down to
+     480px then hide so only burger remains. */
+}
+@media (max-width: 480px) {
+  .m-v2-root .nav-start { display: none; }
+}
+
+.m-v2-root .nav-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 18, 32, 0.5);
+  z-index: 90;
+  backdrop-filter: blur(4px);
+}
+.m-v2-root .nav-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(340px, 92vw);
+  background: #fff;
+  z-index: 91;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px -10px rgba(0, 0, 0, 0.35);
+  animation: drawerIn 240ms ease-out;
+}
+@keyframes drawerIn {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+.m-v2-root .nav-drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--divider, #E5E7EB);
+}
+.m-v2-root .nav-drawer-close {
+  width: 36px;
+  height: 36px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-size: 28px;
+  line-height: 1;
+  color: var(--text-secondary, #4B5563);
+  border-radius: 10px;
+}
+.m-v2-root .nav-drawer-close:hover { background: #F3F4F6; }
+.m-v2-root .nav-drawer-links {
+  display: flex;
+  flex-direction: column;
+  padding: 12px 12px;
+  flex: 1;
+}
+.m-v2-root .nav-drawer-links a {
+  padding: 14px 16px;
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--text-primary, #0B1220);
+  text-decoration: none;
+  border-radius: 10px;
+}
+.m-v2-root .nav-drawer-links a:hover { background: #F3F4F6; }
+.m-v2-root .nav-drawer-ctas {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 20px 24px;
+  border-top: 1px solid var(--divider, #E5E7EB);
+}
+.m-v2-root .nav-drawer-ctas .btn {
+  width: 100%;
+  justify-content: center;
+}
+
+/* ============================================================
+   Demo stage responsive scaling — the product demos are built at
+   a fixed virtual 980×612 layout (absolutely-positioned panels,
+   flex:0 0 340px left columns etc) and break on narrow viewports.
+   Treat the demo-stage as a container and scale its inner content
+   to match the available width. Everything inside the stage stays
+   on its original virtual canvas so animations don't reflow.
+   ============================================================ */
+.m-v2-root .demo-stage { container-type: inline-size; }
+
+@container (max-width: 820px) {
+  .m-v2-root .demo-stage {
+    aspect-ratio: auto;
+    /* Height = top label (56px) + the inset-bottom gap (40px) +
+       the content frame scaled by (100cqw - inset-x) / 892.
+       892 = 980 content width - 88 inset-x (44 left + 44 right). */
+    height: calc(56px + 40px + 516px * ((100cqw - 88px) / 892));
+    overflow: hidden;
+  }
+  /* The inline-styled inset wrapper becomes the scaled frame. The
+     style attr on the element sets `position: absolute; inset:
+     56px 44px 40px 44px; display: flex; gap: 16px;` — we lock its
+     intrinsic size to the desktop 892x516 content area so children
+     render as designed, then transform-scale it down to the
+     container width. */
+  .m-v2-root .demo-stage > div[style*="position: absolute"] {
+    inset: 56px auto auto 44px !important;
+    width: 892px !important;
+    height: 516px !important;
+    transform: scale(calc((100cqw - 88px) / 892));
+    transform-origin: top left;
+  }
 }


### PR DESCRIPTION
## Summary
Homepage fixes flagged on mobile:

1. **Mobile menu** — iPhone-class viewports showed only the Paybacker logo + \"Start free\". Added a proper hamburger + right-side drawer with full nav + Sign in/Start free CTAs.
2. **Demo scaling** — product demos are built at a fixed virtual 980×612 layout. On iPhone only ~1/3 was visible. Use container queries to scale the inline-styled inset frame down to container width; compute stage height from the scale factor.
3. **Duplicated ICO/FCA/GDPR strip** — removed the lower \`.trust-strip\` section; compact \`.trust-bar\` at the top already covers these credentials.
4. **\"Paybacker success fee 0%\" stat** — was \`<Counter to={0}>\` so it sat static while siblings counted up. Re-framed as \"Of your refund you keep\" counting to 100%; 0% fee wording preserved in the blurb.
5. **Stale \`#pillars\` anchor** — nav \"Product\" and three footer links pointed at a non-existent anchor. Point them at \`#features\`.
6. **Squashed \"Generate letter\" button** — mini-form CTA bumped to \`12px 16px\` padding on mobile.

## Test plan
- [ ] iPhone: hamburger opens drawer with nav + Sign in + Start free
- [ ] Drawer closes on backdrop tap / Esc / link click
- [ ] Each product demo now visible in full on 390px viewport (scaled)
- [ ] Only one ICO/FCA/GDPR strip renders (compact one at top)
- [ ] Third stat counts up to 100% like the siblings
- [ ] Nav \"Product\" scrolls to the features section
- [ ] Generate-letter button label not cramped on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)