### PR TITLE
feat(spaces): remember last-clicked + user-preferred landing Space

### DIFF
--- a/src/app/api/spaces/preferred/route.ts
+++ b/src/app/api/spaces/preferred/route.ts
@@ -1,0 +1,43 @@
+/**
+ * POST /api/spaces/preferred
+ *
+ * Body: { space_id: string | null }
+ *
+ * Pins a Space as the user's preferred landing view (or clears it
+ * with null). The Money Hub falls back through: URL param →
+ * localStorage → preferred_space_id → built-in default.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = (await request.json().catch(() => ({}))) as { space_id?: string | null };
+  const spaceId = body.space_id ?? null;
+
+  if (spaceId !== null) {
+    // Verify ownership so no one can pin another user's Space.
+    const { data: owned } = await supabase
+      .from('account_spaces')
+      .select('id')
+      .eq('id', spaceId)
+      .eq('user_id', user.id)
+      .maybeSingle();
+    if (!owned) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ preferred_space_id: spaceId })
+    .eq('id', user.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true, preferred_space_id: spaceId });
+}

--- a/src/app/api/spaces/route.ts
+++ b/src/app/api/spaces/route.ts
@@ -22,19 +22,23 @@ export async function GET() {
   await ensureDefaultSpace(supabase, user.id);
   const spaces = await listSpaces(supabase, user.id);
 
-  // Report the connections the user actually has so the settings UI
-  // can render a checkbox per connection. Also include provider
-  // account_ids + display names so multi-account banks can be split
-  // into sub-checkboxes (e.g. NatWest personal + NatWest business).
-  const { data: connections } = await supabase
-    .from('bank_connections')
-    .select('id, bank_name, provider, status, account_ids, account_display_names')
-    .eq('user_id', user.id)
-    .order('connected_at', { ascending: true });
+  const [connectionsRes, profileRes] = await Promise.all([
+    supabase
+      .from('bank_connections')
+      .select('id, bank_name, provider, status, account_ids, account_display_names')
+      .eq('user_id', user.id)
+      .order('connected_at', { ascending: true }),
+    supabase
+      .from('profiles')
+      .select('preferred_space_id')
+      .eq('id', user.id)
+      .maybeSingle(),
+  ]);
 
   return NextResponse.json({
     spaces,
-    connections: connections ?? [],
+    connections: connectionsRes.data ?? [],
+    preferred_space_id: profileRes.data?.preferred_space_id ?? null,
   });
 }
 

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -98,6 +98,7 @@ export default function MoneyHubPage() {
  const [selectedMonth, setSelectedMonth] = useState('');
  const [spaces, setSpaces] = useState<Array<{ id: string; name: string; emoji: string | null; is_default: boolean }>>([]);
  const [activeSpaceId, setActiveSpaceId] = useState<string | null>(null);
+ const [preferredSpaceId, setPreferredSpaceId] = useState<string | null>(null);
  const [showBankPicker, setShowBankPicker] = useState(false);
  const [showFcaBanner, setShowFcaBanner] = useState(false);
  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
@@ -174,15 +175,45 @@ export default function MoneyHubPage() {
  }
  }, [selectedMonth, activeSpaceId]);
 
- // Load the user's Spaces once on mount so the switcher is populated.
+ // Load the user's Spaces once on mount. Also pick the initial
+ // active Space using priority order:
+ //   1. ?space_id=X URL param (already handled by Money Hub API)
+ //   2. localStorage 'lastSpaceId' (per-device memory)
+ //   3. profile.preferred_space_id (cross-device preference)
+ //   4. Fallback: whichever Space the API returned as active (default)
  useEffect(() => {
  let alive = true;
  fetch('/api/spaces')
  .then((r) => r.json())
- .then((d) => { if (alive && d.spaces) setSpaces(d.spaces); })
+ .then((d) => {
+ if (!alive) return;
+ if (d.spaces) setSpaces(d.spaces);
+ if (d.preferred_space_id) setPreferredSpaceId(d.preferred_space_id);
+ const urlParams = new URLSearchParams(window.location.search);
+ const urlSpace = urlParams.get('space_id');
+ let candidate: string | null = null;
+ if (urlSpace) candidate = urlSpace;
+ else if (typeof window !== 'undefined') {
+ const stored = localStorage.getItem('lastSpaceId');
+ if (stored && (d.spaces ?? []).some((s: any) => s.id === stored)) candidate = stored;
+ }
+ if (!candidate && d.preferred_space_id) candidate = d.preferred_space_id;
+ if (candidate && candidate !== activeSpaceId) {
+ setActiveSpaceId(candidate);
+ void refreshData(undefined, candidate);
+ }
+ })
  .catch(() => { /* silent */ });
  return () => { alive = false; };
+ // eslint-disable-next-line react-hooks/exhaustive-deps
  }, []);
