### PR TITLE
feat(notifications): unified preferences + dispatcher (foundation)

### DIFF
--- a/src/app/api/notification-preferences/route.ts
+++ b/src/app/api/notification-preferences/route.ts
@@ -1,0 +1,117 @@
+/**
+ * GET  — read the current user's notification preferences (merged
+ *        with defaults from the event catalog).
+ * PUT  — replace preferences for one or many events, plus optional
+ *        quiet hours update.
+ *
+ * Both routes require a logged-in session (RLS on the table enforces
+ * the user can only see/write their own rows — service-role not used).
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { EVENT_CATALOG, type NotificationEventType } from '@/lib/notifications/events';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type ChannelState = { email: boolean; telegram: boolean; push: boolean };
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const [prefsRes, profileRes] = await Promise.all([
+    supabase
+      .from('notification_preferences')
+      .select('event_type, email, telegram, push')
+      .eq('user_id', user.id),
+    supabase
+      .from('profiles')
+      .select('quiet_hours_start, quiet_hours_end, notification_timezone')
+      .eq('id', user.id)
+      .maybeSingle(),
+  ]);
+
+  const overrides = new Map<string, ChannelState>();
+  for (const row of prefsRes.data ?? []) {
+    overrides.set(row.event_type, { email: row.email, telegram: row.telegram, push: row.push });
+  }
+
+  const events = EVENT_CATALOG.map((meta) => ({
+    event: meta.event,
+    label: meta.label,
+    description: meta.description,
+    group: meta.group,
+    allowedChannels: meta.allowedChannels,
+    channels: overrides.get(meta.event) ?? {
+      email: meta.defaultEmail,
+      telegram: meta.defaultTelegram,
+      push: meta.defaultPush,
+    },
+  }));
+
+  return NextResponse.json({
+    events,
+    quiet_hours_start: profileRes.data?.quiet_hours_start ?? null,
+    quiet_hours_end: profileRes.data?.quiet_hours_end ?? null,
+    timezone: profileRes.data?.notification_timezone ?? 'Europe/London',
+  });
+}
+
+interface PutBody {
+  events?: Array<{ event: NotificationEventType; email: boolean; telegram: boolean; push: boolean }>;
+  quiet_hours_start?: string | null;
+  quiet_hours_end?: string | null;
+}
+
+export async function PUT(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = (await request.json()) as PutBody;
+
+  if (body.events && body.events.length > 0) {
+    const validEvents = new Set(EVENT_CATALOG.map((e) => e.event));
+    const rows = body.events
+      .filter((e) => validEvents.has(e.event))
+      .map((e) => ({
+        user_id: user.id,
+        event_type: e.event,
+        email: !!e.email,
+        telegram: !!e.telegram,
+        push: !!e.push,
+        updated_at: new Date().toISOString(),
+      }));
+    if (rows.length > 0) {
+      const { error } = await supabase
+        .from('notification_preferences')
+        .upsert(rows, { onConflict: 'user_id,event_type' });
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      }
+    }
+  }
+
+  if (body.quiet_hours_start !== undefined || body.quiet_hours_end !== undefined) {
+    const update: Record<string, unknown> = {};
+    if (body.quiet_hours_start !== undefined) update.quiet_hours_start = body.quiet_hours_start;
+    if (body.quiet_hours_end !== undefined) update.quiet_hours_end = body.quiet_hours_end;
+    const { error } = await supabase.from('profiles').update(update).eq('id', user.id);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1276,6 +1276,23 @@ export default function ProfilePage() {
       </>)}
 
       {section === 'notifications' && (<>
+      {/* Notification preferences */}
+      <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl p-8 mt-6">
+        <h2 style={{fontSize:18,fontWeight:700,letterSpacing:"-.01em",margin:"0 0 10px"}}>
+          <Mail className="h-5 w-5 text-emerald-600" />
+          Where should alerts land?
+        </h2>
+        <p className="text-slate-600 text-sm mb-4">
+          Choose email, Telegram or push per event type — and set quiet hours if you\'d like the buzzes paused at night.
+        </p>
+        <Link
+          href="/dashboard/settings/notifications"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-700 rounded-xl text-sm font-medium transition-colors"
+        >
+          Manage notification preferences
+        </Link>
+      </div>
+
       {/* Pocket Agent */}
       <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl p-8 mt-6">
         <h2 style={{fontSize:18,fontWeight:700,letterSpacing:"-.01em",margin:"0 0 10px"}}>

