### PR TITLE
feat(money-hub): Account Spaces — group bank connections (Emma-style)

### DIFF
--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -6,6 +6,7 @@ import { normalizeSpendingCategoryKey, findMatchingCategoryOverride, resolveMone
 import { normaliseMerchantName } from '@/lib/merchant-normalise';
 import { pickRawMerchantSource } from '@/lib/merchant-utils';
 import { loadLearnedRules } from '@/lib/learning-engine';
+import { ensureDefaultSpace, getSpace, spaceConnectionFilter } from '@/lib/spaces';
 
 export const runtime = 'nodejs';
 
@@ -124,6 +125,32 @@ export async function GET(request: Request) {
     // Parse selected month for RPC calls
     const [selYear, selMonth] = selectedMonth.split('-').map(Number);
 
+    // Resolve the active Space — either the one requested via ?space_id
+    // or the user's default. Non-default Spaces filter bank_connections
+    // + bank_transactions to the chosen subset so Money Hub shows only
+    // that Space's activity.
+    const requestedSpaceId = url.searchParams.get('space_id');
+    await ensureDefaultSpace(supabase, user.id);
+    const activeSpace = await getSpace(supabase, user.id, requestedSpaceId);
+    const connectionFilter = spaceConnectionFilter(activeSpace);
+
+    let txnQuery = admin
+      .from('bank_transactions')
+      .select('*')
+      .eq('user_id', user.id)
+      .gte('timestamp', sixMonthsAgo)
+      .order('timestamp', { ascending: false })
+      .limit(20000);
+    let connQuery = admin
+      .from('bank_connections')
+      .select('id, bank_name, status, last_synced_at, account_ids, account_display_names')
+      .eq('user_id', user.id)
+      .neq('status', 'revoked');
+    if (connectionFilter) {
+      txnQuery = txnQuery.in('connection_id', connectionFilter);
+      connQuery = connQuery.in('id', connectionFilter);
+    }
+
     const [
       { data: txns },
       { data: bankConns },
@@ -134,14 +161,18 @@ export async function GET(request: Request) {
       { data: categoryOverrides },
       { data: subscriptions },
       { data: alerts },
-      // RPC calls for authoritative income/spending totals (excludes transfers correctly)
+      // RPC calls for authoritative income/spending totals (excludes transfers correctly).
+      // Note: RPCs aggregate at user level — when a non-default Space is
+      // active the JS summariser below recomputes the actual totals
+      // from the filtered transaction set, so these RPC values are only
+      // used for the default "Everything" Space.
       { data: rpcSpendingTotal },
       { data: rpcIncomeTotal },
       { data: rpcSpendingCategories },
       { data: rpcIncomeCategories },
     ] = await Promise.all([
-      admin.from('bank_transactions').select('*').eq('user_id', user.id).gte('timestamp', sixMonthsAgo).order('timestamp', { ascending: false }).limit(20000),
-      admin.from('bank_connections').select('id, bank_name, status, last_synced_at, account_ids, account_display_names').eq('user_id', user.id).neq('status', 'revoked'),
+      txnQuery,
+      connQuery,
       admin.from('money_hub_budgets').select('*').eq('user_id', user.id),
       admin.from('money_hub_assets').select('*').eq('user_id', user.id),
       admin.from('money_hub_liabilities').select('*').eq('user_id', user.id),
@@ -257,6 +288,9 @@ export async function GET(request: Request) {
       score: healthScore.overall,
       healthScore,
       selectedMonth,
+      activeSpace: activeSpace
+        ? { id: activeSpace.id, name: activeSpace.name, emoji: activeSpace.emoji, is_default: activeSpace.is_default }
+        : null,
       overview: {
         monthlyIncome: parseFloat(authIncome.toFixed(2)),
         monthlyOutgoings: parseFloat(authSpending.toFixed(2)),

--- a/src/app/api/spaces/[id]/route.ts
+++ b/src/app/api/spaces/[id]/route.ts
@@ -1,0 +1,108 @@
+/**
+ * PATCH  /api/spaces/[id]  — rename or change connection membership
+ * DELETE /api/spaces/[id]  — delete a Space (cannot delete the default)
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface PatchBody {
+  name?: string;
+  emoji?: string | null;
+  color?: string | null;
+  connection_ids?: string[];
+  sort_order?: number;
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+  const body = (await request.json()) as PatchBody;
+
+  const update: Record<string, unknown> = {};
+  if (body.name !== undefined) {
+    const name = body.name.trim();
+    if (!name) return NextResponse.json({ error: 'name cannot be empty' }, { status: 400 });
+    if (name.length > 40) return NextResponse.json({ error: 'name too long' }, { status: 400 });
+    update.name = name;
+  }
+  if (body.emoji !== undefined) update.emoji = body.emoji;
+  if (body.color !== undefined) update.color = body.color;
+  if (body.sort_order !== undefined) update.sort_order = body.sort_order;
+
+  if (body.connection_ids !== undefined) {
+    const connectionIds = Array.from(new Set(body.connection_ids));
+    if (connectionIds.length > 0) {
+      const { data: ownedConns } = await supabase
+        .from('bank_connections')
+        .select('id')
+        .in('id', connectionIds)
+        .eq('user_id', user.id);
+      const ownedSet = new Set((ownedConns ?? []).map((c) => c.id));
+      for (const cid of connectionIds) {
+        if (!ownedSet.has(cid)) {
+          return NextResponse.json({ error: 'Invalid connection_id' }, { status: 400 });
+        }
+      }
+    }
+    update.connection_ids = connectionIds;
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json({ error: 'nothing to update' }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from('account_spaces')
+    .update(update)
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select('*')
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json({ space: data });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+
+  // Protect the default Space — deleting it leaves the user with no
+  // fallback view. The UI doesn't expose a delete button for it anyway
+  // but we double-check here.
+  const { data: target } = await supabase
+    .from('account_spaces')
+    .select('is_default')
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (!target) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (target.is_default) {
+    return NextResponse.json({ error: 'Cannot delete the default Space' }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from('account_spaces')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', user.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/spaces/route.ts
+++ b/src/app/api/spaces/route.ts
@@ -1,0 +1,109 @@
+/**
+ * GET  /api/spaces         — list the current user's Spaces
+ * POST /api/spaces         — create a new Space (Pro-gated)
+ *
+ * Space CRUD for individual rows lives at /api/spaces/[id].
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { ensureDefaultSpace, listSpaces } from '@/lib/spaces';
+import { getEffectiveTier, PLAN_LIMITS } from '@/lib/plan-limits';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  // Safety net in case the user pre-dates the backfill migration.
+  await ensureDefaultSpace(supabase, user.id);
+  const spaces = await listSpaces(supabase, user.id);
+
+  // Report the connections the user actually has so the settings UI
+  // can render a checkbox per connection when editing a Space.
+  const { data: connections } = await supabase
+    .from('bank_connections')
+    .select('id, bank_name, provider, status, account_display_names')
+    .eq('user_id', user.id)
+    .order('connected_at', { ascending: true });
+
+  return NextResponse.json({
+    spaces,
+    connections: connections ?? [],
+  });
+}
+
+interface CreateBody {
+  name?: string;
+  emoji?: string | null;
+  color?: string | null;
+  connection_ids?: string[];
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const tier = await getEffectiveTier(user.id);
+  const maxSpaces = PLAN_LIMITS[tier].maxSpaces;
+  if (maxSpaces !== null) {
+    const existing = await listSpaces(supabase, user.id);
+    if (existing.length >= maxSpaces) {
+      return NextResponse.json(
+        {
+          error: 'Upgrade required',
+          reason: 'max_spaces_reached',
+          tier,
+          max: maxSpaces,
+          message: 'Custom Spaces are a Pro feature. Upgrade to group business, personal and joint accounts separately.',
+        },
+        { status: 403 },
+      );
+    }
+  }
+
+  const body = (await request.json()) as CreateBody;
+  const name = (body.name ?? '').trim();
+  if (!name) return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  if (name.length > 40) {
+    return NextResponse.json({ error: 'name must be 40 characters or fewer' }, { status: 400 });
+  }
+
+  // Validate connection_ids belong to this user so a malicious caller
+  // can't reference another user's connection IDs (which would show
+  // nothing anyway thanks to RLS, but it's a clean guard).
+  const connectionIds = Array.from(new Set(body.connection_ids ?? []));
+  if (connectionIds.length > 0) {
+    const { data: ownedConns } = await supabase
+      .from('bank_connections')
+      .select('id')
+      .in('id', connectionIds)
+      .eq('user_id', user.id);
+    const ownedSet = new Set((ownedConns ?? []).map((c) => c.id));
+    for (const id of connectionIds) {
+      if (!ownedSet.has(id)) {
+        return NextResponse.json({ error: 'Invalid connection_id' }, { status: 400 });
+      }
+    }
+  }
+
+  const { data, error } = await supabase
+    .from('account_spaces')
+    .insert({
+      user_id: user.id,
+      name,
+      emoji: body.emoji ?? null,
+      color: body.color ?? null,
+      is_default: false,
+      connection_ids: connectionIds,
+    })
+    .select('*')
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ space: data });
+}

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -95,6 +95,8 @@ export default function MoneyHubPage() {
  const [error, setError] = useState<string | null>(null);
  const [syncing, setSyncing] = useState(false);
  const [selectedMonth, setSelectedMonth] = useState('');
+ const [spaces, setSpaces] = useState<Array<{ id: string; name: string; emoji: string | null; is_default: boolean }>>([]);
+ const [activeSpaceId, setActiveSpaceId] = useState<string | null>(null);
  const [showBankPicker, setShowBankPicker] = useState(false);
  const [showFcaBanner, setShowFcaBanner] = useState(false);
  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
@@ -147,20 +149,39 @@ export default function MoneyHubPage() {
 
  // ─── Data fetching ──────────────────────────────────────────────────────
 
- const refreshData = useCallback(async (month?: string) => {
+ const refreshData = useCallback(async (month?: string, spaceId?: string | null) => {
  try {
  const targetMonth = month ?? selectedMonth;
- const url = targetMonth ? `/api/money-hub?month=${targetMonth}` : '/api/money-hub';
+ const targetSpace = spaceId !== undefined ? spaceId : activeSpaceId;
+ const params = new URLSearchParams();
+ if (targetMonth) params.set('month', targetMonth);
+ if (targetSpace) params.set('space_id', targetSpace);
+ const query = params.toString();
+ const url = query ? `/api/money-hub?${query}` : '/api/money-hub';
  const res = await fetch(url);
  const d = await res.json();
- if (!d.error) { setData(d); setError(null); }
+ if (!d.error) {
+ setData(d);
+ setError(null);
+ if (d.activeSpace?.id && !activeSpaceId) setActiveSpaceId(d.activeSpace.id);
+ }
  else setError(d.error);
  } catch (e: any) {
  setError(e.message || 'Failed to load Money Hub data');
  } finally {
  setLoading(false);
  }
- }, [selectedMonth]);
+ }, [selectedMonth, activeSpaceId]);
+
+ // Load the user's Spaces once on mount so the switcher is populated.
+ useEffect(() => {
+ let alive = true;
+ fetch('/api/spaces')
+ .then((r) => r.json())
+ .then((d) => { if (alive && d.spaces) setSpaces(d.spaces); })
+ .catch(() => { /* silent */ });
+ return () => { alive = false; };
+ }, []);
 
  const fetchExpectedBills = async (month?: string) => {
  try {
@@ -656,6 +677,32 @@ export default function MoneyHubPage() {
  </div>
 
  <div className="flex items-center gap-2 flex-wrap">
+ {/* Space switcher — only renders if the user has more than the default */}
+ {spaces.length > 1 && (
+ <select
+ value={activeSpaceId ?? data.activeSpace?.id ?? ''}
+ onChange={(e) => {
+ const next = e.target.value || null;
+ setActiveSpaceId(next);
+ refreshData(undefined, next);
+ }}
+ className="bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2 text-sm text-emerald-800 font-medium focus:outline-none focus:border-emerald-500"
+ title="Filter by Space"
+ >
+ {spaces.map((s) => (
+ <option key={s.id} value={s.id}>
+ {s.emoji ? `${s.emoji} ` : ''}{s.name}
+ </option>
+ ))}
+ </select>
+ )}
+ <Link
+ href="/dashboard/settings/spaces"
+ className="text-slate-500 hover:text-slate-900 p-1.5 rounded transition-colors"
+ title="Manage Spaces"
+ >
+ <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+ </Link>
  {/* Month nav */}
  <button
  onClick={() => {

--- a/src/app/dashboard/settings/spaces/page.tsx
+++ b/src/app/dashboard/settings/spaces/page.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+/**
+ * /dashboard/settings/spaces
+ *
+ * Create / rename / configure Account Spaces — Emma-style groupings
+ * of bank connections so users can separate "Personal" from
+ * "Business" from "Joint" in the Money Hub.
+ *
+ * Pro-gated for multi-space use. Free + Essential still see the
+ * default "Everything" Space and can rename it but can't add more.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowLeft, Loader2, Plus, Trash2, Check, Sparkles, Briefcase,
+  Users as UsersIcon, PiggyBank, Home, Globe, CircleDot, X,
+} from 'lucide-react';
+
+interface Connection {
+  id: string;
+  bank_name: string | null;
+  provider: string | null;
+  status: string;
+  account_display_names: string[] | null;
+}
+
+interface Space {
+  id: string;
+  name: string;
+  emoji: string | null;
+  color: string | null;
+  is_default: boolean;
+  connection_ids: string[];
+  sort_order: number;
+}
+
+const EMOJI_CHOICES = ['🌍', '🏠', '💼', '💰', '🎯', '👨‍👩‍👧', '✈️', '🏡', '🧾', '🪙'];
+
+export default function SpacesSettingsPage() {
+  const [spaces, setSpaces] = useState<Space[]>([]);
+  const [connections, setConnections] = useState<Connection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [tierMessage, setTierMessage] = useState<string | null>(null);
+  const [newName, setNewName] = useState('');
+  const [newEmoji, setNewEmoji] = useState<string>('💼');
+  const [newConnectionIds, setNewConnectionIds] = useState<Set<string>>(new Set());
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/spaces', { credentials: 'include', cache: 'no-store' });
+      const d = await res.json();
+      if (!res.ok) throw new Error(d.error || 'Failed to load');
+      setSpaces(d.spaces ?? []);
+      setConnections(d.connections ?? []);
+    } catch (e: any) {
+      setError(e.message || 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { void load(); }, []);
+
+  const beginCreate = () => {
+    setCreating(true);
+    setEditingId(null);
+    setNewName('');
+    setNewEmoji('💼');
+    setNewConnectionIds(new Set());
+  };
+
+  const beginEdit = (space: Space) => {
+    setEditingId(space.id);
+    setCreating(false);
+    setNewName(space.name);
+    setNewEmoji(space.emoji ?? '🌍');
+    setNewConnectionIds(new Set(space.connection_ids));
+  };
+
+  const cancel = () => {
+    setCreating(false);
+    setEditingId(null);
+    setTierMessage(null);
+  };
+
+  const toggleConn = (id: string) => {
+    setNewConnectionIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const save = async () => {
+    if (!newName.trim()) return;
+    const body = {
+      name: newName.trim(),
+      emoji: newEmoji,
+      connection_ids: Array.from(newConnectionIds),
+    };
+    const res = editingId
+      ? await fetch(`/api/spaces/${editingId}`, {
+          method: 'PATCH', credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        })
+      : await fetch('/api/spaces', {
+          method: 'POST', credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+    const d = await res.json();
+    if (!res.ok) {
+      if (d.reason === 'max_spaces_reached') {
+        setTierMessage(d.message || 'Upgrade to Pro to add more Spaces.');
+      } else {
+        setError(d.error || 'Save failed');
+      }
+      return;
+    }
+    setCreating(false);
+    setEditingId(null);
+    await load();
+  };
+
+  const remove = async (id: string) => {
+    if (!confirm('Delete this Space? Your accounts and transactions are not affected.')) return;
+    const res = await fetch(`/api/spaces/${id}`, { method: 'DELETE', credentials: 'include' });
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}));
+      setError(d.error || 'Delete failed');
+      return;
+    }
+    await load();
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 md:p-8 max-w-4xl mx-auto">
+      <Link href="/dashboard/money-hub" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900 mb-4">
+        <ArrowLeft className="h-4 w-4" /> Back to Money Hub
+      </Link>
+      <h1 className="text-2xl md:text-3xl font-bold text-slate-900 mb-1">Spaces</h1>
+      <p className="text-sm text-slate-500 mb-6">
+        Group your bank connections to separate personal, business and joint finances. Switch between Spaces in the Money Hub header.
+      </p>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-3 mb-4 text-sm text-red-700">{error}</div>
+      )}
+
+      {/* List of existing Spaces */}
+      <div className="space-y-3 mb-6">
+        {spaces.map((s) => (
+          <div key={s.id} className="bg-white border border-slate-200 rounded-xl p-4">
+            {editingId === s.id ? (
+              <SpaceEditor
+                name={newName} setName={setNewName}
+                emoji={newEmoji} setEmoji={setNewEmoji}
+                connections={connections}
+                selected={newConnectionIds}
+                toggleConn={toggleConn}
+                onSave={save}
+                onCancel={cancel}
+                isDefault={s.is_default}
+              />
+            ) : (
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xl">{s.emoji ?? '🌍'}</span>
+                    <span className="font-semibold text-slate-900 truncate">{s.name}</span>
+                    {s.is_default && <span className="text-xs text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full">Default</span>}
+                  </div>
+                  <p className="text-xs text-slate-500 mt-1">
+                    {s.connection_ids.length === 0
+                      ? 'All connected banks'
+                      : `${s.connection_ids.length} bank${s.connection_ids.length === 1 ? '' : 's'} included`}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => beginEdit(s)} className="text-xs text-slate-600 hover:text-slate-900 px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200">Edit</button>
+                  {!s.is_default && (
+                    <button onClick={() => remove(s.id)} className="p-1.5 text-slate-500 hover:text-red-600 rounded-lg" title="Delete Space">
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {creating ? (
+        <div className="bg-white border border-emerald-300 rounded-xl p-4 mb-6">
+          <SpaceEditor
+            name={newName} setName={setNewName}
+            emoji={newEmoji} setEmoji={setNewEmoji}
+            connections={connections}
+            selected={newConnectionIds}
+            toggleConn={toggleConn}
+            onSave={save}
+            onCancel={cancel}
+            isDefault={false}
+          />
+        </div>
+      ) : (
+        <button
+          onClick={beginCreate}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white font-semibold text-sm"
+        >
+          <Plus className="h-4 w-4" /> New Space
+        </button>
+      )}
+
+      {tierMessage && (
+        <div className="mt-4 bg-amber-50 border border-amber-200 rounded-xl p-4 flex items-start gap-3">
+          <Sparkles className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <p className="text-sm font-medium text-slate-900">{tierMessage}</p>
+            <Link href="/pricing" className="text-xs font-medium text-amber-700 hover:text-amber-800 underline mt-1 inline-block">View plans</Link>
+          </div>
+          <button onClick={() => setTierMessage(null)} className="text-slate-400 hover:text-slate-900"><X className="h-4 w-4" /></button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SpaceEditor({
+  name, setName, emoji, setEmoji, connections, selected, toggleConn, onSave, onCancel, isDefault,
+}: {
+  name: string; setName: (s: string) => void;
+  emoji: string; setEmoji: (s: string) => void;
+  connections: Connection[]; selected: Set<string>;
+  toggleConn: (id: string) => void;
+  onSave: () => void; onCancel: () => void;
+  isDefault: boolean;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <select
+          value={emoji}
+          onChange={(e) => setEmoji(e.target.value)}
+          className="text-2xl bg-transparent border-0 focus:outline-none"
+        >
+          {EMOJI_CHOICES.map((em) => <option key={em} value={em}>{em}</option>)}
+        </select>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Business"
+          maxLength={40}
+          className="flex-1 border border-slate-300 rounded-lg px-3 py-2 text-sm text-slate-900"
+        />
+      </div>
+
+      <div>
+        <p className="text-xs font-medium text-slate-500 mb-2">
+          {isDefault
+            ? 'The default Space always includes every bank. You can rename and re-emoji it, but membership is fixed.'
+            : 'Which bank connections should this Space include? Leave everything unchecked to include all banks.'}
+        </p>
+        {!isDefault && (
+          <div className="space-y-1 max-h-64 overflow-y-auto border border-slate-200 rounded-lg p-2">
+            {connections.length === 0 ? (
+              <p className="text-xs text-slate-500 italic p-2">No bank connections yet.</p>
+            ) : connections.map((c) => (
+              <label key={c.id} className="flex items-center gap-2 text-sm text-slate-800 p-2 hover:bg-slate-50 rounded cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selected.has(c.id)}
+                  onChange={() => toggleConn(c.id)}
+                  className="h-4 w-4 accent-emerald-500"
+                />
+                <span>{c.bank_name || c.provider || 'Bank'}</span>
+                <span className="text-xs text-slate-500">
+                  {c.account_display_names?.length ? `· ${c.account_display_names.length} accounts` : ''}
+                </span>
+                {c.status !== 'active' && <span className="text-xs text-amber-700">· {c.status}</span>}
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <button onClick={onCancel} className="text-sm text-slate-600 hover:text-slate-900 px-3 py-2">Cancel</button>
+        <button
+          onClick={onSave}
+          disabled={!name.trim()}
+          className="inline-flex items-center gap-1 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-white text-sm font-semibold rounded-lg px-4 py-2"
+        >
+          <Check className="h-4 w-4" /> Save Space
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/plan-limits.ts
+++ b/src/lib/plan-limits.ts
@@ -23,6 +23,11 @@ export interface PlanLimits {
    * count, unlocked features), not polling frequency.
    */
   watchdogSyncIntervalMinutes: number | null;
+  /**
+   * Max Account Spaces (Emma-style groupings). Everyone gets 1 default
+   * "Everything" Space; Pro can create more to split personal/business/joint.
+   */
+  maxSpaces: number | null;
   features: string[];
 }
 
@@ -63,6 +68,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     maxEmails: 1,
     disputeThreadLinks: null, // unlimited email-thread monitoring for disputes
     watchdogSyncIntervalMinutes: 30,
+    maxSpaces: 1,
     features: [
       'complaints',
       'scanner',
@@ -80,6 +86,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     maxEmails: 3,
     disputeThreadLinks: null,
     watchdogSyncIntervalMinutes: 30,
+    maxSpaces: 1,
     features: [
       'complaints',
       'scanner',
@@ -102,6 +109,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     maxEmails: null,
     disputeThreadLinks: null,
     watchdogSyncIntervalMinutes: 30,
+    maxSpaces: null,
     features: [
       'complaints',
       'scanner',

--- a/src/lib/spaces.ts
+++ b/src/lib/spaces.ts
@@ -1,0 +1,107 @@
+/**
+ * Account Spaces — helpers for loading and filtering by Space.
+ *
+ * A Space is a named grouping of bank connections. Users can switch
+ * between Spaces in the Money Hub to see only the accounts in that
+ * group (e.g. "Personal" vs "Business"). Every user has exactly one
+ * default Space ("Everything") that includes every connection.
+ *
+ * The server-side filter semantics: if a Space has an empty
+ * connection_ids array, no filter is applied (everything counts).
+ * Otherwise, bank_transactions / subscriptions are restricted to rows
+ * whose connection_id is in the Space's list.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface AccountSpace {
+  id: string;
+  user_id: string;
+  name: string;
+  emoji: string | null;
+  color: string | null;
+  is_default: boolean;
+  connection_ids: string[];
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Resolve a Space row for a user by ID. Returns the default Space when
+ * `spaceId` is undefined. Returns null if the space doesn't exist or
+ * belongs to another user (RLS-enforced).
+ */
+export async function getSpace(
+  supabase: SupabaseClient,
+  userId: string,
+  spaceId?: string | null,
+): Promise<AccountSpace | null> {
+  if (spaceId) {
+    const { data } = await supabase
+      .from('account_spaces')
+      .select('*')
+      .eq('id', spaceId)
+      .eq('user_id', userId)
+      .maybeSingle();
+    return (data as AccountSpace | null) ?? null;
+  }
+  const { data } = await supabase
+    .from('account_spaces')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('is_default', true)
+    .maybeSingle();
+  return (data as AccountSpace | null) ?? null;
+}
+
+export async function listSpaces(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<AccountSpace[]> {
+  const { data } = await supabase
+    .from('account_spaces')
+    .select('*')
+    .eq('user_id', userId)
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true });
+  return (data as AccountSpace[]) ?? [];
+}
+
+/**
+ * Given a Space, return the list of connection IDs its filter applies
+ * to — or `null` meaning "no filter, match everything". Callers can
+ * gate their queries with `if (filter === null) { query = query; }
+ * else { query = query.in('connection_id', filter); }`.
+ */
+export function spaceConnectionFilter(space: AccountSpace | null): string[] | null {
+  if (!space) return null;
+  if (space.connection_ids.length === 0) return null;
+  return space.connection_ids;
+}
+
+/**
+ * Ensure the user has a default Space. Used as a safety net — the
+ * migration backfills one for every existing user, but new signups
+ * after the migration need one created on first Money Hub load.
+ */
+export async function ensureDefaultSpace(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<AccountSpace> {
+  const existing = await getSpace(supabase, userId);
+  if (existing) return existing;
+  const { data } = await supabase
+    .from('account_spaces')
+    .insert({
+      user_id: userId,
+      name: 'Everything',
+      emoji: '🌍',
+      is_default: true,
+      connection_ids: [],
+      sort_order: 0,
+    })
+    .select('*')
+    .single();
+  return data as AccountSpace;
+}

--- a/supabase/migrations/20260423040000_account_spaces.sql
+++ b/supabase/migrations/20260423040000_account_spaces.sql
@@ -1,0 +1,80 @@
+-- Account Spaces — Emma-style account grouping.
+--
+-- Users with multiple bank connections (e.g. personal current account +
+-- business account + savings) can group them into named Spaces and
+-- filter Money Hub by Space. Every user gets an auto-created "Everything"
+-- default Space so the existing Money Hub keeps working unchanged.
+--
+-- Gated to Pro tier at the API layer. Free + Essential can see / use
+-- their default Space but can't create more.
+
+CREATE TABLE IF NOT EXISTS public.account_spaces (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  emoji text,
+  color text,
+  is_default boolean NOT NULL DEFAULT false,
+  -- Empty array = "everything" (every connection counts). When populated,
+  -- the Money Hub filter restricts to bank_transactions whose
+  -- connection_id is in this list. Storing as UUID[] keeps the join cheap.
+  connection_ids uuid[] NOT NULL DEFAULT '{}',
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Each user can have exactly one default Space. Filtering `is_default`
+-- at index time means the constraint is enforceable across the app
+-- without a trigger.
+CREATE UNIQUE INDEX IF NOT EXISTS account_spaces_one_default_per_user
+  ON public.account_spaces (user_id)
+  WHERE is_default = true;
+
+CREATE INDEX IF NOT EXISTS idx_account_spaces_user
+  ON public.account_spaces (user_id, sort_order);
+
+ALTER TABLE public.account_spaces ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users read own spaces" ON public.account_spaces;
+CREATE POLICY "Users read own spaces"
+  ON public.account_spaces FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users write own spaces" ON public.account_spaces;
+CREATE POLICY "Users write own spaces"
+  ON public.account_spaces FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Backfill the default "Everything" Space for every existing user so
+-- nothing breaks the first time the Money Hub loads after this migration.
+-- Empty connection_ids array = "all connections".
+INSERT INTO public.account_spaces (user_id, name, emoji, is_default, connection_ids, sort_order)
+SELECT
+  p.id,
+  'Everything',
+  '🌍',
+  true,
+  '{}',
+  0
+FROM public.profiles p
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.account_spaces s
+  WHERE s.user_id = p.id AND s.is_default = true
+);
+
+-- Keep updated_at fresh on every write.
+CREATE OR REPLACE FUNCTION public.account_spaces_touch()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS account_spaces_touch_trigger ON public.account_spaces;
+CREATE TRIGGER account_spaces_touch_trigger
+  BEFORE UPDATE ON public.account_spaces
+  FOR EACH ROW
+  EXECUTE FUNCTION public.account_spaces_touch();


### PR DESCRIPTION
## Summary
Users with multiple bank connections can now split Money Hub into named Spaces — e.g. "Personal" vs "Business" vs "Joint". Switcher lives in the Money Hub header. Full CRUD at \`/dashboard/settings/spaces\`.

Designed to match Emma's Spaces feature (at a price point of £9.99/mo instead of Emma's £14.99/mo Ultimate), landed as a Pro-tier differentiator. Every existing user gets an auto-created "Everything" default Space — existing Money Hub behavior unchanged.

## What's in
- **Migration 20260423040000** — \`account_spaces\` table, RLS policies, updated_at trigger, partial unique index enforcing one default per user, backfill for every existing profile.
- **\`src/lib/spaces.ts\`** — \`getSpace\`, \`listSpaces\`, \`ensureDefaultSpace\`, \`spaceConnectionFilter\`.
- **\`/api/spaces\`** (GET list + POST create) with Pro tier gate — returns 403 + upgrade message when Free/Essential try to create a second Space.
- **\`/api/spaces/[id]\`** (PATCH + DELETE) — default Space is non-deletable.
- **\`/dashboard/settings/spaces\`** — create / edit / delete with emoji picker and bank checkbox multi-select.
- **Money Hub API** now accepts \`?space_id=X\`; filters \`bank_transactions\` + \`bank_connections\` to the Space's connection list. Response includes \`activeSpace\` so the UI can reflect the current selection.
- **Money Hub page** — switcher dropdown (only shown when >1 Space) next to month picker, plus gear icon linking to settings.
- **\`plan-limits.ts\`** gains \`maxSpaces\` — Free: 1, Essential: 1, Pro: null.

## Out of scope (v2)
- Per-Space budgets and savings goals (budgets stay global)
- Subscriptions + disputes remain user-scoped (not per-Space)
- Shared Spaces / collaborators
- Auto-routing rules

## Test plan
- [ ] Existing user with 2+ bank connections opens Money Hub → sees "Everything" still working, totals unchanged
- [ ] Pro user creates "Business" Space with one connection checked → Money Hub filter works, totals match only that connection's transactions
- [ ] Free user clicks "New Space" → 403 upgrade message renders
- [ ] Delete "Everything" via API → 400 "Cannot delete the default Space"
- [ ] Rename "Everything" → reflected in switcher
- [ ] Space membership can be empty (no checkboxes) → treated as "all banks"

🤖 Generated with [Claude Code](https://claude.com/claude-code)