### PR TITLE
feat(disputes): AI overview card + newest-first collapsible timeline

### DIFF
--- a/src/app/api/disputes/[id]/ai-overview/route.ts
+++ b/src/app/api/disputes/[id]/ai-overview/route.ts
@@ -1,0 +1,167 @@
+/**
+ * GET /api/disputes/[id]/ai-overview
+ *
+ * Returns a cached Haiku-generated overview of the dispute for the
+ * detail page header card:
+ *   - summary       : 2-3 sentence "what is this dispute"
+ *   - latest_update : one-sentence note on the most recent activity
+ *   - next_action   : what the user should do right now
+ *   - suggested_steps: 2-3 concrete bullets
+ *
+ * Caching is keyed on the correspondence count — a new message
+ * arriving naturally invalidates the cache and re-runs Haiku next
+ * page load. Force a refresh with ?refresh=1.
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createClient as createAdmin } from '@supabase/supabase-js';
+import Anthropic from '@anthropic-ai/sdk';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+function getAdmin() {
+  return createAdmin(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+interface OverviewPayload {
+  summary: string;
+  latest_update: string;
+  next_action: string;
+  suggested_steps: string[];
+  generated_at: string;
+  correspondence_count: number;
+  cached: boolean;
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = await params;
+  const url = new URL(request.url);
+  const forceRefresh = url.searchParams.get('refresh') === '1';
+
+  const admin = getAdmin();
+  const { data: dispute } = await admin
+    .from('disputes')
+    .select('id, user_id, provider_name, issue_type, issue_summary, desired_outcome, status, created_at, ai_summary, ai_latest_update, ai_next_action, ai_suggested_steps, ai_summary_correspondence_count, ai_summary_at')
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (!dispute) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const { data: correspondence } = await admin
+    .from('correspondence')
+    .select('id, entry_type, direction, content, sender_name, occurred_at, entry_date, title')
+    .eq('dispute_id', id)
+    .order('occurred_at', { ascending: true, nullsFirst: false });
+  const corrs = correspondence ?? [];
+
+  // Cache hit — same number of messages and we already have a summary.
+  if (
+    !forceRefresh
+    && dispute.ai_summary
+    && dispute.ai_summary_correspondence_count === corrs.length
+  ) {
+    const payload: OverviewPayload = {
+      summary: dispute.ai_summary,
+      latest_update: dispute.ai_latest_update ?? '',
+      next_action: dispute.ai_next_action ?? '',
+      suggested_steps: Array.isArray(dispute.ai_suggested_steps) ? dispute.ai_suggested_steps : [],
+      generated_at: dispute.ai_summary_at ?? new Date().toISOString(),
+      correspondence_count: corrs.length,
+      cached: true,
+    };
+    return NextResponse.json(payload);
+  }
+
+  // Build a compact thread digest for the prompt — cap each entry so
+  // we stay within Haiku\'s context budget on long disputes.
+  const lines = corrs.map((c) => {
+    const date = (c.occurred_at || c.entry_date || '').slice(0, 10);
+    const who = c.entry_type === 'ai_letter' ? 'You sent (AI letter)'
+      : c.entry_type === 'user_note' || c.entry_type === 'user_reply' ? `You wrote`
+      : c.entry_type === 'company_email' ? `${c.sender_name ?? 'Company'} replied`
+      : c.entry_type === 'company_response' || c.entry_type === 'company_letter' ? 'Company responded'
+      : c.entry_type === 'phone_call' ? 'Phone call'
+      : c.entry_type;
+    const body = (c.content || '').slice(0, 600);
+    return `[${date}] ${who}${c.title ? ` — ${c.title}` : ''}\n${body}`;
+  }).join('\n\n---\n\n');
+
+  const prompt = `You\'re writing a status update for a UK consumer dispute, addressed to the customer (the person reading this is the customer, not the company).
+
+Provider being disputed: ${dispute.provider_name}
+Type: ${dispute.issue_type}
+What the dispute is about: ${dispute.issue_summary || 'not stated'}
+Desired outcome: ${dispute.desired_outcome || 'not stated'}
+Status: ${dispute.status}
+
+Correspondence so far (oldest → newest):
+${lines || '(no correspondence yet — only the user\'s opening note)'}
+
+Return JSON only with these keys:
+- "summary": 2-3 sentence neutral overview of what this dispute is about and the current state. Plain English.
+- "latest_update": one sentence describing the MOST RECENT activity (e.g. "The company replied on 21 April offering a £50 partial refund", "Your AI letter was sent on 18 April but no reply yet"). If no correspondence beyond the opening note: "No reply yet from ${dispute.provider_name}."
+- "next_action": one short sentence telling the user what to do RIGHT NOW. Start with a verb. Examples: "Reply to their partial-refund offer.", "Wait 14 days then escalate to the ombudsman.", "Send the first complaint letter."
+- "suggested_steps": array of 2-3 concrete bullet-point next steps in plain English. Each ≤ 18 words.
+
+Output JSON only.`;
+
+  let parsed: any;
+  try {
+    const res = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 600,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const text = res.content[0];
+    const raw = text.type === 'text' ? text.text : '{}';
+    const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error('no json');
+    parsed = JSON.parse(match[0]);
+  } catch (err) {
+    return NextResponse.json({ error: `AI overview failed: ${err instanceof Error ? err.message : 'unknown'}` }, { status: 500 });
+  }
+
+  const summary = String(parsed.summary ?? '').trim();
+  const latestUpdate = String(parsed.latest_update ?? '').trim();
+  const nextAction = String(parsed.next_action ?? '').trim();
+  const steps = Array.isArray(parsed.suggested_steps) ? parsed.suggested_steps.map((s: any) => String(s).trim()).filter(Boolean).slice(0, 5) : [];
+
+  await admin
+    .from('disputes')
+    .update({
+      ai_summary: summary,
+      ai_latest_update: latestUpdate,
+      ai_next_action: nextAction,
+      ai_suggested_steps: steps,
+      ai_summary_correspondence_count: corrs.length,
+      ai_summary_at: new Date().toISOString(),
+    })
+    .eq('id', id);
+
+  const payload: OverviewPayload = {
+    summary,
+    latest_update: latestUpdate,
+    next_action: nextAction,
+    suggested_steps: steps,
+    generated_at: new Date().toISOString(),
+    correspondence_count: corrs.length,
+    cached: false,
+  };
+  return NextResponse.json(payload);
+}

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -17,6 +17,7 @@ import { AI_LETTER_DISCLAIMER_HTML } from '@/lib/legal-disclaimer';
 import ShareWinModal from '@/components/share/ShareWinModal';
 import { shouldShowShareModal, hasSharedThisSession } from '@/lib/share-triggers';
 import EmailDisputeFinder from '@/components/dispute/EmailDisputeFinder';
+import DisputeOverviewCard from '@/components/dispute/DisputeOverviewCard';
 import WatchdogCard from '@/components/dispute/WatchdogCard';
 
 // ============================================================
@@ -885,6 +886,10 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
   const [contractUploading, setContractUploading] = useState(false);
   const [justExtracted, setJustExtracted] = useState(false);
   const [providerInfo, setProviderInfo] = useState<any>(null);
+  // Collapse all but the most recent timeline entry by default so
+  // long disputes are skimmable. User taps "Show full history" to
+  // unfurl the rest.
+  const [showFullHistory, setShowFullHistory] = useState(false);
 
   const fetchDispute = async () => {
     try {
@@ -1184,6 +1189,11 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
         </div>
       </div>
 
+      {/* AI overview — summary + latest update + next action.
+          Renders above the progress tracker so the user knows where
+          they stand before touching anything else. */}
+      <DisputeOverviewCard disputeId={dispute.id} />
+
       {/* Progress Tracker */}
       <DisputeProgressTracker dispute={dispute} providerInfo={providerInfo} />
 