--- a/src/app/dashboard/settings/notifications/page.tsx
+++ b/src/app/dashboard/settings/notifications/page.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+/**
+ * /dashboard/settings/notifications
+ *
+ * Matrix settings page — rows = notification events, columns = channels
+ * (email / telegram / push). Plus a quiet-hours picker that applies to
+ * every channel.
+ *
+ * Push is enabled in the UI so users can pre-configure before the
+ * mobile app ships; the dispatcher treats push as a no-op today.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowLeft, Loader2, Mail, MessageCircle, Smartphone, Moon, Save,
+  Bell, Calendar, BarChart3, Megaphone, ShieldCheck, CheckCircle2,
+} from 'lucide-react';
+
+type Channel = 'email' | 'telegram' | 'push';
+
+interface EventRow {
+  event: string;
+  label: string;
+  description: string;
+  group: 'alerts' | 'reminders' | 'summaries' | 'marketing' | 'service';
+  allowedChannels: Channel[];
+  channels: { email: boolean; telegram: boolean; push: boolean };
+}
+
+interface Payload {
+  events: EventRow[];
+  quiet_hours_start: string | null;
+  quiet_hours_end: string | null;
+  timezone: string;
+}
+
+const GROUP_LABELS: Record<EventRow['group'], { label: string; icon: any; blurb: string }> = {
+  alerts:     { label: 'Real-time alerts',           icon: Bell,         blurb: 'Fires the moment something changes.' },
+  reminders:  { label: 'Reminders',                  icon: Calendar,     blurb: 'Upcoming renewals, contract endings, dispute escalations.' },
+  summaries:  { label: 'Daily & weekly summaries',   icon: BarChart3,    blurb: 'Scheduled recaps of where your money went.' },
+  marketing:  { label: 'Offers & recommendations',   icon: Megaphone,    blurb: 'Switching deals and category-specific offers.' },
+  service:    { label: 'Account & service',          icon: ShieldCheck,  blurb: 'Support replies, onboarding and service notices.' },
+};
+
+const GROUP_ORDER: EventRow['group'][] = ['alerts', 'reminders', 'summaries', 'marketing', 'service'];
+
+export default function NotificationsSettingsPage() {
+  const [data, setData] = useState<Payload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/notification-preferences', { credentials: 'include', cache: 'no-store' });
+      if (!res.ok) throw new Error(`${res.status}`);
+      setData(await res.json());
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { void load(); }, []);
+
+  const toggle = (event: string, channel: Channel) => {
+    if (!data) return;
+    setData({
+      ...data,
+      events: data.events.map((e) =>
+        e.event === event ? { ...e, channels: { ...e.channels, [channel]: !e.channels[channel] } } : e,
+      ),
+    });
+  };
+
+  const setQuietHour = (key: 'quiet_hours_start' | 'quiet_hours_end', value: string) => {
+    if (!data) return;
+    setData({ ...data, [key]: value || null });
+  };
+
+  const save = async () => {
+    if (!data) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/notification-preferences', {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          events: data.events.map((e) => ({
+            event: e.event,
+            email: e.channels.email,
+            telegram: e.channels.telegram,
+            push: e.channels.push,
+          })),
+          quiet_hours_start: data.quiet_hours_start,
+          quiet_hours_end: data.quiet_hours_end,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Save failed (${res.status})`);
+      }
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2500);
+    } catch (e: any) {
+      setError(e?.message || 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="p-8 max-w-xl mx-auto">
+        <p className="text-red-600 text-sm">{error || 'Something went wrong.'}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 md:p-8 max-w-4xl mx-auto">
+      <Link href="/dashboard/profile" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900 mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to profile
+      </Link>
+      <h1 className="text-2xl md:text-3xl font-bold text-slate-900 mb-1">Notification preferences</h1>
+      <p className="text-sm text-slate-500 mb-6">
+        Pick where each kind of alert lands. Turn off the channels you don\'t want — leave Paybacker to reach you how you prefer.
+      </p>
+
+      {/* Quiet hours */}
+      <section className="bg-white border border-slate-200 rounded-2xl p-5 mb-6">
+        <div className="flex items-center gap-3 mb-3">
+          <div className="p-2 rounded-lg bg-slate-100">
+            <Moon className="h-5 w-5 text-slate-700" />
+          </div>
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">Quiet hours</h2>
+            <p className="text-xs text-slate-500">We hold push + Telegram during these hours. Emails still land in your inbox.</p>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3 max-w-md">
+          <label className="text-sm">
+            <span className="block text-slate-500 text-xs mb-1">Start</span>
+            <input
+              type="time"
+              value={data.quiet_hours_start ?? ''}
+              onChange={(e) => setQuietHour('quiet_hours_start', e.target.value)}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-slate-900"
+            />
+          </label>
+          <label className="text-sm">
+            <span className="block text-slate-500 text-xs mb-1">End</span>
+            <input
+              type="time"
+              value={data.quiet_hours_end ?? ''}
+              onChange={(e) => setQuietHour('quiet_hours_end', e.target.value)}
+              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-slate-900"
+            />
+          </label>
+        </div>
+        <p className="text-xs text-slate-500 mt-2">
+          Timezone: {data.timezone} · Leave blank for 24/7 delivery.
+        </p>
+      </section>
+
+      {/* Event matrix grouped */}
+      {GROUP_ORDER.map((groupKey) => {
+        const rows = data.events.filter((e) => e.group === groupKey);
+        if (rows.length === 0) return null;
+        const groupMeta = GROUP_LABELS[groupKey];
+        const Icon = groupMeta.icon;
+        return (
+          <section key={groupKey} className="bg-white border border-slate-200 rounded-2xl p-5 mb-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 rounded-lg bg-slate-100">
+                <Icon className="h-5 w-5 text-slate-700" />
+              </div>
+              <div>
+                <h2 className="text-base font-semibold text-slate-900">{groupMeta.label}</h2>
+                <p className="text-xs text-slate-500">{groupMeta.blurb}</p>
+              </div>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs uppercase tracking-wider text-slate-500 border-b border-slate-200">
+                    <th className="py-2 pr-4 font-medium">Event</th>
+                    <th className="py-2 px-2 text-center font-medium w-20">
+                      <div className="flex flex-col items-center gap-0.5"><Mail className="h-4 w-4" /> Email</div>
+                    </th>
+                    <th className="py-2 px-2 text-center font-medium w-24">
+                      <div className="flex flex-col items-center gap-0.5"><MessageCircle className="h-4 w-4" /> Telegram</div>
+                    </th>
+                    <th className="py-2 px-2 text-center font-medium w-20">
+                      <div className="flex flex-col items-center gap-0.5"><Smartphone className="h-4 w-4" /> Push</div>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((r) => (
+                    <tr key={r.event} className="border-b border-slate-100 last:border-0">
+                      <td className="py-3 pr-4">
+                        <div className="text-sm text-slate-900 font-medium">{r.label}</div>
+                        <div className="text-xs text-slate-500">{r.description}</div>
+                      </td>
+                      {(['email', 'telegram', 'push'] as Channel[]).map((ch) => {
+                        const allowed = r.allowedChannels.includes(ch);
+                        return (
+                          <td key={ch} className="py-3 px-2 text-center">
+                            <input
+                              type="checkbox"
+                              disabled={!allowed}
+                              checked={allowed && r.channels[ch]}
+                              onChange={() => toggle(r.event, ch)}
+                              className="h-4 w-4 accent-emerald-500 disabled:opacity-20 cursor-pointer disabled:cursor-not-allowed"
+                              aria-label={`${r.label} via ${ch}`}
+                            />
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        );
+      })}
+
+      {/* Sticky save bar */}
+      <div className="sticky bottom-4 flex items-center justify-between gap-3 bg-white border border-slate-200 rounded-2xl px-4 py-3 shadow-lg">
+        <div className="flex items-center gap-2">
+          {saved && (
+            <span className="inline-flex items-center gap-1 text-sm text-emerald-600">
+              <CheckCircle2 className="h-4 w-4" /> Saved
+            </span>
+          )}
+          {error && <span className="text-sm text-red-600">{error}</span>}
+          {!saved && !error && (
+            <span className="text-xs text-slate-500">Push is set up now — notifications begin when our mobile app lands.</span>
+          )}
+        </div>
+        <button
+          onClick={save}
+          disabled={saving}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white font-semibold text-sm disabled:opacity-50"
+        >
+          {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+          Save preferences
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/notifications/dispatch.ts
+++ b/src/lib/notifications/dispatch.ts
@@ -1,0 +1,259 @@
+/**
+ * Unified notification dispatcher.
+ *
+ * One call — sendNotification() — decides whether the user wants this
+ * event on email, telegram, push or a mix, respects quiet hours, and
+ * fans out to the right transports.
+ *
+ * Legacy notification code paths still exist (each cron hits Resend /
+ * Telegram directly). They will be migrated to this dispatcher as they
+ * are touched. Behaviour is backwards-compatible: if a user has no
+ * row in `notification_preferences` for an event, the defaults from
+ * events.ts apply — which match the previous hard-coded behaviour.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { EVENT_CATALOG, type NotificationEventType } from './events';
+
+export type Channel = 'email' | 'telegram' | 'push';
+
+export interface EmailPayload {
+  subject: string;
+  html: string;
+  to?: string; // overrides profile.email
+}
+
+export interface TelegramPayload {
+  text: string; // Markdown-friendly — the bot already handles escaping
+}
+
+export interface PushPayload {
+  title: string;
+  body: string;
+  deepLink?: string; // e.g. /dashboard/complaints#entry-<id>
+  data?: Record<string, string>;
+}
+
+export interface DispatchInput {
+  userId: string;
+  event: NotificationEventType;
+  email?: EmailPayload;
+  telegram?: TelegramPayload;
+  push?: PushPayload;
+  /** Non-transactional events respect email rate limits; default true */
+  rateLimited?: boolean;
+  /** Bypass quiet hours (only use for genuine urgencies) */
+  bypassQuietHours?: boolean;
+}
+
+export interface DispatchResult {
+  delivered: Channel[];
+  skipped: Array<{ channel: Channel; reason: string }>;
+}
+
+interface UserRouting {
+  email: string | null;
+  tier: string | null;
+  quietStart: string | null;
+  quietEnd: string | null;
+  timezone: string;
+  telegramChatId: number | null;
+  prefs: Record<string, { email: boolean; telegram: boolean; push: boolean }>;
+}
+
+async function loadUserRouting(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<UserRouting | null> {
+  const [profileRes, telegramRes, prefsRes] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('email, subscription_tier, quiet_hours_start, quiet_hours_end, notification_timezone')
+      .eq('id', userId)
+      .maybeSingle(),
+    supabase
+      .from('telegram_sessions')
+      .select('telegram_chat_id, is_active')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .maybeSingle(),
+    supabase
+      .from('notification_preferences')
+      .select('event_type, email, telegram, push')
+      .eq('user_id', userId),
+  ]);
+
+  if (!profileRes.data) return null;
+
+  const prefs: UserRouting['prefs'] = {};
+  for (const row of prefsRes.data ?? []) {
+    prefs[row.event_type] = { email: row.email, telegram: row.telegram, push: row.push };
+  }
+
+  return {
+    email: profileRes.data.email ?? null,
+    tier: profileRes.data.subscription_tier ?? null,
+    quietStart: profileRes.data.quiet_hours_start ?? null,
+    quietEnd: profileRes.data.quiet_hours_end ?? null,
+    timezone: profileRes.data.notification_timezone || 'Europe/London',
+    telegramChatId: telegramRes.data?.telegram_chat_id ?? null,
+    prefs,
+  };
+}
+
+/**
+ * Returns true if the CURRENT time in the user's timezone falls
+ * inside their quiet-hours window. Handles windows that cross
+ * midnight (e.g. 22:00–07:00).
+ */
+function inQuietHours(routing: UserRouting): boolean {
+  const { quietStart, quietEnd, timezone } = routing;
+  if (!quietStart || !quietEnd) return false;
+  try {
+    const fmt = new Intl.DateTimeFormat('en-GB', {
+      timeZone: timezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    const parts = fmt.formatToParts(new Date());
+    const hh = parseInt(parts.find((p) => p.type === 'hour')?.value ?? '0', 10);
+    const mm = parseInt(parts.find((p) => p.type === 'minute')?.value ?? '0', 10);
+    const nowMin = hh * 60 + mm;
+
+    const [qsH, qsM] = quietStart.split(':').map((x) => parseInt(x, 10));
+    const [qeH, qeM] = quietEnd.split(':').map((x) => parseInt(x, 10));
+    const startMin = qsH * 60 + qsM;
+    const endMin = qeH * 60 + qeM;
+
+    if (startMin <= endMin) {
+      return nowMin >= startMin && nowMin < endMin;
+    }
+    // Window crosses midnight
+    return nowMin >= startMin || nowMin < endMin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Decide which channels a notification should fan out to for this user.
+ * Combines the event's default, any explicit pref row, and what the
+ * caller actually provided payloads for.
+ */
+function resolveChannels(
+  routing: UserRouting,
+  event: NotificationEventType,
+  hasPayload: Record<Channel, boolean>,
+): Channel[] {
+  const meta = EVENT_CATALOG.find((e) => e.event === event);
+  const defaults = meta
+    ? { email: meta.defaultEmail, telegram: meta.defaultTelegram, push: meta.defaultPush }
+    : { email: true, telegram: true, push: true };
+  const override = routing.prefs[event];
+  const wants = override ?? defaults;
+
+  const out: Channel[] = [];
+  if (wants.email && hasPayload.email && routing.email) out.push('email');
+  if (wants.telegram && hasPayload.telegram && routing.telegramChatId) out.push('telegram');
+  if (wants.push && hasPayload.push) out.push('push');
+  return out;
+}
+
+async function sendEmail(email: string, payload: EmailPayload): Promise<boolean> {
+  try {
+    const { resend, FROM_EMAIL } = await import('@/lib/resend');
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: payload.to ?? email,
+      subject: payload.subject,
+      html: payload.html,
+    });
+    return true;
+  } catch (err) {
+    console.error('[notifications] email send failed:', err);
+    return false;
+  }
+}
+
+async function sendTelegram(chatId: number, payload: TelegramPayload): Promise<boolean> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) return false;
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text: payload.text, parse_mode: 'Markdown' }),
+    });
+    return res.ok;
+  } catch (err) {
+    console.error('[notifications] telegram send failed:', err);
+    return false;
+  }
+}
+
+/**
+ * Push stub — becomes a real APNs/FCM sender once the mobile app
+ * lands and `push_tokens` is populated. Until then it's a no-op that
+ * records intent so the settings UI can show "push" as selectable.
+ */
+async function sendPush(
+  supabase: SupabaseClient,
+  userId: string,
+  payload: PushPayload,
+): Promise<boolean> {
+  try {
+    await supabase.from('notification_log').insert({
+      user_id: userId,
+      notification_type: 'push_pending',
+      reference_key: `${payload.title}|${Date.now()}`,
+    });
+  } catch {
+    // notification_log may not have this shape — log and move on
+  }
+  return false; // always "skipped" until real transport exists
+}
+
+export async function sendNotification(
+  supabase: SupabaseClient,
+  input: DispatchInput,
+): Promise<DispatchResult> {
+  const routing = await loadUserRouting(supabase, input.userId);
+  if (!routing) {
+    return { delivered: [], skipped: [{ channel: 'email', reason: 'user not found' }] };
+  }
+
+  const hasPayload: Record<Channel, boolean> = {
+    email: !!input.email,
+    telegram: !!input.telegram,
+    push: !!input.push,
+  };
+
+  const channels = resolveChannels(routing, input.event, hasPayload);
+
+  const quiet = !input.bypassQuietHours && inQuietHours(routing);
+  const delivered: Channel[] = [];
+  const skipped: Array<{ channel: Channel; reason: string }> = [];
+
+  // Quiet-hours rule: push + telegram are suppressed; email still sends
+  // (it goes to an inbox, not a buzz, so it's the polite fallback).
+  for (const channel of channels) {
+    if (quiet && (channel === 'push' || channel === 'telegram')) {
+      skipped.push({ channel, reason: 'quiet hours' });
+      continue;
+    }
+
+    if (channel === 'email' && input.email && routing.email) {
+      if (await sendEmail(routing.email, input.email)) delivered.push('email');
+      else skipped.push({ channel: 'email', reason: 'send failed' });
+    } else if (channel === 'telegram' && input.telegram && routing.telegramChatId) {
+      if (await sendTelegram(routing.telegramChatId, input.telegram)) delivered.push('telegram');
+      else skipped.push({ channel: 'telegram', reason: 'send failed' });
+    } else if (channel === 'push' && input.push) {
+      if (await sendPush(supabase, input.userId, input.push)) delivered.push('push');
+      else skipped.push({ channel: 'push', reason: 'no transport yet' });
+    }
+  }
+
+  return { delivered, skipped };
+}

