### PR TITLE
fix(watchdog): derive supplier domain from non-user messages

### DIFF
--- a/src/app/api/disputes/from-email/route.ts
+++ b/src/app/api/disputes/from-email/route.ts
@@ -224,8 +224,20 @@ export async function POST(request: Request) {
   }
 
   // 5. Link the email thread for ongoing Watchdog monitoring + import history.
+  //
+  // Pick the SUPPLIER side of the conversation. fetchNewMessages already
+  // strips user-own messages, so walking backwards here picks the most
+  // recent supplier sender. If every message is from the user (outbound-
+  // only thread, e.g. they only just sent the complaint), fall back to the
+  // user\'s own address so we at least store something non-null — a
+  // follow-up sync will replace this once the supplier replies.
+  let supplierMsg = [...messages].reverse().find((m) => {
+    const addr = (m.fromAddress ?? '').toLowerCase();
+    return addr && addr !== (conn.email_address ?? '').toLowerCase();
+  });
+  if (!supplierMsg) supplierMsg = messages[messages.length - 1];
+  const senderDomain = (supplierMsg.fromAddress.split('@')[1] || '').toLowerCase();
   const lastMsg = messages[messages.length - 1];
-  const senderDomain = (lastMsg.fromAddress.split('@')[1] || '').toLowerCase();
   const { data: link, error: linkErr } = await admin
     .from('dispute_watchdog_links')
     .insert({
@@ -236,7 +248,7 @@ export async function POST(request: Request) {
       thread_id: threadId,
       subject: lastMsg.subject,
       sender_domain: senderDomain,
-      sender_address: lastMsg.fromAddress.toLowerCase(),
+      sender_address: supplierMsg.fromAddress.toLowerCase(),
       sync_enabled: true,
       match_source: 'user_confirmed',
       match_confidence: 1.0,

--- a/src/app/api/email/browse-disputable/route.ts
+++ b/src/app/api/email/browse-disputable/route.ts
@@ -78,22 +78,52 @@ async function listGmailRecent(conn: any, q: string, days: number, includeAll: b
   const list = await res.json();
   if (!list.threads?.length) return [];
 
+  const ownAddr = (conn.email_address ?? '').toLowerCase().trim();
   const out: BrowsedThread[] = [];
   for (const t of list.threads as Array<{ id: string }>) {
     const detail = await fetch(
-      `https://gmail.googleapis.com/gmail/v1/users/me/threads/${t.id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`,
+      `https://gmail.googleapis.com/gmail/v1/users/me/threads/${t.id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date&metadataHeaders=To`,
       { headers: { Authorization: `Bearer ${token}` } },
     );
     if (!detail.ok) continue;
     const thr = await detail.json();
     const msgs = thr.messages ?? [];
     if (msgs.length === 0) continue;
+
+    // Identify the "supplier" side of the thread by walking backwards
+    // from the most recent message until we find one NOT sent by the
+    // user. If every message is from the user (e.g. a complaint
+    // letter that hasn\'t been replied to yet) we fall back to the
+    // last message\'s To: address so domain-scan later still has a
+    // valid supplier domain to search on.
+    let supplierMsg: any = null;
+    let fallbackTo: string | null = null;
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i];
+      const hdrs = (m.payload?.headers ?? []) as Array<{ name: string; value: string }>;
+      const readH = (n: string) => hdrs.find((x) => x.name.toLowerCase() === n.toLowerCase())?.value ?? '';
+      const fStr = readH('From');
+      const fAddr = fStr.match(/[\w.+-]+@[\w-]+(?:\.[\w-]+)+/)?.[0]?.toLowerCase() ?? '';
+      if (fAddr && fAddr !== ownAddr) { supplierMsg = m; break; }
+      if (!fallbackTo) {
+        const toStr = readH('To');
+        fallbackTo = toStr.match(/[\w.+-]+@[\w-]+(?:\.[\w-]+)+/)?.[0]?.toLowerCase() ?? null;
+      }
+    }
+    const rep = supplierMsg ?? msgs[msgs.length - 1];
+    const repHdrs = (rep.payload?.headers ?? []) as Array<{ name: string; value: string }>;
+    const h = (n: string) => repHdrs.find((x) => x.name.toLowerCase() === n.toLowerCase())?.value ?? '';
     const last = msgs[msgs.length - 1];
-    const headers = (last.payload?.headers ?? []) as Array<{ name: string; value: string }>;
-    const h = (n: string) => headers.find((x) => x.name.toLowerCase() === n.toLowerCase())?.value ?? '';
     const fromStr = h('From');
-    const fromAddr = fromStr.match(/[\w.+-]+@[\w-]+(?:\.[\w-]+)+/)?.[0]?.toLowerCase() ?? '';
-    const fromName = (fromStr.split('<')[0] || '').replace(/"/g, '').trim() || fromAddr;
+    let fromAddr = fromStr.match(/[\w.+-]+@[\w-]+(?:\.[\w-]+)+/)?.[0]?.toLowerCase() ?? '';
+    let fromName = (fromStr.split('<')[0] || '').replace(/"/g, '').trim() || fromAddr;
+    if (!supplierMsg && fallbackTo && fallbackTo !== ownAddr) {
+      // Thread is entirely outbound; surface the recipient domain
+      // so the Watchdog link ends up with the supplier domain
+      // instead of the user\'s own.
+      fromAddr = fallbackTo;
+      fromName = fallbackTo;
+    }
     out.push({
       connectionId: conn.id,
       emailAddress: conn.email_address,


### PR DESCRIPTION
## Summary
Relinking a thread where the user\'s own reply was the most recent message stored \`sender_domain='<user own domain>'\` on the Watchdog link. The domain-scan pass from #232 then searched for messages from the user\'s own domain — finding nothing but their outbound mail.

Manifested in practice for an ACI dispute: link showed \`sender_domain='airproperty.co.uk'\`, so "Check for replies" never imported the \`autoresponse@aciuk.uk\` ack that had actually landed.

## Fix
- **browse-disputable (Gmail)** walks backwards through thread messages to pick the most recent non-user sender for \`senderAddress\` / \`senderDomain\`. If the thread is entirely outbound, falls back to the To: header of the latest message so the link still carries a valid supplier domain.
- **from-email** applies the same "walk for supplier" logic at link-creation time. \`sender_address\` + \`sender_domain\` on the new \`dispute_watchdog_links\` row now track the supplier side.

The existing ACI link was patched via SQL (\`sender_domain='aciuk.uk'\`, \`last_synced_at = created_at - 7 days\`) so the founder\'s next "Check for replies" imports the auto-response that already arrived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)