### PR TITLE
fix(pricing): sync homepage bullets + UpgradePrompt copy with Emma matrix

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -1375,8 +1375,10 @@ export default function HomepageV3PreviewPage() {
               <div className="founding" style={{ visibility: 'hidden' }}>—</div>
               <ul>
                 <li>3 AI dispute letters / month</li>
-                <li>Manual subscription tracker</li>
-                <li>Public deals marketplace</li>
+                <li>2 bank accounts · daily auto-sync</li>
+                <li>1 email inbox · Watchdog reply monitoring</li>
+                <li>Unlimited subscription tracker</li>
+                <li>Pocket Agent + AI chatbot</li>
               </ul>
               <Link className="btn btn-ghost cta" href="/auth/signup" style={{ justifyContent: 'center' }}>
                 Start free →
@@ -1387,27 +1389,31 @@ export default function HomepageV3PreviewPage() {
               <span className="ribbon">Most popular</span>
               <div className="tier">Essential</div>
               <div className="price">£4.99<span className="per">/month</span></div>
-              <div className="founding">Founding member · locked-in forever</div>
+              <div className="founding">or £44.99/yr · Founding rate locked-in</div>
               <ul>
                 <li>Unlimited AI dispute letters</li>
-                <li>Bank sync — 2 accounts</li>
-                <li>Email inbox scan</li>
-                <li>Pocket Agent in Telegram</li>
+                <li>3 bank accounts · daily auto-sync</li>
+                <li>3 email inboxes · Watchdog reply monitoring</li>
+                <li>AI cancellation emails + renewal reminders</li>
+                <li>Full spending intelligence + budgets</li>
+                <li>Price-increase alerts by email</li>
               </ul>
               <Link className="btn btn-mint cta" href="/auth/signup" style={{ justifyContent: 'center' }}>
-                Start free →
+                Get Essential →
               </Link>
             </Reveal>
 
             <Reveal className="price-card" delay={160}>
               <div className="tier">Pro</div>
               <div className="price">£9.99<span className="per">/month</span></div>
-              <div className="founding">Founding member · locked-in forever</div>
+              <div className="founding">or £94.99/yr · Founding rate locked-in</div>
               <ul>
                 <li>Everything in Essential</li>
                 <li>Unlimited bank &amp; email connections</li>
-                <li>Deal alerts on bill changes</li>
-                <li>Priority human review on complex disputes</li>
+                <li>Price-increase alerts via Telegram (instant)</li>
+                <li>Money Hub top merchants + transaction analysis</li>
+                <li>Paybacker MCP (Claude Desktop)</li>
+                <li>CSV / PDF export · priority support</li>
               </ul>
               <Link className="btn btn-ghost cta" href="/auth/signup" style={{ justifyContent: 'center' }}>
                 Go Pro →

--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -50,16 +50,19 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-mint-400/10 border border-mint-400/30 mb-4">
               <Sparkles className="h-8 w-8 text-mint-400" />
             </div>
-            <h2 className="text-2xl font-bold text-slate-900 mb-2">Upgrade to Keep Scanning</h2>
-            <p className="text-slate-500">Free users get one email scan. Upgrade to Essential for unlimited scans, daily bank sync, and full spending intelligence.</p>
+            <h2 className="text-2xl font-bold text-slate-900 mb-2">Upgrade to unlock more</h2>
+            <p className="text-slate-500">You&apos;re on the Free plan. Upgrade to Essential to unlock unlimited letters, 3 bank accounts, 3 email inboxes, and the full Money Hub.</p>
           </div>
           <div className="bg-white rounded-xl p-4 mb-6 border border-slate-200">
             <ul className="space-y-2 text-sm text-slate-700">
-              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Unlimited email scans</li>
-              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Unlimited complaint letters</li>
-              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Daily bank sync</li>
-              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Full spending intelligence</li>
-              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Renewal reminders &amp; cancellation emails</li>
+              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Unlimited AI dispute letters</li>
+              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> 3 bank accounts &middot; daily auto-sync</li>
+              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> 3 email inboxes &middot; Watchdog reply monitoring</li>
+              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> AI cancellation emails with legal context</li>
+              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Full spending intelligence (20+ categories)</li>
+              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Budgets + savings goals</li>
+              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Renewal reminders (30/14/7 days)</li>
+              <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Price-increase alerts by email</li>
             </ul>
           </div>
           <div className="flex flex-col gap-3">


### PR DESCRIPTION
Audit found PLAN_LIMITS + endpoint 403s correctly match CLAUDE.md. Drift was only in marketing copy — homepage pricing section + UpgradePrompt modal. Updated to match CLAUDE.md authoritative matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)