### PR TITLE
fix(marketing): blog/pricing copy + footer 404s

### DIFF
--- a/src/app/blog/_shared.tsx
+++ b/src/app/blog/_shared.tsx
@@ -56,7 +56,6 @@ export function MarkFoot() {
             <Link href="/how-it-works">How it works</Link>
             <Link href="/pricing">Pricing</Link>
             <Link href="/deals">Deals</Link>
-            <Link href="/templates">Letter templates</Link>
           </div>
           <div className="footer-col">
             <h5>Company</h5>
@@ -67,10 +66,9 @@ export function MarkFoot() {
           </div>
           <div className="footer-col">
             <h5>Legal</h5>
-            <Link href="/privacy">Privacy</Link>
-            <Link href="/terms">Terms</Link>
-            <Link href="/cookies">Cookies</Link>
-            <Link href="/ico-notice">ICO notice</Link>
+            <Link href="/legal/privacy">Privacy</Link>
+            <Link href="/legal/terms">Terms</Link>
+            <Link href="/cookie-policy">Cookies</Link>
           </div>
           <div className="footer-col">
             <h5>Connect</h5>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -48,13 +48,39 @@ type Post = {
   emoji: string;
 };
 
-const GRADIENTS = [
-  { bg: 'linear-gradient(135deg, #34D399, #059669)', emoji: '✉' },
-  { bg: 'linear-gradient(135deg, #F59E0B, #D97706)', emoji: '📡' },
-  { bg: 'linear-gradient(135deg, #3B82F6, #2563EB)', emoji: '✈' },
-  { bg: 'linear-gradient(135deg, #8B5CF6, #6D28D9)', emoji: '⚖' },
-  { bg: 'linear-gradient(135deg, #F43F5E, #DC2626)', emoji: '💷' },
+// Topic-keyed art. Each entry has a keyword list and the gradient+emoji to use
+// when the post title / category / slug mentions that topic. Order matters —
+// the first match wins, so more specific topics go first.
+const TOPIC_ART: ReadonlyArray<{
+  keywords: readonly string[];
+  bg: string;
+  emoji: string;
+}> = [
+  { keywords: ['flight', 'airline', 'eu261', 'uk261', 'delay', 'cancell'], bg: 'linear-gradient(135deg, #3B82F6, #2563EB)', emoji: '✈' },
+  { keywords: ['parking', 'pcn', 'dvla', 'driving', 'car park'], bg: 'linear-gradient(135deg, #8B5CF6, #6D28D9)', emoji: '🅿' },
+  { keywords: ['broadband', 'internet', 'wifi', 'router', 'fibre'], bg: 'linear-gradient(135deg, #F59E0B, #D97706)', emoji: '📡' },
+  { keywords: ['energy', 'gas', 'electric', 'tariff', 'ofgem', 'bill cap'], bg: 'linear-gradient(135deg, #FACC15, #CA8A04)', emoji: '⚡' },
+  { keywords: ['mobile', 'phone contract', 'sim', 'roaming'], bg: 'linear-gradient(135deg, #0EA5E9, #0369A1)', emoji: '📱' },
+  { keywords: ['insurance', 'claim', 'policy', 'ombudsman'], bg: 'linear-gradient(135deg, #06B6D4, #0E7490)', emoji: '🛡' },
+  { keywords: ['council tax', 'council-tax'], bg: 'linear-gradient(135deg, #64748B, #334155)', emoji: '🏛' },
+  { keywords: ['hmrc', 'tax rebate', 'tax-rebate'], bg: 'linear-gradient(135deg, #14B8A6, #0F766E)', emoji: '📄' },
+  { keywords: ['debt', 'collection', 'bailiff', 'ccj'], bg: 'linear-gradient(135deg, #EF4444, #B91C1C)', emoji: '⛔' },
+  { keywords: ['bank', 'overdraft', 'refund', 'chargeback'], bg: 'linear-gradient(135deg, #F43F5E, #DC2626)', emoji: '💷' },
+  { keywords: ['subscription', 'netflix', 'streaming', 'gym'], bg: 'linear-gradient(135deg, #14B8A6, #0D9488)', emoji: '🎬' },
+  { keywords: ['consumer rights', 'cra 2015', 'statute', 'law', 'legislation'], bg: 'linear-gradient(135deg, #8B5CF6, #6D28D9)', emoji: '⚖' },
+  { keywords: ['complaint', 'dispute', 'letter', 'template'], bg: 'linear-gradient(135deg, #34D399, #059669)', emoji: '✉' },
 ];
+
+// Default art for posts that don't match any keyword.
+const DEFAULT_ART = { bg: 'linear-gradient(135deg, #34D399, #059669)', emoji: '✉' };
+
+function artFor(post: { title: string; cat?: string | null; href: string }): { bg: string; emoji: string } {
+  const haystack = `${post.title} ${post.cat ?? ''} ${post.href}`.toLowerCase();
+  for (const t of TOPIC_ART) {
+    if (t.keywords.some((k) => haystack.includes(k))) return { bg: t.bg, emoji: t.emoji };
+  }
+  return DEFAULT_ART;
+}
 
 // Hand-coded SEO posts that already exist as live pages under /blog/*.
 const STATIC_POSTS: ReadonlyArray<Omit<Post, 'gradient' | 'emoji'>> = [
@@ -100,20 +126,22 @@ async function fetchDynamicPosts(): Promise<Post[]> {
       .order('published_at', { ascending: false })
       .limit(20);
     if (!data) return [];
-    return data.map((p, i): Post => {
-      const g = GRADIENTS[i % GRADIENTS.length];
+    return data.map((p): Post => {
+      const cat = (p.category as string | null) ?? 'Essay';
+      const href = `/blog/${p.slug}`;
+      const art = artFor({ title: p.title, cat, href });
       return {
         title: p.title,
         excerpt: p.excerpt ?? '',
-        href: `/blog/${p.slug}`,
+        href,
         date: new Date(p.published_at).toLocaleDateString('en-GB', {
           day: 'numeric',
           month: 'long',
           year: 'numeric',
         }),
-        cat: (p.category as string | null) ?? 'Essay',
-        gradient: g.bg,
-        emoji: g.emoji,
+        cat,
+        gradient: art.bg,
+        emoji: art.emoji,
       };
     });
   } catch {
@@ -123,9 +151,9 @@ async function fetchDynamicPosts(): Promise<Post[]> {
 
 export default async function BlogIndexPage() {
   const dynamicPosts = await fetchDynamicPosts();
-  const staticWithArt: Post[] = STATIC_POSTS.map((p, i) => {
-    const g = GRADIENTS[(dynamicPosts.length + i) % GRADIENTS.length];
-    return { ...p, gradient: g.bg, emoji: g.emoji };
+  const staticWithArt: Post[] = STATIC_POSTS.map((p) => {
+    const art = artFor(p);
+    return { ...p, gradient: art.bg, emoji: art.emoji };
   });
   const allPosts: Post[] = [...dynamicPosts, ...staticWithArt];
   const [featured, ...rest] = allPosts;

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -143,13 +143,24 @@ const MATH_ROWS: ReadonlyArray<{
 
 const COMPARE_ROWS: ReadonlyArray<readonly [string, string, string, string]> = [
   ['AI dispute letters', '3 / month', 'Unlimited', 'Unlimited'],
-  ['Bank sync (read-only, FCA via Yapily)', '—', '2 accounts', 'Unlimited'],
-  ['Email inbox scan', '—', '•', '•'],
-  ['Subscription tracker', 'Manual only', '•', '•'],
-  ['Public deals marketplace', '•', '•', '•'],
-  ['Pocket Agent in Telegram', '—', '•', '•'],
-  ['Deal alerts on bill changes', '—', '—', '•'],
-  ['Priority human review', '—', '—', '•'],
+  ['Bank accounts (read-only, FCA via Yapily)', '2', '3', 'Unlimited'],
+  ['Email inboxes (Watchdog reply monitoring)', '1', '3', 'Unlimited'],
+  ['Subscription tracker', 'Unlimited', 'Unlimited', 'Unlimited'],
+  ['Pocket Agent in Telegram', '•', '•', '•'],
+  ['AI chatbot', '•', '•', '•'],
+  ['Spending intelligence', 'Top 5 categories', 'All 20+ categories', 'All 20+ categories'],
+  ['AI cancellation emails with legal context', '—', '•', '•'],
+  ['Renewal reminders (30/14/7 days)', '—', '•', '•'],
+  ['Money Hub budgets + savings goals', '—', '•', '•'],
+  ['Price-increase alerts by email', '—', '•', '•'],
+  ['Contract end-date tracking', '—', '•', '•'],
+  ['Money Hub top merchants', '—', '—', '•'],
+  ['Full transaction-level analysis', '—', '—', '•'],
+  ['Price-increase alerts via Telegram (instant)', '—', '—', '•'],
+  ['Export (CSV / PDF)', '—', '—', '•'],
+  ['Paybacker MCP (Claude Desktop)', '—', '—', '•'],
+  ['On-demand bank sync', '—', '—', '•'],
+  ['Priority support', '—', '—', '•'],
   ['Success fee on refunds', '0%', '0%', '0%'],
 ];
 
@@ -230,8 +241,11 @@ export default function PricingPage() {
               <div className="founding" style={{ visibility: 'hidden' }}>—</div>
               <ul>
                 <li>3 AI dispute letters / month</li>
-                <li>Manual subscription tracker</li>
-                <li>Public deals marketplace</li>
+                <li>2 bank accounts · daily auto-sync</li>
+                <li>1 email inbox · Watchdog reply monitoring</li>
+                <li>Unlimited subscription tracker</li>
+                <li>Basic spending overview (top 5 categories)</li>
+                <li>Pocket Agent in Telegram + AI chatbot</li>
               </ul>
               <Link className="btn btn-ghost cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
                 Start free →
@@ -244,15 +258,19 @@ export default function PricingPage() {
               <div className="price">
                 £4.99<span className="per">/month</span>
               </div>
-              <div className="founding">Founding member · locked-in forever</div>
+              <div className="founding">or £44.99/yr · Founding rate locked-in forever</div>
               <ul>
                 <li>Unlimited AI dispute letters</li>
-                <li>Bank sync — 2 accounts</li>
-                <li>Email inbox scan</li>
-                <li>Pocket Agent in Telegram</li>
+                <li>3 bank accounts · daily auto-sync</li>
+                <li>3 email inboxes · Watchdog reply monitoring</li>
+                <li>AI cancellation emails with legal context</li>
+                <li>Full spending intelligence (20+ categories)</li>
+                <li>Budgets + savings goals</li>
+                <li>Renewal reminders (30/14/7 days)</li>
+                <li>Price-increase alerts by email</li>
               </ul>
               <Link className="btn btn-mint cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
-                Start 14-day trial →
+                Get Essential →
               </Link>
             </div>
 
@@ -261,12 +279,16 @@ export default function PricingPage() {
               <div className="price">
                 £9.99<span className="per">/month</span>
               </div>
-              <div className="founding">Founding member · locked-in forever</div>
+              <div className="founding">or £94.99/yr · Founding rate locked-in forever</div>
               <ul>
                 <li>Everything in Essential</li>
                 <li>Unlimited bank &amp; email connections</li>
-                <li>Deal alerts on bill changes</li>
-                <li>Priority human review on complex disputes</li>
+                <li>Money Hub top merchants + transaction analysis</li>
+                <li>Price-increase alerts via Telegram (instant)</li>
+                <li>Export to CSV &amp; PDF</li>
+                <li>Paybacker MCP (Claude Desktop integration)</li>
+                <li>On-demand bank sync</li>
+                <li>Priority support</li>
               </ul>
               <Link className="btn btn-ghost cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
                 Go Pro →


### PR DESCRIPTION
## Summary

Three bundled fixes against the public marketing surface.

### 1. Blog card images picked by topic, not cycling index

Each post's gradient + emoji was assigned by \`GRADIENTS[i % 5]\`, so the "appeal a parking fine" post ended up with an aeroplane. New \`artFor()\` helper picks gradient + emoji based on keyword matches in title/category/slug:

- flight/airline/EU261 → ✈ blue
- parking/PCN/DVLA → 🅿 purple
- broadband/fibre → 📡 orange
- energy/gas/tariff → ⚡ yellow
- mobile/SIM → 📱 deep blue
- insurance/claim → 🛡 cyan
- council tax → 🏛 grey
- HMRC/tax rebate → 📄 teal
- debt/bailiff/CCJ → ⛔ red
- bank/refund/chargeback → 💷 rose
- subscription/streaming → 🎬 teal
- consumer rights/CRA/law → ⚖ purple
- complaint/dispute/letter → ✉ mint
- unknown → neutral ✉

### 2. Pricing page matches Emma-matched tier matrix

Updated bullet lists on all three tier cards + the feature comparison table to reflect what \`src/lib/plan-limits.ts\` actually grants (agreed 2026-04-22). Key changes:

- **Free** now shows: 2 banks / 1 email / 3 letters / unlimited sub tracker / basic spending / Pocket Agent + AI chatbot
- **Essential** now shows: unlimited letters / 3 banks / 3 emails / AI cancellation emails / full spending / budgets + goals / renewal reminders / price-increase alerts by email. "or £44.99/yr" strapline added.
- **Pro** now shows: everything in Essential + unlimited banks/emails / top merchants + transaction analysis / instant Telegram alerts / CSV + PDF export / Paybacker MCP / on-demand sync / priority support. "or £94.99/yr" strapline added.
- **Removed "Start 14-day trial →"** CTA per \`CLAUDE.md\` rule ("No 14-day Pro trial"). Changed to "Get Essential →".
- Full \`COMPARE_ROWS\` rebuilt from the authoritative matrix.

### 3. Footer 404s on the blog

\`src/app/blog/_shared.tsx\` \`MarkFoot\` linked to four non-existent paths. Fixed:

- \`/privacy\` → \`/legal/privacy\`
- \`/terms\` → \`/legal/terms\`
- \`/cookies\` → \`/cookie-policy\`
- \`/templates\` (Letter templates) — **removed** (confirmed not needed)
- \`/ico-notice\` — **removed** (no page exists; ICO registration info lives inside /legal/privacy)

## Files

- \`src/app/blog/_shared.tsx\` — footer paths
- \`src/app/blog/page.tsx\` — topic-keyed \`artFor()\`
- \`src/app/pricing/page.tsx\` — tier bullets + CTA + comparison table

## Test plan

- [ ] /pricing shows 8 bullets on Essential + 8 on Pro; free shows 6; CTA reads "Get Essential →"
- [ ] /pricing comparison table shows unlimited-banks-on-Pro, MCP on Pro, Top Merchants on Pro, instant Telegram alerts on Pro
- [ ] /blog cards show correct emoji per topic (flight = ✈, parking = 🅿, energy = ⚡, broadband = 📡)
- [ ] /blog footer — Privacy, Terms, Cookies all load (no 404)
- [ ] /blog footer — no "Letter templates" or "ICO notice" links

🤖 Generated with [Claude Code](https://claude.com/claude-code)