### PR TITLE
feat(notifications): route price-increase alerts through dispatcher

### DIFF
--- a/src/app/api/cron/price-increases/route.ts
+++ b/src/app/api/cron/price-increases/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { detectPriceIncreases } from '@/lib/price-increase-detector';
-import { sendPriceIncreaseAlert } from '@/lib/email/price-increase-alerts';
+import { buildPriceIncreaseEmail } from '@/lib/email/price-increase-alerts';
 import { canSendEmail } from '@/lib/email-rate-limit';
+import { sendNotification } from '@/lib/notifications/dispatch';
 
 export const maxDuration = 60;
 
@@ -106,14 +107,27 @@ export async function GET(request: NextRequest) {
         newIncreases.push(increase);
       }
 
-      // Send ONE consolidated email with ALL price increases for this user
-      if (isPaid && profile?.email && newIncreases.length > 0) {
-        // Global daily email rate limit
+      // Route via the unified dispatcher — user's notification_preferences
+      // decide which of email / telegram / push fires. Free users still
+      // skip email (the dispatcher doesn't enforce tier, but this cron does).
+      if (newIncreases.length > 0) {
         const rateCheck = await canSendEmail(supabase, userId, 'price_increase_alert');
-        if (rateCheck.allowed) {
-          const sent = await sendPriceIncreaseAlert(profile.email, userName, newIncreases as any);
-          if (sent) totalEmailsSent++;
-        }
+        const emailAllowed = isPaid && rateCheck.allowed;
+
+        const { subject, html } = buildPriceIncreaseEmail(userName, newIncreases as any);
+        const headline = newIncreases.length === 1
+          ? `💸 *${newIncreases[0].merchantNormalized}* went up £${(newIncreases[0].newAmount - newIncreases[0].oldAmount).toFixed(2)} (+${newIncreases[0].increasePct}%)`
+          : `💸 *${newIncreases.length} price increases detected* on your bills`;
+        const telegramText = `${headline}\n\n${newIncreases.map(i => `• ${i.merchantNormalized}: £${i.oldAmount} → £${i.newAmount} (+${i.increasePct}%)`).join('\n')}\n\nOpen Paybacker → Dashboard → Price increase alerts to action.`;
+
+        const result = await sendNotification(supabase, {
+          userId,
+          event: 'price_increase',
+          email: emailAllowed ? { subject, html } : undefined,
+          telegram: { text: telegramText },
+          push: { title: 'Price hike detected', body: headline.replace(/\*/g, '') },
+        });
+        if (result.delivered.includes('email')) totalEmailsSent++;
       }
     } catch (err) {
       errors.push(`Error processing user ${userId}: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary
First cron migration to the unified notification dispatcher from #214. Previously:
- \`/api/cron/price-increases\` sent email only (paid users)
- \`/api/cron/telegram-price-increase-detection\` did its own parallel detection + sent Telegram messages
- Telegram users got double-detection, free users never got Telegram

Now one detection pass, one dispatcher call per user. User preferences decide email / Telegram / push. Quiet hours respected for push + Telegram; email keeps its tier + rate-limit guard.

## Test plan
- [ ] User with \`price_increase\` email enabled + paid tier → receives email
- [ ] User with Telegram enabled + linked session → receives Telegram message
- [ ] User with both channels disabled → no notification (alert still inserted in DB)
- [ ] Quiet hours 22:00–07:00, cron runs inside window → Telegram suppressed, email still delivered
- [ ] Free user with Telegram enabled → Telegram still fires (no tier gate on Telegram in this PR)

## Follow-ups still TBD
- telegram-price-increase-detection cron can now be deprecated (duplicate logic) — flagged as a cleanup task
- Dispute reminders, renewal reminders, budget alerts still to migrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)