--- a/src/lib/notifications/events.ts
+++ b/src/lib/notifications/events.ts
@@ -1,0 +1,213 @@
+/**
+ * Canonical list of notification event types.
+ *
+ * Every user-facing alert in the system should map to one of these
+ * so the dispatcher can route it through the user's configured
+ * channels (email / telegram / push).
+ *
+ * Add new event types here — no migration needed.
+ */
+
+export type NotificationEventType =
+  | 'price_increase'         // Bill detected going up
+  | 'dispute_reply'          // Provider replied to an active dispute
+  | 'dispute_reminder'       // Dispute escalation milestones (14/28/56d)
+  | 'renewal_reminder'       // Contract renewing in 30/14/7 days
+  | 'contract_expiry'        // Contract ending soon
+  | 'budget_alert'           // Approaching or over budget threshold
+  | 'unused_subscription'    // No spend in 30+ days on tracked sub
+  | 'savings_milestone'      // £500/£1000/£5000 saved
+  | 'overcharge_detected'    // Duplicate charge detected
+  | 'new_opportunity'        // Email scan found something to action
+  | 'support_reply'          // Support ticket reply landed
+  | 'weekly_digest'          // Weekly spending/savings summary
+  | 'monthly_recap'          // Month-end financial recap
+  | 'morning_summary'        // Daily 7:30am Telegram briefing
+  | 'evening_summary'        // Daily 5pm Telegram recap
+  | 'payday_summary'         // After payday income/bills breakdown
+  | 'deal_alert'             // Personalised switching deal
+  | 'targeted_deal'          // Category-specific offer
+  | 'onboarding';            // Onboarding email sequence
+
+export interface EventMeta {
+  event: NotificationEventType;
+  label: string;
+  description: string;
+  defaultEmail: boolean;
+  defaultTelegram: boolean;
+  defaultPush: boolean;
+  allowedChannels: Array<'email' | 'telegram' | 'push'>;
+  group: 'alerts' | 'reminders' | 'summaries' | 'marketing' | 'service';
+}
+
+/**
+ * What each event does + sensible defaults. `allowedChannels`
+ * reflects real plumbing (e.g. onboarding is email-only because
+ * Telegram onboarding would need reinventing the welcome flow).
+ */
+export const EVENT_CATALOG: EventMeta[] = [
+  {
+    event: 'price_increase',
+    label: 'Price hike detected',
+    description: 'When a recurring bill (council tax, energy, insurance etc.) goes up by 5%+.',
+    defaultEmail: true, defaultTelegram: true, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'alerts',
+  },
+  {
+    event: 'dispute_reply',
+    label: 'Dispute reply received',
+    description: 'A provider has replied to one of your active complaint letters.',
+    defaultEmail: true, defaultTelegram: true, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'alerts',
+  },
+  {
+    event: 'dispute_reminder',
+    label: 'Dispute escalation reminder',
+    description: 'Milestone reminders to escalate a stuck dispute (14/28/56 days).',
+    defaultEmail: true, defaultTelegram: true, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'reminders',
+  },
+  {
+    event: 'renewal_reminder',
+    label: 'Renewal reminders',
+    description: 'Contract or subscription renewing in 30 / 14 / 7 days.',
+    defaultEmail: true, defaultTelegram: true, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'reminders',
+  },
+  {
+    event: 'contract_expiry',
+    label: 'Contract ending soon',
+    description: 'A tracked contract is about to end — time to switch.',
+    defaultEmail: true, defaultTelegram: true, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'reminders',
+  },
+  {
+    event: 'budget_alert',
+    label: 'Budget alerts',
+    description: 'You\'ve hit 80% or 100% of a budget category.',
+    defaultEmail: false, defaultTelegram: true, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'alerts',
+  },
+  {
+    event: 'unused_subscription',
+    label: 'Unused subscription',
+    description: 'Subscriptions you haven\'t used in 30+ days.',
+    defaultEmail: true, defaultTelegram: true, defaultPush: false,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'alerts',
+  },
+  {
+    event: 'savings_milestone',
+    label: 'Savings milestones',
+    description: 'Hit £500 / £1,000 / £5,000 saved through Paybacker.',
+    defaultEmail: true, defaultTelegram: true, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'alerts',
+  },
+  {
+    event: 'overcharge_detected',
+    label: 'Overcharge detected',
+    description: 'A duplicate or anomalous charge has landed on your account.',
+    defaultEmail: true, defaultTelegram: true, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'alerts',
+  },
+  {
+    event: 'new_opportunity',
+    label: 'Email-scan opportunities',
+    description: 'The inbox scanner has found a refund, dispute or saving worth actioning.',
+    defaultEmail: true, defaultTelegram: false, defaultPush: true,
+    allowedChannels: ['email', 'telegram', 'push'],
+    group: 'alerts',
+  },
+  {
+    event: 'support_reply',
+    label: 'Support replies',
+    description: 'We\'ve replied to your support ticket.',
+    defaultEmail: true, defaultTelegram: false, defaultPush: true,
+    allowedChannels: ['email', 'push'],
+    group: 'service',
+  },
+  {
+    event: 'weekly_digest',
+    label: 'Weekly digest',
+    description: 'Weekly recap of spending, savings and what you actioned.',
+    defaultEmail: true, defaultTelegram: false, defaultPush: false,
+    allowedChannels: ['email', 'telegram'],
+    group: 'summaries',
+  },
+  {
+    event: 'monthly_recap',
+    label: 'Monthly recap',
+    description: 'End-of-month financial summary.',
+    defaultEmail: true, defaultTelegram: true, defaultPush: false,
+    allowedChannels: ['email', 'telegram'],
+    group: 'summaries',
+  },
+  {
+    event: 'morning_summary',
+    label: 'Morning briefing (7:30am)',
+    description: 'Daily morning Telegram briefing — spending, renewals, disputes.',
+    defaultEmail: false, defaultTelegram: true, defaultPush: false,
+    allowedChannels: ['telegram', 'push'],
+    group: 'summaries',
+  },
+  {
+    event: 'evening_summary',
+    label: 'Evening recap (5pm)',
+    description: 'End-of-day spending recap.',
+    defaultEmail: false, defaultTelegram: true, defaultPush: false,
+    allowedChannels: ['telegram', 'push'],
+    group: 'summaries',
+  },
+  {
+    event: 'payday_summary',
+    label: 'Payday summary',
+    description: 'Income matched to upcoming bills the day after payday.',
+    defaultEmail: false, defaultTelegram: true, defaultPush: false,
+    allowedChannels: ['telegram', 'push'],
+    group: 'summaries',
+  },
+  {
+    event: 'deal_alert',
+    label: 'Deal recommendations',
+    description: 'Hand-picked switching deals that match your spend.',
+    defaultEmail: true, defaultTelegram: false, defaultPush: false,
+    allowedChannels: ['email', 'telegram'],
+    group: 'marketing',
+  },
+  {
+    event: 'targeted_deal',
+    label: 'Category offers',
+    description: 'Offers in categories you already spend in.',
+    defaultEmail: true, defaultTelegram: false, defaultPush: false,
+    allowedChannels: ['email', 'telegram'],
+    group: 'marketing',
+  },
+  {
+    event: 'onboarding',
+    label: 'Onboarding emails',
+    description: 'Welcome + tips in your first week.',
+    defaultEmail: true, defaultTelegram: false, defaultPush: false,
+    allowedChannels: ['email'],
+    group: 'service',
+  },
+];
+
+export const EVENT_GROUPS: Record<EventMeta['group'], string> = {
+  alerts: 'Real-time alerts',
+  reminders: 'Reminders',
+  summaries: 'Daily & weekly summaries',
+  marketing: 'Offers & recommendations',
+  service: 'Account & service',
+};
+
+export function getEventMeta(event: NotificationEventType): EventMeta | undefined {
+  return EVENT_CATALOG.find((e) => e.event === event);
+}

