### PR TITLE
fix(homepage): iPhone video clipping — add @media fallback for demo scaling

### DIFF
--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1583,6 +1583,30 @@
   }
 }
 
+/* Phone fallback (≤560px). iOS Safari has intermittent bugs where
+   `transform: scale(calc(100cqw / ...))` evaluates to scale(1) on
+   mount, leaving the 980×612.5 demo at native size — the wrapper's
+   overflow:hidden then clips it to a top-left corner, which is the
+   "only half the video renders" symptom reported on iPhone.
+   The @container rule above still applies on working browsers; this
+   rule is later in the cascade so it wins there too and produces the
+   same visible result (on iPhone the wrap padding is 0 16px, so the
+   container inline-size equals 100vw − 32px).
+   Both .feature-stage and .demo-slot live inside .wrap on this page,
+   so the 32px subtrahend is valid for every demo.  */
+@media (max-width: 560px) {
+  .m-v2-root .feature-stage > .demo-stage,
+  .m-v2-root .demo-slot > .demo-stage {
+    width: 980px;
+    height: 612.5px;
+    max-width: none;
+    aspect-ratio: auto;
+    margin: 0;
+    transform-origin: top left;
+    transform: scale(calc((100vw - 32px) / 980));
+  }
+}
+
 /* The wrapper itself must reserve the scaled height so the page
    layout doesn't collapse around the now-transformed child. */
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary

Users keep reporting that homepage demos only render half on iPhone despite PR #189 / #193 / #194. I've finally root-caused it:

iOS Safari has intermittent bugs where `transform: scale(calc(100cqw / 980))` evaluates to `scale(1)` on mount — the `cqw` unit resolves before the container-query container has finished laying out. With the demo stuck at native 980×612.5 inside a 358×224 wrapper, `overflow: hidden` clips it to the top-left corner. That's exactly the "only half the video" symptom the user described.

## Fix

Adds a plain `@media (max-width: 560px)` rule that applies the same transform using `(100vw - 32px) / 980`. The 32px matches the `.wrap` padding on phones (set under `@media (max-width: 560px)` at line 1868 — `padding: 0 16px`).

Both `.feature-stage` and `.demo-slot` live inside `.wrap` on this page, so the formula is valid for every demo.

## Cascade

- Modern browsers where `@container` works: the `@media` rule is later in source with equal specificity → it overrides with a visually identical result (100vw-32px ≈ 100cqw on phones).
- iOS Safari where `@container` + `cqw` + `transform` misfires: `@media` fires alone → demo scales correctly.

Tablets (560–900px) keep the `@container` path — they were never the problem and the padding differs from phones.

## Test plan

- [ ] Open https://paybacker.co.uk on iPhone — all 7 demos render fully inside their frames (Disputes, Pocket Agent, Money Hub, Subscriptions, Export, Deals, MCP)
- [ ] Open on Android Chrome — same behaviour
- [ ] Open on iPad — @container path still scales correctly (no regression)
- [ ] Open on desktop >900px — no change, demos render at native size

🤖 Generated with [Claude Code](https://claude.com/claude-code)