### PR TITLE
fix(money-hub): SpendingPanel labels + '2th' ordinal + 'Ad' merchant

### DIFF
--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -4,6 +4,7 @@ import { createClient as createAdmin } from '@supabase/supabase-js';
 import { calculateHealthScore } from '@/lib/financial-health-score';
 import { normalizeSpendingCategoryKey, findMatchingCategoryOverride, resolveMoneyHubTransaction, buildMoneyHubOverrideMaps, applyInternalTransferHeuristic } from '@/lib/money-hub-classification';
 import { normaliseMerchantName } from '@/lib/merchant-normalise';
+import { pickRawMerchantSource } from '@/lib/merchant-utils';
 import { loadLearnedRules } from '@/lib/learning-engine';
 
 export const runtime = 'nodejs';
@@ -183,7 +184,12 @@ export async function GET(request: Request) {
     // Compute top merchants from JS-based current summary (RPCs don't provide per-merchant data)
     const merchantTotals: Record<string, number> = {};
     for (const t of currentSummary.spendingTransactions) {
-      const merchant = normaliseMerchantName(t.merchant_name || t.description || '');
+      // TrueLayer sometimes returns junk (e.g. merchant_name='ad') from an
+      // upstream field extraction — pickRawMerchantSource falls back to the
+      // description when the merchant_name field is clearly garbage so the
+      // "Top merchants" list doesn't collapse unrelated payments under a 2-
+      // letter heading.
+      const merchant = normaliseMerchantName(pickRawMerchantSource(t.merchant_name, t.description));
       merchantTotals[merchant] = (merchantTotals[merchant] || 0) + Math.abs(parseFloat(String(t.amount)));
     }
     const topMerchants = Object.entries(merchantTotals)

--- a/src/app/api/money-hub/transactions/route.ts
+++ b/src/app/api/money-hub/transactions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createClient as createAdmin } from '@supabase/supabase-js';
 import { normaliseMerchantName } from '@/lib/merchant-normalise';
