### PR TITLE
fix(money-hub): show loan receipts in income breakdown + total

### DIFF
--- a/src/lib/income-normalise.ts
+++ b/src/lib/income-normalise.ts
@@ -1,6 +1,13 @@
 const OTHER_INCOME_KEYS = new Set(['other', 'other_income', 'unknown', 'uncategorised', '']);
 const RENTAL_INCOME_KEYS = new Set(['rental', 'rental_airbnb', 'rental_direct', 'rental_booking']);
-const EXCLUDED_INCOME_KEYS = new Set(['transfer', 'credit_loan']);
+// Only internal transfers are excluded from the income breakdown — loan
+// receipts (credit_loan) used to be excluded too, but that made the totals
+// misleading: a £12k loan drawdown would vanish from the Income tile and
+// leave the savings rate looking negative when the account balance had
+// actually gone up. Loan receipts now surface as a "Credit / Loan" row in
+// the breakdown and count toward monthly income. See the label in
+// OverviewPanel.tsx and the matching row in the pie/stats.
+const EXCLUDED_INCOME_KEYS = new Set(['transfer']);
 
 export function normalizeIncomeTypeKey(value: string | null | undefined): string {
   const key = (value || '').toLowerCase().trim();


### PR DESCRIPTION
## Summary

Paul recategorised a £12,000 Iwoca incoming payment from "salary" to "loan" and his Income this month dropped by exactly £12,000 with no new "Loan" row appearing. Savings rate went negative because the remaining income no longer covered the spending — even though his actual account balance went up this month.

## Root cause

\`EXCLUDED_INCOME_KEYS\` in \`src/lib/income-normalise.ts\` included \`'credit_loan'\`, so the classifier's \`isExcludedIncomeType()\` returned true for loan drawdowns. That in turn:

1. Made \`isTransferLikeTransaction()\` return true for any positive \`credit_loan\` txn — so \`resolveMoneyHubTransaction()\` returned \`kind='transfer'\` for them.
2. Stopped the \`hasRealIncomeType\` branch from firing — so even with \`bank_transactions.user_category='loan'\` the row never landed in \`incomeRows\`.
3. Result: the £12k vanished from both the Income tile and the breakdown, leaving an apparent deficit that doesn't match the account.

The intent (don't let loan drawdowns inflate a savings-rate calc) was defensible but the user-visible effect was worse than the problem it was solving. A loan receipt is cash that landed in the account — hiding it makes the totals lie.

## Fix

Drop \`'credit_loan'\` from \`EXCLUDED_INCOME_KEYS\`. The classifier now returns \`kind='income'\` with \`incomeType='credit_loan'\` for loan drawdowns; the Money Hub aggregator adds them to \`monthlyIncome\` and to \`incomeRows['credit_loan']\`. \`OverviewPanel\` already has the matching \`INCOME_LABELS\` entry ("Credit / Loan", 🏦 icon, red accent) so the row renders without further change.

\`'transfer'\` stays excluded — internal self-transfers still shouldn't count as income.

## Follow-up (separate PR — not in this one)

The Supabase RPCs \`get_monthly_income\` / \`get_monthly_income_total\` still exclude \`credit_loan\`. The Money Hub UI currently uses the JS-computed totals (\`authIncome = currentSummary.monthlyIncome\` in \`money-hub/route.ts\`) as authoritative, so the visible bug is fixed by this PR alone. A follow-up migration can align the RPC for consistency on historical-month queries that might hit the RPC directly.

## Test plan

- [ ] Paul: refresh Money Hub — the £12k Iwoca payment now appears as a "Credit / Loan" row in the Income breakdown, total monthly income goes back up, savings rate returns to positive
- [ ] Regression: a pure internal transfer (savings → current account) still shouldn't show in income
- [ ] Regression: a real salary payment still shows as "Salary"
- [ ] Regression: a loan repayment OUT of the account (negative amount) still shows as spending under "loan" category

🤖 Generated with [Claude Code](https://claude.com/claude-code)