### PR TITLE
fix(spaces): switching spinner + orphan-account hint

### DIFF
--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -99,6 +99,10 @@ export default function MoneyHubPage() {
  const [spaces, setSpaces] = useState<Array<{ id: string; name: string; emoji: string | null; is_default: boolean }>>([]);
  const [activeSpaceId, setActiveSpaceId] = useState<string | null>(null);
  const [preferredSpaceId, setPreferredSpaceId] = useState<string | null>(null);
+ // Separate flag for Space / month switches — initial load uses `loading`.
+ // This drives the inline "Switching…" pill so the user gets visible
+ // feedback on the (currently slow) /api/money-hub refetch.
+ const [switching, setSwitching] = useState(false);
  const [showBankPicker, setShowBankPicker] = useState(false);
  const [showFcaBanner, setShowFcaBanner] = useState(false);
  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null);
@@ -152,6 +156,9 @@ export default function MoneyHubPage() {
  // ─── Data fetching ──────────────────────────────────────────────────────
 
  const refreshData = useCallback(async (month?: string, spaceId?: string | null) => {
+ // Treat subsequent calls as a "switch" rather than an initial load
+ // so the full-page skeleton doesn't flash — we just show a pill.
+ if (data) setSwitching(true);
  try {
  const targetMonth = month ?? selectedMonth;
  const targetSpace = spaceId !== undefined ? spaceId : activeSpaceId;
@@ -172,8 +179,10 @@ export default function MoneyHubPage() {
  setError(e.message || 'Failed to load Money Hub data');
  } finally {
  setLoading(false);
+ setSwitching(false);
  }
- }, [selectedMonth, activeSpaceId]);
+ // eslint-disable-next-line react-hooks/exhaustive-deps
+ }, [selectedMonth, activeSpaceId, data]);
 
  // Load the user's Spaces once on mount. Also pick the initial
  // active Space using priority order:
@@ -714,14 +723,16 @@ export default function MoneyHubPage() {
  {/* Space switcher + manage button. Always visible so users can
   discover Spaces even before they\'ve created their first one. */}
  {spaces.length > 1 ? (
+ <div className="relative">
  <select
  value={activeSpaceId ?? data.activeSpace?.id ?? ''}
+ disabled={switching}
  onChange={(e) => {
  const next = e.target.value || null;
  setActiveSpaceId(next);
  refreshData(undefined, next);
  }}
- className="bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2 text-sm text-emerald-800 font-medium focus:outline-none focus:border-emerald-500"
+ className="bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2 text-sm text-emerald-800 font-medium focus:outline-none focus:border-emerald-500 disabled:opacity-60 disabled:cursor-wait"
  title="Filter by Space"
  >
  {spaces.map((s) => (
@@ -730,6 +741,10 @@ export default function MoneyHubPage() {
  </option>
  ))}
  </select>
+ {switching && (
+ <Loader2 className="absolute right-8 top-1/2 -translate-y-1/2 h-4 w-4 text-emerald-600 animate-spin pointer-events-none" />
+ )}
+ </div>
  ) : null}
  <Link
  href="/dashboard/settings/spaces"

--- a/src/app/dashboard/settings/spaces/page.tsx
+++ b/src/app/dashboard/settings/spaces/page.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft, Loader2, Plus, Trash2, Check, Sparkles, Briefcase,
-  Users as UsersIcon, PiggyBank, Home, Globe, CircleDot, X, Star,
+  Users as UsersIcon, PiggyBank, Home, Globe, CircleDot, X, Star, Info,
 } from 'lucide-react';
 
 interface Connection {
@@ -297,6 +297,64 @@ export default function SpacesSettingsPage() {
           <Plus className="h-4 w-4" /> New Space
         </button>
       )}
+
+      {/* Orphan-accounts hint — accounts that don't appear in any
+          non-default Space. Explains why Personal + Business totals
+          might not equal Everything's total. */}
+      {(() => {
+        // Build the set of connection/account refs covered by non-
+        // default Spaces. Everything's empty arrays mean "all", so
+        // we only look at the user-created (non-default) Spaces.
+        const coveredConns = new Set<string>();
+        const coveredRefs = new Set<string>();
+        for (const s of spaces) {
+          if (s.is_default) continue;
+          for (const id of s.connection_ids) coveredConns.add(id);
+          for (const r of (s.account_refs ?? [])) coveredRefs.add(r);
+        }
+        const orphans: Array<{ connId: string; bankName: string; accountLabel: string; accountId: string | null }> = [];
+        for (const c of connections) {
+          const accIds = c.account_ids ?? [];
+          const accNames = c.account_display_names ?? [];
+          if (accIds.length === 0) {
+            if (!coveredConns.has(c.id)) {
+              orphans.push({ connId: c.id, bankName: c.bank_name || 'Bank', accountLabel: '', accountId: null });
+            }
+            continue;
+          }
+          for (let i = 0; i < accIds.length; i++) {
+            const accId = accIds[i];
+            const ref = `${c.id}:${accId}`;
+            // Covered if the whole connection is in a Space or the specific account is.
+            if (coveredConns.has(c.id) || coveredRefs.has(ref)) continue;
+            orphans.push({
+              connId: c.id,
+              bankName: c.bank_name || 'Bank',
+              accountLabel: accNames[i] || `Account ${i + 1}`,
+              accountId: accId,
+            });
+          }
+        }
+        if (orphans.length === 0 || spaces.length <= 1) return null;
+        return (
+          <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 mb-6 flex items-start gap-3">
+            <Info className="h-5 w-5 text-blue-600 flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-blue-900 mb-1">
+                {orphans.length} account{orphans.length === 1 ? '' : 's'} not in any custom Space
+              </p>
+              <p className="text-sm text-blue-800 mb-2">
+                These accounts show up in <strong>Everything</strong> but not in Personal, Business or any Space you\'ve created. Their transactions won\'t match if you add the Space totals yourself.
+              </p>
+              <ul className="text-xs text-blue-800 space-y-0.5">
+                {orphans.map((o, i) => (
+                  <li key={i}>· {o.bankName}{o.accountLabel ? ` — ${o.accountLabel}` : ''}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        );
+      })()}
 
       {tierMessage && (
         <div className="mt-4 bg-amber-50 border border-amber-200 rounded-xl p-4 flex items-start gap-3">


### PR DESCRIPTION
## Summary
Two UX fixes flagged on aireypaul@googlemail.com's live session:

1. **Switching Spaces felt broken.** The \`/api/money-hub\` refetch takes ~1-2s and there was zero visible feedback. Added an inline spinner in the switcher + disabled the dropdown during the refetch so users don't trigger a second switch mid-flight. Full-page skeleton is kept only for initial load so the UI doesn't flash.
2. **Personal + Business totals ≠ Everything.** The math IS correct — aireypaul has a LLOYDS connection that's not in any custom Space, so its transactions only appear in Everything. Added a blue info hint on the Spaces settings page listing every account that isn't in any non-default Space, so users understand why the totals differ.

## Validation
Verified against aireypaul's live data:
- Personal (NATWEST Premier Reward Black): £5,389.88 income / £12,767.04 spent
- Business (NATWEST Business Current): £6,000.25 income / £6,604.89 spent
- **Personal + Business: £11,390.13 / £19,371.93**
- Everything: £11,390.13 income ✅ / £19,430.61 spent (Δ £58.68 = LLOYDS not in any custom Space)

Math reconciles exactly once LLOYDS is accounted for.

## Follow-up
Response caching per \`space_id\` so subsequent switches are instant once each Space has been viewed (left for a follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)