### PR TITLE
fix(ui): Spaces button always visible; hide Pocket Agent when linked

### DIFF
--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -677,8 +677,9 @@ export default function MoneyHubPage() {
  </div>
 
  <div className="flex items-center gap-2 flex-wrap">
- {/* Space switcher — only renders if the user has more than the default */}
- {spaces.length > 1 && (
+ {/* Space switcher + manage button. Always visible so users can
+  discover Spaces even before they\'ve created their first one. */}
+ {spaces.length > 1 ? (
  <select
  value={activeSpaceId ?? data.activeSpace?.id ?? ''}
  onChange={(e) => {
@@ -695,13 +696,14 @@ export default function MoneyHubPage() {
  </option>
  ))}
  </select>
- )}
+ ) : null}
  <Link
  href="/dashboard/settings/spaces"
- className="text-slate-500 hover:text-slate-900 p-1.5 rounded transition-colors"
- title="Manage Spaces"
+ className="inline-flex items-center gap-1.5 bg-slate-100 hover:bg-slate-200 border border-slate-200/50 rounded-lg px-3 py-2 text-sm text-slate-700 font-medium transition-colors"
+ title="Group personal + business accounts into Spaces"
  >
  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+ <span>{spaces.length > 1 ? 'Manage' : 'Spaces'}</span>
  </Link>
  {/* Month nav */}
  <button

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1293,35 +1293,26 @@ export default function ProfilePage() {
         </Link>
       </div>
 
-      {/* Pocket Agent */}
-      <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl p-8 mt-6">
-        <h2 style={{fontSize:18,fontWeight:700,letterSpacing:"-.01em",margin:"0 0 10px"}}>
-          <Mail className="h-5 w-5 text-amber-500" />
-          Pocket Agent
-        </h2>
-        <p className="text-slate-600 text-sm mb-4">
-          Connect your Paybacker account to Pocket Agent for proactive alerts, spending queries, and complaint letters — all from your phone.
-        </p>
-        {telegramLinked === true ? (
-          <div className="flex items-center gap-3">
-            <CheckCircle2 className="h-5 w-5 text-green-500 flex-shrink-0" />
-            <span className="text-green-400 text-sm font-medium">Pocket Agent Connected</span>
-            <Link
-              href="/dashboard/pocket-agent"
-              className="ml-2 inline-flex items-center gap-2 px-4 py-2 bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-xl text-sm font-medium transition-colors border border-slate-200/50"
-            >
-              Manage
-            </Link>
-          </div>
-        ) : (
+      {/* Pocket Agent — only surfaced while unlinked. Once the user
+          has linked Telegram the manage flow lives at /dashboard/pocket-agent
+          and this pitch just wastes vertical space. */}
+      {telegramLinked === false && (
+        <div className="bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl p-8 mt-6">
+          <h2 style={{fontSize:18,fontWeight:700,letterSpacing:"-.01em",margin:"0 0 10px"}}>
+            <Mail className="h-5 w-5 text-amber-500" />
+            Pocket Agent
+          </h2>
+          <p className="text-slate-600 text-sm mb-4">
+            Connect your Paybacker account to Pocket Agent for proactive alerts, spending queries, and complaint letters — all from your phone.
+          </p>
           <Link
             href="/dashboard/pocket-agent"
             className="inline-flex items-center gap-2 px-4 py-2 bg-orange-500/10 hover:bg-orange-500/20 text-amber-600 rounded-xl text-sm font-medium transition-colors"
           >
             Set Up Pocket Agent
           </Link>
-        )}
-      </div>
+        </div>
+      )}
       </>)}
 
       {section === 'privacy' && (<>


### PR DESCRIPTION
## Summary
Two quick UI fixes flagged on aireypaul@googlemail.com's Pro account:

1. **Spaces manage button wasn't discoverable.** PR #216 added a 16px grid icon next to the month picker. On mobile it was invisible — a Pro user with only the default "Everything" Space had no way to find the feature. Now it's a full labelled pill — "Spaces" before any are created, "Manage" alongside the switcher once a second Space exists.

2. **Pocket Agent card kept showing when already linked.** Once Telegram is linked the user already has a manage page at \`/dashboard/pocket-agent\` — repeating the pitch on profile just wastes vertical space. Hidden when linked; still shown to unlinked users.

## Test plan
- [ ] Log in as aireypaul@googlemail.com, open Money Hub → "Spaces" button is visible in the header, clicks through to \`/dashboard/settings/spaces\`
- [ ] Create a second Space → switcher appears, button re-labels to "Manage"
- [ ] Profile → Notifications tab with Telegram linked → Pocket Agent card hidden; with Telegram unlinked → card shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)