### PR TITLE
fix(disputes): thread UX — newest-first + collapsible, notification deep-link, Telegram draft in timeline, full thread context

### DIFF
--- a/src/app/api/complaints/generate/route.ts
+++ b/src/app/api/complaints/generate/route.ts
@@ -60,6 +60,7 @@ export async function POST(request: NextRequest) {
           const date = new Date(c.entry_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
           const typeLabel: Record<string, string> = {
             ai_letter: 'Our letter sent',
+            user_reply: 'User reply sent (drafted via Telegram)',
             company_email: 'Email from company',
             company_letter: 'Letter from company',
             phone_call: 'Phone call summary',

--- a/src/app/api/disputes/[id]/route.ts
+++ b/src/app/api/disputes/[id]/route.ts
@@ -33,10 +33,12 @@ export async function GET(
     return NextResponse.json({ error: 'Dispute not found' }, { status: 404 });
   }
 
-  // Sort correspondence by date ascending (oldest first = thread order)
+  // Sort correspondence newest-first so the user sees the latest reply at the
+  // top of the thread without scrolling. The dashboard UI collapses older
+  // entries under a "Show older" toggle.
   if (dispute.correspondence) {
     dispute.correspondence.sort(
-      (a: any, b: any) => new Date(a.entry_date).getTime() - new Date(b.entry_date).getTime()
+      (a: any, b: any) => new Date(b.entry_date).getTime() - new Date(a.entry_date).getTime(),
     );
   }
 

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -170,6 +170,7 @@ interface DisputeSummary {
 
 const ENTRY_TYPE_CONFIG: Record<string, { label: string; icon: typeof FileText; className: string }> = {
   ai_letter: { label: 'Your letter', icon: FileText, className: 'border-emerald-500/30 bg-emerald-500/5' },
+  user_reply: { label: 'Your reply', icon: FileText, className: 'border-emerald-500/30 bg-emerald-500/5' },
   company_email: { label: 'Their email', icon: Mail, className: 'border-orange-400/30 bg-orange-400/5' },
   company_letter: { label: 'Their letter', icon: FileText, className: 'border-orange-400/30 bg-orange-400/5' },
   phone_call: { label: 'Phone call', icon: Phone, className: 'border-blue-400/30 bg-blue-400/5' },
@@ -906,6 +907,9 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
   const [loadingCaption, setLoadingCaption] = useState(0);
   const latestLetterRef = useRef<HTMLDivElement>(null);
   const [previousLength, setPreviousLength] = useState(0);
+  // Older entries are collapsed by default on disputes with many replies so
+  // the latest correspondence is always visible without scrolling.
+  const [showAllEntries, setShowAllEntries] = useState(false);
 
   useEffect(() => {
     if (generating) {
@@ -927,6 +931,24 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
       setPreviousLength(dispute.correspondence.length);
     }
   }, [dispute?.correspondence?.length]);
+
+  // Deep-link from in-app notifications — when the URL has #entry-<id>, scroll
+  // the specific correspondence entry into view and auto-expand older entries
+  // if the target was hidden.
+  useEffect(() => {
+    if (!dispute?.correspondence || typeof window === 'undefined') return;
+    const hash = window.location.hash;
+    if (!hash.startsWith('#entry-')) return;
+    const targetId = hash.slice('#entry-'.length);
+    const idx = dispute.correspondence.findIndex((e) => e.id === targetId);
+    if (idx < 0) return;
+    // If the target is beyond the collapsed visible window, expand.
+    if (idx >= 2) setShowAllEntries(true);
+    // Wait a tick so the DOM is up-to-date after (potential) re-render, then scroll.
+    setTimeout(() => {
+      document.getElementById(`entry-${targetId}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 250);
+  }, [dispute?.correspondence]);
 
   useEffect(() => { fetchDispute(); }, [disputeId]);
 
@@ -1298,15 +1320,28 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
         ) : (
           <>
           <div className="space-y-4">
-            {dispute.correspondence?.map((entry, index) => {
-              const config = ENTRY_TYPE_CONFIG[entry.entry_type] || ENTRY_TYPE_CONFIG.user_note;
-              const Icon = config.icon;
-              const isAiLetter = entry.entry_type === 'ai_letter';
-              const isFromCompany = ['company_email', 'company_letter', 'company_response'].includes(entry.entry_type);
-
+            {(() => {
+              const entries = dispute.correspondence ?? [];
+              // Newest-first (API already sorts desc). Show the top 2 expanded
+              // and hide the rest behind a toggle unless showAllEntries is on.
+              const COLLAPSE_AFTER = 2;
+              const visible = showAllEntries || entries.length <= COLLAPSE_AFTER
+                ? entries
+                : entries.slice(0, COLLAPSE_AFTER);
+              const hiddenCount = entries.length - visible.length;
               return (
+                <>
+                  {visible.map((entry, index) => {
+                    const config = ENTRY_TYPE_CONFIG[entry.entry_type] || ENTRY_TYPE_CONFIG.user_note;
+                    const Icon = config.icon;
+                    const isAiLetter = entry.entry_type === 'ai_letter';
+                    const isUserReply = entry.entry_type === 'user_reply';
+                    const isFromCompany = ['company_email', 'company_letter', 'company_response'].includes(entry.entry_type);
+
+                    return (
                 <div
-                  ref={index === (dispute.correspondence?.length || 0) - 1 ? latestLetterRef : null}
+                  id={`entry-${entry.id}`}
+                  ref={index === 0 ? latestLetterRef : null}
                   key={entry.id}
                   className={`border rounded-2xl p-5 transition-all ${config.className} ${
                     isAiLetter ? 'cursor-pointer hover:border-emerald-500/50' : ''
@@ -1475,8 +1510,27 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                     </div>
                   )}
                 </div>
+                    );
+                  })}
+                  {hiddenCount > 0 && !showAllEntries && (
+                    <button
+                      onClick={() => setShowAllEntries(true)}
+                      className="w-full text-center py-3 text-sm font-semibold text-emerald-600 hover:text-emerald-700 border border-dashed border-slate-300 rounded-xl transition-colors"
+                    >
+                      Show {hiddenCount} older {hiddenCount === 1 ? 'entry' : 'entries'} ↓
+                    </button>
+                  )}
+                  {showAllEntries && entries.length > COLLAPSE_AFTER && (
+                    <button
+                      onClick={() => setShowAllEntries(false)}
+                      className="w-full text-center py-2 text-xs font-medium text-slate-500 hover:text-slate-700 transition-colors"
+                    >
+                      Collapse older entries ↑
+                    </button>
+                  )}
+                </>
               );
-            })}
+            })()}
           </div>
 
           {/* Action buttons at bottom of thread */}