+
+ // Persist the current Space to localStorage whenever the user switches.
+ useEffect(() => {
+ if (typeof window !== 'undefined' && activeSpaceId) {
+ localStorage.setItem('lastSpaceId', activeSpaceId);
+ }
+ }, [activeSpaceId]);
 
  const fetchExpectedBills = async (month?: string) => {
  try {

--- a/src/app/dashboard/settings/spaces/page.tsx
+++ b/src/app/dashboard/settings/spaces/page.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft, Loader2, Plus, Trash2, Check, Sparkles, Briefcase,
-  Users as UsersIcon, PiggyBank, Home, Globe, CircleDot, X,
+  Users as UsersIcon, PiggyBank, Home, Globe, CircleDot, X, Star,
 } from 'lucide-react';
 
 interface Connection {
@@ -43,6 +43,7 @@ const EMOJI_CHOICES = ['🌍', '🏠', '💼', '💰', '🎯', '👨‍👩‍�
 export default function SpacesSettingsPage() {
   const [spaces, setSpaces] = useState<Space[]>([]);
   const [connections, setConnections] = useState<Connection[]>([]);
+  const [preferredSpaceId, setPreferredSpaceId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -61,6 +62,7 @@ export default function SpacesSettingsPage() {
       if (!res.ok) throw new Error(d.error || 'Failed to load');
       setSpaces(d.spaces ?? []);
       setConnections(d.connections ?? []);
+      setPreferredSpaceId(d.preferred_space_id ?? null);
     } catch (e: any) {
       setError(e.message || 'Failed to load');
     } finally {
@@ -161,6 +163,17 @@ export default function SpacesSettingsPage() {
     await load();
   };
 
+  const setPreferred = async (id: string | null) => {
+    const res = await fetch('/api/spaces/preferred', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ space_id: id }),
+    });
+    if (!res.ok) return;
+    setPreferredSpaceId(id);
+  };
+
   const remove = async (id: string) => {
     if (!confirm('Delete this Space? Your accounts and transactions are not affected.')) return;
     const res = await fetch(`/api/spaces/${id}`, { method: 'DELETE', credentials: 'include' });
@@ -214,10 +227,15 @@ export default function SpacesSettingsPage() {
             ) : (
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <span className="text-xl">{s.emoji ?? '🌍'}</span>
                     <span className="font-semibold text-slate-900 truncate">{s.name}</span>
-                    {s.is_default && <span className="text-xs text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full">Default</span>}
+                    {s.is_default && <span className="text-xs text-slate-600 bg-slate-100 px-2 py-0.5 rounded-full">Built-in</span>}
+                    {preferredSpaceId === s.id && (
+                      <span className="inline-flex items-center gap-1 text-xs text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full">
+                        <Star className="h-3 w-3 fill-amber-500 text-amber-500" /> My default view
+                      </span>
+                    )}
                   </div>
                   <p className="text-xs text-slate-500 mt-1">
                     {s.connection_ids.length === 0 && (s.account_refs?.length ?? 0) === 0
@@ -226,6 +244,23 @@ export default function SpacesSettingsPage() {
                   </p>
                 </div>
                 <div className="flex items-center gap-1">
+                  {preferredSpaceId === s.id ? (
+                    <button
+                      onClick={() => setPreferred(null)}
+                      className="text-xs text-amber-700 hover:text-amber-900 px-3 py-1.5 rounded-lg bg-amber-50 hover:bg-amber-100 inline-flex items-center gap-1"
+                      title="Unpin default view"
+                    >
+                      <Star className="h-3.5 w-3.5 fill-amber-500 text-amber-500" /> Default view
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => setPreferred(s.id)}
+                      className="text-xs text-slate-600 hover:text-slate-900 px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200 inline-flex items-center gap-1"
+                      title="Use this Space as my default view"
+                    >
+                      <Star className="h-3.5 w-3.5" /> Set default
+                    </button>
+                  )}
                   <button onClick={() => beginEdit(s)} className="text-xs text-slate-600 hover:text-slate-900 px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200">Edit</button>
                   {!s.is_default && (
                     <button onClick={() => remove(s.id)} className="p-1.5 text-slate-500 hover:text-red-600 rounded-lg" title="Delete Space">

--- a/supabase/migrations/20260423070000_preferred_space.sql
+++ b/supabase/migrations/20260423070000_preferred_space.sql
@@ -1,0 +1,11 @@
+-- User-preferred landing Space.
+--
+-- Separate from account_spaces.is_default (which marks the auto-
+-- created, un-deletable "Everything" Space). A user may want their
+-- Money Hub to land on "Business" instead — this column lets them
+-- pin any Space. NULL means "no preference, use the built-in
+-- default Space".
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS preferred_space_id uuid
+    REFERENCES public.account_spaces(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
Two complementary persistence mechanisms for Space state so users don't get bumped back to "Everything" every login:

1. **localStorage** remembers the last-clicked Space on that device — persists across sessions, per-device.
2. **\`profiles.preferred_space_id\`** lets users pin a preferred landing Space that follows them across devices.

Load-order priority on Money Hub:
1. \`?space_id=X\` URL param
2. localStorage \`lastSpaceId\` (per-device memory)
3. \`profile.preferred_space_id\` (cross-device pin)
4. Built-in default "Everything" Space

## Changes
- **Migration 20260423070000** — \`profiles.preferred_space_id uuid\` with \`ON DELETE SET NULL\` so deleting a pinned Space just clears the preference.
- **\`GET /api/spaces\`** now returns \`preferred_space_id\` alongside spaces + connections.
- **\`POST /api/spaces/preferred\`** — \`{ space_id: string | null }\`, ownership-validated.
- **Money Hub page** — load-order logic on mount + writes the active Space to localStorage on every switch.
- **Settings page** — "Set default" / "Default view" pill per Space with a star icon. Existing "Default" badge on the built-in Everything Space renamed to "Built-in" to disambiguate.

## Test plan
- [ ] Create "Business" Space, switch to it in Money Hub, log out + log back in → lands on Business
- [ ] On a different device → lands on whatever was set via "Set default" (or Everything if nothing pinned)
- [ ] Pin "Business" as default → star icon + "My default view" badge appears
- [ ] Click the starred button again → preference cleared
- [ ] Delete the pinned Space → preferred_space_id falls back to NULL automatically, user lands on Everything next time

🤖 Generated with [Claude Code](https://claude.com/claude-code)