--- a/supabase/migrations/20260423030000_notification_preferences.sql
+++ b/supabase/migrations/20260423030000_notification_preferences.sql
@@ -1,0 +1,60 @@
+-- Unified notification preferences: per event type, which channels
+-- should deliver it. Replaces the scattered booleans across email
+-- code paths + telegram_alert_preferences.
+--
+-- Design:
+--   - One row per (user_id, event_type)
+--   - Each row holds email + telegram + push flags
+--   - Default = all channels enabled (matches existing behaviour
+--     so nobody silently stops getting alerts)
+--
+-- Event types are deliberately string-typed (not an enum) so new
+-- event types can be added without a migration. Canonical list is
+-- maintained in src/lib/notifications/events.ts.
+--
+-- Quiet hours + preferred timezone live on `profiles` because they
+-- apply globally across channels, not per-event.
+
+CREATE TABLE IF NOT EXISTS public.notification_preferences (
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_type text NOT NULL,
+  email boolean NOT NULL DEFAULT true,
+  telegram boolean NOT NULL DEFAULT true,
+  push boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, event_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_preferences_user
+  ON public.notification_preferences (user_id);
+
+ALTER TABLE public.notification_preferences ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users read own notification prefs" ON public.notification_preferences;
+CREATE POLICY "Users read own notification prefs"
+  ON public.notification_preferences FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users update own notification prefs" ON public.notification_preferences;
+CREATE POLICY "Users update own notification prefs"
+  ON public.notification_preferences FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Quiet hours at the user level. NULL start/end = 24/7 delivery OK.
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS quiet_hours_start time,
+  ADD COLUMN IF NOT EXISTS quiet_hours_end time,
+  ADD COLUMN IF NOT EXISTS notification_timezone text DEFAULT 'Europe/London';
+
+-- Backfill: copy existing telegram_alert_preferences so nobody
+-- loses quiet hours when the new code starts reading profiles.
+UPDATE public.profiles p
+SET
+  quiet_hours_start = COALESCE(p.quiet_hours_start, tap.quiet_start::time),
+  quiet_hours_end   = COALESCE(p.quiet_hours_end, tap.quiet_end::time)
+FROM public.telegram_alert_preferences tap
+WHERE tap.user_id = p.id
+  AND tap.quiet_start IS NOT NULL
+  AND tap.quiet_end IS NOT NULL
+  AND (p.quiet_hours_start IS NULL OR p.quiet_hours_end IS NULL);


### PR DESCRIPTION
## Summary
Users should be able to decide which channel each type of alert lands on — email, Telegram, or push (ready for the mobile app). This PR ships the foundation: a preferences table, a dispatcher, a settings UI, and an event catalog. Existing cron jobs are unaffected; they'll be migrated to the dispatcher one at a time in follow-up PRs.

## What's in this PR
- **Migration 20260423030000** — new \`notification_preferences\` table (PK user_id+event_type, RLS restricts to own rows) + \`quiet_hours_start\` / \`quiet_hours_end\` / \`notification_timezone\` columns on \`profiles\`. Backfills quiet hours from the existing \`telegram_alert_preferences\` table.
- **\`src/lib/notifications/events.ts\`** — canonical catalog of 19 event types across 5 groups (alerts, reminders, summaries, marketing, service). Each event has sensible defaults + an \`allowedChannels\` allowlist so e.g. onboarding emails can't accidentally be re-routed to Telegram.
- **\`src/lib/notifications/dispatch.ts\`** — \`sendNotification(supabase, input)\` resolves user prefs, enforces quiet hours (push+telegram held, email still sends), fans out to Resend + Telegram Bot API. Push is a structured no-op until the mobile app ships.
- **\`GET/PUT /api/notification-preferences\`** — session-authed, RLS-gated.
- **\`/dashboard/settings/notifications\`** — matrix UI grouped by category, quiet-hours picker, sticky save bar.
- **Profile "Notifications" section** links to the new settings page.

## Not in this PR (deliberate scope control)
- Existing cron jobs (\`price-increases\`, \`dispute-reminders\`, \`renewal-reminders\`, all 12 telegram-* crons) are NOT migrated yet — they keep their current behaviour.
- Follow-up PRs will migrate call sites one at a time.

## Test plan
- [ ] Log in → /dashboard/settings/notifications — matrix loads with sensible defaults
- [ ] Untick all channels for "weekly_digest", save, reload → values persist
- [ ] Set quiet hours 22:00–07:00, save → reflected on reload
- [ ] Hit \`/api/notification-preferences\` while logged out → 401
- [ ] SQL: \`SELECT * FROM notification_preferences LIMIT 5\` returns nothing until a user saves

## Next PRs
1. Migrate \`sendPriceIncreaseAlert\` + telegram-price-increase cron to \`sendNotification\`
2. Dispute watchdog → dispatcher
3. Renewal reminders + budget alerts → dispatcher
4. Once mobile app scaffolded: wire \`push\` transport (APNs + FCM) and push_tokens table

🤖 Generated with [Claude Code](https://claude.com/claude-code)