### PR TITLE
fix(disputes): clean email body + auto-reply badge + skip noisy backfill notifications

### DIFF
--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -19,6 +19,7 @@ import { shouldShowShareModal, hasSharedThisSession } from '@/lib/share-triggers
 import EmailDisputeFinder from '@/components/dispute/EmailDisputeFinder';
 import DisputeOverviewCard from '@/components/dispute/DisputeOverviewCard';
 import EditDisputeDetailsModal from '@/components/dispute/EditDisputeDetailsModal';
+import EmailCorrespondenceBody from '@/components/dispute/EmailCorrespondenceBody';
 import WatchdogCard from '@/components/dispute/WatchdogCard';
 
 // ============================================================
@@ -92,7 +93,12 @@ interface Correspondence {
   escalation_path?: string;
   detected_from_email?: boolean;
   sender_address?: string | null;
+  sender_name?: string | null;
   email_thread_id?: string | null;
+  ai_category?: string | null;
+  ai_respond_needed?: boolean | null;
+  ai_urgency?: string | null;
+  ai_rationale?: string | null;
 }
 
 // ============================================================
@@ -1385,6 +1391,20 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                           Auto-imported
                         </span>
                       )}
+                      {/* Classifier-driven badge so auto-replies and acks
+                          don\'t masquerade as substantive replies that need
+                          action. `ai_respond_needed === false` = holding/ack;
+                          true = real response the user should answer. */}
+                      {isFromCompany && entry.ai_respond_needed === false && (
+                        <span className="text-[10px] bg-slate-100 text-slate-600 border border-slate-300 px-1.5 py-0.5 rounded-full font-medium uppercase tracking-wide" title={entry.ai_rationale ?? undefined}>
+                          Auto-reply · no action
+                        </span>
+                      )}
+                      {isFromCompany && entry.ai_respond_needed === true && (
+                        <span className="text-[10px] bg-amber-100 text-amber-700 border border-amber-300 px-1.5 py-0.5 rounded-full font-medium uppercase tracking-wide" title={entry.ai_rationale ?? undefined}>
+                          Action needed
+                        </span>
+                      )}
                     </div>
                     <div className="flex items-center gap-2">
                       <span className="text-slate-600 text-xs flex items-center gap-1">
@@ -1503,6 +1523,8 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                         </div>
                       )}
                     </>
+                  ) : isFromCompany ? (
+                    <EmailCorrespondenceBody content={entry.content} />
                   ) : (
                     <p className="text-sm text-slate-600 whitespace-pre-wrap">{entry.content}</p>
                   )}

