### PR TITLE
feat(disputes): create dispute from an existing inbox email

### DIFF
--- a/src/app/api/disputes/from-email/route.ts
+++ b/src/app/api/disputes/from-email/route.ts
@@ -1,0 +1,288 @@
+/**
+ * POST /api/disputes/from-email
+ *
+ * One-shot "create a dispute from an existing email thread" flow.
+ *
+ * Body:
+ *   { connectionId, threadId, userContext, desiredOutcome, issueTypeHint? }
+ *
+ * Steps:
+ *   1. Verify connection ownership; load it.
+ *   2. Fetch the full thread via fetchNewMessages (threads up to 365d back).
+ *   3. AI-extract structured facts from the thread + user context
+ *      (Claude Haiku for cost — this isn\'t the user-facing letter,
+ *       just key/value extraction).
+ *   4. Create the dispute row with extracted + user-supplied data.
+ *   5. Insert a `dispute_watchdog_links` row so the thread is
+ *      monitored from now on; backfill correspondence with the
+ *      thread history.
+ *   6. Generate the actual complaint letter (Sonnet) using the
+ *      existing /api/complaints/generate endpoint as a sub-call.
+ *   7. Return the dispute id so the UI can route to the detail page.
+ *
+ * The reply-detection cron + telegram alerting are unchanged — once
+ * the watchdog link exists, every new message in the thread triggers
+ * the existing pipeline.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createAdmin } from '@supabase/supabase-js';
+import Anthropic from '@anthropic-ai/sdk';
+import { fetchNewMessages } from '@/lib/dispute-sync/fetchers';
+import type { EmailConnection } from '@/lib/dispute-sync/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const ALLOWED_ISSUE_TYPES = new Set([
+  'complaint', 'energy_dispute', 'broadband_complaint', 'flight_compensation',
+  'parking_appeal', 'debt_dispute', 'refund_request', 'hmrc_tax_rebate',
+  'council_tax_band', 'dvla_vehicle', 'nhs_complaint',
+]);
+
+interface ExtractedFacts {
+  provider_name: string;
+  account_number: string | null;
+  disputed_amount: number | null;
+  issue_type: string;
+  issue_summary: string;
+  thread_summary: string;
+}
+
+function getAdmin() {
+  return createAdmin(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+async function extractFacts(
+  threadText: string,
+  userContext: string,
+  desiredOutcome: string,
+  issueTypeHint?: string,
+): Promise<ExtractedFacts> {
+  const prompt = `You are extracting structured facts from an email thread so a UK consumer-rights tool can build a dispute. Return ONLY valid JSON, no preamble.
+
+EMAIL THREAD (most recent last):
+${threadText.slice(0, 8000)}
+
+USER CONTEXT (what happened from their side):
+${userContext.slice(0, 1000)}
+
+DESIRED OUTCOME (what they want):
+${desiredOutcome.slice(0, 500)}
+
+USER\'S CATEGORY HINT (may be empty): ${issueTypeHint ?? ''}
+
+Return JSON with exactly these keys:
+- "provider_name": the company involved (clean, e.g. "British Gas", "Broxbourne Borough Council", "EuroCarParks Ltd"). NEVER an email domain or technical id.
+- "account_number": account / reference / ticket number found in the email, or null if none.
+- "disputed_amount": the GBP amount in dispute as a positive number (no symbols), or null if not specified.
+- "issue_type": ONE of these UK-specific dispute categories — pick the closest match:
+    "complaint" (generic / shopping / service)
+    "energy_dispute"
+    "broadband_complaint" (broadband, mobile, phone)
+    "flight_compensation"
+    "parking_appeal"
+    "debt_dispute" (debt collector, missed payment, CCJ)
+    "refund_request"
+    "hmrc_tax_rebate"
+    "council_tax_band" (also use for council tax billing or business rates)
+    "dvla_vehicle"
+    "nhs_complaint"
+- "issue_summary": ONE-SENTENCE summary of the dispute (≤ 30 words).
+- "thread_summary": 2-3 sentence summary of the email thread for context.
+
+Output JSON only.`;
+
+  const res = await anthropic.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 600,
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const text = res.content[0];
+  const raw = text.type === 'text' ? text.text : '{}';
+  const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+  const match = cleaned.match(/\{[\s\S]*\}/);
+  if (!match) throw new Error('AI extraction returned no JSON');
+  let parsed: any;
+  try {
+    parsed = JSON.parse(match[0]);
+  } catch {
+    throw new Error('AI extraction returned invalid JSON');
+  }
+  const facts: ExtractedFacts = {
+    provider_name: String(parsed.provider_name ?? '').trim() || 'Unknown company',
+    account_number: parsed.account_number ? String(parsed.account_number) : null,
+    disputed_amount: typeof parsed.disputed_amount === 'number' ? parsed.disputed_amount : null,
+    issue_type: ALLOWED_ISSUE_TYPES.has(parsed.issue_type) ? parsed.issue_type : (issueTypeHint && ALLOWED_ISSUE_TYPES.has(issueTypeHint) ? issueTypeHint : 'complaint'),
+    issue_summary: String(parsed.issue_summary ?? '').trim() || userContext.slice(0, 120),
+    thread_summary: String(parsed.thread_summary ?? '').trim(),
+  };
+  return facts;
+}
+
+interface Body {
+  connectionId?: string;
+  threadId?: string;
+  userContext?: string;
+  desiredOutcome?: string;
+  issueTypeHint?: string;
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = (await request.json().catch(() => ({}))) as Body;
+  const { connectionId, threadId } = body;
+  const userContext = (body.userContext ?? '').trim();
+  const desiredOutcome = (body.desiredOutcome ?? '').trim();
+  if (!connectionId || !threadId) {
+    return NextResponse.json({ error: 'connectionId and threadId are required' }, { status: 400 });
+  }
+  if (!userContext || !desiredOutcome) {
+    return NextResponse.json({ error: 'Tell us what happened and what outcome you want.' }, { status: 400 });
+  }
+
+  // Use the service-role client for the connection load + writes —
+  // RLS would still gate it but this matches the existing complaint
+  // generator pattern (token decryption etc).
+  const admin = getAdmin();
+  const { data: conn } = await admin
+    .from('email_connections')
+    .select('*')
+    .eq('id', connectionId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (!conn) return NextResponse.json({ error: 'Email connection not found' }, { status: 404 });
+
+  // 1. Pull the entire thread (since: null = full history) for AI context.
+  let messages: Array<{ subject: string; fromAddress: string; fromName: string; receivedAt: Date; body: string; snippet: string }>;
+  try {
+    messages = await fetchNewMessages(conn as unknown as EmailConnection, threadId, null);
+  } catch (err) {
+    return NextResponse.json({ error: `Couldn\'t read the email thread: ${err instanceof Error ? err.message : 'unknown'}` }, { status: 502 });
+  }
+  if (messages.length === 0) {
+    return NextResponse.json({ error: 'Thread is empty.' }, { status: 400 });
+  }
+
+  // 2. Build a compact text dump for the extraction prompt.
+  const threadText = messages
+    .map((m) => `From: ${m.fromName || m.fromAddress}\nDate: ${m.receivedAt.toISOString()}\nSubject: ${m.subject}\n\n${m.body || m.snippet}`)
+    .join('\n\n---\n\n');
+
+  // 3. AI extraction.
+  let facts: ExtractedFacts;
+  try {
+    facts = await extractFacts(threadText, userContext, desiredOutcome, body.issueTypeHint);
+  } catch (err) {
+    return NextResponse.json({ error: `AI extraction failed: ${err instanceof Error ? err.message : 'unknown'}` }, { status: 500 });
+  }
+
+  // 4. Create dispute row directly so we can also stamp the
+  // detected_from_email + thread_summary fields.
+  const { data: dispute, error: insertErr } = await admin
+    .from('disputes')
+    .insert({
+      user_id: user.id,
+      provider_name: facts.provider_name,
+      issue_type: facts.issue_type,
+      issue_summary: facts.issue_summary,
+      desired_outcome: desiredOutcome,
+      account_number: facts.account_number,
+      disputed_amount: facts.disputed_amount,
+      status: 'open',
+    })
+    .select('*')
+    .single();
+  if (insertErr || !dispute) {
+    return NextResponse.json({ error: insertErr?.message || 'Failed to create dispute' }, { status: 500 });
+  }
+
+  // 5. Link the email thread for ongoing Watchdog monitoring + import history.
+  const lastMsg = messages[messages.length - 1];
+  const senderDomain = (lastMsg.fromAddress.split('@')[1] || '').toLowerCase();
+  const { data: link, error: linkErr } = await admin
+    .from('dispute_watchdog_links')
+    .insert({
+      dispute_id: dispute.id,
+      user_id: user.id,
+      email_connection_id: connectionId,
+      provider: ((conn.provider_type ?? '').toLowerCase().startsWith('g') ? 'gmail' : 'outlook'),
+      thread_id: threadId,
+      subject: lastMsg.subject,
+      sender_domain: senderDomain,
+      sender_address: lastMsg.fromAddress.toLowerCase(),
+      sync_enabled: true,
+      match_source: 'user_confirmed',
+      match_confidence: 1.0,
+      last_synced_at: new Date().toISOString(),
+    })
+    .select('id')
+    .single();
+  if (linkErr) {
+    console.error('[from-email] watchdog link insert failed:', linkErr.message);
+  }
+
+  // 6. Import the thread history into correspondence so the dispute
+  // detail page renders the existing emails immediately.
+  if (messages.length > 0) {
+    const rows = messages.map((m) => ({
+      dispute_id: dispute.id,
+      user_id: user.id,
+      entry_type: 'company_email',
+      direction: 'inbound',
+      content: m.body || m.snippet || '',
+      sender_name: m.fromName || m.fromAddress,
+      sender_address: m.fromAddress.toLowerCase(),
+      detected_from_email: true,
+      external_message_id: undefined,
+      occurred_at: m.receivedAt.toISOString(),
+    }));
+    await admin.from('correspondence').insert(rows);
+  }
+
+  // 7. Kick off the AI letter generation by calling the existing
+  // /api/complaints/generate endpoint via internal fetch — keeps
+  // the same legal-reference injection + verification path.
+  let draftLetter: string | null = null;
+  try {
+    const origin = new URL(request.url).origin;
+    const cookieHeader = request.headers.get('cookie') ?? '';
+    const genRes = await fetch(`${origin}/api/complaints/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie: cookieHeader },
+      body: JSON.stringify({
+        companyName: facts.provider_name,
+        issueDescription: `${facts.issue_summary}\n\nUser context:\n${userContext}\n\nThread summary:\n${facts.thread_summary}`,
+        desiredOutcome,
+        amount: facts.disputed_amount ? String(facts.disputed_amount) : '',
+        accountNumber: facts.account_number ?? '',
+        letterType: facts.issue_type,
+        disputeId: dispute.id,
+      }),
+    });
+    if (genRes.ok) {
+      const genJson = await genRes.json();
+      draftLetter = genJson.letter ?? null;
+    }
+  } catch (err) {
+    console.error('[from-email] complaint generation failed:', err);
+  }
+
+  return NextResponse.json({
+    dispute,
+    extracted: facts,
+    watchdogLinkId: link?.id ?? null,
+    importedMessages: messages.length,
+    draftLetter,
+  });
+}

--- a/src/app/api/email/browse-disputable/route.ts
+++ b/src/app/api/email/browse-disputable/route.ts
@@ -1,0 +1,181 @@
+/**
+ * GET /api/email/browse-disputable
+ *
+ * Returns recent threads from every connected (non-archived) email
+ * connection so the user can pick one to start a dispute from. The
+ * "from email" entry on the New Dispute flow calls this.
+ *
+ * Optional query params:
+ *   ?q=<text>   — keyword filter (subject + sender)
+ *   ?days=<n>   — look-back window (default 90, max 365)
+ *
+ * We deliberately don\'t pre-filter for "looks disputable" — users
+ * know which email they want to act on better than any heuristic.
+ * Pure marketing emails get sorted naturally lower because users
+ * scroll for the bill / debt / parking notice they remember.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { refreshAccessToken as refreshGmailToken } from '@/lib/gmail';
+import { refreshMicrosoftToken } from '@/lib/outlook';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+interface BrowsedThread {
+  connectionId: string;
+  emailAddress: string;
+  provider: 'gmail' | 'outlook';
+  threadId: string;
+  subject: string;
+  senderName: string;
+  senderAddress: string;
+  senderDomain: string;
+  latestDate: string;
+  messageCount: number;
+  snippet: string;
+}
+
+async function ensureToken(conn: any): Promise<string> {
+  const expiresAt = conn.token_expiry ? new Date(conn.token_expiry).getTime() : 0;
+  if (conn.access_token && expiresAt - Date.now() > 60_000) return conn.access_token;
+  if (!conn.refresh_token) throw new Error('No refresh token');
+  if (conn.provider_type === 'google' || conn.provider_type === 'gmail') {
+    const r = await refreshGmailToken(conn.refresh_token);
+    return r.access_token;
+  }
+  const r = await refreshMicrosoftToken(conn.refresh_token);
+  return r.access_token;
+}
+
+async function listGmailRecent(conn: any, q: string, days: number): Promise<BrowsedThread[]> {
+  const token = await ensureToken(conn);
+  const queryParts = [`newer_than:${days}d`];
+  if (q) queryParts.push(q);
+  // Skip Gmail\'s own "Promotions" + "Updates" categories so the picker
+  // is closer to actionable mail. Users with everything in Primary still
+  // see all their threads.
+  queryParts.push('-category:promotions -category:updates -category:social');
+  const listUrl = new URL('https://gmail.googleapis.com/gmail/v1/users/me/threads');
+  listUrl.searchParams.set('q', queryParts.join(' '));
+  listUrl.searchParams.set('maxResults', '25');
+  const res = await fetch(listUrl.toString(), { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) return [];
+  const list = await res.json();
+  if (!list.threads?.length) return [];
+
+  const out: BrowsedThread[] = [];
+  for (const t of list.threads as Array<{ id: string }>) {
+    const detail = await fetch(
+      `https://gmail.googleapis.com/gmail/v1/users/me/threads/${t.id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!detail.ok) continue;
+    const thr = await detail.json();
+    const msgs = thr.messages ?? [];
+    if (msgs.length === 0) continue;
+    const last = msgs[msgs.length - 1];
+    const headers = (last.payload?.headers ?? []) as Array<{ name: string; value: string }>;
+    const h = (n: string) => headers.find((x) => x.name.toLowerCase() === n.toLowerCase())?.value ?? '';
+    const fromStr = h('From');
+    const fromAddr = fromStr.match(/[\w.+-]+@[\w-]+(?:\.[\w-]+)+/)?.[0]?.toLowerCase() ?? '';
+    const fromName = (fromStr.split('<')[0] || '').replace(/"/g, '').trim() || fromAddr;
+    out.push({
+      connectionId: conn.id,
+      emailAddress: conn.email_address,
+      provider: 'gmail',
+      threadId: thr.id,
+      subject: h('Subject') || '(no subject)',
+      senderName: fromName,
+      senderAddress: fromAddr,
+      senderDomain: fromAddr.split('@')[1] ?? '',
+      latestDate: new Date(Number(last.internalDate ?? 0)).toISOString(),
+      messageCount: msgs.length,
+      snippet: thr.snippet ?? '',
+    });
+  }
+  return out;
+}
+
+async function listOutlookRecent(conn: any, q: string, days: number): Promise<BrowsedThread[]> {
+  const token = await ensureToken(conn);
+  const sinceIso = new Date(Date.now() - days * 86400_000).toISOString();
+  const url = new URL('https://graph.microsoft.com/v1.0/me/messages');
+  url.searchParams.set('$top', '25');
+  url.searchParams.set('$select', 'id,conversationId,subject,from,receivedDateTime,bodyPreview');
+  url.searchParams.set('$orderby', 'receivedDateTime desc');
+  if (q) url.searchParams.set('$search', `"${q}"`);
+  else url.searchParams.set('$filter', `receivedDateTime ge ${sinceIso}`);
+  const res = await fetch(url.toString(), { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) return [];
+  const data = await res.json();
+  const seen = new Map<string, BrowsedThread>();
+  for (const m of (data.value ?? []) as Array<any>) {
+    const convId = m.conversationId;
+    if (!convId || seen.has(convId)) continue;
+    const fromAddr = (m.from?.emailAddress?.address ?? '').toLowerCase();
+    const fromName = m.from?.emailAddress?.name ?? fromAddr;
+    seen.set(convId, {
+      connectionId: conn.id,
+      emailAddress: conn.email_address,
+      provider: 'outlook',
+      threadId: convId,
+      subject: m.subject || '(no subject)',
+      senderName: fromName,
+      senderAddress: fromAddr,
+      senderDomain: fromAddr.split('@')[1] ?? '',
+      latestDate: m.receivedDateTime,
+      messageCount: 1,
+      snippet: m.bodyPreview ?? '',
+    });
+  }
+  return Array.from(seen.values());
+}
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { searchParams } = new URL(request.url);
+  const q = (searchParams.get('q') ?? '').trim();
+  const days = Math.min(365, Math.max(7, parseInt(searchParams.get('days') ?? '90', 10) || 90));
+
+  // Active, non-archived email connections only.
+  const { data: connections } = await supabase
+    .from('email_connections')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('status', 'active')
+    .is('archived_at', null);
+
+  if (!connections || connections.length === 0) {
+    return NextResponse.json({ threads: [], connections: [], reason: 'no_email_connection' });
+  }
+
+  const all: BrowsedThread[] = [];
+  const errors: string[] = [];
+  for (const conn of connections) {
+    try {
+      const provider = (conn.provider_type ?? '').toLowerCase();
+      if (provider === 'google' || provider === 'gmail') {
+        all.push(...await listGmailRecent(conn, q, days));
+      } else if (provider === 'microsoft' || provider === 'outlook') {
+        all.push(...await listOutlookRecent(conn, q, days));
+      }
+    } catch (err) {
+      errors.push(`${conn.email_address}: ${err instanceof Error ? err.message : 'fetch failed'}`);
+    }
+  }
+
+  // Sort newest first; cap at 50 across all inboxes so the picker
+  // stays usable on mobile.
+  all.sort((a, b) => new Date(b.latestDate).getTime() - new Date(a.latestDate).getTime());
+  return NextResponse.json({
+    threads: all.slice(0, 50),
+    connections: connections.map((c) => ({ id: c.id, email_address: c.email_address, provider: c.provider_type })),
+    errors: errors.length > 0 ? errors : undefined,
+  });
+}

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -16,6 +16,7 @@ import UpgradeModal from '@/components/UpgradeModal';
 import { AI_LETTER_DISCLAIMER_HTML } from '@/lib/legal-disclaimer';
 import ShareWinModal from '@/components/share/ShareWinModal';
 import { shouldShowShareModal, hasSharedThisSession } from '@/lib/share-triggers';
+import EmailDisputeFinder from '@/components/dispute/EmailDisputeFinder';
 import WatchdogCard from '@/components/dispute/WatchdogCard';
 
 // ============================================================
@@ -2485,11 +2486,19 @@ function ComplaintsPageInner() {
   const searchParams = useSearchParams();
   const [view, setView] = useState<'list' | 'new' | 'detail'>('list');
   const [selectedDisputeId, setSelectedDisputeId] = useState<string | null>(null);
+  // 'closed' = no chooser, 'open' = "from scratch / from email" picker shown,
+  // 'email' = the EmailDisputeFinder modal active.
+  const [newFlow, setNewFlow] = useState<'closed' | 'open' | 'email'>('closed');
 
-  // If URL has ?new=1 or sessionStorage has pb_preview_letter, open new dispute form
+  // If URL has ?new=1 or sessionStorage has pb_preview_letter, open the
+  // chooser. URL parameters that include a company / type / alertId
+  // (legacy direct entry from price-alert links) skip straight to the
+  // existing scratch form so deep links keep working unchanged.
   useEffect(() => {
+    const hasDirectLink = searchParams.get('company') || searchParams.get('type') || searchParams.get('alertId') || searchParams.get('category');
     if (searchParams.get('new') === '1') {
-      setView('new');
+      if (hasDirectLink) setView('new');
+      else setNewFlow('open');
     } else if (typeof window !== 'undefined' && sessionStorage.getItem('pb_preview_letter')) {
       setView('new');
     }
@@ -2514,10 +2523,68 @@ function ComplaintsPageInner() {
   }
 
   return (
-    <DisputesList
-      onSelect={(id) => { setSelectedDisputeId(id); setView('detail'); }}
-      onNew={() => setView('new')}
-    />
+    <>
+      <DisputesList
+        onSelect={(id) => { setSelectedDisputeId(id); setView('detail'); }}
+        onNew={() => setNewFlow('open')}
+      />
+      {newFlow === 'open' && (
+        <NewDisputeChooser
+          onScratch={() => { setNewFlow('closed'); setView('new'); }}
+          onFromEmail={() => setNewFlow('email')}
+          onClose={() => setNewFlow('closed')}
+        />
+      )}
+      {newFlow === 'email' && (
+        <EmailDisputeFinder
+          onClose={() => setNewFlow('closed')}
+          onCreated={(id) => { setNewFlow('closed'); setSelectedDisputeId(id); setView('detail'); }}
+        />
+      )}
+    </>
+  );
+}
+
+function NewDisputeChooser({
+  onScratch, onFromEmail, onClose,
+}: { onScratch: () => void; onFromEmail: () => void; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-lg w-full p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-slate-900">Start a new dispute</h2>
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 text-xl leading-none">×</button>
+        </div>
+        <p className="text-sm text-slate-600 mb-5">How do you want to begin?</p>
+        <div className="grid grid-cols-1 gap-3">
+          <button
+            onClick={onFromEmail}
+            className="text-left p-4 rounded-xl border-2 border-emerald-200 bg-emerald-50 hover:border-emerald-400 transition-all"
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-2xl">📨</span>
+              <span className="font-semibold text-slate-900">From an email in my inbox</span>
+              <span className="ml-auto text-[10px] uppercase tracking-wider text-emerald-700 bg-white px-1.5 py-0.5 rounded">New</span>
+            </div>
+            <p className="text-sm text-slate-700">
+              Pick the email — bill, parking ticket, debt letter, anything — and we\'ll read it, ask what you want, and write a legally-grounded reply. We\'ll also watch the thread for the company\'s response.
+            </p>
+          </button>
+          <button
+            onClick={onScratch}
+            className="text-left p-4 rounded-xl border-2 border-slate-200 hover:border-slate-400 transition-all"
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-2xl">✍️</span>
+              <span className="font-semibold text-slate-900">From scratch</span>
+            </div>
+            <p className="text-sm text-slate-600">
+              Start with a blank form — type the company name, what happened, and what outcome you want.
+            </p>
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/dispute/EmailDisputeFinder.tsx
+++ b/src/components/dispute/EmailDisputeFinder.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+/**
+ * Two-step modal: pick an email from the user's connected inbox(es)
+ * → add user context + desired outcome → fire `/api/disputes/from-email`
+ * which extracts facts via AI, creates the dispute, links the thread
+ * for Watchdog monitoring, and drafts the complaint letter.
+ *
+ * Used as the "From an email" entry point on the New Dispute flow.
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  X, Loader2, Mail, ArrowLeft, ArrowRight, Search, Sparkles, Inbox, AlertCircle, Check,
+} from 'lucide-react';
+
+interface BrowsedThread {
+  connectionId: string;
+  emailAddress: string;
+  provider: 'gmail' | 'outlook';
+  threadId: string;
+  subject: string;
+  senderName: string;
+  senderAddress: string;
+  senderDomain: string;
+  latestDate: string;
+  messageCount: number;
+  snippet: string;
+}
+
+interface Props {
+  onClose: () => void;
+  onCreated: (disputeId: string) => void;
+}
+
+export default function EmailDisputeFinder({ onClose, onCreated }: Props) {
+  const [step, setStep] = useState<'pick' | 'context' | 'creating'>('pick');
+  const [threads, setThreads] = useState<BrowsedThread[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState<BrowsedThread | null>(null);
+  const [userContext, setUserContext] = useState('');
+  const [desiredOutcome, setDesiredOutcome] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [hasNoEmail, setHasNoEmail] = useState(false);
+
+  const fetchThreads = async (q?: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (q) params.set('q', q);
+      const res = await fetch(`/api/email/browse-disputable?${params.toString()}`, { credentials: 'include' });
+      const d = await res.json();
+      if (d.reason === 'no_email_connection') {
+        setHasNoEmail(true);
+        setThreads([]);
+      } else {
+        setThreads(d.threads ?? []);
+      }
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load emails');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { void fetchThreads(); }, []);
+
+  const onSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void fetchThreads(search.trim());
+  };
+
+  const create = async () => {
+    if (!selected) return;
+    if (!userContext.trim() || !desiredOutcome.trim()) return;
+    setCreating(true);
+    setStep('creating');
+    setError(null);
+    try {
+      const res = await fetch('/api/disputes/from-email', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          connectionId: selected.connectionId,
+          threadId: selected.threadId,
+          userContext: userContext.trim(),
+          desiredOutcome: desiredOutcome.trim(),
+        }),
+      });
+      const d = await res.json();
+      if (!res.ok) throw new Error(d.error || `Failed (${res.status})`);
+      onCreated(d.dispute.id);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to create dispute');
+      setStep('context');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between p-4 border-b border-slate-200">
+          <div className="flex items-center gap-2">
+            <Inbox className="h-5 w-5 text-emerald-600" />
+            <h2 className="text-lg font-semibold text-slate-900">
+              {step === 'pick' && 'Pick an email to dispute'}
+              {step === 'context' && 'Add a bit of context'}
+              {step === 'creating' && 'Creating your dispute…'}
+            </h2>
+          </div>
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-1">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {step === 'pick' && (
+          <div className="flex-1 overflow-y-auto p-4">
+            {hasNoEmail ? (
+              <div className="text-center py-12">
+                <Mail className="h-10 w-10 text-slate-400 mx-auto mb-3" />
+                <p className="text-sm text-slate-700 font-medium mb-1">No connected inbox</p>
+                <p className="text-xs text-slate-500 mb-4">Connect Gmail or Outlook to find emails to dispute.</p>
+                <a href="/dashboard/profile?section=accounts" className="inline-block bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-semibold rounded-lg px-4 py-2">
+                  Connect inbox
+                </a>
+              </div>
+            ) : (
+              <>
+                <form onSubmit={onSearchSubmit} className="flex items-center gap-2 mb-3">
+                  <div className="flex-1 relative">
+                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+                    <input
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      placeholder="Search subject or sender (e.g. Broxbourne, parking, energy)"
+                      className="w-full pl-8 pr-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:border-emerald-500"
+                    />
+                  </div>
+                  <button type="submit" className="bg-emerald-500 hover:bg-emerald-600 text-white text-sm font-medium rounded-lg px-3 py-2">Search</button>
+                </form>
+
+                {loading && (
+                  <div className="py-12 flex items-center justify-center">
+                    <Loader2 className="h-6 w-6 text-emerald-600 animate-spin" />
+                  </div>
+                )}
+
+                {!loading && error && (
+                  <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700 mb-3 flex items-center gap-2">
+                    <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                    {error}
+                  </div>
+                )}
+
+                {!loading && !error && threads.length === 0 && (
+                  <p className="text-sm text-slate-500 italic text-center py-8">No threads found in the last 90 days. Try a different search term.</p>
+                )}
+
+                <ul className="space-y-2">
+                  {threads.map((t) => {
+                    const date = new Date(t.latestDate);
+                    return (
+                      <li key={`${t.connectionId}:${t.threadId}`}>
+                        <button
+                          onClick={() => { setSelected(t); setStep('context'); }}
+                          className="w-full text-left p-3 rounded-xl border border-slate-200 hover:border-emerald-400 hover:bg-emerald-50/50 transition-all"
+                        >
+                          <div className="flex items-start justify-between gap-2 mb-1">
+                            <p className="text-sm font-semibold text-slate-900 line-clamp-1 flex-1">{t.subject}</p>
+                            <span className="text-xs text-slate-500 flex-shrink-0">
+                              {date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}
+                            </span>
+                          </div>
+                          <p className="text-xs text-slate-600 mb-1">
+                            {t.senderName} <span className="text-slate-400">·</span> <span className="text-slate-500">{t.senderAddress}</span>
+                          </p>
+                          <p className="text-xs text-slate-500 line-clamp-2">{t.snippet}</p>
+                          {t.messageCount > 1 && (
+                            <span className="inline-block mt-1.5 text-[10px] uppercase tracking-wider text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full">
+                              {t.messageCount} messages
+                            </span>
+                          )}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            )}
+          </div>
+        )}
+
+        {step === 'context' && selected && (
+          <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+              <p className="text-xs text-slate-500 mb-1">Selected email</p>
+              <p className="text-sm font-semibold text-slate-900 mb-1">{selected.subject}</p>
+              <p className="text-xs text-slate-600">{selected.senderName} · {selected.senderAddress}</p>
+              <button onClick={() => { setSelected(null); setStep('pick'); }} className="text-xs text-emerald-700 hover:underline mt-2 inline-flex items-center gap-1">
+                <ArrowLeft className="h-3 w-3" /> Pick a different email
+              </button>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-900 mb-1">What\'s your side of the story?</label>
+              <p className="text-xs text-slate-500 mb-2">Tell us what actually happened — anything the company doesn\'t know yet, or where they\'ve got the facts wrong.</p>
+              <textarea
+                value={userContext}
+                onChange={(e) => setUserContext(e.target.value)}
+                rows={5}
+                placeholder="e.g. The parking ticket was issued at 14:03 but I have proof I left at 13:55 — I was there for 8 minutes only and the signage was obscured by a delivery van."
+                className="w-full px-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:border-emerald-500"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-900 mb-1">What outcome do you want?</label>
+              <p className="text-xs text-slate-500 mb-2">Be specific — refund of £X, cancel without penalty, write off the debt, etc.</p>
+              <textarea
+                value={desiredOutcome}
+                onChange={(e) => setDesiredOutcome(e.target.value)}
+                rows={3}
+                placeholder="e.g. Cancel the parking charge in full and confirm in writing it won\'t escalate to debt recovery."
+                className="w-full px-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:border-emerald-500"
+              />
+            </div>
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700 flex items-center gap-2">
+                <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                {error}
+              </div>
+            )}
+
+            <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-3 flex items-start gap-2">
+              <Sparkles className="h-4 w-4 text-emerald-600 flex-shrink-0 mt-0.5" />
+              <p className="text-xs text-emerald-900">
+                We\'ll read the email, combine it with your context, and write a complaint letter that cites the exact UK consumer law that protects you. We\'ll also start watching the email thread — when the company replies you\'ll get a notification.
+              </p>
+            </div>
+
+            <div className="flex items-center justify-between gap-2 pt-2">
+              <button onClick={() => { setStep('pick'); }} className="text-sm text-slate-600 hover:text-slate-900 px-3 py-2">
+                Back
+              </button>
+              <button
+                onClick={create}
+                disabled={!userContext.trim() || !desiredOutcome.trim() || creating}
+                className="inline-flex items-center gap-1.5 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-white text-sm font-semibold rounded-lg px-4 py-2"
+              >
+                Generate response <ArrowRight className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === 'creating' && (
+          <div className="flex-1 flex flex-col items-center justify-center p-12 text-center">
+            <Loader2 className="h-10 w-10 text-emerald-600 animate-spin mb-4" />
+            <p className="text-sm font-semibold text-slate-900 mb-1">Writing your dispute</p>
+            <p className="text-xs text-slate-500 max-w-xs">Reading the thread, extracting the key facts, and drafting a legally-grounded reply. About 20 seconds.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Bills, debt letters, parking tickets, council notices — most things users want to dispute land in their inbox first. Until today starting a dispute meant retyping what the email already said. New flow: pick the email, add what happened from your side + desired outcome, AI extracts the facts and writes a legally-grounded reply. The thread is then monitored like any other dispute Watchdog link.

## What's in
- **\`GET /api/email/browse-disputable\`** — recent threads from every active Gmail / Outlook connection (last 90 days, optional \`?q\` search). Excludes Gmail Promotions / Updates / Social.
- **\`POST /api/disputes/from-email\`** — orchestrator. Pulls the full thread via the existing \`fetchNewMessages\` helper, calls Claude Haiku to extract \`{ provider_name, account_number, disputed_amount, issue_type, issue_summary, thread_summary }\`, validates against the \`disputes.issue_type\` CHECK constraint, inserts the dispute + a \`dispute_watchdog_links\` row with \`match_source='user_confirmed'\`, backfills correspondence with thread history, then internal-fetches \`/api/complaints/generate\` so the legal-reference injection + anti-hallucination guard run unchanged.
- **\`src/components/dispute/EmailDisputeFinder.tsx\`** — two-step modal (pick → context → submit) with empty-state for users who haven't connected an inbox yet.
- **\`/dashboard/complaints\`** — "+ New" now opens a chooser modal: "From an email" (default highlight, badged **New**) vs "From scratch". Deep links with pre-filled \`company\` / \`type\` / \`alertId\` still skip straight to the existing scratch form so price-alert → dispute flow doesn't regress.

## What ships in this PR
- AI extraction (Haiku for cost) including UK-specific issue type mapping (\`council_tax_band\` reused for council tax + business rates billing, etc.)
- Backfill of past thread messages into \`correspondence\` so the dispute detail page renders a populated thread immediately.
- Reuses the existing reply sync runner — no new cron needed. Replies surface via the unified notification dispatcher (#214).

## Test plan
- [ ] Pro user with a Gmail connection clicks "+ New" → chooser appears; "From an email" picks the green highlighted card
- [ ] Email picker loads recent threads grouped by connection
- [ ] Search filters by sender / subject
- [ ] Pick a parking-ticket email → context form prompts "what's your side / what outcome"
- [ ] Submit → dispute is created in 15-30s with a draft letter populated
- [ ] Dispute detail page shows the original email thread under "Correspondence"
- [ ] Reply from the company arrives → notification fires per the user's notification_preferences
- [ ] User with no email connection sees "Connect inbox" empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)