### PR TITLE
feat(mobile): backend scaffold — push tokens, AASA, asset links

### DIFF
--- a/src/app/.well-known/apple-app-site-association/route.ts
+++ b/src/app/.well-known/apple-app-site-association/route.ts
@@ -1,0 +1,52 @@
+/**
+ * Apple App Site Association (AASA).
+ *
+ * Served at `/.well-known/apple-app-site-association` with
+ * Content-Type: application/json. iOS fetches this to verify
+ * Universal Link ownership — tapping a link to paybacker.co.uk
+ * from Mail / Messages / anywhere opens the native app instead
+ * of Safari once the AASA is in place.
+ *
+ * The appIDs are `TEAMID.co.uk.paybacker.app`. TEAMID is the
+ * Apple Developer Team ID for aireypaul@googlemail.com. Swap the
+ * placeholder once the app is provisioned in App Store Connect;
+ * iOS will refuse to honour Universal Links until a real Team ID
+ * appears here.
+ */
+
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+// TODO: replace TEAMID once the Apple Developer Team ID is known.
+const APP_ID = 'TEAMID.co.uk.paybacker.app';
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      applinks: {
+        apps: [],
+        details: [
+          {
+            appIDs: [APP_ID],
+            components: [
+              { '/': '/dashboard/*', comment: 'Dashboard links open in-app' },
+              { '/': '/auth/*', comment: 'Email-link sign-ins route through the app' },
+              { '/': '/complaints/*', comment: 'Complaint letter deep links' },
+              { '/': '/', comment: 'Home page when launched via Universal Link' },
+            ],
+          },
+        ],
+      },
+      webcredentials: { apps: [APP_ID] },
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    },
+  );
+}

--- a/src/app/.well-known/assetlinks.json/route.ts
+++ b/src/app/.well-known/assetlinks.json/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Android Digital Asset Links.
+ *
+ * Served at `/.well-known/assetlinks.json`. When a user taps a
+ * paybacker.co.uk link on an Android device, Android checks this
+ * file to verify the domain is owned by the app with our package
+ * name (`co.uk.paybacker.app`) — if the SHA-256 fingerprint below
+ * matches the signing key, the link opens in the native app.
+ *
+ * `sha256_cert_fingerprints` must be the fingerprint of the key
+ * used to sign the Play Store release (or Google's internal signing
+ * key if you\'ve enabled Play App Signing). Grab it from:
+ *   keytool -list -v -keystore your-release-key.keystore
+ * or from Play Console → Release → Setup → App signing.
+ */
+
+import { NextResponse } from 'next/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-static';
+export const revalidate = false;
+
+// TODO: replace with the SHA-256 fingerprint of the signing key
+// (upload key OR the Google-managed Play App Signing key, depending
+// on which Android verifies against — check Play Console setup).
+const SHA256_FINGERPRINT = 'REPLACE_WITH_SHA256_OF_PLAY_SIGNING_KEY';
+
+export async function GET() {
+  return NextResponse.json(
+    [
+      {
+        relation: [
+          'delegate_permission/common.handle_all_urls',
+          'delegate_permission/common.get_login_creds',
+        ],
+        target: {
+          namespace: 'android_app',
+          package_name: 'co.uk.paybacker.app',
+          sha256_cert_fingerprints: [SHA256_FINGERPRINT],
+        },
+      },
+    ],
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    },
+  );
+}

