### PR TITLE
fix(homepage): demo double-scaling, remove 14-day trial copy, make 'open full draft' work

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -27,9 +27,22 @@ export default function SignupPage() {
   const searchParams = useSearchParams();
   const supabase = createClient();
   const rawRedirect = searchParams.get('redirect');
-  const redirectTo = rawRedirect?.startsWith('/') && !rawRedirect.startsWith('//')
+  let redirectTo = rawRedirect?.startsWith('/') && !rawRedirect.startsWith('//')
     ? rawRedirect
     : null;
+
+  // Homepage "Sign up free to open the full draft" flow — carry the
+  // demo form intent straight into the dispute composer so the user
+  // doesn't re-type what they just described. See HeroDemo in
+  // src/app/preview/homepage/page.tsx for the source of these params.
+  if (!redirectTo && searchParams.get('from') === 'homepage_demo') {
+    const t = searchParams.get('type');
+    const iss = searchParams.get('issue');
+    const params = new URLSearchParams({ new: '1' });
+    if (t) params.set('type', t);
+    if (iss) params.set('issue', iss);
+    redirectTo = `/dashboard/complaints?${params.toString()}`;
+  }
 
   useEffect(() => {
     if (WAITLIST_MODE) {

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -295,7 +295,7 @@ function Nav() {
                 Sign in
               </Link>
               <Link className="btn btn-mint" href="/auth/signup" onClick={() => setMenuOpen(false)}>
-                Start free 14-day trial
+                Sign up free
               </Link>
             </div>
           </div>
@@ -464,9 +464,38 @@ function HeroDemo() {
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    if (status === 'drafting') return;
+    if (status !== 'idle') return;
     setStatus('drafting');
     window.setTimeout(() => setStatus('ready'), 900);
+  };
+
+  // When the demo has a drafted letter, we stash the intent in
+  // sessionStorage + pass it via query param so the signup flow
+  // can carry it into /dashboard/complaints?new=1 with the form
+  // already pre-filled. User signs up → lands inside the dispute
+  // composer → their free-tier 3-letters-a-month allowance now
+  // funds this letter for real. No quota is decremented at the
+  // preview stage because nothing was generated server-side.
+  const signupHref = useMemo(() => {
+    const params = new URLSearchParams({
+      from: 'homepage_demo',
+      type: issueId,
+      issue: desc || issue.placeholder,
+    });
+    return `/auth/signup?${params.toString()}`;
+  }, [issueId, desc, issue.placeholder]);
+
+  const handleOpenFullDraft = () => {
+    // Persist across the signup round-trip so the composer can
+    // pre-fill even if the user lands back via email confirmation.
+    if (typeof window !== 'undefined') {
+      try {
+        sessionStorage.setItem(
+          'pb_homepage_letter_intent',
+          JSON.stringify({ type: issueId, issue: desc || issue.placeholder, cite: issue.cite }),
+        );
+      } catch {}
+    }
   };
 
   return (
@@ -509,31 +538,109 @@ function HeroDemo() {
         We&rsquo;ll cite: <span style={{ color: 'var(--accent-mint)' }}>{issue.cite}</span>
       </div>
 
-      <button type="submit" disabled={status === 'drafting'}>
-        {status === 'idle' && 'Generate letter →'}
-        {status === 'drafting' && 'Drafting…'}
-        {status === 'ready' && '✓ Letter ready — open the full draft'}
-      </button>
+      {status !== 'ready' && (
+        <button type="submit" disabled={status === 'drafting'}>
+          {status === 'idle' && 'Generate letter →'}
+          {status === 'drafting' && 'Drafting…'}
+        </button>
+      )}
 
       {status === 'ready' && (
-        <div
-          style={{
-            marginTop: '14px',
-            padding: '14px',
-            borderRadius: '12px',
-            background: 'rgba(52, 211, 153, 0.08)',
-            border: '1px dashed var(--divider-ink)',
-            fontSize: '12px',
-            lineHeight: 1.55,
-            color: 'var(--text-on-ink-dim)',
-          }}
-        >
-          <strong style={{ color: 'var(--accent-mint)' }}>Preview:</strong> &ldquo;Under
-          {' '}
-          <span style={{ color: 'var(--accent-mint)' }}>{issue.cite}</span>, you are
-          required to&hellip;&rdquo; — the full letter takes 30 seconds inside the
-          Disputes Centre.
-        </div>
+        <>
+          <div
+            style={{
+              marginTop: '14px',
+              padding: '16px 18px',
+              borderRadius: '12px',
+              background: 'rgba(52, 211, 153, 0.08)',
+              border: '1px solid rgba(52, 211, 153, 0.3)',
+              fontSize: '12.5px',
+              lineHeight: 1.6,
+              color: 'var(--text-on-ink-dim)',
+            }}
+          >
+            <div
+              style={{
+                fontSize: '10px',
+                fontWeight: 700,
+                letterSpacing: '0.1em',
+                textTransform: 'uppercase',
+                color: 'var(--accent-mint)',
+                marginBottom: 8,
+              }}
+            >
+              ✓ Letter ready · preview
+            </div>
+            <p style={{ margin: 0, color: 'var(--text-on-ink)' }}>
+              <strong>Dear Sir/Madam,</strong>
+            </p>
+            <p style={{ margin: '8px 0 0' }}>
+              I am writing to formally dispute{' '}
+              {desc
+                ? `the following issue: "${desc}"`
+                : 'the matter described below'}
+              . Under{' '}
+              <span style={{ color: 'var(--accent-mint)', fontWeight: 600 }}>{issue.cite}</span>,
+              you are required to…
+            </p>
+            <p style={{ margin: '8px 0 0', fontStyle: 'italic', opacity: 0.7 }}>
+              [… the rest of the letter, including the specific remedy we&rsquo;re
+              asking for and the statutory deadline for their response, is only
+              shown once you sign up for a free account.]
+            </p>
+          </div>
+
+          <Link
+            href={signupHref}
+            onClick={handleOpenFullDraft}
+            style={{ display: 'block', marginTop: 10, textDecoration: 'none' }}
+          >
+            <span
+              style={{
+                display: 'block',
+                width: '100%',
+                padding: 12,
+                background: 'var(--accent-mint)',
+                color: '#052E1C',
+                borderRadius: 10,
+                fontWeight: 700,
+                fontSize: 14,
+                textAlign: 'center',
+              }}
+            >
+              Sign up free to open the full draft →
+            </span>
+          </Link>
+
+          <div
+            style={{
+              marginTop: 6,
+              fontSize: 11,
+              textAlign: 'center',
+              color: 'var(--text-on-ink-dim)',
+            }}
+          >
+            No card. Free tier gets 3 letters / month — this one is on us.
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setStatus('idle')}
+            style={{
+              marginTop: 4,
+              background: 'transparent',
+              border: 0,
+              color: 'var(--text-on-ink-dim)',
+              fontSize: 11.5,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              width: '100%',
+              padding: 6,
+            }}
+          >
+            Try another issue
+          </button>
+        </>
       )}
     </form>
   );
@@ -702,7 +809,7 @@ export default function HomepageV3PreviewPage() {
         <div className="wrap">
           <div className="hero-grid">
             <Reveal className="hero-copy">
-              <span className="eyebrow">Free 14-day Pro trial · No card required</span>
+              <span className="eyebrow">Free forever tier · No card required</span>
               <h1>
                 <span className="l1">Find Hidden Overcharges.</span>
                 <span className="l2">Fight Unfair Bills.</span>
@@ -715,7 +822,7 @@ export default function HomepageV3PreviewPage() {
               </p>
               <div className="hero-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup">
-                  Start free 14-day Pro trial →
+                  Sign up for free →
                 </Link>
                 <a className="btn btn-ghost" href="#how">
                   See how it works
@@ -1288,7 +1395,7 @@ export default function HomepageV3PreviewPage() {
                 <li>Pocket Agent in Telegram</li>
               </ul>
               <Link className="btn btn-mint cta" href="/auth/signup" style={{ justifyContent: 'center' }}>
-                Start 14-day trial →
+                Start free →
               </Link>
             </Reveal>
 
@@ -1371,7 +1478,7 @@ export default function HomepageV3PreviewPage() {
           </Reveal>
           <Reveal className="fc-btn-row">
             <Link className="btn btn-mint" href="/auth/signup">
-              Start your free 14-day Pro trial →
+              Sign up for free →
             </Link>
           </Reveal>
           <p className="fine">No card. Cancel anytime. Your data stays in the UK.</p>

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -2023,54 +2023,11 @@
   justify-content: center;
 }
 
-/* ============================================================
-   Demo stage responsive scaling — the product demos are built at
-   a fixed virtual 980×612 layout (absolutely-positioned panels,
-   flex:0 0 340px left columns etc) and break on narrow viewports.
-   Scale the inner frame to fit. Uses plain viewport units so it
-   works without container-query support.
-
-   Previous attempt relied on `[style*="position: absolute"]` which
-   React serialises WITHOUT the space after the colon in production
-   (`position:absolute`), so the selector never matched and the
-   demos continued to clip on iPhone. Now we match by direct-child
-   div, which unambiguously hits the inset-positioned wrapper since
-   the only other child of `.demo-stage` is `<span class="demo-label">`.
-   ============================================================ */
-@media (max-width: 820px) {
-  .m-v2-root .demo-stage {
-    /* Break out of the 16:10 intrinsic ratio so our calc height wins */
-    aspect-ratio: auto;
-    /* Scaled height = 56px label band + scaled content frame.
-       Content frame is the desktop 892×516 inner box; the scale
-       factor is the viewport-minus-wrap-padding divided by 892. */
-    height: calc(56px + 516px * ((100vw - 32px) / 892));
-    overflow: hidden;
-    position: relative;
-  }
-  /* Scale the only non-label child — the inline-styled inset
-     wrapper that holds the demo panels. */
-  .m-v2-root .demo-stage > div {
-    /* Pin to the canonical desktop inner-box coordinates so the
-       absolute inset + flex:0 0 340px children render as designed. */
-    position: absolute !important;
-    inset: 56px auto auto 44px !important;
-    width: 892px !important;
-    height: 516px !important;
-    /* Shrink to the container width. Using viewport units keeps
-       this correct across every demo instance on the page. */
-    transform: scale(calc((100vw - 32px) / 892));
-    transform-origin: top left;
-  }
-}
-@media (max-width: 560px) {
-  /* At the narrowest breakpoint the wrap padding drops to 16px/side
-     (see rules above), so recompute the scale factor against the
-     new available width. */
-  .m-v2-root .demo-stage {
-    height: calc(56px + 516px * ((100vw - 32px) / 892));
-  }
-  .m-v2-root .demo-stage > div {
-    transform: scale(calc((100vw - 32px) / 892));
-  }
-}
+/* NB: the previous two-layer mobile-scaling block (PR #189 + #193)
+   used to live here, targeting `.demo-stage > div` with its own
+   transform: scale. That stacked on top of the older wrapper-based
+   rule at ~line 1573 (`.feature-stage > .demo-stage` / `.demo-slot >
+   .demo-stage`), so the content was being scaled twice and rendered
+   at ~16% on iPhone. Removed — the wrapper-based rule alone handles
+   every demo cleanly because every demo is placed inside a
+   `.feature-stage` or `.demo-slot` wrapper on the homepage. */


### PR DESCRIPTION
Three user-flagged homepage issues in one PR.

## 1. Videos still clipping on iPhone
**Root cause:** \`styles.css\` had an older wrapper-based mobile scaling rule at ~line 1573 that scales \`.feature-stage > .demo-stage\` / \`.demo-slot > .demo-stage\` via transform. My PR #189 (+ refined by #193) added a second rule that also transform-scales \`.demo-stage > div\`. Both fire below 820px, so every demo was being scaled twice and rendering at ~16% on iPhone.

**Fix:** Remove my block entirely. Every demo is wrapped in \`.feature-stage\` or \`.demo-slot\`; the older single-layer rule handles them cleanly.

## 2. Remove 14-day Pro trial copy
Per CLAUDE.md the trial is dead (\"No 14-day Pro trial — it produced silent downgrades at expiry\") but the copy still promised it in six places. Updated eyebrow / hero CTA / mobile drawer / founding-tier / final CTA / Pricing page.

## 3. Homepage \"Letter ready\" button did nothing
HeroDemo's button was \`type=\"submit\"\` in the ready state, so clicking it just re-submitted the form.

- Hide the submit in ready state
- Show a proper preview block (greeting + one-sentence body using the user's issue + citation + \"[rest only shown once you sign up]\" teaser)
- Full-width **Sign up free to open the full draft →** Link that sets sessionStorage + deep-links to \`/auth/signup?from=homepage_demo&type=<issue>&issue=<desc>\`
- Signup page now recognises \`from=homepage_demo\` and redirects post-signup to \`/dashboard/complaints?new=1&type=…&issue=…\` — the existing NewDisputeForm already consumes those query params, so the user lands inside the composer with everything pre-filled
- Subtext: \"Free tier gets 3 letters / month — this one is on us.\"
- \"Try another issue\" link resets the demo

## Test plan
- [ ] iPhone: product demos render at proper ~40% scale, not miniature
- [ ] No instance of \"14-day\" / \"Pro trial\" anywhere on the homepage
- [ ] Mobile drawer CTA reads \"Sign up free\"
- [ ] Generate letter on homepage → click \"Sign up free to open the full draft\" → signup → lands in NewDisputeForm with issue_type + description pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)