### PR TITLE
feat(watchdog): sync auto-responses from same domain (relevance-filtered)

### DIFF
--- a/src/lib/dispute-sync/fetchers.ts
+++ b/src/lib/dispute-sync/fetchers.ts
@@ -358,3 +358,118 @@ export async function fetchNewMessages(
     .filter((m) => m.fromAddress && m.fromAddress.toLowerCase() !== ownAddr)
     .sort((a, b) => a.receivedAt.getTime() - b.receivedAt.getTime());
 }
+
+/**
+ * Fetch recent messages from a sender domain that ARE NOT in the currently-
+ * linked thread. Catches auto-responses and follow-up replies that suppliers
+ * send from a different address on the same domain
+ * (e.g. an `autoresponse@aciuk.uk` ack after you wrote to `customer@aciuk.uk`)
+ * which Gmail / Outlook treat as a brand-new thread.
+ *
+ * Returns messages in oldest → newest order. Caller is responsible for
+ * deduping against already-imported correspondence via supplier_message_id.
+ */
+export async function fetchDomainMessages(
+  conn: EmailConnection,
+  senderDomain: string,
+  since: Date | null,
+  excludeThreadId: string,
+): Promise<FetchedMessage[]> {
+  if (!senderDomain) return [];
+  const provider = providerFromConnection(conn);
+  const ownAddr = conn.email_address.toLowerCase().trim();
+
+  if (provider === 'gmail') {
+    const token = await ensureFreshToken(conn, 'gmail');
+    const afterTs = since ? `after:${Math.floor(since.getTime() / 1000)}` : 'newer_than:90d';
+    const q = `from:@${senderDomain} ${afterTs}`;
+    const listUrl = new URL('https://gmail.googleapis.com/gmail/v1/users/me/messages');
+    listUrl.searchParams.set('q', q);
+    listUrl.searchParams.set('maxResults', '20');
+    const listRes = await fetch(listUrl.toString(), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!listRes.ok) return [];
+    const list = await listRes.json();
+    const out: FetchedMessage[] = [];
+    for (const m of (list.messages ?? []) as Array<{ id: string; threadId: string }>) {
+      if (m.threadId === excludeThreadId) continue; // already covered by thread sync
+      const detailRes = await fetch(
+        `https://gmail.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=full`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      if (!detailRes.ok) continue;
+      const msg = await detailRes.json();
+      const headers: { name: string; value: string }[] = msg.payload?.headers ?? [];
+      const get = (h: string) =>
+        headers.find((x) => x.name.toLowerCase() === h.toLowerCase())?.value ?? '';
+      const from = parseFrom(get('From'));
+      if (!from.address || from.address.toLowerCase() === ownAddr) continue;
+      const body = extractGmailBody(msg.payload);
+      out.push({
+        messageId: msg.id,
+        threadId: msg.threadId,
+        subject: get('Subject'),
+        fromRaw: get('From'),
+        fromAddress: from.address,
+        fromName: from.name,
+        fromDomain: from.domain,
+        receivedAt: new Date(Number(msg.internalDate)),
+        snippet: makeSnippet(body || msg.snippet || ''),
+        body,
+      });
+    }
+    return out.sort((a, b) => a.receivedAt.getTime() - b.receivedAt.getTime());
+  }
+
+  if (provider === 'outlook') {
+    const token = await ensureFreshToken(conn, 'outlook');
+    const sinceIso = (since ?? new Date(Date.now() - 90 * 86400_000)).toISOString();
+    const url = new URL('https://graph.microsoft.com/v1.0/me/messages');
+    // Graph doesn't expose `from:@domain` in $filter, but it does in $search
+    // — which scans headers. We then exclude the current thread client-side.
+    url.searchParams.set('$search', `"from:${senderDomain}"`);
+    url.searchParams.set('$top', '20');
+    url.searchParams.set(
+      '$select',
+      'id,conversationId,subject,from,receivedDateTime,bodyPreview,body',
+    );
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    const out: FetchedMessage[] = [];
+    for (const m of (data.value ?? []) as GraphMessage[]) {
+      if (m.conversationId === excludeThreadId) continue;
+      const received = new Date(m.receivedDateTime);
+      if (received < new Date(sinceIso)) continue;
+      const raw = m.from?.emailAddress?.address ?? '';
+      if (!raw || raw.toLowerCase() === ownAddr) continue;
+      const name = m.from?.emailAddress?.name ?? '';
+      const fromRaw = name ? `${name} <${raw}>` : raw;
+      const parsed = parseFrom(fromRaw);
+      if (!parsed.domain.toLowerCase().endsWith(senderDomain.toLowerCase())) continue;
+      const bodyText =
+        m.body?.contentType === 'html'
+          ? stripHtml(m.body.content ?? '')
+          : (m.body?.content ?? '').trim();
+      out.push({
+        messageId: m.id,
+        threadId: m.conversationId ?? '',
+        subject: m.subject ?? '',
+        fromRaw,
+        fromAddress: parsed.address,
+        fromName: parsed.name,
+        fromDomain: parsed.domain,
+        receivedAt: received,
+        snippet: makeSnippet(bodyText || m.bodyPreview || ''),
+        body: bodyText.slice(0, 8000),
+      });
+    }
+    return out.sort((a, b) => a.receivedAt.getTime() - b.receivedAt.getTime());
+  }
+
+  // IMAP domain-scan not implemented yet — uncommon on Watchdog right now.
+  return [];
+}

--- a/src/lib/dispute-sync/sync-runner.ts
+++ b/src/lib/dispute-sync/sync-runner.ts
@@ -16,7 +16,7 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { fetchNewMessages } from './fetchers';
+import { fetchNewMessages, fetchDomainMessages } from './fetchers';
 import type { EmailConnection } from './types';
 import {
   classifyReply,
@@ -38,6 +38,88 @@ export interface SyncResult {
   disputeId: string;
   imported: number;
   error?: string;
+}
+
+// Subject patterns that strongly indicate the message is an auto-reply
+// / acknowledgement of a complaint — these fire even when the subject
+// doesn't mention the original thread.
+const AUTO_REPLY_PATTERNS = [
+  /\bauto[- ]?reply\b/i,
+  /\bout of office\b/i,
+  /\bwe(?:'ve| have) received\b/i,
+  /\bthanks? for (?:contacting|getting in touch|your email)\b/i,
+  /\byour (?:case|ticket|reference|complaint|message|enquiry)\b/i,
+  /\backnowledg(?:e|ment|ement)\b/i,
+  /\breceipt of\b/i,
+  /\bconfirm(?:ation|ing) receipt\b/i,
+];
+
+/**
+ * Decide whether a domain-matched message (not from the originally linked
+ * thread) belongs on THIS dispute's timeline. Prevents a separate ACI
+ * thread about an unrelated invoice from polluting the user's current
+ * dispute context.
+ *
+ * Import only if at least one of:
+ *   1. Subject contains a strong auto-reply / acknowledgement pattern
+ *   2. Subject or body mentions the dispute's account_number / ref
+ *   3. Received within 7 days of the dispute's most recent correspondence
+ *      AND (subject echoes some keyword from the dispute's subject, OR
+ *      the sender looks like an auto-reply mailbox: starts with
+ *      autoresponse / noreply / no-reply / donotreply / reply / support)
+ */
+function isDomainMessageRelevant(
+  msg: { subject: string; body: string; fromAddress: string; receivedAt: Date },
+  dispute: {
+    issue_summary?: string | null;
+    account_number?: string | null;
+    thread_subject?: string | null;
+    latest_activity_at?: Date | null;
+  },
+): { relevant: boolean; reason: string } {
+  const subject = (msg.subject || '').trim();
+  const body = (msg.body || '').trim();
+  const haystack = `${subject}\n${body}`;
+
+  // 1. Auto-reply patterns
+  for (const re of AUTO_REPLY_PATTERNS) {
+    if (re.test(subject)) return { relevant: true, reason: 'auto-reply subject' };
+  }
+
+  // 2. Account / reference number match (highest signal)
+  if (dispute.account_number) {
+    const acct = dispute.account_number.trim();
+    if (acct.length >= 4 && haystack.toLowerCase().includes(acct.toLowerCase())) {
+      return { relevant: true, reason: 'account number match' };
+    }
+  }
+
+  // 3. Time-and-subject-similarity match. Only trust sender-hint senders
+  // (autoresponse@, noreply@ etc.) when the message landed in the window.
+  const localPart = msg.fromAddress.split('@')[0]?.toLowerCase() ?? '';
+  const senderLooksAutomated = /^(autoresponse|noreply|no-reply|donotreply|reply|support|customer|help|complaints?)(?:$|[.+-])/.test(localPart);
+
+  const latest = dispute.latest_activity_at ?? null;
+  const withinWindow = latest
+    ? Math.abs(msg.receivedAt.getTime() - latest.getTime()) <= 7 * 86400_000
+    : false;
+
+  if (withinWindow && senderLooksAutomated) {
+    const originalSubj = (dispute.thread_subject || dispute.issue_summary || '').toLowerCase();
+    if (originalSubj) {
+      // Share any 4+ char keyword from the original subject
+      const tokens = originalSubj
+        .split(/\W+/)
+        .filter((t) => t.length >= 4 && !['this', 'that', 'with', 'your', 'from', 'have', 'been'].includes(t));
+      for (const t of tokens) {
+        if (subject.toLowerCase().includes(t)) {
+          return { relevant: true, reason: `within window; matches "${t}"` };
+        }
+      }
+    }
+  }
+
+  return { relevant: false, reason: 'not clearly related to this dispute' };
 }
 
 /**
@@ -89,6 +171,63 @@ export async function syncLinkedThread(
     // Still bump last_synced_at a little so we don't loop fast on persistent errors
     return { linkId, disputeId: link.dispute_id, imported: 0, error: message };
   }
+
+  // Second pass — scan for auto-responses / acknowledgements that the
+  // supplier sent from a different address on the same domain. Gmail /
+  // Outlook surface these as brand-new threads, so the thread-scoped
+  // sync above would never see them. Relevance filter below prevents
+  // unrelated threads from the same domain polluting this dispute.
+  let domainMessages: Awaited<ReturnType<typeof fetchDomainMessages>> = [];
+  if (link.sender_domain) {
+    try {
+      // On initial link we import the full thread history already, so
+      // a full-history domain scan would duplicate. Anchor on the link
+      // creation time when no prior sync ran.
+      const domainSince = since ?? new Date(new Date(link.created_at ?? Date.now()).getTime() - 7 * 86400_000);
+      domainMessages = await fetchDomainMessages(conn, link.sender_domain, domainSince, link.thread_id);
+    } catch (err) {
+      console.warn(`[watchdog] domain scan failed for link ${linkId}:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  // Resolve dispute context for the relevance filter — account_number
+  // is the strongest signal we have.
+  let disputeForRelevance: { issue_summary?: string | null; account_number?: string | null; thread_subject?: string | null; latest_activity_at?: Date | null } = {
+    thread_subject: link.subject ?? null,
+  };
+  try {
+    const { data: d } = await db
+      .from('disputes')
+      .select('issue_summary, account_number, last_reply_received_at, updated_at')
+      .eq('id', link.dispute_id)
+      .maybeSingle();
+    if (d) {
+      disputeForRelevance = {
+        issue_summary: d.issue_summary,
+        account_number: d.account_number,
+        thread_subject: link.subject ?? null,
+        latest_activity_at: d.last_reply_received_at ? new Date(d.last_reply_received_at) : d.updated_at ? new Date(d.updated_at) : null,
+      };
+    }
+  } catch {
+    // Fall through with defaults.
+  }
+
+  // Filter + merge. Messages we can confidently attribute get appended
+  // to the same import loop as thread messages so the classifier and
+  // notification path run identically.
+  for (const m of domainMessages) {
+    const verdict = isDomainMessageRelevant(
+      { subject: m.subject, body: m.body, fromAddress: m.fromAddress, receivedAt: m.receivedAt },
+      disputeForRelevance,
+    );
+    if (!verdict.relevant) {
+      console.log(`[watchdog] skipped domain message ${m.messageId}: ${verdict.reason}`);
+      continue;
+    }
+    messages.push(m);
+  }
+  messages.sort((a, b) => a.receivedAt.getTime() - b.receivedAt.getTime());
 
   const disputeRow = link.disputes as {
     provider_name?: string;


### PR DESCRIPTION
## Summary
Suppliers often send the acknowledgement / auto-reply from a **different address on the same domain** — e.g. \`autoresponse@aciuk.uk\` after you wrote to \`customer@aciuk.uk\`. Gmail and Outlook treat those as brand-new threads, so the thread-scoped Watchdog sync never sees them. Founder flagged this after an ACI ack failed to import.

## How it works
- **\`fetchDomainMessages\`** in \`fetchers.ts\` — new helper that pulls recent messages from the linked thread's sender domain, excluding the original thread's id. Works for Gmail (\`from:@domain\` query) and Outlook (\`$search\` on \`from:domain\` + post-filter on the returned domain).
- **\`syncLinkedThread\`** runs it as a second pass after the existing thread sync, merges + resorts the message list, and runs each candidate through the **relevance filter** before import.

## Relevance filter — "only pull what's actually this dispute"
Founder flagged in follow-up that we must not pollute the dispute with unrelated threads from the same sender. Message must satisfy ≥1 of:
1. **Strong auto-reply subject pattern** — \`auto-reply\`, \`out of office\`, \`we've received\`, \`thanks for contacting\`, \`your case/ticket/reference/complaint/message/enquiry\`, \`acknowledgement\`, \`receipt of\`, \`confirming receipt\`.
2. **Account / reference number match** — dispute's \`account_number\` appears in subject or body (≥4 chars).
3. **Time-and-subject-similarity** — received within 7 days of the dispute's latest activity, AND sender looks automated (\`autoresponse@\` / \`noreply@\` / \`donotreply@\` / \`support@\` / \`customer@\` / \`complaints@\` etc.), AND subject shares a 4+ char keyword with the original thread subject.

Messages that fail every check are logged + skipped, never imported. Relevant imports get the same classifier + notification treatment as direct thread replies, so the dispute timeline + AI overview stay coherent.

## Test plan
- [ ] ACI dispute linked to the customer thread → "Check for replies now" → the \`autoresponse@aciuk.uk\` ack now imports
- [ ] Unrelated ACI thread (different account, different week) from the same domain → stays OUT of this dispute
- [ ] User's own outbound mail on the domain → excluded (existing \`fromAddress !== ownAddr\` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)