### PR TITLE
feat(spaces): per-account membership — split NatWest personal vs business

### DIFF
--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -6,7 +6,7 @@ import { normalizeSpendingCategoryKey, findMatchingCategoryOverride, resolveMone
 import { normaliseMerchantName } from '@/lib/merchant-normalise';
 import { pickRawMerchantSource } from '@/lib/merchant-utils';
 import { loadLearnedRules } from '@/lib/learning-engine';
-import { ensureDefaultSpace, getSpace, spaceConnectionFilter } from '@/lib/spaces';
+import { ensureDefaultSpace, getSpace, spaceConnectionFilter, spaceTransactionFilter } from '@/lib/spaces';
 
 export const runtime = 'nodejs';
 
@@ -133,6 +133,7 @@ export async function GET(request: Request) {
     await ensureDefaultSpace(supabase, user.id);
     const activeSpace = await getSpace(supabase, user.id, requestedSpaceId);
     const connectionFilter = spaceConnectionFilter(activeSpace);
+    const txFilter = spaceTransactionFilter(activeSpace);
 
     let txnQuery = admin
       .from('bank_transactions')
@@ -147,8 +148,22 @@ export async function GET(request: Request) {
       .eq('user_id', user.id)
       .neq('status', 'revoked');
     if (connectionFilter) {
-      txnQuery = txnQuery.in('connection_id', connectionFilter);
       connQuery = connQuery.in('id', connectionFilter);
+    }
+    if (txFilter) {
+      if (txFilter.accountPairs.length === 0) {
+        txnQuery = txnQuery.in('connection_id', txFilter.connectionIds);
+      } else {
+        // OR-combine connection-wide filter with specific account pairs
+        const parts: string[] = [];
+        if (txFilter.connectionIds.length > 0) {
+          parts.push(`connection_id.in.(${txFilter.connectionIds.join(',')})`);
+        }
+        for (const { connectionId, accountId } of txFilter.accountPairs) {
+          parts.push(`and(connection_id.eq.${connectionId},account_id.eq.${accountId})`);
+        }
+        txnQuery = txnQuery.or(parts.join(','));
+      }
     }
 
     const [

--- a/src/app/api/spaces/[id]/route.ts
+++ b/src/app/api/spaces/[id]/route.ts
@@ -14,6 +14,7 @@ interface PatchBody {
   emoji?: string | null;
   color?: string | null;
   connection_ids?: string[];
+  account_refs?: string[];
   sort_order?: number;
 }
 
@@ -39,22 +40,26 @@ export async function PATCH(
   if (body.color !== undefined) update.color = body.color;
   if (body.sort_order !== undefined) update.sort_order = body.sort_order;
 
-  if (body.connection_ids !== undefined) {
-    const connectionIds = Array.from(new Set(body.connection_ids));
-    if (connectionIds.length > 0) {
+  if (body.connection_ids !== undefined || body.account_refs !== undefined) {
+    const connectionIds = Array.from(new Set(body.connection_ids ?? []));
+    const accountRefs = Array.from(new Set(body.account_refs ?? []));
+    const refConnIds = accountRefs.map((r) => r.split(':')[0]).filter(Boolean);
+    const allConnIds = Array.from(new Set([...connectionIds, ...refConnIds]));
+    if (allConnIds.length > 0) {
       const { data: ownedConns } = await supabase
         .from('bank_connections')
         .select('id')
-        .in('id', connectionIds)
+        .in('id', allConnIds)
         .eq('user_id', user.id);
       const ownedSet = new Set((ownedConns ?? []).map((c) => c.id));
-      for (const cid of connectionIds) {
+      for (const cid of allConnIds) {
         if (!ownedSet.has(cid)) {
           return NextResponse.json({ error: 'Invalid connection_id' }, { status: 400 });
         }
       }
     }
-    update.connection_ids = connectionIds;
+    if (body.connection_ids !== undefined) update.connection_ids = connectionIds;
+    if (body.account_refs !== undefined) update.account_refs = accountRefs;
   }
 
   if (Object.keys(update).length === 0) {

--- a/src/app/api/spaces/route.ts
+++ b/src/app/api/spaces/route.ts
@@ -23,10 +23,12 @@ export async function GET() {
   const spaces = await listSpaces(supabase, user.id);
 
   // Report the connections the user actually has so the settings UI
-  // can render a checkbox per connection when editing a Space.
+  // can render a checkbox per connection. Also include provider
+  // account_ids + display names so multi-account banks can be split
+  // into sub-checkboxes (e.g. NatWest personal + NatWest business).
   const { data: connections } = await supabase
     .from('bank_connections')
-    .select('id, bank_name, provider, status, account_display_names')
+    .select('id, bank_name, provider, status, account_ids, account_display_names')
     .eq('user_id', user.id)
     .order('connected_at', { ascending: true });
 
@@ -41,6 +43,7 @@ interface CreateBody {
   emoji?: string | null;
   color?: string | null;
   connection_ids?: string[];
+  account_refs?: string[];
 }
 
 export async function POST(request: Request) {
@@ -73,18 +76,19 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'name must be 40 characters or fewer' }, { status: 400 });
   }
 
-  // Validate connection_ids belong to this user so a malicious caller
-  // can't reference another user's connection IDs (which would show
-  // nothing anyway thanks to RLS, but it's a clean guard).
+  // Validate connection_ids + account_refs belong to this user.
   const connectionIds = Array.from(new Set(body.connection_ids ?? []));
-  if (connectionIds.length > 0) {
+  const accountRefs = Array.from(new Set(body.account_refs ?? []));
+  const refConnIds = accountRefs.map((r) => r.split(':')[0]).filter(Boolean);
+  const allConnIds = Array.from(new Set([...connectionIds, ...refConnIds]));
+  if (allConnIds.length > 0) {
     const { data: ownedConns } = await supabase
       .from('bank_connections')
       .select('id')
-      .in('id', connectionIds)
+      .in('id', allConnIds)
       .eq('user_id', user.id);
     const ownedSet = new Set((ownedConns ?? []).map((c) => c.id));
-    for (const id of connectionIds) {
+    for (const id of allConnIds) {
       if (!ownedSet.has(id)) {
         return NextResponse.json({ error: 'Invalid connection_id' }, { status: 400 });
       }
@@ -100,6 +104,7 @@ export async function POST(request: Request) {
       color: body.color ?? null,
       is_default: false,
       connection_ids: connectionIds,
+      account_refs: accountRefs,
     })
     .select('*')
     .single();

--- a/src/app/dashboard/settings/spaces/page.tsx
+++ b/src/app/dashboard/settings/spaces/page.tsx
@@ -23,6 +23,7 @@ interface Connection {
   bank_name: string | null;
   provider: string | null;
   status: string;
+  account_ids: string[] | null;
   account_display_names: string[] | null;
 }
 
@@ -33,6 +34,7 @@ interface Space {
   color: string | null;
   is_default: boolean;
   connection_ids: string[];
+  account_refs: string[];
   sort_order: number;
 }
 
@@ -49,6 +51,7 @@ export default function SpacesSettingsPage() {
   const [newName, setNewName] = useState('');
   const [newEmoji, setNewEmoji] = useState<string>('💼');
   const [newConnectionIds, setNewConnectionIds] = useState<Set<string>>(new Set());
+  const [newAccountRefs, setNewAccountRefs] = useState<Set<string>>(new Set());
 
   const load = async () => {
     setLoading(true);
@@ -73,6 +76,7 @@ export default function SpacesSettingsPage() {
     setNewName('');
     setNewEmoji('💼');
     setNewConnectionIds(new Set());
+    setNewAccountRefs(new Set());
   };
 
   const beginEdit = (space: Space) => {
@@ -81,6 +85,7 @@ export default function SpacesSettingsPage() {
     setNewName(space.name);
     setNewEmoji(space.emoji ?? '🌍');
     setNewConnectionIds(new Set(space.connection_ids));
+    setNewAccountRefs(new Set(space.account_refs ?? []));
   };
 
   const cancel = () => {
@@ -90,10 +95,35 @@ export default function SpacesSettingsPage() {
   };
 
   const toggleConn = (id: string) => {
+    // When toggling the whole-connection checkbox, also strip any
+    // per-account refs for that connection so we don't store both.
     setNewConnectionIds((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
+      return next;
+    });
+    setNewAccountRefs((prev) => {
+      const next = new Set(prev);
+      for (const ref of prev) if (ref.startsWith(`${id}:`)) next.delete(ref);
+      return next;
+    });
+  };
+
+  const toggleAccount = (connId: string, providerAccountId: string) => {
+    const ref = `${connId}:${providerAccountId}`;
+    // Clicking an individual sub-account should clear the
+    // whole-connection toggle (otherwise checking/unchecking
+    // individual accounts silently does nothing).
+    setNewConnectionIds((prev) => {
+      const next = new Set(prev);
+      next.delete(connId);
+      return next;
+    });
+    setNewAccountRefs((prev) => {
+      const next = new Set(prev);
+      if (next.has(ref)) next.delete(ref);
+      else next.add(ref);
       return next;
     });
   };
@@ -104,6 +134,7 @@ export default function SpacesSettingsPage() {
       name: newName.trim(),
       emoji: newEmoji,
       connection_ids: Array.from(newConnectionIds),
+      account_refs: Array.from(newAccountRefs),
     };
     const res = editingId
       ? await fetch(`/api/spaces/${editingId}`, {
@@ -172,8 +203,10 @@ export default function SpacesSettingsPage() {
                 name={newName} setName={setNewName}
                 emoji={newEmoji} setEmoji={setNewEmoji}
                 connections={connections}
-                selected={newConnectionIds}
+                selectedConns={newConnectionIds}
+                selectedRefs={newAccountRefs}
                 toggleConn={toggleConn}
+                toggleAccount={toggleAccount}
                 onSave={save}
                 onCancel={cancel}
                 isDefault={s.is_default}
@@ -187,9 +220,9 @@ export default function SpacesSettingsPage() {
                     {s.is_default && <span className="text-xs text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full">Default</span>}
                   </div>
                   <p className="text-xs text-slate-500 mt-1">
-                    {s.connection_ids.length === 0
+                    {s.connection_ids.length === 0 && (s.account_refs?.length ?? 0) === 0
                       ? 'All connected banks'
-                      : `${s.connection_ids.length} bank${s.connection_ids.length === 1 ? '' : 's'} included`}
+                      : `${s.connection_ids.length + (s.account_refs?.length ?? 0)} account${s.connection_ids.length + (s.account_refs?.length ?? 0) === 1 ? '' : 's'} included`}
                   </p>
                 </div>
                 <div className="flex items-center gap-1">
@@ -212,8 +245,10 @@ export default function SpacesSettingsPage() {
             name={newName} setName={setNewName}
             emoji={newEmoji} setEmoji={setNewEmoji}
             connections={connections}
-            selected={newConnectionIds}
+            selectedConns={newConnectionIds}
+            selectedRefs={newAccountRefs}
             toggleConn={toggleConn}
+            toggleAccount={toggleAccount}
             onSave={save}
             onCancel={cancel}
             isDefault={false}
@@ -243,12 +278,16 @@ export default function SpacesSettingsPage() {
 }
 
 function SpaceEditor({
-  name, setName, emoji, setEmoji, connections, selected, toggleConn, onSave, onCancel, isDefault,
+  name, setName, emoji, setEmoji, connections, selectedConns, selectedRefs,
+  toggleConn, toggleAccount, onSave, onCancel, isDefault,
 }: {
   name: string; setName: (s: string) => void;
   emoji: string; setEmoji: (s: string) => void;
-  connections: Connection[]; selected: Set<string>;
+  connections: Connection[];
+  selectedConns: Set<string>;
+  selectedRefs: Set<string>;
   toggleConn: (id: string) => void;
+  toggleAccount: (connId: string, accountId: string) => void;
   onSave: () => void; onCancel: () => void;
   isDefault: boolean;
 }) {
@@ -275,27 +314,53 @@ function SpaceEditor({
         <p className="text-xs font-medium text-slate-500 mb-2">
           {isDefault
             ? 'The default Space always includes every bank. You can rename and re-emoji it, but membership is fixed.'
-            : 'Which bank connections should this Space include? Leave everything unchecked to include all banks.'}
+            : 'Pick which banks — or specific accounts within a bank — belong in this Space. Leave everything unchecked to include all banks.'}
         </p>
         {!isDefault && (
-          <div className="space-y-1 max-h-64 overflow-y-auto border border-slate-200 rounded-lg p-2">
+          <div className="space-y-1 max-h-80 overflow-y-auto border border-slate-200 rounded-lg p-2">
             {connections.length === 0 ? (
               <p className="text-xs text-slate-500 italic p-2">No bank connections yet.</p>
-            ) : connections.map((c) => (
-              <label key={c.id} className="flex items-center gap-2 text-sm text-slate-800 p-2 hover:bg-slate-50 rounded cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={selected.has(c.id)}
-                  onChange={() => toggleConn(c.id)}
-                  className="h-4 w-4 accent-emerald-500"
-                />
-                <span>{c.bank_name || c.provider || 'Bank'}</span>
-                <span className="text-xs text-slate-500">
-                  {c.account_display_names?.length ? `· ${c.account_display_names.length} accounts` : ''}
-                </span>
-                {c.status !== 'active' && <span className="text-xs text-amber-700">· {c.status}</span>}
-              </label>
-            ))}
+            ) : connections.map((c) => {
+              const accountIds = c.account_ids ?? [];
+              const displayNames = c.account_display_names ?? [];
+              const hasMultiple = accountIds.length > 1;
+              const wholeSelected = selectedConns.has(c.id);
+              const refsForThisConn = accountIds.filter((accId) => selectedRefs.has(`${c.id}:${accId}`));
+              const partiallySelected = !wholeSelected && refsForThisConn.length > 0;
+              return (
+                <div key={c.id} className="border-b border-slate-100 last:border-0 pb-1 mb-1 last:mb-0">
+                  <label className="flex items-center gap-2 text-sm text-slate-800 p-2 hover:bg-slate-50 rounded cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={wholeSelected}
+                      ref={(el) => { if (el) el.indeterminate = partiallySelected; }}
+                      onChange={() => toggleConn(c.id)}
+                      className="h-4 w-4 accent-emerald-500"
+                    />
+                    <span className="font-medium">{c.bank_name || c.provider || 'Bank'}</span>
+                    <span className="text-xs text-slate-500">
+                      {hasMultiple ? `· ${accountIds.length} accounts` : ''}
+                    </span>
+                    {c.status !== 'active' && <span className="text-xs text-amber-700">· {c.status}</span>}
+                  </label>
+                  {hasMultiple && !wholeSelected && (
+                    <div className="ml-6 pl-2 border-l border-slate-200 space-y-0.5">
+                      {accountIds.map((accId, i) => (
+                        <label key={accId} className="flex items-center gap-2 text-xs text-slate-700 p-1.5 hover:bg-slate-50 rounded cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={selectedRefs.has(`${c.id}:${accId}`)}
+                            onChange={() => toggleAccount(c.id, accId)}
+                            className="h-3.5 w-3.5 accent-emerald-500"
+                          />
+                          <span>{displayNames[i] || `Account ${i + 1}`}</span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/lib/spaces.ts
+++ b/src/lib/spaces.ts
@@ -22,6 +22,11 @@ export interface AccountSpace {
   color: string | null;
   is_default: boolean;
   connection_ids: string[];
+  /** Per-account refs in `"connectionId:providerAccountId"` format.
+   *  Use these when a single connection contains both personal
+   *  and business accounts and the user wants them in separate
+   *  Spaces. Matches are OR-combined with `connection_ids`. */
+  account_refs: string[];
   sort_order: number;
   created_at: string;
   updated_at: string;
@@ -70,14 +75,51 @@ export async function listSpaces(
 
 /**
  * Given a Space, return the list of connection IDs its filter applies
- * to — or `null` meaning "no filter, match everything". Callers can
- * gate their queries with `if (filter === null) { query = query; }
- * else { query = query.in('connection_id', filter); }`.
+ * to — or `null` meaning "no filter, match everything". When a Space
+ * has account_refs but no connection_ids, returns the distinct
+ * connection IDs implied by those refs so the bank_connections query
+ * can be narrowed too.
  */
 export function spaceConnectionFilter(space: AccountSpace | null): string[] | null {
   if (!space) return null;
-  if (space.connection_ids.length === 0) return null;
-  return space.connection_ids;
+  const refs = space.account_refs ?? [];
+  const conns = space.connection_ids ?? [];
+  if (conns.length === 0 && refs.length === 0) return null;
+  const set = new Set<string>(conns);
+  for (const ref of refs) {
+    const connId = ref.split(':')[0];
+    if (connId) set.add(connId);
+  }
+  return Array.from(set);
+}
+
+/**
+ * Richer filter for bank_transactions. Returns either null (match all)
+ * or a structured filter that callers can translate into a query:
+ *
+ *   - `connectionIds` = "all accounts in these connections"
+ *   - `accountPairs`  = "only this specific account on this connection"
+ *
+ * At query time, the two are OR-combined. Using this over the simpler
+ * spaceConnectionFilter ensures that a ref like "connA:acc1" doesn't
+ * accidentally pull in acc2 from connA.
+ */
+export function spaceTransactionFilter(space: AccountSpace | null):
+  | null
+  | { connectionIds: string[]; accountPairs: Array<{ connectionId: string; accountId: string }> } {
+  if (!space) return null;
+  const refs = space.account_refs ?? [];
+  const conns = new Set<string>(space.connection_ids ?? []);
+  if (conns.size === 0 && refs.length === 0) return null;
+  const accountPairs: Array<{ connectionId: string; accountId: string }> = [];
+  for (const ref of refs) {
+    const [connId, accountId] = ref.split(':');
+    if (!connId || !accountId) continue;
+    // If the whole connection is already included, skip the narrower ref.
+    if (conns.has(connId)) continue;
+    accountPairs.push({ connectionId: connId, accountId });
+  }
+  return { connectionIds: Array.from(conns), accountPairs };
 }
 
 /**

--- a/supabase/migrations/20260423060000_account_spaces_refs.sql
+++ b/supabase/migrations/20260423060000_account_spaces_refs.sql
@@ -1,0 +1,19 @@
+-- Account Spaces: account-level membership.
+--
+-- The initial Spaces release (PR #216) let users pick which
+-- bank_connections go into a Space, but a single connection can
+-- hold multiple accounts (e.g. NatWest personal + NatWest business
+-- under one consent). Users need finer-grained control to split
+-- personal vs business when they share a connection.
+--
+-- Design: add an `account_refs text[]` column alongside the existing
+-- `connection_ids uuid[]`. Each ref is `"<connection_id>:<account_id>"`
+-- — same format the Money Hub already uses internally. Both arrays
+-- are additive: the Space matches rows whose connection_id is in
+-- connection_ids OR (connection_id, account_id) matches a ref.
+--
+-- connection_ids remains the "include all accounts on this bank"
+-- shortcut. account_refs lets users split a bank between Spaces.
+
+ALTER TABLE public.account_spaces
+  ADD COLUMN IF NOT EXISTS account_refs text[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## Summary
Per founder feedback: a single bank connection (one open-banking consent) can hold multiple accounts. NatWest is the common case — one consent covers both a personal current account and a business current account. PR #216 only let users toggle the whole connection, so splitting them across Spaces was impossible.

This PR adds per-account membership.

## Changes
- **Migration 20260423060000** — new \`account_spaces.account_refs text[]\` (default empty). Each ref is \`"<connection_id>:<provider_account_id>"\`, matching the format the Money Hub already uses internally for sub-account identifiers.
- **\`src/lib/spaces.ts\`** — new \`spaceTransactionFilter\` helper returns \`{ connectionIds, accountPairs }\` so callers can OR-combine "whole connection" and "specific account" matches.
- **\`/api/money-hub\`** translates that into a Supabase \`.or(...)\` clause. Narrows \`bank_connections\` to the union of touched connection IDs.
- **\`/api/spaces\` + \`/api/spaces/[id]\`** accept \`account_refs\` alongside \`connection_ids\`; both arrays validated for ownership.
- **Spaces settings UI** — multi-account connections now render sub-checkboxes (e.g. NATWEST · 2 accounts → Personal + Business). Parent checkbox shows indeterminate state when only some children are selected. Checking parent clears children; checking child clears parent — keeps storage canonical.

## Test plan
- [ ] Pro user with a NatWest connection containing 2 accounts opens \`/dashboard/settings/spaces\` → sees NATWEST with 2 expandable sub-checkboxes
- [ ] Create "Business" Space with only the business account checked → Money Hub filter shows only business transactions
- [ ] Create "Personal" Space with only the personal account checked → Money Hub filter shows only personal transactions
- [ ] Check the parent NATWEST checkbox → sub-refs cleared; Space now covers both accounts
- [ ] Existing connection-level Spaces continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)