+import { isGarbageMerchantName, pickRawMerchantSource } from '@/lib/merchant-utils';
 import { loadLearnedRules } from '@/lib/learning-engine';
 import { matchesIncomeTypeFilter, normalizeIncomeTypeKey } from '@/lib/income-normalise';
 import {
@@ -102,7 +103,11 @@ export async function GET(request: NextRequest) {
 
     const sourceTotals: Record<string, { total: number; count: number }> = {};
     for (const t of filtered) {
-      const source = t.merchant_name || (t.description || '').replace(/FP \d.*/, '').replace(/\d{6,}.*/, '').trim().substring(0, 40) || 'Unknown';
+      // Skip junk merchant_name values ("ad", "tr", etc. — TrueLayer fragments)
+      // and fall back to a cleaned description so aggregations don't collapse
+      // unrelated payments under a 2-letter heading.
+      const rawMerchant = isGarbageMerchantName(t.merchant_name) ? null : t.merchant_name;
+      const source = rawMerchant || (t.description || '').replace(/FP \d.*/, '').replace(/\d{6,}.*/, '').trim().substring(0, 40) || 'Unknown';
       if (!sourceTotals[source]) sourceTotals[source] = { total: 0, count: 0 };
       sourceTotals[source].total += t.amount;
       sourceTotals[source].count++;
@@ -132,7 +137,7 @@ export async function GET(request: NextRequest) {
     const merchantTotals: Record<string, { total: number; count: number }> = {};
     for (const t of resolvedTransactions) {
       if (t.amount >= 0) continue;
-      const merchant = normaliseMerchantName(t.merchant_name || t.description || '');
+      const merchant = normaliseMerchantName(pickRawMerchantSource(t.merchant_name, t.description));
       if (!merchantTotals[merchant]) merchantTotals[merchant] = { total: 0, count: 0 };
       merchantTotals[merchant].total += Math.abs(t.amount);
       merchantTotals[merchant].count++;
@@ -169,7 +174,7 @@ export async function GET(request: NextRequest) {
   const merchantTotals: Record<string, { total: number; count: number }> = {};
   for (const t of filtered) {
     if (t.amount >= 0) continue;
-    const merchant = normaliseMerchantName(t.merchant_name || t.description || '');
+    const merchant = normaliseMerchantName(pickRawMerchantSource(t.merchant_name, t.description));
     if (!merchantTotals[merchant]) merchantTotals[merchant] = { total: 0, count: 0 };
     merchantTotals[merchant].total += Math.abs(t.amount);
     merchantTotals[merchant].count++;

--- a/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
+++ b/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { X, Search, ChevronDown, CheckCircle2, Loader2, ArrowRight } from 'lucide-react';
 import { fmtNum } from '@/lib/format';
-import { cleanMerchantName } from '@/lib/merchant-utils';
+import { cleanMerchantName, isGarbageMerchantName, pickRawMerchantSource } from '@/lib/merchant-utils';
 
 interface CategoryDrillDownModalProps {
   isOpen: boolean;
@@ -245,7 +245,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                     return (
                       <div key={txn.id || idx} className="p-4 flex items-center justify-between group relative">
                         <div>
-                          <p className="text-slate-900 text-sm font-medium">{txn.merchant_name || txn.description}</p>
+                          <p className="text-slate-900 text-sm font-medium">{isGarbageMerchantName(txn.merchant_name) ? (txn.description || txn.merchant_name) : txn.merchant_name}</p>
                           <p className="text-slate-500 text-xs mt-0.5">{dt.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}</p>
                         </div>
                         <div className="text-right">

--- a/src/app/dashboard/money-hub/SpendingPanel.tsx
+++ b/src/app/dashboard/money-hub/SpendingPanel.tsx
@@ -9,6 +9,7 @@ import CategoryDrillDownModal from './CategoryDrillDownModal';
 
 const CATEGORY_LABELS: Record<string, { label: string; icon: string; color: string }> = {
   mortgage: { label: 'Mortgage', icon: '🏠', color: '#8b5cf6' },
+  loan: { label: 'Loans', icon: '🏦', color: '#ef4444' },
   loans: { label: 'Loans', icon: '🏦', color: '#ef4444' },
   council_tax: { label: 'Council Tax', icon: '🏛️', color: '#6366f1' },
   energy: { label: 'Energy', icon: '⚡', color: '#f59e0b' },
@@ -19,6 +20,7 @@ const CATEGORY_LABELS: Record<string, { label: string; icon: string; color: stri
   fitness: { label: 'Fitness', icon: '💪', color: '#10b981' },
   groceries: { label: 'Groceries', icon: '🛒', color: '#22c55e' },
   eating_out: { label: 'Eating Out', icon: '🍽️', color: '#f97316' },
+  food: { label: 'Food & Drink', icon: '🍽️', color: '#f97316' },
   fuel: { label: 'Fuel', icon: '⛽', color: '#64748b' },
   shopping: { label: 'Shopping', icon: '🛍️', color: '#a855f7' },
   insurance: { label: 'Insurance', icon: '🛡️', color: '#14b8a6' },
@@ -26,23 +28,47 @@ const CATEGORY_LABELS: Record<string, { label: string; icon: string; color: stri
   tax: { label: 'Tax', icon: '🏛️', color: '#dc2626' },
   bills: { label: 'Bills', icon: '📄', color: '#64748b' },
   software: { label: 'Software', icon: '💻', color: '#818cf8' },
+  professional: { label: 'Professional', icon: '💼', color: '#8b5cf6' },
+  professional_services: { label: 'Professional', icon: '💼', color: '#8b5cf6' },
+  property_management: { label: 'Property Management', icon: '🏢', color: '#8b5cf6' },
   healthcare: { label: 'Healthcare', icon: '❤️', color: '#fca5a5' },
   charity: { label: 'Charity', icon: '🤝', color: '#2dd4bf' },
   education: { label: 'Education', icon: '🎓', color: '#93c5fd' },
   pets: { label: 'Pets', icon: '🐾', color: '#fcd34d' },
+  parking: { label: 'Parking', icon: '🅿️', color: '#6366f1' },
   travel: { label: 'Travel', icon: '✈️', color: '#7dd3fc' },
   gambling: { label: 'Gambling', icon: '🎲', color: '#fde047' },
   fees: { label: 'Fees', icon: '💳', color: '#a3a3a3' },
   fee: { label: 'Fees', icon: '💳', color: '#a3a3a3' },
-  credit: { label: 'Credit Cards', icon: '💳', color: '#f43f5e' },
+  credit: { label: 'Credit', icon: '💳', color: '#f43f5e' },
+  credit_card: { label: 'Credit Card', icon: '💳', color: '#f43f5e' },
+  credit_monitoring: { label: 'Credit Monitoring', icon: '📊', color: '#64748b' },
   cash: { label: 'Cash', icon: '🏧', color: '#78716c' },
   childcare: { label: 'Childcare', icon: '👶', color: '#f472b6' },
   motoring: { label: 'Motoring', icon: '🚗', color: '#94a3b8' },
+  music: { label: 'Music', icon: '🎵', color: '#ec4899' },
+  gaming: { label: 'Gaming', icon: '🎮', color: '#8b5cf6' },
+  storage: { label: 'Cloud Storage', icon: '☁️', color: '#3b82f6' },
+  security: { label: 'Security', icon: '🔒', color: '#64748b' },
+  utility: { label: 'Utilities', icon: '💡', color: '#f59e0b' },
+  utilities: { label: 'Utilities', icon: '💡', color: '#f59e0b' },
+  rent: { label: 'Rent', icon: '🏠', color: '#8b5cf6' },
+  transfers: { label: 'Transfers', icon: '🔄', color: '#64748b' },
   other: { label: 'Other', icon: '📋', color: '#475569' },
 };
 
+/** Title-case a raw category key so the fallback never shows lowercase labels. */
+function titleCaseCategory(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
+
 function getCatMeta(key: string) {
-  return CATEGORY_LABELS[key] || { label: key.replace(/_/g, ' '), icon: '📋', color: '#475569' };
+  return CATEGORY_LABELS[key] || { label: titleCaseCategory(key), icon: '📋', color: '#475569' };
 }
 
 export default function SpendingPanel({ data, isPro, refreshData, selectedMonth }: { data: any, isPro: boolean, refreshData: () => void, selectedMonth: string }) {

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -72,6 +72,21 @@ const SCAN_CAPTIONS: { icon: string; text: string }[] = [
  { icon: '🎯', text: 'Almost done — packaging everything we found...' },
 ];
 
+// English ordinal suffix — "1st, 2nd, 3rd, 4th..., 21st, 22nd, 23rd, 24th...".
+// Previous code hard-coded "th" which produced "2th", "3th", "21th".
+function ordinal(n: number): string {
+  if (n <= 0 || !Number.isFinite(n)) return String(n);
+  const lastTwo = n % 100;
+  const last = n % 10;
+  const suffix =
+    lastTwo >= 11 && lastTwo <= 13 ? 'th'
+    : last === 1 ? 'st'
+    : last === 2 ? 'nd'
+    : last === 3 ? 'rd'
+    : 'th';
+  return `${n}${suffix}`;
+}
+
 // ─── Main Page ──────────────────────────────────────────────────────────────
 
 export default function MoneyHubPage() {
@@ -814,7 +829,7 @@ export default function MoneyHubPage() {
  <div className="min-w-0 flex-1">
  <p className={`text-sm font-medium truncate ${bill.paid ? 'text-slate-600 line-through' : 'text-slate-900'}`}>{bill.name}</p>
  <div className="flex items-center gap-2 mt-0.5">
- {bill.billing_day > 0 && <span className="text-[10px] text-slate-500">Due ~{bill.billing_day}th</span>}
+ {bill.billing_day > 0 && <span className="text-[10px] text-slate-500">Due ~{ordinal(bill.billing_day)}</span>}
  {catLabel && <span className="text-[10px] text-slate-500 capitalize">{catLabel}</span>}
  {bill.paid && <span className="text-[10px] text-green-400 font-medium">✓ Paid</span>}
  {bill.past_due && !bill.paid && <span className="text-[10px] text-red-400 font-medium">⚠ Not seen</span>}

--- a/src/lib/merchant-utils.ts
+++ b/src/lib/merchant-utils.ts
@@ -27,6 +27,47 @@ const HARDCODED_MERCHANT_RULES: Record<string, string> = {
 };
 
 /**
+ * TrueLayer (and occasionally Yapily) sometimes return junk in the
+ * `merchant_name` field — 2-letter fragments like "ad", "tr", "d" that look
+ * like first-few-chars of the raw description. These produce nonsense
+ * "Ad", "Tr" rows in the top-merchants list. This helper detects those
+ * garbage values and falls through to the description so we can derive a
+ * sane name via normaliseMerchantName().
+ *
+ * A short-known-brand whitelist (BT, EE, O2, AXA, TfL, M&S) keeps legitimate
+ * short merchant names working.
+ */
+const VALID_SHORT_MERCHANTS = new Set([
+  'bt', 'ee', 'o2', 'axa', 'tfl', 'lbh', 'hmv', 'dhl', 'ups', 'ikea', 'asda',
+  'aldi', 'lidl', 'b&q', 'bp', 'esso', 'bmw', 'aa', 'rac', 'nhs', 'hmrc',
+  'dvla', 'bbc', 'itv', 'odeon', 'vue', 'cex', 'm&s', 'h&m', 'ba', 'npd',
+]);
+
+export function isGarbageMerchantName(name: string | null | undefined): boolean {
+  if (!name) return true;
+  const trimmed = name.trim();
+  if (!trimmed) return true;
+  if (VALID_SHORT_MERCHANTS.has(trimmed.toLowerCase())) return false;
+  // Short + all-lowercase + no spaces = very likely a prefix fragment
+  if (trimmed.length <= 3 && trimmed === trimmed.toLowerCase() && !/\s/.test(trimmed)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Pick the best raw name to feed to cleanMerchantName / normaliseMerchantName.
+ * Returns the description when the merchant_name field is clearly garbage.
+ */
+export function pickRawMerchantSource(
+  merchantName: string | null | undefined,
+  description: string | null | undefined,
+): string {
+  if (isGarbageMerchantName(merchantName)) return description || merchantName || '';
+  return merchantName || description || '';
+}
+
+/**
  * Resolve a clean display name for a raw bank transaction description.
  *
  * Rules:


### PR DESCRIPTION
Three small Money-Hub bugs from Paul's latest screenshot.

1. **SpendingPanel labels** — PR #205 only fixed OverviewPanel. SpendingPanel has its own CATEGORY_LABELS map that was missing loan / property_management / professional / credit_card / utility / rent / storage / music / gaming / security / parking / etc. Also the fallback now title-cases (`property management` → `Property Management`).

2. **'Due ~2th' bug** — expected-bills row hardcoded `th`. New `ordinal(n)` helper returns correct st/nd/rd/th including the 11-13 exception.

3. **'Ad' merchant false aggregation** — TrueLayer returned 2-letter fragments in `merchant_name` for some transactions. Paul had 6 different transactions all tagged 'ad' from totally unrelated descriptions (TRAVELUP, SAINSBURYS, Google ADS, ADVICE CONFIRMS…). New `isGarbageMerchantName` + `pickRawMerchantSource` helpers fall back to the description when merchant_name is junk. Also backfilled 81 existing rows via Supabase MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)