### PR TITLE
fix(homepage): scale feature demos on iPhone via vw fallback

### DIFF
--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1595,6 +1595,35 @@
   }
 }
 
+/* iOS Safari fallback — same root cause as PR #198 (hero video).
+   Mobile Safari occasionally evaluates `100cqw` to 1px on first paint
+   when a `transform: scale(calc(100cqw / N))` resolves before the
+   container query stabilises, leaving each demo rendered at its
+   native 980px and clipped against the wrapper. Re-state the same
+   transform using `100vw` (which IS reliably available on first
+   paint) so the scale lands correctly. The @media rule comes after
+   the @container rule so the cascade hands it the win. The two
+   subtractions account for the .wrap horizontal padding at each
+   breakpoint (24px each side ≤900, 16px each side ≤560). */
+@media (max-width: 900px) {
+  .m-v2-root .feature-stage > .demo-stage,
+  .m-v2-root .demo-slot > .demo-stage {
+    width: 980px;
+    height: 612.5px;
+    max-width: none;
+    aspect-ratio: auto;
+    margin: 0;
+    transform-origin: top left;
+    transform: scale(calc((100vw - 48px) / 980));
+  }
+}
+@media (max-width: 560px) {
+  .m-v2-root .feature-stage > .demo-stage,
+  .m-v2-root .demo-slot > .demo-stage {
+    transform: scale(calc((100vw - 32px) / 980));
+  }
+}
+
 /* ============================================================
    Section grids — desktop two-column layout for sections that
    are currently unstyled (why-grid, subs-grid, etc.).


### PR DESCRIPTION
## Summary
Founder reports that the **AI Disputes Centre, Pocket Agent, Money Hub, Subscriptions** (and the rest) feature demos on the homepage are still cut off on iPhone — despite PR #198 fixing the hero. Root cause is identical: the per-feature demos use container-query scaling (\`transform: scale(calc(100cqw / 980))\`) which mobile Safari occasionally evaluates to 1 on first paint, leaving each 980×612.5 demo at native size and clipped against its wrapper.

## Fix
Added a \`@media (max-width: 900px)\` (with a tighter \`@media (max-width: 560px)\` for phones) fallback that restates the same transform using \`100vw\`. The @media rule comes after the @container rule in the file, so the cascade always picks the reliable value on iOS Safari.

Subtractions account for the existing \`.wrap\` horizontal padding (48px combined ≤900px, 32px combined ≤560px).

Pure CSS, scoped to the existing \`.feature-stage\` and \`.demo-slot\` wrappers — no JS, no content change.

## Test plan
- [ ] Open paybacker.co.uk in Mobile Safari (iPhone or simulator)
- [ ] Scroll to AI Disputes Centre demo → no horizontal clipping; full demo visible
- [ ] Same check for Pocket Agent, Money Hub, Subscriptions, Export, Deals, MCP demos
- [ ] No regression on desktop / tablet (≥901px) — container query still applies there

🤖 Generated with [Claude Code](https://claude.com/claude-code)