### PR TITLE
feat(plan-limits): over-cap banner + status endpoint

### DIFF
--- a/src/app/api/plan-status/route.ts
+++ b/src/app/api/plan-status/route.ts
@@ -1,0 +1,83 @@
+/**
+ * GET /api/plan-status
+ *
+ * Returns the user's current tier, the matrix of what their tier
+ * allows, and where they currently stand on each axis. Powers the
+ * over-limit banner + Pro-feature locks across the dashboard.
+ *
+ * Note: this is read-only diagnostic data. It does not enforce
+ * limits — that happens at the connect/create endpoints. A user
+ * who is "over limit" keeps using their existing banks/spaces/etc.
+ * unaffected.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getEffectiveTier, PLAN_LIMITS } from '@/lib/plan-limits';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function over(usage: number, limit: number | null): boolean {
+  if (limit === null) return false;
+  return usage > limit;
+}
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const tier = await getEffectiveTier(user.id);
+  const limits = PLAN_LIMITS[tier];
+
+  const [banksRes, emailsRes, spacesRes] = await Promise.all([
+    supabase
+      .from('bank_connections')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .eq('status', 'active'),
+    supabase
+      .from('email_connections')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .eq('status', 'active'),
+    supabase
+      .from('account_spaces')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id),
+  ]);
+
+  const banks = banksRes.count ?? 0;
+  const emails = emailsRes.count ?? 0;
+  const spaces = spacesRes.count ?? 0;
+
+  const status = {
+    tier,
+    limits: {
+      maxBanks: limits.maxBanks,
+      maxEmails: limits.maxEmails,
+      maxSpaces: limits.maxSpaces,
+    },
+    usage: {
+      banks,
+      emails,
+      spaces,
+    },
+    overLimit: {
+      banks: over(banks, limits.maxBanks),
+      emails: over(emails, limits.maxEmails),
+      spaces: over(spaces, limits.maxSpaces),
+    },
+    features: {
+      topMerchants: limits.features.includes('top_merchants'),
+      export: limits.features.includes('export'),
+      mcp: limits.features.includes('mcp'),
+      priceAlertTelegram: limits.features.includes('price_alert_telegram'),
+      fullSpending: limits.features.includes('full_spending'),
+      budgetsGoals: limits.features.includes('budgets_goals'),
+    },
+  };
+
+  return NextResponse.json(status);
+}

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -14,6 +14,7 @@ import { fmtNum } from '@/lib/format';
 import { createClient } from '@/lib/supabase/client';
 import BankPickerModal, { connectBankDirect } from '@/components/BankPickerModal';
 import { isDealValid } from '@/lib/savings-utils';
+import PlanLimitsBanner from '@/components/PlanLimitsBanner';
 
 import OverviewPanel from './OverviewPanel';
 import SpendingPanel from './SpendingPanel';
@@ -666,6 +667,8 @@ export default function MoneyHubPage() {
  <button onClick={() => setToast(null)} className="hover:opacity-70"><X className="h-4 w-4" /></button>
  </div>
  )}
+
+ <PlanLimitsBanner />
 
  {/* HEADER */}
  <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from 'next/navigation';
 import UpgradePrompt from '@/components/UpgradePrompt';
 import OnboardingFlow from '@/components/onboarding/OnboardingFlow';
 import UpgradeTrigger from '@/components/UpgradeTrigger';
