### PR TITLE
fix(admin): remove CRON_SECRET from client bundles, use session auth

### DIFF
--- a/src/app/api/admin/meeting/route.ts
+++ b/src/app/api/admin/meeting/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const runtime = 'nodejs';
 export const maxDuration = 300;
@@ -23,9 +24,9 @@ interface MeetingMessage {
 }
 
 export async function POST(request: NextRequest) {
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const { message, agents: requestedAgents, history, meetingId, action } = await request.json();

--- a/src/app/api/admin/members/route.ts
+++ b/src/app/api/admin/members/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const runtime = 'nodejs';
 
@@ -11,9 +12,9 @@ function getAdmin() {
 }
 
 export async function GET(request: NextRequest) {
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const supabase = getAdmin();

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const runtime = 'nodejs';
-
-const ADMIN_EMAIL = 'aireypaul@googlemail.com';
 
 function getAdmin() {
   return createClient(
@@ -13,10 +12,9 @@ function getAdmin() {
 }
 
 export async function GET(request: NextRequest) {
-  // Auth check via CRON_SECRET or cookie-based admin check
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const supabase = getAdmin();

--- a/src/app/api/admin/proposals/route.ts
+++ b/src/app/api/admin/proposals/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { randomBytes } from 'crypto';
 import { resend, FROM_EMAIL } from '@/lib/resend';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const runtime = 'nodejs';
 
@@ -16,9 +17,9 @@ const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://paybacker.co.uk';
 
 // GET — list proposals
 export async function GET(request: NextRequest) {
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const supabase = getAdmin();
@@ -44,9 +45,9 @@ export async function GET(request: NextRequest) {
 
 // POST — create a new proposal (called by agents or meeting)
 export async function POST(request: NextRequest) {
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const body = await request.json();

--- a/src/app/api/admin/team-status/route.ts
+++ b/src/app/api/admin/team-status/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const runtime = 'nodejs';
 
@@ -133,9 +134,9 @@ function nextExpectedRun(lastRunAt: string | null, agent: AgentDef): string | nu
 }
 
 export async function GET(request: NextRequest) {
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const supabase = getAdmin();

--- a/src/app/api/cron/legal-updates/route.ts
+++ b/src/app/api/cron/legal-updates/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const maxDuration = 300;
 
@@ -90,9 +91,9 @@ interface Change {
  * 6. Sends Telegram summary to founder
  */
 export async function GET(request: NextRequest) {
-  const authHeader = request.headers.get('authorization');
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const supabase = getAdmin();

--- a/src/app/api/cron/verify-legal-refs/route.ts
+++ b/src/app/api/cron/verify-legal-refs/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
 import { createHash } from 'crypto';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const maxDuration = 300; // 5 minutes — checking many sources
 
@@ -30,9 +31,9 @@ function hashContent(text: string): string {
  * When content changes, creates a legal_update_queue entry instead of directly overwriting.
  */
 export async function GET(request: NextRequest) {
-  const authHeader = request.headers.get('authorization');
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const supabase = getAdmin();

--- a/src/app/api/support/tickets/[id]/messages/route.ts
+++ b/src/app/api/support/tickets/[id]/messages/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { resend, FROM_EMAIL } from '@/lib/resend';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 // Reply-to uses inbound subdomain so replies go through Resend webhook and auto-update tickets
 const TICKET_REPLY_TO = 'support@mail.paybacker.co.uk';
@@ -25,9 +26,9 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const { id: ticketId } = await params;

--- a/src/app/api/support/tickets/[id]/route.ts
+++ b/src/app/api/support/tickets/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const runtime = 'nodejs';
 
@@ -14,9 +15,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const { id } = await params;
@@ -56,9 +57,9 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const { id } = await params;

--- a/src/app/api/support/tickets/route.ts
+++ b/src/app/api/support/tickets/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const runtime = 'nodejs';
 
@@ -97,10 +98,9 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
-  // Admin auth
-  const secret = request.headers.get('authorization');
-  if (secret !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
   }
 
   const supabase = getAdmin();

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -103,10 +103,7 @@ export default function LegalRefsAdminPage() {
     setVerifying(true);
     setVerifyResult(null);
     try {
-      const cronSecret = process.env.NEXT_PUBLIC_CRON_SECRET || '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
-      const res = await fetch('/api/cron/verify-legal-refs', {
-        headers: { Authorization: `Bearer ${cronSecret}` },
-      });
+      const res = await fetch('/api/cron/verify-legal-refs', { credentials: 'include' });
       const data = await res.json();
       if (data.ok) {
         setVerifyResult(

--- a/src/app/dashboard/admin/legal-updates/page.tsx
+++ b/src/app/dashboard/admin/legal-updates/page.tsx
@@ -139,10 +139,7 @@ export default function LegalUpdatesAdminPage() {
     setScanning(true);
     setScanResult(null);
     try {
-      const cronSecret = process.env.NEXT_PUBLIC_CRON_SECRET || '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
-      const res = await fetch('/api/cron/legal-updates', {
-        headers: { Authorization: `Bearer ${cronSecret}` },
-      });
+      const res = await fetch('/api/cron/legal-updates', { credentials: 'include' });
       const data = await res.json();
       if (data.ok) {
         setScanResult(

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -70,12 +70,10 @@ export default function AdminPage() {
       }
       setAuthorized(true);
 
-      // Fetch via admin API (uses service role, bypasses RLS)
-      const cronSecret = '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
+      // Session-auth handles admin gating server-side (see authorizeAdminOrCron).
+      // No bearer secret needed — the cookie travels with same-origin fetch.
       const [metricsRes, dealsRes] = await Promise.all([
-        fetch('/api/admin/metrics', {
-          headers: { Authorization: `Bearer ${cronSecret}` },
-        }).then(r => r.json()),
+        fetch('/api/admin/metrics', { credentials: 'include' }).then(r => r.json()),
         // Fetch all deals (active + inactive) for health stats
         supabase.from('affiliate_deals').select('is_active, last_verified_at'),
       ]);
@@ -111,10 +109,7 @@ export default function AdminPage() {
   }, [supabase]);
 
   const loadMembers = async () => {
-    const cronSecret = '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
-    const res = await fetch('/api/admin/members', {
-      headers: { Authorization: `Bearer ${cronSecret}` },
-    }).then(r => r.json());
+    const res = await fetch('/api/admin/members', { credentials: 'include' }).then(r => r.json());
 
     if (res.members) {
       setMembers(res.members.map((m: any) => ({
@@ -135,10 +130,7 @@ export default function AdminPage() {
   const loadMemberDetail = async (memberId: string) => {
     setSelectedMemberId(memberId);
 
-    const cronSecret = '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
-    const res = await fetch(`/api/admin/members?id=${memberId}`, {
-      headers: { Authorization: `Bearer ${cronSecret}` },
-    }).then(r => r.json());
+    const res = await fetch(`/api/admin/members?id=${memberId}`, { credentials: 'include' }).then(r => r.json());
 
     if (res.profile) {
       setSelectedMember(res);

--- a/src/components/admin/AITeamPanel.tsx
+++ b/src/components/admin/AITeamPanel.tsx
@@ -49,8 +49,6 @@ const agentIcons: Record<string, React.ElementType> = {
   'upwork-scout': Search,
 };
 
-const CRON_SECRET = '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
-
 function timeAgo(dateStr: string | null): string {
   if (!dateStr) return 'Never';
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -107,9 +105,7 @@ export default function AITeamPanel() {
   const load = async () => {
     setLoading(true);
     try {
-      const res = await fetch('/api/admin/team-status', {
-        headers: { Authorization: `Bearer ${CRON_SECRET}` },
-      });
+      const res = await fetch('/api/admin/team-status', { credentials: 'include' });
       const data = await res.json();
       if (data.agents) setAgents(data.agents);
       if (data.summary) setSummary(data.summary);

--- a/src/components/admin/MeetingRoom.tsx
+++ b/src/components/admin/MeetingRoom.tsx
@@ -68,8 +68,6 @@ const roleBgColors: Record<string, string> = {
   support_agent: 'bg-slate-500/10 border-slate-500/30',
 };
 
-const CRON_SECRET = '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
-
 interface MeetingRoomProps {
   onClose: () => void;
 }
@@ -87,10 +85,8 @@ export default function MeetingRoom({ onClose }: MeetingRoomProps) {
     try {
       await fetch('/api/admin/proposals', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${CRON_SECRET}`,
-        },
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: `${msg.agent}: ${msg.content.slice(0, 80)}...`,
           description: msg.content,
@@ -124,10 +120,8 @@ export default function MeetingRoom({ onClose }: MeetingRoomProps) {
     try {
       const res = await fetch('/api/admin/meeting', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${CRON_SECRET}`,
-        },
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           message: text,
           history: updatedMessages,
@@ -201,7 +195,8 @@ export default function MeetingRoom({ onClose }: MeetingRoomProps) {
                   try {
                     await fetch('/api/admin/meeting', {
                       method: 'POST',
-                      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${CRON_SECRET}` },
+                      credentials: 'include',
+                      headers: { 'Content-Type': 'application/json' },
                       body: JSON.stringify({ action: 'end_meeting', meetingId }),
                     });
                   } catch {}

--- a/src/components/admin/TicketList.tsx
+++ b/src/components/admin/TicketList.tsx
@@ -47,8 +47,6 @@ const priorityColors: Record<string, string> = {
   low: 'bg-slate-500/20 text-slate-500',
 };
 
-const CRON_SECRET = '894f466aff1425f8b4416762e709fab2df7d24b06ba9711aeaacadda2757024f';
-
 export default function TicketList() {
   const [tickets, setTickets] = useState<TicketData[]>([]);
   const [selectedTicket, setSelectedTicket] = useState<TicketData | null>(null);
@@ -65,9 +63,7 @@ export default function TicketList() {
     if (filterStatus) params.set('status', filterStatus);
     if (filterPriority) params.set('priority', filterPriority);
 
-    const res = await fetch(`/api/support/tickets?${params}`, {
-      headers: { Authorization: `Bearer ${CRON_SECRET}` },
-    }).then(r => r.json());
+    const res = await fetch(`/api/support/tickets?${params}`, { credentials: 'include' }).then(r => r.json());
 
     if (res.tickets) setTickets(res.tickets);
     setLoading(false);
@@ -75,9 +71,7 @@ export default function TicketList() {
 
   const loadTicketDetail = async (ticket: TicketData) => {
     setSelectedTicket(ticket);
-    const res = await fetch(`/api/support/tickets/${ticket.id}`, {
-      headers: { Authorization: `Bearer ${CRON_SECRET}` },
-    }).then(r => r.json());
+    const res = await fetch(`/api/support/tickets/${ticket.id}`, { credentials: 'include' }).then(r => r.json());
 
     if (res.messages) setMessages(res.messages);
   };
@@ -88,10 +82,8 @@ export default function TicketList() {
 
     await fetch(`/api/support/tickets/${selectedTicket.id}/messages`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${CRON_SECRET}`,
-      },
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         sender_type: 'agent',
         sender_name: 'Admin',
@@ -109,16 +101,12 @@ export default function TicketList() {
     if (!selectedTicket) return;
     await fetch(`/api/support/tickets/${selectedTicket.id}`, {
       method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${CRON_SECRET}`,
-      },
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ [field]: value }),
     });
     // Refresh
-    const res = await fetch(`/api/support/tickets/${selectedTicket.id}`, {
-      headers: { Authorization: `Bearer ${CRON_SECRET}` },
-    }).then(r => r.json());
+    const res = await fetch(`/api/support/tickets/${selectedTicket.id}`, { credentials: 'include' }).then(r => r.json());
     if (res.ticket) setSelectedTicket(res.ticket);
   };
 

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared auth guard for admin-only endpoints that also need to accept
+ * legitimate cron invocations. Callers should pass both the request
+ * (for the Bearer header) and let this helper resolve the session
+ * cookie via the server Supabase client.
+ *
+ * Why two auth modes:
+ *   - Vercel cron jobs and server-side internal calls use
+ *     `Authorization: Bearer ${CRON_SECRET}` because they have no
+ *     user session.
+ *   - The admin dashboard UI calls these endpoints from the browser.
+ *     Putting CRON_SECRET in the client bundle leaks it to anyone
+ *     who views source — so the browser path authenticates via the
+ *     Supabase session cookie + a fixed admin-email allowlist.
+ *
+ * If neither path validates, return `{ ok: false, status }` and the
+ * caller should early-return with the corresponding 401/403.
+ */
+
+import type { NextRequest } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const ADMIN_EMAIL = 'aireypaul@googlemail.com';
+
+export interface AuthResult {
+  ok: boolean;
+  status: 401 | 403 | 200;
+  reason?: string;
+  userId?: string;
+}
+
+export async function authorizeAdminOrCron(request: NextRequest | Request): Promise<AuthResult> {
+  // Path 1 — Bearer CRON_SECRET (cron, server-to-server)
+  const auth = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && auth === `Bearer ${cronSecret}`) {
+    return { ok: true, status: 200 };
+  }
+
+  // Path 2 — logged-in admin session
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user && user.email === ADMIN_EMAIL) {
+      return { ok: true, status: 200, userId: user.id };
+    }
+    if (user) {
+      return { ok: false, status: 403, reason: 'Not an admin' };
+    }
+  } catch {
+    // Fall through to 401
+  }
+
+  return { ok: false, status: 401, reason: 'Unauthorized' };
+}


### PR DESCRIPTION
## Summary
Six admin client files hardcoded the CRON_SECRET as a Bearer token sent from the browser. Anyone hitting view-source on any admin page could lift the secret and impersonate a Vercel cron job against every admin/cron endpoint.

## Root cause
Admin endpoints (\`/api/admin/metrics\`, \`/api/admin/members\`, \`/api/support/tickets/*\`, etc.) only accepted \`Bearer CRON_SECRET\` — there was no server-side session auth path, so the UI had to ship the secret client-side.

## Changes
- New \`src/lib/admin-auth.ts\` exposing \`authorizeAdminOrCron(request)\`. Two valid paths:
  - **(a)** \`Bearer \${CRON_SECRET}\` — cron / server-to-server, unchanged
  - **(b)** Supabase session cookie belonging to \`ADMIN_EMAIL\` (\`aireypaul@googlemail.com\`)

- 10 endpoints migrated:
  - \`/api/admin/metrics\`, \`/api/admin/members\`, \`/api/admin/team-status\`, \`/api/admin/proposals\` (GET+POST), \`/api/admin/meeting\`
  - \`/api/support/tickets\`, \`/api/support/tickets/[id]\` (GET+PUT), \`/api/support/tickets/[id]/messages\`
  - \`/api/cron/verify-legal-refs\`, \`/api/cron/legal-updates\`

- 6 client files stripped:
  - \`src/app/dashboard/admin/page.tsx\`
  - \`src/app/dashboard/admin/legal-refs/page.tsx\`
  - \`src/app/dashboard/admin/legal-updates/page.tsx\`
  - \`src/components/admin/AITeamPanel.tsx\`
  - \`src/components/admin/TicketList.tsx\`
  - \`src/components/admin/MeetingRoom.tsx\`

  All admin fetches now use \`credentials: 'include'\` so the Supabase session cookie travels with the same-origin request.

## IMPORTANT — rotate after merge
The old CRON_SECRET value was exposed in git history and the production bundle. After this merges and deploys, rotate \`CRON_SECRET\` in the Vercel env and redeploy.

## Test plan
- [ ] Admin page loads for aireypaul@googlemail.com without any Bearer in DevTools Network tab
- [ ] Vercel cron hitting \`/api/cron/verify-legal-refs\` with the new bearer still succeeds (check business_log next morning)
- [ ] Ticket reply works from admin UI
- [ ] Team-status panel populates
- [ ] Legal-refs \"Run verification\" button works
- [ ] Non-admin user hitting \`/api/admin/metrics\` directly gets 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)