@@ -2486,11 +2540,26 @@ function ComplaintsPageInner() {
   const [view, setView] = useState<'list' | 'new' | 'detail'>('list');
   const [selectedDisputeId, setSelectedDisputeId] = useState<string | null>(null);
 
-  // If URL has ?new=1 or sessionStorage has pb_preview_letter, open new dispute form
+  // URL routing:
+  //   ?new=1                → open new-dispute form
+  //   ?dispute=UUID         → open that dispute's detail view (used by the
+  //                           in-app notification deep link so clicking a
+  //                           dispute-reply alert lands on the specific
+  //                           dispute, not the list). If the URL also has a
+  //                           #entry-<id> hash the detail view scrolls to
+  //                           that correspondence entry.
   useEffect(() => {
     if (searchParams.get('new') === '1') {
       setView('new');
-    } else if (typeof window !== 'undefined' && sessionStorage.getItem('pb_preview_letter')) {
+      return;
+    }
+    const disputeParam = searchParams.get('dispute');
+    if (disputeParam) {
+      setSelectedDisputeId(disputeParam);
+      setView('detail');
+      return;
+    }
+    if (typeof window !== 'undefined' && sessionStorage.getItem('pb_preview_letter')) {
       setView('new');
     }
   }, [searchParams]);

--- a/src/lib/dispute-sync/sync-runner.ts
+++ b/src/lib/dispute-sync/sync-runner.ts
@@ -99,7 +99,10 @@ export async function syncLinkedThread(
   const providerName = disputeRow?.provider_name ?? 'supplier';
   const disputeTitle = disputeRow?.issue_summary ?? null;
   const disputeCategory = disputeRow?.issue_type ?? disputeRow?.provider_type ?? null;
-  const linkUrl = `/dashboard/complaints?dispute=${link.dispute_id}`;
+  // Deep-link base: specific correspondence entry hash is appended inside the
+  // loop below, so clicking the notification scrolls straight to the reply
+  // the user is being pinged about rather than dumping them at the index.
+  const baseLinkUrl = `/dashboard/complaints?dispute=${link.dispute_id}`;
 
   // Pull the user's most recent letter to this supplier (if any) so the
   // classifier can reason about whether the reply answers what the user asked.
@@ -202,18 +205,21 @@ export async function syncLinkedThread(
         classification,
       });
 
-      // In-app notification
+      // In-app notification — link directly to the correspondence entry so
+      // tapping the notification scrolls that reply into view instead of
+      // dropping the user at the top of the disputes index.
       await db.from('user_notifications').insert({
         user_id: link.user_id,
         type: classification?.respondNeeded ? 'dispute_reply_action' : 'dispute_reply',
         title: notifCopy.title,
         body: notifCopy.body,
-        link_url: linkUrl,
+        link_url: `${baseLinkUrl}#entry-${inserted.id}`,
         dispute_id: link.dispute_id,
         metadata: {
           subject: m.subject,
           from: m.fromAddress,
           messageId: m.messageId,
+          correspondenceId: inserted.id,
           ai_category: classification?.category ?? null,
           ai_urgency: classification?.urgency ?? null,
           ai_respond_needed: classification?.respondNeeded ?? null,
@@ -234,7 +240,7 @@ export async function syncLinkedThread(
           providerName,
           subject: m.subject,
           snippet: m.snippet,
-          linkUrl,
+          linkUrl: `${baseLinkUrl}#entry-${inserted.id}`,
           classification,
         });
       } catch (err) {

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -1260,13 +1260,29 @@ Return JSON: { "subject": "...", "body": "..." }`;
           .select('full_name, first_name, last_name, address, postcode')
           .eq('id', supplierMsg.user_id)
           .maybeSingle(),
+        // Pull the last 6 correspondence entries so the draft reflects the
+        // full back-and-forth, not just the most recent outbound letter. We
+        // include supplier messages (company_email / company_response /
+        // company_letter) as well as the user's own letters / replies /
+        // notes so the model can track whether a question has already been
+        // answered, whether prior offers were rejected, etc. 6 entries is
+        // enough to cover a typical "letter → reply → letter → reply"
+        // exchange with a couple of notes in between without blowing the
+        // prompt budget.
         supabase
           .from('correspondence')
-          .select('content, entry_date, entry_type')
+          .select('content, entry_date, entry_type, summary')
           .eq('dispute_id', supplierMsg.dispute_id)
-          .in('entry_type', ['ai_letter', 'user_note'])
+          .in('entry_type', [
+            'ai_letter',
+            'user_reply',
+            'user_note',
+            'company_email',
+            'company_letter',
+            'company_response',
+          ])
           .order('entry_date', { ascending: false })
-          .limit(1),
+          .limit(6),
       ]);
 
       const fullName =
@@ -1276,9 +1292,24 @@ Return JSON: { "subject": "...", "body": "..." }`;
       const providerName = dispute?.provider_name ?? supplierMsg.sender_name ?? 'Provider';
       const today = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
       const addrLine = [profile?.address, profile?.postcode].filter(Boolean).join(', ') || '[Your address]';
-      const lastOutboundBody = recentOutbound?.[0]?.content
-        ? String(recentOutbound[0].content).slice(0, 1500)
-        : '(no earlier letter on record)';
+      // Thread history — newest-first on query, but render oldest-first in the
+      // prompt so the model reads it chronologically. Trim each entry to keep
+      // the prompt under budget; supplier replies get a bit more room since
+      // they set the context the draft has to answer.
+      const threadLines: string[] = [];
+      for (const c of [...(recentOutbound || [])].reverse()) {
+        const role = c.entry_type === 'ai_letter' ? 'USER_LETTER'
+          : c.entry_type === 'user_reply' ? 'USER_REPLY'
+          : c.entry_type === 'user_note' ? 'USER_NOTE'
+          : 'SUPPLIER';
+        const maxLen = role === 'SUPPLIER' ? 1500 : 1000;
+        const body = String(c.content || '').slice(0, maxLen);
+        const when = c.entry_date ? new Date(c.entry_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '';
+        threadLines.push(`[${role} — ${when}]\n${body}`);
+      }
+      const lastOutboundBody = threadLines.length
+        ? threadLines.join('\n\n---\n\n')
+        : '(no earlier correspondence on record)';
 
       const supplierExcerpt = String(supplierMsg.content || '').slice(0, 4000);
       const category = (supplierMsg.ai_category as string | null) || 'unknown';
@@ -1350,7 +1381,7 @@ Return JSON: { "subject": "...", "body": "..." }`;
         `Short hint on what the reply should cover: ${supplierMsg.ai_suggested_reply_context || 'n/a'}`,
         `Supplier message category (from our classifier): ${category}`,
         '',
-        'What the user previously wrote to this supplier (background context only — do NOT quote or paraphrase):',
+        'Full dispute thread so far (chronological, oldest first — read to avoid repeating points, acknowledging things already settled, or re-asking answered questions). Do NOT quote or paraphrase verbatim:',
         '"""',
         lastOutboundBody,
         '"""',
@@ -1554,14 +1585,17 @@ Return JSON: { "subject": "...", "body": "..." }`;
         return;
       }
 
-      // Write a user_note confirming the draft was sent. Keep the full text
-      // for the audit trail so the dispute history tells the full story.
+      // Record the actual reply the user sent as a 'user_reply' correspondence
+      // entry. This shows up in the dispute timeline as "Your reply" alongside
+      // AI letters and company responses, so the thread tells the full story
+      // without the reader having to read between the lines of a note.
       await supabase.from('correspondence').insert({
         dispute_id: draft.dispute_id,
         user_id: draft.user_id,
-        entry_type: 'user_note',
-        title: 'User confirmed reply was sent',
-        content: `User confirmed they sent the following reply to the supplier via their own email. Logged from Telegram on ${new Date().toISOString()}.\n\n---\n\n${draft.content}`,
+        entry_type: 'user_reply',
+        title: 'Your reply (sent via Telegram draft)',
+        content: draft.content,
+        summary: 'Reply drafted in Telegram and confirmed sent to the supplier.',
         source: 'telegram_watchdog',
         telegram_chat_id: chatId,
         entry_date: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Four related dispute-thread bugs, one PR.

### 1. Thread order — newest-first + collapsible

Correspondence was sorted oldest-first, so on a dispute with 10+ replies the user had to scroll to the bottom to see the latest one.

- \`src/app/api/disputes/[id]/route.ts\` — \`.sort()\` now descending
- \`src/app/dashboard/complaints/page.tsx\` — shows the 2 most recent entries expanded, collapses older ones behind a "Show N older entries" toggle, reverses the \`latestLetterRef\` to target the top of the list

### 2. Telegram draft missing from timeline

When the user tapped "I sent this" on a Telegram draft, the confirm handler wrote a \`user_note\` wrapping the reply in a paragraph — so the dashboard showed a note saying *"User confirmed they sent the following reply..."* instead of the reply itself appearing as an outbound letter.

- \`src/lib/telegram/user-bot.ts\` — \`cfsnt_\` callback now writes an \`entry_type: 'user_reply'\` with the reply body as \`content\`
- \`src/app/dashboard/complaints/page.tsx\` — new \`user_reply\` entry in \`ENTRY_TYPE_CONFIG\` ("Your reply", mint styling)
- \`src/app/api/complaints/generate/route.ts\` — \`typeLabel\` map now recognises \`user_reply\` so subsequent AI drafts see it as a sent letter, not a note

### 3. Notification deep-link dumped the user on the list

In-app notifications linked to \`/dashboard/complaints?dispute=UUID\` but the page only honoured \`?new=1\` — every notification landed the user on the disputes list.

- \`src/lib/dispute-sync/sync-runner.ts\` — \`link_url\` now includes \`#entry-<correspondenceId>\`; Telegram \`linkUrl\` gets the same treatment
- \`src/app/dashboard/complaints/page.tsx\` — reads \`?dispute=UUID\`, opens that dispute's detail view, reads \`window.location.hash\` on mount, auto-expands older entries if the target was collapsed, scrolls the specific entry into view

### 4. AI drafts only saw the last letter

The Telegram draft-reply prompt pulled exactly 1 prior outbound letter (last 1500 chars) as "context". So Claude couldn't tell if a question was already answered, which offers had been rejected, or what the tone of the exchange had become.

- \`src/lib/telegram/user-bot.ts\` — fetches the last 6 correspondence entries across both sides of the conversation (\`ai_letter\`, \`user_reply\`, \`user_note\`, \`company_email\`, \`company_letter\`, \`company_response\`), renders them chronologically with role labels (\`[SUPPLIER — 12 Apr]\` / \`[USER_LETTER — 14 Apr]\`), and feeds the whole thread to Claude. Prompt wording changed from "what the user previously wrote" to "full dispute thread so far".
- The in-app complaint generator already pulled the full thread; it just needed \`user_reply\` added to its \`typeLabel\` map.

## Test plan

- [ ] Open a dispute with 5+ replies — latest is at the top, older ones hidden behind "Show older" toggle; click toggle expands them, "Collapse older" button hides them again
- [ ] Trigger a new dispute-reply notification (inbound supplier email) — clicking the bell notification drops you straight onto that dispute with the specific entry scrolled into view
- [ ] Reply to a dispute via Telegram's "Draft response" flow, hit "I sent this" — the reply appears in the dashboard timeline as "Your reply" with the full body (not as a meta-note)
- [ ] Ask Telegram to draft a follow-up on a dispute that already has a few exchanges — the drafted letter references specifics from the prior thread (supplier's last question, a prior offer, etc.) rather than treating the latest supplier message in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)