### PR TITLE
fix(money-hub): sync button, disconnect persistence, multi-account display

### DIFF
--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -144,7 +144,7 @@ export async function GET(request: Request) {
       .limit(20000);
     let connQuery = admin
       .from('bank_connections')
-      .select('id, bank_name, status, last_synced_at, account_ids, account_display_names')
+      .select('id, bank_name, status, last_synced_at, last_manual_sync_at, account_ids, account_display_names')
       .eq('user_id', user.id)
       .neq('status', 'revoked');
     if (connectionFilter) {
@@ -294,8 +294,8 @@ export async function GET(request: Request) {
     const accounts = (bankConns || []).flatMap((conn: any) => {
       const accountIds = conn.account_ids || [];
       const displayNames = conn.account_display_names || [];
-      if (accountIds.length <= 1) return [{ id: conn.id, bank_name: conn.bank_name || 'Bank', status: conn.status, last_synced_at: conn.last_synced_at }];
-      return accountIds.map((accId: string, i: number) => ({ id: `${conn.id}_${accId}`, bank_name: displayNames[i] || conn.bank_name || 'Bank', status: conn.status, last_synced_at: conn.last_synced_at }));
+      if (accountIds.length <= 1) return [{ id: conn.id, bank_name: conn.bank_name || 'Bank', status: conn.status, last_synced_at: conn.last_synced_at, last_manual_sync_at: conn.last_manual_sync_at }];
+      return accountIds.map((accId: string, i: number) => ({ id: `${conn.id}_${accId}`, bank_name: displayNames[i] || conn.bank_name || 'Bank', status: conn.status, last_synced_at: conn.last_synced_at, last_manual_sync_at: conn.last_manual_sync_at }));
     });
 
     return NextResponse.json({

--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -299,7 +299,9 @@ export async function GET(request: Request) {
     });
 
     return NextResponse.json({
-      tier,
+      // Use effectiveTier so onboarding-trial users see Pro UI (including the
+      // manual Sync button), matching the server-side getUserPlan() override.
+      tier: effectiveTier,
       score: healthScore.overall,
       healthScore,
       selectedMonth,

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -429,15 +429,15 @@ export default function MoneyHubPage() {
  if (user) {
  setUserId(user.id);
  const { data: conns } = await supabase.from('bank_connections')
- .select('id, bank_name, status')
+ .select('id, bank_name, status, account_ids, account_display_names')
  .eq('user_id', user.id)
- .in('status', ['expired', 'token_expired', 'expired_legacy', 'revoked', 'expiring_soon']);
+ .in('status', ['expired', 'token_expired', 'expired_legacy', 'expiring_soon']);
  if (conns?.length) setExpiredConnections(conns);
  else setExpiredConnections([]); // Clear if all now active
 
  // Fetch active connections too
  const { data: activeConns } = await supabase.from('bank_connections')
- .select('id, bank_name, status')
+ .select('id, bank_name, status, account_ids, account_display_names')
  .eq('user_id', user.id)
  .eq('status', 'active');
  setActiveConnections(activeConns || []);
@@ -501,10 +501,10 @@ export default function MoneyHubPage() {
  body: JSON.stringify({ connectionId }),
  });
  if (res.ok) {
- // Remove from local state optimistically
  setActiveConnections(activeConnections.filter(c => c.id !== connectionId));
  setExpiredConnections(expiredConnections.filter(c => c.id !== connectionId));
  showToast(`${bankName || 'Bank'} disconnected`, 'success');
+ await refreshData();
  } else {
  showToast('Failed to disconnect bank', 'error');
  }
@@ -693,12 +693,21 @@ export default function MoneyHubPage() {
  return new Date(acc.last_synced_at) > new Date(latest) ? acc.last_synced_at : latest;
  }, null as string | null);
 
+ const lastManualSyncAt = data.accounts.reduce((latest: string | null, acc: any) => {
+ if (!acc.last_manual_sync_at) return latest;
+ if (!latest) return acc.last_manual_sync_at;
+ return new Date(acc.last_manual_sync_at) > new Date(latest) ? acc.last_manual_sync_at : latest;
+ }, null as string | null);
+
  const lastSyncMins = lastSyncedAt ? Math.round((Date.now() - new Date(lastSyncedAt).getTime()) / 60000) : null;
+ // Cooldown gate must mirror the server: it is keyed on the last *manual* sync,
+ // not the cron-driven last_synced_at — otherwise a recent cron run disables the button.
+ const lastManualSyncMins = lastManualSyncAt ? Math.round((Date.now() - new Date(lastManualSyncAt).getTime()) / 60000) : null;
  const canSync = (() => {
  if (syncing) return false;
- if (!lastSyncMins) return true;
- if (data.tier === 'pro') return lastSyncMins >= 360;
- return lastSyncMins >= 1440;
+ if (data.tier !== 'pro' && !data.isTestUserOverride) return false;
+ if (!lastManualSyncMins) return true;
+ return lastManualSyncMins >= 360;
  })();
 
  const syncTierText = (() => {
@@ -856,21 +865,32 @@ export default function MoneyHubPage() {
  <button onClick={() => { setBankPromptDismissed(true); localStorage.setItem('bank_prompt_dismissed_at', new Date().toISOString()); }} className="text-slate-500 hover:text-slate-900"><X className="h-4 w-4" /></button>
  </div>
  <div className="space-y-2">
- {expiredConnections.map((conn) => (
- <div key={conn.id} className="flex items-center justify-between bg-slate-50/40 rounded-lg px-3 py-2">
+ {expiredConnections.flatMap((conn) => {
+ const names: string[] = (conn.account_display_names && conn.account_display_names.length > 0)
+ ? conn.account_display_names
+ : [];
+ const rows = names.length > 0 ? names : [null];
+ return rows.map((accName, i) => (
+ <div key={`${conn.id}-${i}`} className="flex items-center justify-between bg-slate-50/40 rounded-lg px-3 py-2">
  <div className="flex items-center gap-2">
  <Building2 className="h-4 w-4 text-amber-600" />
  <span className="text-slate-900 text-sm font-medium">{conn.bank_name || 'Bank'}</span>
+ {accName && names.length > 1 && <span className="text-slate-500 text-xs">· {accName}</span>}
  <span className="text-slate-500 text-xs">· expired</span>
  </div>
  <div className="flex items-center gap-2">
+ {i === 0 && (
+ <>
  <button onClick={() => { if (!connectBankDirect()) setShowBankPicker(true); }} className="bg-orange-500 hover:bg-orange-600 text-black font-semibold px-3 py-1 rounded-lg text-xs">Reconnect</button>
  <button onClick={() => disconnectBank(conn.id, conn.bank_name)} disabled={disconnectingId === conn.id} className="text-slate-500 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
  <Trash2 className="h-4 w-4" />
  </button>
+ </>
+ )}
  </div>
  </div>
- ))}
+ ));
+ })}
  </div>
  <p className="text-slate-500 text-xs mt-2">Reconnect to keep your data up to date</p>
  </div>
@@ -886,18 +906,27 @@ export default function MoneyHubPage() {
  </div>
  </div>
  <div className="space-y-2">
- {activeConnections.map((conn) => (
- <div key={conn.id} className="flex items-center justify-between bg-slate-50/40 rounded-lg px-3 py-2">
+ {activeConnections.flatMap((conn) => {
+ const names: string[] = (conn.account_display_names && conn.account_display_names.length > 0)
+ ? conn.account_display_names
+ : [];
+ const rows = names.length > 0 ? names : [null];
+ return rows.map((accName, i) => (
+ <div key={`${conn.id}-${i}`} className="flex items-center justify-between bg-slate-50/40 rounded-lg px-3 py-2">
  <div className="flex items-center gap-2">
  <Building2 className="h-4 w-4 text-green-400" />
  <span className="text-slate-900 text-sm font-medium">{conn.bank_name || 'Bank'}</span>
+ {accName && names.length > 1 && <span className="text-slate-500 text-xs">· {accName}</span>}
  <span className="text-slate-500 text-xs">· active</span>
  </div>
+ {i === 0 && (
  <button onClick={() => disconnectBank(conn.id, conn.bank_name)} disabled={disconnectingId === conn.id} className="text-slate-500 hover:text-red-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors" title="Disconnect this bank">
  <Trash2 className="h-4 w-4" />
  </button>
+ )}
  </div>
- ))}
+ ));
+ })}
  </div>
  <p className="text-slate-500 text-xs mt-2">Click the trash icon to disconnect a bank account</p>
  </div>


### PR DESCRIPTION
## Summary
Fixes three Money Hub bugs reported by the user:

1. **Sync button doing nothing** — Client `canSync` was gated on `last_synced_at` (which the cron updates nightly), disabling the button for 6h every time the cron ran. Now mirrors the server authority and gates on `last_manual_sync_at`, plus restricts to Pro/test users.
2. **Disconnected bank reappears after reload** — `/dashboard/money-hub/page.tsx` re-fetched `status IN (..., 'revoked', ...)` into `expiredConnections`, resurfacing a revoked bank as "expired" with a Reconnect button. `'revoked'` removed from the filter; `refreshData()` also runs after a successful disconnect to keep derived state consistent.
3. **NatWest two accounts showing as one** — UI rendered one row per `bank_connections` row, ignoring the `account_display_names` array (e.g. `PREMIER REWARD BLACK` + `BUSINESS CURRENT`). Active/expired lists now `flatMap` accounts, one row per account. Reconnect/Trash controls stay on the parent connection.

Also exposes `last_manual_sync_at` via `/api/money-hub` so the Pro cooldown gate can read it.

Cherry-picked from `feature/sprint-20260423-initial-sync-enrichment` (9396708) so it can ship to master without waiting for the whole sprint branch.

## Test plan
- [ ] Pro user: Sync button clickable when `last_manual_sync_at` older than 6h even if cron ran in the last 6h.
- [ ] Disconnect a Yapily sandbox → reload the page → the bank no longer appears in the expired banner.
- [ ] NatWest (2 accounts) renders two rows — `PREMIER REWARD BLACK` and `BUSINESS CURRENT` — sharing one disconnect control.
- [ ] Free/Essential user: Sync button disabled (tier gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)