+import PlanLimitsBanner from '@/components/PlanLimitsBanner';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
 import {
@@ -629,6 +630,7 @@ export default function DashboardPage() {
 
   return (
     <div>
+      <PlanLimitsBanner />
       {userTier === 'free' && <UpgradePrompt variant="banner" />}
 
       {syncMessage && (

--- a/src/components/PlanLimitsBanner.tsx
+++ b/src/components/PlanLimitsBanner.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+/**
+ * Over-limit warning banner.
+ *
+ * Polls /api/plan-status on mount. If any dimension (banks, emails,
+ * spaces) is over the current tier's cap — typically because the
+ * user downgraded — we show an amber banner listing exactly what's
+ * over and a deep link to /pricing.
+ *
+ * This is advisory only. Existing bank/email/Space records keep
+ * working. Enforcement happens at the connect / create endpoints,
+ * not via data removal. A future "soft-archive after grace period"
+ * flow can hang off the same data.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { AlertTriangle, X, Sparkles } from 'lucide-react';
+
+interface PlanStatus {
+  tier: 'free' | 'essential' | 'pro';
+  limits: { maxBanks: number | null; maxEmails: number | null; maxSpaces: number | null };
+  usage: { banks: number; emails: number; spaces: number };
+  overLimit: { banks: boolean; emails: boolean; spaces: boolean };
+}
+
+export default function PlanLimitsBanner() {
+  const [status, setStatus] = useState<PlanStatus | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    fetch('/api/plan-status', { credentials: 'include' })
+      .then((r) => r.json())
+      .then((d) => { if (alive && !d.error) setStatus(d); })
+      .catch(() => { /* silent */ });
+    return () => { alive = false; };
+  }, []);
+
+  if (!status || dismissed) return null;
+  const { banks, emails, spaces } = status.overLimit;
+  if (!banks && !emails && !spaces) return null;
+
+  const reasons: string[] = [];
+  if (banks)  reasons.push(`${status.usage.banks} bank connections (${status.tier} tier allows ${status.limits.maxBanks})`);
+  if (emails) reasons.push(`${status.usage.emails} email connections (${status.tier} tier allows ${status.limits.maxEmails})`);
+  if (spaces) reasons.push(`${status.usage.spaces} Spaces (${status.tier} tier allows ${status.limits.maxSpaces})`);
+
+  return (
+    <div className="bg-amber-50 border border-amber-300 rounded-xl p-4 mb-6 flex items-start gap-3">
+      <AlertTriangle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-amber-900 mb-1">You\'re over your plan limits</p>
+        <p className="text-sm text-amber-800">
+          {reasons.join(' · ')}. Everything still works — nothing has been removed. Upgrade to keep it all, or disconnect the ones you no longer need.
+        </p>
+        <div className="flex items-center gap-3 mt-3">
+          <Link
+            href="/pricing"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-600 hover:bg-amber-700 text-white text-xs font-semibold"
+          >
+            <Sparkles className="h-3.5 w-3.5" /> View plans
+          </Link>
+          <Link href="/dashboard/profile" className="text-xs font-medium text-amber-800 hover:text-amber-900 underline">
+            Manage connections
+          </Link>
+        </div>
+      </div>
+      <button onClick={() => setDismissed(true)} className="text-amber-600 hover:text-amber-900" title="Dismiss">
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Option B for the downgrade story. When a user goes Pro → Essential/Free with existing Pro-scale assets (5 bank connections, 4 Spaces, etc.), nothing is currently removed — and there was no visual indication. This closes the "silent downgrade is confusing" gap with an amber advisory banner that lists exactly what's over and how to resolve it.

## What's in
- **\`GET /api/plan-status\`** — session-authed, returns \`{ tier, limits, usage, overLimit, features }\`. Over-limit flags compare live counts of \`bank_connections(status='active')\`, \`email_connections(status='active')\`, and \`account_spaces\` against \`PLAN_LIMITS[tier]\`.
- **\`<PlanLimitsBanner />\`** — polls the endpoint on mount. Renders only when something is over. Dismissable per-session. Deep-links to \`/pricing\` and \`/dashboard/profile\`.
- **Shown on \`/dashboard\` and \`/dashboard/money-hub\`.**

No data is removed. Existing bank/email/Space records keep working — enforcement remains at the connect/create endpoints. Pro-only feature cards (Top Merchants, Export, MCP, instant Telegram price alerts) already use \`LockedSection\` patterns, so those lock behind upgrade prompts automatically when tier drops.

## Deferred
Full grace-period / soft-archive system (Option C from the conversation) — deferred to after mobile launch. The dispatch logic in \`plan-limits.ts\` stays the same; this PR is purely additive UI.

## Test plan
- [ ] Pro user hits \`/api/plan-status\` → \`overLimit: {banks: false, emails: false, spaces: false}\`
- [ ] Manually downgrade an active user in DB (\`UPDATE profiles SET subscription_tier='essential' WHERE id=X\`) → banner appears on their next dashboard load
- [ ] Dismiss button hides the banner until next refresh
- [ ] Click "View plans" → lands on /pricing; click "Manage connections" → lands on /dashboard/profile
- [ ] User with no over-cap items (e.g. Pro with 2 banks) → banner never renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)