--- a/src/app/api/push/register/route.ts
+++ b/src/app/api/push/register/route.ts
@@ -1,0 +1,54 @@
+/**
+ * POST /api/push/register
+ *
+ * The native mobile shell calls this on launch once the user has
+ * granted push-notification permission. Upserts by (user_id,
+ * platform, token) so multiple devices per user work.
+ *
+ * Body: { token: string, platform: 'ios' | 'android', device_name?: string }
+ *
+ * Auth: session cookie — the app loads paybacker.co.uk in a
+ * WebView, so the user's Supabase session travels naturally.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface Body {
+  token?: string;
+  platform?: 'ios' | 'android';
+  device_name?: string;
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = (await request.json().catch(() => ({}))) as Body;
+  const token = (body.token ?? '').trim();
+  const platform = body.platform;
+  if (!token) return NextResponse.json({ error: 'token required' }, { status: 400 });
+  if (platform !== 'ios' && platform !== 'android') {
+    return NextResponse.json({ error: "platform must be 'ios' or 'android'" }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from('push_tokens')
+    .upsert(
+      {
+        user_id: user.id,
+        platform,
+        token,
+        device_name: body.device_name ?? null,
+        last_seen_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,platform,token' },
+    );
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/notifications/dispatch.ts
+++ b/src/lib/notifications/dispatch.ts
@@ -193,9 +193,19 @@ async function sendTelegram(chatId: number, payload: TelegramPayload): Promise<b
 }
 
 /**
- * Push stub — becomes a real APNs/FCM sender once the mobile app
- * lands and `push_tokens` is populated. Until then it's a no-op that
- * records intent so the settings UI can show "push" as selectable.
+ * Push transport.
+ *
+ * Reads the user's registered devices from `push_tokens` (populated
+ * by /api/push/register when the mobile shell boots). If no tokens
+ * exist yet — the user hasn't installed the app or denied permission
+ * — we log "push_pending" and exit silently.
+ *
+ * Real APNs / FCM delivery is stubbed pending two env vars:
+ *   APNS_KEY_ID + APNS_TEAM_ID + APNS_KEY_P8  (iOS)
+ *   FCM_SERVICE_ACCOUNT_JSON                  (Android)
+ * When those land, the marked TODO below becomes an apns2 +
+ * firebase-admin call. Returning false keeps the event routed
+ * through email/telegram fallbacks so users aren\'t silenced.
  */
 async function sendPush(
   supabase: SupabaseClient,
@@ -203,15 +213,31 @@ async function sendPush(
   payload: PushPayload,
 ): Promise<boolean> {
   try {
+    const { data: tokens } = await supabase
+      .from('push_tokens')
+      .select('platform, token')
+      .eq('user_id', userId);
+    if (!tokens || tokens.length === 0) {
+      await supabase.from('notification_log').insert({
+        user_id: userId,
+        notification_type: 'push_no_device',
+        reference_key: `${payload.title}|${Date.now()}`,
+      });
+      return false;
+    }
+    // TODO: wire APNs (iOS) + FCM (Android) senders here. For each
+    // token row, dispatch based on row.platform. Today we log
+    // intent — users with the app installed will start receiving
+    // pushes once the credentials env vars are set.
     await supabase.from('notification_log').insert({
       user_id: userId,
-      notification_type: 'push_pending',
-      reference_key: `${payload.title}|${Date.now()}`,
+      notification_type: 'push_pending_transport',
+      reference_key: `${payload.title}|${tokens.length}|${Date.now()}`,
     });
   } catch {
     // notification_log may not have this shape — log and move on
   }
-  return false; // always "skipped" until real transport exists
+  return false;
 }
 
 export async function sendNotification(

--- a/supabase/migrations/20260423080000_push_tokens.sql
+++ b/supabase/migrations/20260423080000_push_tokens.sql
@@ -1,0 +1,32 @@
+-- Push-notification tokens for the Paybacker native apps.
+--
+-- The mobile shell (scripts/build-shell.mjs in paybacker-mobile)
+-- calls POST /api/push/register on launch once the user has granted
+-- notification permission. We upsert by (user_id, platform, token)
+-- so multiple devices per user work (iPhone + iPad + Android).
+
+CREATE TABLE IF NOT EXISTS public.push_tokens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  platform text NOT NULL CHECK (platform IN ('ios', 'android')),
+  token text NOT NULL,
+  device_name text,
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, platform, token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_tokens_user ON public.push_tokens (user_id);
+
+ALTER TABLE public.push_tokens ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users read own push tokens" ON public.push_tokens;
+CREATE POLICY "Users read own push tokens"
+  ON public.push_tokens FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users write own push tokens" ON public.push_tokens;
+CREATE POLICY "Users write own push tokens"
+  ON public.push_tokens FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
Backend prerequisites for the new Paybacker mobile app ([airpau/paybacker-mobile](https://github.com/airpau/paybacker-mobile)). Wires the server so the native shell can register its push token and so Universal Links / App Links open the app instead of Safari.

## What's in
- **Migration 20260423080000** — \`push_tokens\` table (RLS, unique on user+platform+token, last_seen_at tracked).
- **\`POST /api/push/register\`** — session-authed. Body \`{ token, platform: 'ios' | 'android', device_name? }\`. The mobile shell calls this on every app launch after the user grants notification permission.
- **\`GET /.well-known/apple-app-site-association\`** — Next route handler so the JSON Content-Type is correct. AppIDs use \`TEAMID.co.uk.paybacker.app\` — needs the real Apple Developer Team ID before shipping or iOS won't honour Universal Links.
- **\`GET /.well-known/assetlinks.json\`** — same pattern for Android App Links. SHA256 fingerprint placeholder; swap once the Play signing key is generated.
- **\`src/lib/notifications/dispatch.ts\`** push stub now reads \`push_tokens\` and logs \`push_pending_transport\` / \`push_no_device\` for observability. Real APNs + FCM wiring still TODO — needs:
  - iOS: APNs \`.p8\` key, Team ID, Key ID (from Apple Developer Portal)
  - Android: FCM service-account JSON (from Firebase Console)

## Related work
- New repo [github.com/airpau/paybacker-mobile](https://github.com/airpau/paybacker-mobile) (private) has the Capacitor 6 scaffold + README with step-by-step setup for Apple + Google dev accounts.

## What Paul needs to do next (not in this PR)
1. In Apple Developer Portal: register bundle ID \`co.uk.paybacker.app\`, enable Push Notifications + Associated Domains.
2. Generate an APNs \`.p8\` auth key.
3. Note the Team ID — update \`TEAMID\` placeholder in the AASA route + set \`APNS_TEAM_ID\` env var.
4. In Google Play Console: register package \`co.uk.paybacker.app\`.
5. Create Firebase project + Android app → download \`google-services.json\` → drop in \`android/app/\` on the mobile repo.
6. Run \`npx cap add ios && npx cap add android\` locally; commit generated folders.
7. Open \`ios/App/App.xcworkspace\` in Xcode, sign with your team, build to simulator or TestFlight.

## Test plan (once app scaffolded)
- [ ] Install app on simulator → \`POST /api/push/register\` fires with device token → row lands in \`push_tokens\`
- [ ] Tap a paybacker.co.uk link in iMessage → opens the app, not Safari (AASA verified)
- [ ] Disconnect network → app shows branded offline screen from www/offline.html
- [ ] Biometric unlock on Money Hub works on a device with Face ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)