### PR TITLE
feat(disputes): add sender/subject search to thread picker

### DIFF
--- a/src/app/api/disputes/[id]/suggest-threads/route.ts
+++ b/src/app/api/disputes/[id]/suggest-threads/route.ts
@@ -20,6 +20,8 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id: disputeId } = await params;
+  const searchQueryRaw = request.nextUrl.searchParams.get('q');
+  const searchQuery = searchQueryRaw?.trim() || undefined;
   const supabase = await createClient();
   const {
     data: { user },
@@ -63,9 +65,14 @@ export async function GET(
   const allCandidates: Array<{ candidate: Awaited<ReturnType<typeof findThreadCandidates>>[number]; connectionId: string }> = [];
   const errors: Array<{ connectionId: string; message: string }> = [];
 
+  // Search mode returns more results so the user has room to scroll; auto-
+  // match mode stays at 5 per connection / 3 total to keep the picker tight.
+  const perConnectionLimit = searchQuery ? 20 : 5;
+  const totalLimit = searchQuery ? 25 : 3;
+
   for (const conn of connections as EmailConnection[]) {
     try {
-      const cands = await findThreadCandidates(conn, dispute, 5);
+      const cands = await findThreadCandidates(conn, dispute, perConnectionLimit, searchQuery);
       for (const c of cands) {
         allCandidates.push({ candidate: c, connectionId: conn.id });
       }
@@ -77,15 +84,17 @@ export async function GET(
     }
   }
 
-  // Sort across connections and take top 3
-  allCandidates.sort(
-    (a, b) =>
-      b.candidate.confidence - a.candidate.confidence ||
-      b.candidate.latestDate.getTime() - a.candidate.latestDate.getTime(),
+  // In search mode, sort newest-first (confidence is flat for all search hits).
+  // In auto-match mode, sort by confidence then recency.
+  allCandidates.sort((a, b) =>
+    searchQuery
+      ? b.candidate.latestDate.getTime() - a.candidate.latestDate.getTime()
+      : b.candidate.confidence - a.candidate.confidence ||
+        b.candidate.latestDate.getTime() - a.candidate.latestDate.getTime(),
   );
 
   return NextResponse.json({
-    candidates: allCandidates.slice(0, 3).map((a) => ({
+    candidates: allCandidates.slice(0, totalLimit).map((a) => ({
       connectionId: a.connectionId,
       provider: a.candidate.provider,
       threadId: a.candidate.threadId,

--- a/src/components/dispute/WatchdogCard.tsx
+++ b/src/components/dispute/WatchdogCard.tsx
@@ -16,7 +16,7 @@
  *   - DELETE link-email-thread   -> soft-unlink (sync_enabled=false)
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Loader2, Mail, Link2, RefreshCw, CheckCircle2, AlertCircle, X, Search, Sparkles } from 'lucide-react';
 
 interface LinkedThread {
@@ -82,6 +82,8 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
   const [candidatesError, setCandidatesError] = useState<string | null>(null);
   const [needsEmailConnection, setNeedsEmailConnection] = useState(false);
   const [searchErrors, setSearchErrors] = useState<Array<{ connectionId: string; message: string }>>([]);
+  const [searchInput, setSearchInput] = useState('');
+  const [activeSearch, setActiveSearch] = useState('');
 
   const [linking, setLinking] = useState(false);
   const [syncing, setSyncing] = useState(false);
@@ -143,16 +145,29 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
   const linkedConnectionStale =
     !!linkedConnection && linkedConnection.status !== 'active';
 
-  const openPicker = async () => {
-    setPickerOpen(true);
+  // Cancel any in-flight candidate fetch when a newer one fires, so a
+  // slow request for an older query can't resolve after a newer one and
+  // overwrite state with stale results.
+  const inflightController = useRef<AbortController | null>(null);
+
+  const fetchCandidates = useCallback(async (query: string) => {
+    inflightController.current?.abort();
+    const controller = new AbortController();
+    inflightController.current = controller;
+
     setCandidates(null);
     setCandidatesError(null);
     setNeedsEmailConnection(false);
     setSearchErrors([]);
     setLoadingCandidates(true);
     try {
-      const res = await fetch(`/api/disputes/${disputeId}/suggest-threads`, { cache: 'no-store' });
+      const url = query
+        ? `/api/disputes/${disputeId}/suggest-threads?q=${encodeURIComponent(query)}`
+        : `/api/disputes/${disputeId}/suggest-threads`;
+      const res = await fetch(url, { cache: 'no-store', signal: controller.signal });
       const data = await res.json();
+      // Bail if a newer request has fired since — only the latest wins.
+      if (inflightController.current !== controller) return;
       if (!res.ok) {
         if (data.error === 'no_email_connection') {
           setNeedsEmailConnection(true);
@@ -174,12 +189,38 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
         setSearchErrors(data.errors);
       }
     } catch (e) {
+      // Aborted fetches throw AbortError — silently ignore since a newer
+      // query will have already updated state.
+      if (e instanceof Error && e.name === 'AbortError') return;
+      if (inflightController.current !== controller) return;
       setCandidatesError(e instanceof Error ? e.message : 'Something went wrong');
       setCandidates([]);
     } finally {
-      setLoadingCandidates(false);
+      if (inflightController.current === controller) {
+        setLoadingCandidates(false);
+        inflightController.current = null;
+      }
     }
+  }, [disputeId]);
+
+  const openPicker = async () => {
+    setPickerOpen(true);
+    setSearchInput('');
+    setActiveSearch('');
+    await fetchCandidates('');
   };
+
+  // Debounce the search input — wait 400ms after last keystroke before firing.
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const handle = setTimeout(() => {
+      if (searchInput.trim() !== activeSearch) {
+        setActiveSearch(searchInput.trim());
+        fetchCandidates(searchInput.trim());
+      }
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [searchInput, pickerOpen, activeSearch, fetchCandidates]);
 
   const pickCandidate = async (c: Candidate) => {
     setLinking(true);
@@ -437,6 +478,21 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
                 <X className="h-5 w-5" />
               </button>
             </div>
+            <div className="px-5 pt-4 pb-3 border-b border-navy-700/40">
+              <label className="relative block">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500 pointer-events-none" />
+                <input
+                  type="search"
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  placeholder="Can't find it? Search by sender or subject…"
+                  className="w-full pl-9 pr-3 py-2 text-sm rounded-lg bg-navy-950 border border-navy-700/60 text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-mint-400/40 focus:border-mint-400"
+                />
+              </label>
+              <p className="text-[11px] text-slate-500 mt-1.5 px-1">
+                Tip: try <code className="bg-navy-950 text-slate-300 px-1 rounded">from:directhirebilling</code> or part of the subject line.
+              </p>
+            </div>
             <div className="p-5 overflow-y-auto flex-1">
               {loadingCandidates ? (
                 <div className="flex items-center gap-2 text-slate-500 py-10 justify-center">
@@ -472,8 +528,9 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
                   <Mail className="h-10 w-10 text-slate-700 mx-auto mb-3" />
                   <p className="text-slate-700 font-semibold mb-1">No matching threads found</p>
                   <p className="text-slate-500 text-sm">
-                    We searched the last 365 days for mail mentioning {providerName}. If the thread
-                    is older, forward the most recent message to yourself first, then try again.
+                    {activeSearch
+                      ? `No threads matched "${activeSearch}" in the last 365 days. Try a different sender domain or keyword.`
+                      : `We searched the last 365 days for mail mentioning ${providerName}. If the sender doesn't include "${providerName}" in its address, use the search above.`}
                   </p>
                   {searchErrors.length > 0 && (
                     <div className="mt-4 bg-amber-500/10 border border-amber-500/20 text-amber-300 rounded-lg p-3 text-left text-xs">
@@ -511,9 +568,11 @@ export default function WatchdogCard({ disputeId, providerName, onChanged }: Pro
                           <p className="text-sm font-semibold text-slate-900 truncate" title={c.subject}>
                             {c.subject || '(no subject)'}
                           </p>
-                          <span className="text-[10px] uppercase tracking-wide text-mint-400 font-semibold flex-shrink-0">
-                            {Math.round(c.confidence * 100)}%
-                          </span>
+                          {!activeSearch && (
+                            <span className="text-[10px] uppercase tracking-wide text-mint-400 font-semibold flex-shrink-0">
+                              {Math.round(c.confidence * 100)}%
+                            </span>
+                          )}
                         </div>
                         <p className="text-xs text-slate-500 truncate">from {c.senderAddress}</p>
                         <p className="text-xs text-slate-500 mt-1 line-clamp-2">{c.snippet}</p>

--- a/src/lib/dispute-sync/matcher.ts
+++ b/src/lib/dispute-sync/matcher.ts
@@ -66,28 +66,36 @@ async function ensureFreshToken(conn: EmailConnection, provider: EmailProvider):
 async function findGmailCandidates(
   conn: EmailConnection,
   dispute: DisputeForMatching,
+  searchQuery?: string,
 ): Promise<ThreadCandidate[]> {
   const token = await ensureFreshToken(conn, 'gmail');
   const domains = domainsForProvider(dispute.provider_name);
   const explicit = hasExplicitDomains(dispute.provider_name);
 
-  // Cascading query strategy — start narrow, broaden if nothing found.
-  // This fixes the case where a supplier sends from an unexpected subdomain
-  // (e.g. noreply@billing.onestream-telecom.co.uk) or uses subjects without
-  // the brand name (e.g. "Your January invoice").
   const providerPhrase = dispute.provider_name.trim();
   const subjectTerm = providerPhrase.split(/\s+/)[0].toLowerCase();
   const fromClauses = domains.map((d) => `from:${d}`).join(' OR ');
 
   const queries: string[] = [];
-  if (fromClauses) {
-    queries.push(`(${fromClauses}) newer_than:365d`);
-  }
-  // Broad full-text: catches emails that mention the provider anywhere in
-  // headers/body, even if the from-domain isn't in our allowlist.
-  queries.push(`"${providerPhrase}" newer_than:365d`);
-  if (providerPhrase.toLowerCase() !== subjectTerm) {
-    queries.push(`"${subjectTerm}" newer_than:365d`);
+  if (searchQuery && searchQuery.trim()) {
+    // User-typed search: pass straight through to Gmail. Gmail's q= understands
+    // free text plus operators (from:, subject:, etc.) so the user can type
+    // whatever they like ("directhirebilling", "from:ebay.co.uk", "9M2KMS").
+    queries.push(`${searchQuery.trim()} newer_than:365d`);
+  } else {
+    // Cascading query strategy — start narrow, broaden if nothing found.
+    // This fixes the case where a supplier sends from an unexpected subdomain
+    // (e.g. noreply@billing.onestream-telecom.co.uk) or uses subjects without
+    // the brand name (e.g. "Your January invoice").
+    if (fromClauses) {
+      queries.push(`(${fromClauses}) newer_than:365d`);
+    }
+    // Broad full-text: catches emails that mention the provider anywhere in
+    // headers/body, even if the from-domain isn't in our allowlist.
+    queries.push(`"${providerPhrase}" newer_than:365d`);
+    if (providerPhrase.toLowerCase() !== subjectTerm) {
+      queries.push(`"${subjectTerm}" newer_than:365d`);
+    }
   }
 
   let threads: Array<{ id: string }> = [];
@@ -131,21 +139,28 @@ async function findGmailCandidates(
 
     let confidence = 0.3;
     const reasons: string[] = [];
-    if (explicit && addressMatchesProvider(fromAddr, dispute.provider_name)) {
-      confidence += 0.5;
-      reasons.push(`sender domain matches ${dispute.provider_name}`);
-    } else if (fromDomain.includes(subjectTerm)) {
-      confidence += 0.25;
-      reasons.push(`sender domain contains '${subjectTerm}'`);
-    }
-    const subj = h('Subject').toLowerCase();
-    if (subj.includes(subjectTerm)) {
-      confidence += 0.1;
-      reasons.push('subject mentions provider');
-    }
-    if (msgs.length >= 2) {
-      confidence += 0.1;
-      reasons.push(`${msgs.length} messages in thread`);
+    if (searchQuery && searchQuery.trim()) {
+      // User-driven search — we trust the query and don't score against the
+      // provider. Flat confidence so results sort by latestDate instead.
+      confidence = 0.5;
+      reasons.push('matched your search');
+    } else {
+      if (explicit && addressMatchesProvider(fromAddr, dispute.provider_name)) {
+        confidence += 0.5;
+        reasons.push(`sender domain matches ${dispute.provider_name}`);
+      } else if (fromDomain.includes(subjectTerm)) {
+        confidence += 0.25;
+        reasons.push(`sender domain contains '${subjectTerm}'`);
+      }
+      const subj = h('Subject').toLowerCase();
+      if (subj.includes(subjectTerm)) {
+        confidence += 0.1;
+        reasons.push('subject mentions provider');
+      }
+      if (msgs.length >= 2) {
+        confidence += 0.1;
+        reasons.push(`${msgs.length} messages in thread`);
+      }
     }
 
     candidates.push({
@@ -171,6 +186,7 @@ async function findGmailCandidates(
 async function findOutlookCandidates(
   conn: EmailConnection,
   dispute: DisputeForMatching,
+  searchQuery?: string,
 ): Promise<ThreadCandidate[]> {
   const token = await ensureFreshToken(conn, 'outlook');
   const domains = domainsForProvider(dispute.provider_name);
@@ -178,13 +194,20 @@ async function findOutlookCandidates(
   const providerPhrase = dispute.provider_name.trim();
   const subjectTerm = providerPhrase.split(/\s+/)[0];
 
-  // Cascading Outlook search: full-text on provider phrase first, then domain
-  // fallback. Graph's $search does body+headers so it's more forgiving than
-  // Gmail's default which is why we lead with it here.
-  const searches: string[] = [`"${providerPhrase}"`];
-  if (domains.length) searches.push(`"${domains[0]}"`);
-  if (providerPhrase.toLowerCase() !== subjectTerm.toLowerCase()) {
-    searches.push(`"${subjectTerm}"`);
+  const searches: string[] = [];
+  if (searchQuery && searchQuery.trim()) {
+    // User-typed search: pass through. Graph $search accepts KQL (from:, subject:)
+    // as well as free text so the user can type what they like.
+    searches.push(searchQuery.trim());
+  } else {
+    // Cascading Outlook search: full-text on provider phrase first, then domain
+    // fallback. Graph's $search does body+headers so it's more forgiving than
+    // Gmail's default which is why we lead with it here.
+    searches.push(`"${providerPhrase}"`);
+    if (domains.length) searches.push(`"${domains[0]}"`);
+    if (providerPhrase.toLowerCase() !== subjectTerm.toLowerCase()) {
+      searches.push(`"${subjectTerm}"`);
+    }
   }
 
   let data: { value?: Array<{
@@ -251,20 +274,25 @@ async function findOutlookCandidates(
 
     let confidence = 0.3;
     const reasons: string[] = [];
-    if (explicit && addressMatchesProvider(fromAddr, dispute.provider_name)) {
-      confidence += 0.5;
-      reasons.push(`sender domain matches ${dispute.provider_name}`);
-    } else if (fromDomain.includes(subjectTerm.toLowerCase())) {
-      confidence += 0.25;
-      reasons.push(`sender domain contains '${subjectTerm.toLowerCase()}'`);
-    }
-    if (entry.subject.toLowerCase().includes(subjectTerm.toLowerCase())) {
-      confidence += 0.1;
-      reasons.push('subject mentions provider');
-    }
-    if (entry.messages.length >= 2) {
-      confidence += 0.1;
-      reasons.push(`${entry.messages.length} messages in thread`);
+    if (searchQuery && searchQuery.trim()) {
+      confidence = 0.5;
+      reasons.push('matched your search');
+    } else {
+      if (explicit && addressMatchesProvider(fromAddr, dispute.provider_name)) {
+        confidence += 0.5;
+        reasons.push(`sender domain matches ${dispute.provider_name}`);
+      } else if (fromDomain.includes(subjectTerm.toLowerCase())) {
+        confidence += 0.25;
+        reasons.push(`sender domain contains '${subjectTerm.toLowerCase()}'`);
+      }
+      if (entry.subject.toLowerCase().includes(subjectTerm.toLowerCase())) {
+        confidence += 0.1;
+        reasons.push('subject mentions provider');
+      }
+      if (entry.messages.length >= 2) {
+        confidence += 0.1;
+        reasons.push(`${entry.messages.length} messages in thread`);
+      }
     }
 
     candidates.push({
@@ -308,24 +336,30 @@ export async function findThreadCandidates(
   conn: EmailConnection,
   dispute: DisputeForMatching,
   limit = 3,
+  searchQuery?: string,
 ): Promise<ThreadCandidate[]> {
   const provider = providerFromConnection(conn);
   let candidates: ThreadCandidate[];
 
   switch (provider) {
     case 'gmail':
-      candidates = await findGmailCandidates(conn, dispute);
+      candidates = await findGmailCandidates(conn, dispute, searchQuery);
       break;
     case 'outlook':
-      candidates = await findOutlookCandidates(conn, dispute);
+      candidates = await findOutlookCandidates(conn, dispute, searchQuery);
       break;
     case 'imap':
+      // IMAP search passthrough not wired yet — fall back to provider-name match.
       candidates = await findImapCandidates(conn, dispute);
       break;
   }
 
   return candidates
-    .sort((a, b) => b.confidence - a.confidence || b.latestDate.getTime() - a.latestDate.getTime())
+    .sort((a, b) =>
+      searchQuery
+        ? b.latestDate.getTime() - a.latestDate.getTime()
+        : b.confidence - a.confidence || b.latestDate.getTime() - a.latestDate.getTime(),
+    )
     .slice(0, limit);
 }
 


### PR DESCRIPTION
## Summary

The "Find thread" modal only auto-suggests threads that match the dispute's `provider_name` against sender domains and subjects. That breaks when the supplier replies from an unrelated-looking address — e.g. an Enterprise Rent-A-Car dispute where replies come from `@directhirebilling.*` and never mention "enterprise" in the headers, so no candidates surface and the user is stuck.

Adds a search input to the picker. When the user types, we pass the query straight to Gmail's `q=` / Graph's `$search=`, both of which accept free text plus operators like `from:` and `subject:`.

- Search mode: sort by recency, hide confidence % badge (flat for all search hits), reason reads "matched your search", widen result cap to 25
- Auto-match mode: unchanged when the input is empty
- IMAP falls back to provider-name match (search passthrough can be added later)

## Files

- `src/lib/dispute-sync/matcher.ts` — `findThreadCandidates` gains optional `searchQuery` that short-circuits the cascading query strategy for Gmail + Outlook
- `src/app/api/disputes/[id]/suggest-threads/route.ts` — accept `?q=`, widen the per-connection and total caps when set
- `src/components/dispute/WatchdogCard.tsx` — search input with 400ms debounce, refetches on change, empty state adapts to search mode

## Test plan

- [ ] Open a dispute where the supplier replies from an unrelated domain; confirm empty input returns the pre-existing auto-match and typing the sender's actual domain returns the correct thread
- [ ] Try an operator query like `from:directhirebilling` on a Gmail connection — should return Gmail threads matching that sender
- [ ] Try a free-text query on an Outlook connection — should return $search hits
- [ ] Debounce: rapid typing shouldn't spam the network (400ms settle)
- [ ] Confidence % badge hidden in search mode, visible in auto-match
- [ ] Empty state copy reads sensibly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)