--- a/src/components/dispute/EmailCorrespondenceBody.tsx
+++ b/src/components/dispute/EmailCorrespondenceBody.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * Renders the body of an imported supplier email with sensible
+ * whitespace cleanup + a collapse/expand toggle for long messages.
+ *
+ * Why this exists: Gmail / Outlook bodies stripped to plain text
+ * (see stripHtml in src/lib/dispute-sync/fetchers.ts) end up riddled
+ * with runs of blank lines, tracking-pixel placeholders and
+ * unsubscribe footers that make the dispute timeline unreadable.
+ * This component normalises the text on the fly so older imported
+ * messages benefit too — no DB backfill needed.
+ */
+
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+const SIGNATURE_CUT_PATTERNS = [
+  /^-{2,}\s*$/,
+  /^_{2,}\s*$/,
+  /^unsubscribe\b/i,
+  /^this email was sent to\b/i,
+  /^this message was sent to\b/i,
+  /^manage preferences\b/i,
+  /^notice of confidentiality\b/i,
+  /^disclaimer\b/i,
+  /^if you (?:no longer )?wish (?:to receive|not)\b/i,
+  /^to stop receiving\b/i,
+  /^you (?:are|have been) receiving this\b/i,
+  /^please do not reply\b/i,
+  /^sent from my (?:iphone|ipad|android)\b/i,
+  /^©/,
+  /^copyright\s+©?\s*\d{4}/i,
+];
+
+function cleanEmailBody(raw: string): string {
+  if (!raw) return '';
+  let text = raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  // Drop zero-width + unusual whitespace Gmail leaves behind.
+  text = text.replace(/[​-‍﻿]/g, '');
+  // Collapse non-breaking spaces — they survive stripHtml + cause wide gaps.
+  text = text.replace(/ /g, ' ');
+
+  const lines = text.split('\n');
+  const cleaned: string[] = [];
+  let cutReached = false;
+  for (const rawLine of lines) {
+    if (cutReached) break;
+    const line = rawLine.replace(/\t+/g, ' ').replace(/ {2,}/g, ' ').trim();
+    // Tracking-pixel remnants the HTML strip leaves behind.
+    if (/^\s*\[?\s*(image|logo|banner|tracking|pixel)\s*\]?\s*$/i.test(line)) continue;
+    // Footer / signature start — stop there; anything below is noise.
+    if (SIGNATURE_CUT_PATTERNS.some((re) => re.test(line))) { cutReached = true; break; }
+    cleaned.push(line);
+  }
+
+  // Collapse runs of blank lines down to a single blank.
+  const collapsed: string[] = [];
+  let blank = 0;
+  for (const l of cleaned) {
+    if (l === '') {
+      blank++;
+      if (blank === 1) collapsed.push('');
+    } else {
+      blank = 0;
+      collapsed.push(l);
+    }
+  }
+
+  // Trim leading + trailing blank lines.
+  while (collapsed.length && collapsed[0] === '') collapsed.shift();
+  while (collapsed.length && collapsed[collapsed.length - 1] === '') collapsed.pop();
+
+  return collapsed.join('\n');
+}
+
+function firstNLines(text: string, n: number): { head: string; hasMore: boolean } {
+  const lines = text.split('\n');
+  if (lines.length <= n) return { head: text, hasMore: false };
+  return { head: lines.slice(0, n).join('\n'), hasMore: true };
+}
+
+export default function EmailCorrespondenceBody({ content }: { content: string }) {
+  const cleaned = useMemo(() => cleanEmailBody(content), [content]);
+  const [expanded, setExpanded] = useState(false);
+  const { head, hasMore } = firstNLines(cleaned, 8);
+  const display = expanded || !hasMore ? cleaned : head;
+
+  return (
+    <div>
+      <p className="text-sm text-slate-700 whitespace-pre-wrap leading-relaxed break-words">
+        {display}
+      </p>
+      {hasMore && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
+          className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700 hover:text-emerald-900 mt-2"
+        >
+          {expanded ? (
+            <><ChevronUp className="h-3 w-3" /> Show less</>
+          ) : (
+            <><ChevronDown className="h-3 w-3" /> Show full email</>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/dispute-sync/sync-runner.ts
+++ b/src/lib/dispute-sync/sync-runner.ts
@@ -334,7 +334,17 @@ export async function syncLinkedThread(
       );
     }
 
-    if (options.sendNotifications !== false) {
+    // Don\'t alert on historical / backfill imports. When the user
+    // links a thread we pull past messages in for context, and the
+    // domain-scan pass can also turn up messages that pre-date the
+    // link. Notifying on those is noise (the user already knows
+    // about the 3-week-old default notice they were trying to
+    // dispute). Only alert on messages that arrived AFTER the
+    // Watchdog link existed.
+    const linkCreatedAt = link.created_at ? new Date(link.created_at).getTime() : 0;
+    const isNewSinceLink = m.receivedAt.getTime() >= linkCreatedAt;
+
+    if (options.sendNotifications !== false && isNewSinceLink) {
       const notifCopy = buildNotificationCopy({
         providerName,
         snippet: m.snippet,


### PR DESCRIPTION
Three founder-flagged timeline issues: ugly body rendering, no distinction between substantive replies vs auto-replies, and Telegram noise on historical backfill imports. See commit message for detail. Pure render + notification-gate change; no schema changes.