### PR TITLE
fix(money-hub): rename loan income label to 'Loan Credit' + collapse types

### DIFF
--- a/src/app/dashboard/money-hub/OverviewPanel.tsx
+++ b/src/app/dashboard/money-hub/OverviewPanel.tsx
@@ -14,9 +14,13 @@ const INCOME_LABELS: Record<string, { label: string; icon: string; color: string
   rental_direct: { label: 'Rental Income', icon: '🏠', color: '#f59e0b' },
   investment: { label: 'Investments', icon: '📈', color: '#06b6d4' },
   refund: { label: 'Refunds', icon: '💸', color: '#10b981' },
-  loan_repayment: { label: 'Loan Repayment', icon: '🏦', color: '#ef4444' },
+  // Both loan-shaped income types render with the clearer "Loan Credit" label
+  // — the underlying types stay distinct in the database so we can analyse
+  // drawdowns vs third-party repayments later, but the user-facing copy is
+  // unambiguous that this is money coming INTO the account from a loan.
+  loan_repayment: { label: 'Loan Credit', icon: '🏦', color: '#ef4444' },
   gift: { label: 'Gifts', icon: '🎁', color: '#ec4899' },
-  credit_loan: { label: 'Credit / Loan', icon: '🏦', color: '#ef4444' },
+  credit_loan: { label: 'Loan Credit', icon: '🏦', color: '#ef4444' },
   other: { label: 'Other', icon: '📋', color: '#475569' },
 };
 

--- a/src/lib/income-normalise.ts
+++ b/src/lib/income-normalise.ts
@@ -1,10 +1,17 @@
 const OTHER_INCOME_KEYS = new Set(['other', 'other_income', 'unknown', 'uncategorised', '']);
 const RENTAL_INCOME_KEYS = new Set(['rental', 'rental_airbnb', 'rental_direct', 'rental_booking']);
+// Both loan-shaped income types — 'credit_loan' (money FROM a lender, i.e.
+// a drawdown) and 'loan_repayment' (money FROM a debtor paying you back) —
+// collapse into a single display bucket so the user sees one "Loan Credit"
+// row instead of two rows with near-identical labels. The raw type stays
+// distinct in bank_transactions for future analytics; only the display
+// aggregation is unified.
+const LOAN_INCOME_KEYS = new Set(['credit_loan', 'loan_repayment', 'loan_credit', 'loan_drawdown']);
 // Only internal transfers are excluded from the income breakdown — loan
 // receipts (credit_loan) used to be excluded too, but that made the totals
 // misleading: a £12k loan drawdown would vanish from the Income tile and
 // leave the savings rate looking negative when the account balance had
-// actually gone up. Loan receipts now surface as a "Credit / Loan" row in
+// actually gone up. Loan receipts now surface as a "Loan Credit" row in
 // the breakdown and count toward monthly income. See the label in
 // OverviewPanel.tsx and the matching row in the pie/stats.
 const EXCLUDED_INCOME_KEYS = new Set(['transfer']);
@@ -12,6 +19,7 @@ const EXCLUDED_INCOME_KEYS = new Set(['transfer']);
 export function normalizeIncomeTypeKey(value: string | null | undefined): string {
   const key = (value || '').toLowerCase().trim();
   if (RENTAL_INCOME_KEYS.has(key)) return 'rental';
+  if (LOAN_INCOME_KEYS.has(key)) return 'credit_loan';
   if (OTHER_INCOME_KEYS.has(key)) return 'other';
   return key || 'other';
 }


### PR DESCRIPTION
## Summary

Paul saw #203 deploy and the £12k Iwoca payment reappear in his Income breakdown — but it rendered under the "Loan Repayment" row (because the classifier had tagged it with \`income_type='loan_repayment'\` before his recategorisation). Paul's feedback:

> it shouldn't be called loan repayment, something like loan credit when it comes into the account.

## Two changes

1. **\`OverviewPanel.tsx\`** — both loan-shaped income labels now read **"Loan Credit"** instead of "Loan Repayment" / "Credit / Loan". Short, unambiguous, says "money coming in from a loan".

2. **\`income-normalise.ts\`** — new \`LOAN_INCOME_KEYS\` set collapses \`credit_loan\`, \`loan_repayment\`, \`loan_credit\`, and \`loan_drawdown\` into a single \`credit_loan\` display bucket in \`normalizeIncomeTypeKey\`. Without this, a user with both a lender drawdown and a third-party repayment would see two separate "Loan Credit" rows. Same pattern as the existing \`RENTAL_INCOME_KEYS\` which collapses rental_airbnb / rental_direct / rental_booking into a single 'rental' bucket.

The raw type stays distinct in \`bank_transactions\` for future analytics; only the display aggregation is unified.

## Should auto-merge after #203

#203 (parent) landed at 16:45 UTC. Once Vercel ships that, merge this to fix the label. Two-minute gap is fine — #203 gives Paul the £12k back under "Loan Repayment" immediately; this PR just cleans the label to "Loan Credit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)