@@ -1298,8 +1308,21 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
           </div>
         ) : (
           <>
+          {(() => {
+            // Newest at the top — overrides the API\'s ASC sort so the
+            // page reads top-to-bottom from "what happened most recently"
+            // backwards through history. Collapsed by default past the
+            // first entry; "Show full history" expands the rest.
+            const orderedAll = [...(dispute.correspondence ?? [])].sort(
+              (a, b) => new Date((b.entry_date as any) || (b as any).occurred_at || 0).getTime()
+                       - new Date((a.entry_date as any) || (a as any).occurred_at || 0).getTime(),
+            );
+            const HEAD = 1;
+            const visible = (orderedAll.length > HEAD && !showFullHistory) ? orderedAll.slice(0, HEAD) : orderedAll;
+            const hidden = Math.max(0, orderedAll.length - visible.length);
+            return (
           <div className="space-y-4">
-            {dispute.correspondence?.map((entry, index) => {
+            {visible.map((entry, index) => {
               const config = ENTRY_TYPE_CONFIG[entry.entry_type] || ENTRY_TYPE_CONFIG.user_note;
               const Icon = config.icon;
               const isAiLetter = entry.entry_type === 'ai_letter';
@@ -1478,7 +1501,25 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                 </div>
               );
             })}
+            {hidden > 0 && (
+              <button
+                onClick={() => setShowFullHistory(true)}
+                className="w-full text-center py-3 px-4 rounded-xl border border-dashed border-slate-300 hover:border-emerald-400 hover:bg-emerald-50/40 text-sm font-medium text-slate-600 hover:text-emerald-700 transition-all"
+              >
+                Show full history ({hidden} earlier {hidden === 1 ? 'entry' : 'entries'})
+              </button>
+            )}
+            {showFullHistory && orderedAll.length > HEAD && (
+              <button
+                onClick={() => setShowFullHistory(false)}
+                className="w-full text-center py-2 px-4 text-xs font-medium text-slate-500 hover:text-slate-900"
+              >
+                Collapse history
+              </button>
+            )}
           </div>
+            );
+          })()}
 
           {/* Action buttons at bottom of thread */}
           {!isResolved(dispute.status) && (

--- a/src/components/dispute/DisputeOverviewCard.tsx
+++ b/src/components/dispute/DisputeOverviewCard.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+/**
+ * Dispute detail page header card.
+ *
+ * Renders three things at the very top so the user knows where they
+ * stand without scrolling through 12 letters:
+ *   1. Plain-English summary of the dispute
+ *   2. Most-recent update (one sentence)
+ *   3. What to do right now + 2-3 suggested next steps
+ *
+ * Backed by `/api/disputes/[id]/ai-overview` — Haiku-cached on the
+ * disputes row, keyed on correspondence count, so subsequent loads
+ * are instant and a new reply naturally invalidates the cache.
+ */
+
+import { useEffect, useState } from 'react';
+import { Sparkles, RefreshCw, Loader2, ArrowRight, AlertCircle, Bell } from 'lucide-react';
+
+interface OverviewPayload {
+  summary: string;
+  latest_update: string;
+  next_action: string;
+  suggested_steps: string[];
+  generated_at: string;
+  correspondence_count: number;
+  cached: boolean;
+}
+
+export default function DisputeOverviewCard({ disputeId }: { disputeId: string }) {
+  const [data, setData] = useState<OverviewPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async (force = false) => {
+    if (force) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      const url = `/api/disputes/${disputeId}/ai-overview${force ? '?refresh=1' : ''}`;
+      const res = await fetch(url, { credentials: 'include', cache: 'no-store' });
+      const d = await res.json();
+      if (!res.ok) throw new Error(d.error || 'Failed to load');
+      setData(d as OverviewPayload);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => { void load(false); }, [disputeId]);
+
+  if (loading && !data) {
+    return (
+      <div className="bg-gradient-to-br from-emerald-50 to-blue-50 border border-emerald-200 rounded-2xl p-5 mb-4">
+        <div className="flex items-center gap-2 text-sm text-emerald-700">
+          <Loader2 className="h-4 w-4 animate-spin" /> Reading the thread for you…
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 mb-4 flex items-start gap-2">
+        <AlertCircle className="h-4 w-4 text-amber-600 flex-shrink-0 mt-0.5" />
+        <div>
+          <p className="text-sm font-medium text-amber-900">Couldn\'t generate overview</p>
+          <button onClick={() => load(true)} className="text-xs text-amber-700 underline hover:text-amber-900">
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="bg-gradient-to-br from-emerald-50 to-blue-50 border border-emerald-200 rounded-2xl p-5 mb-4">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-emerald-700" />
+          <h3 className="text-sm font-semibold text-emerald-900">Where this dispute stands</h3>
+        </div>
+        <button
+          onClick={() => load(true)}
+          disabled={refreshing}
+          className="text-xs text-emerald-700 hover:text-emerald-900 inline-flex items-center gap-1 disabled:opacity-50"
+          title="Re-run AI overview"
+        >
+          <RefreshCw className={`h-3 w-3 ${refreshing ? 'animate-spin' : ''}`} />
+          {refreshing ? 'Updating' : 'Refresh'}
+        </button>
+      </div>
+
+      <p className="text-sm text-slate-800 leading-relaxed mb-4">{data.summary}</p>
+
+      {data.latest_update && (
+        <div className="bg-white/80 border border-emerald-200 rounded-xl p-3 mb-3">
+          <p className="text-[10px] uppercase tracking-wider text-emerald-700 font-semibold mb-1 flex items-center gap-1">
+            <Bell className="h-3 w-3" /> Latest update
+          </p>
+          <p className="text-sm text-slate-900">{data.latest_update}</p>
+        </div>
+      )}
+
+      {data.next_action && (
+        <div className="bg-emerald-600 text-white rounded-xl p-3 mb-2">
+          <p className="text-[10px] uppercase tracking-wider text-emerald-100 font-semibold mb-1 flex items-center gap-1">
+            <ArrowRight className="h-3 w-3" /> Do this next
+          </p>
+          <p className="text-sm font-semibold">{data.next_action}</p>
+        </div>
+      )}
+
+      {data.suggested_steps.length > 0 && (
+        <ul className="text-xs text-slate-700 space-y-1 mt-3">
+          {data.suggested_steps.map((s, i) => (
+            <li key={i} className="flex items-start gap-2">
+              <span className="text-emerald-700 font-bold mt-0.5">{i + 1}.</span>
+              <span>{s}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260424010000_dispute_ai_overview.sql
+++ b/supabase/migrations/20260424010000_dispute_ai_overview.sql
@@ -1,0 +1,15 @@
+-- Cached AI overview for the dispute detail page.
+--
+-- The dispute timeline gets unreadable fast — by message 4 or 5 the
+-- user has no quick way to see "where am I, what should I do next?".
+-- We cache a small Haiku-generated overview keyed on the
+-- correspondence count so we don\'t re-run on every page load, but
+-- naturally invalidate when a new message lands.
+
+ALTER TABLE public.disputes
+  ADD COLUMN IF NOT EXISTS ai_summary text,
+  ADD COLUMN IF NOT EXISTS ai_latest_update text,
+  ADD COLUMN IF NOT EXISTS ai_next_action text,
+  ADD COLUMN IF NOT EXISTS ai_suggested_steps jsonb,
+  ADD COLUMN IF NOT EXISTS ai_summary_correspondence_count integer,
+  ADD COLUMN IF NOT EXISTS ai_summary_at timestamptz;


### PR DESCRIPTION
## Summary
The dispute detail page becomes unreadable past 2-3 messages. The "Waiting for reply" header also just echoed the user's original opening note instead of the actual latest activity. This PR adds a Haiku-cached overview card at the very top + collapses the timeline so the page is skimmable.

## What's new

### Top-of-page overview card
Three pieces of information the user wants immediately:
- **Where this dispute stands** — 2-3 sentence plain-English summary
- **Latest update** — one-sentence note on the most recent activity (e.g. "The company replied on 21 April with a £50 partial-refund offer")
- **Do this next** — green action card with the immediate next move + 2-3 suggested concrete steps

### Timeline rework
- Sorted **newest-at-the-top** client-side (API contract unchanged so letter-generation order is preserved)
- Past the first entry, hidden behind a **"Show full history (N earlier entries)"** pill — long disputes are now skimmable
- Collapse button reverts to head-only view

## Caching
Migration adds 6 columns to the \`disputes\` table for caching the Haiku output. Cache key is the correspondence count, so a new reply automatically invalidates the cache. Manual \`?refresh=1\` available for the refresh button.

## Test plan
- [ ] Open any dispute with ≥2 correspondence entries → green overview card renders within ~5s
- [ ] Reading the card top-to-bottom answers "what's this about, what just happened, what should I do"
- [ ] Timeline shows only the newest entry by default; "Show full history" reveals the rest
- [ ] Click refresh → AI re-runs even if the correspondence count hasn't changed
- [ ] Open a brand-new dispute (only the opening note) → next_action says "Send the first complaint letter" or similar

🤖 Generated with [Claude Code](https://claude.com/claude-code)