### PR TITLE
fix(money-hub): accurate Upcoming empty state + remove dead theme toggle

### DIFF
--- a/src/app/api/money-hub/upcoming/route.ts
+++ b/src/app/api/money-hub/upcoming/route.ts
@@ -50,6 +50,14 @@ export interface UpcomingApiResponse {
     confirmedCount: number;
     predictedCount: number;
   };
+  // Empty-state context so the widget can distinguish between
+  // "no bank yet" and "bank connected but nothing scheduled".
+  hasBankConnected: boolean;
+  // Whether any of the connected banks are on a provider that
+  // actually feeds upcoming_payments (currently Yapily only).
+  // TrueLayer-only users will see a "nothing scheduled" state
+  // because upcoming-payments data is not available for them.
+  hasUpcomingCapableBank: boolean;
 }
 
 export async function GET(request: NextRequest) {
@@ -86,11 +94,23 @@ export async function GET(request: NextRequest) {
     query = query.neq('source', 'predicted_recurring');
   }
 
-  const { data, error } = await query;
+  const [{ data, error }, { data: connections }] = await Promise.all([
+    query,
+    supabase
+      .from('bank_connections')
+      .select('provider, status')
+      .eq('user_id', user.id)
+      .neq('status', 'revoked'),
+  ]);
   if (error) {
     console.error('[upcoming] list failed:', error.message);
     return NextResponse.json({ error: 'Failed to load upcoming payments' }, { status: 500 });
   }
+
+  const conns = connections || [];
+  const hasBankConnected = conns.length > 0;
+  // Only Yapily connections populate upcoming_payments today.
+  const hasUpcomingCapableBank = conns.some((c) => c.provider === 'yapily' && c.status === 'active');
 
   const rows = (data || []) as UpcomingPaymentRow[];
   const groupsMap = new Map<string, UpcomingDayGroup>();
@@ -139,6 +159,8 @@ export async function GET(request: NextRequest) {
       confirmedCount,
       predictedCount,
     },
+    hasBankConnected,
+    hasUpcomingCapableBank,
   };
 
   return NextResponse.json(body);

--- a/src/app/dashboard/money-hub/UpcomingWidget.tsx
+++ b/src/app/dashboard/money-hub/UpcomingWidget.tsx
@@ -109,6 +109,13 @@ export default function UpcomingWidget() {
   }
 
   if (!data || flat.length === 0) {
+    const hasBank = data?.hasBankConnected ?? false;
+    const upcomingCapable = data?.hasUpcomingCapableBank ?? false;
+    const subtitle = !hasBank
+      ? 'Connect your bank via Open Banking to track upcoming payments.'
+      : !upcomingCapable
+        ? 'Upcoming payments are detected via Yapily. Your current bank connection only syncs past transactions.'
+        : "We'll show direct debits, standing orders and scheduled payments here as your bank reports them.";
     return (
       <div className="card" style={{ padding: 18 }}>
         <div className="k-label" style={{ marginBottom: 8 }}>
@@ -117,9 +124,7 @@ export default function UpcomingWidget() {
         <div className="k-val" style={{ color: 'var(--text-3)', fontSize: 16 }}>
           Nothing scheduled
         </div>
-        <div className="k-delta">
-          Connect your bank via Open Banking to track upcoming payments.
-        </div>
+        <div className="k-delta">{subtitle}</div>
       </div>
     );
   }

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -49,22 +49,6 @@ function Icon({ n, ...p }: { n: IconName } & React.SVGProps<SVGSVGElement>) {
   );
 }
 
-function IconSun(p: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      {...p}
-    >
-      <circle cx={12} cy={12} r={4} />
-      <path d={I.sun} />
-    </svg>
-  );
-}
-
 // ─── Nav structure ───────────────────────────────────────────────────────
 // Groups follow the Claude design handoff (Main / Save money / Account).
 // hrefs map to the existing app routes — we keep dashboard paths as they
@@ -382,14 +366,6 @@ function Topbar({ crumb }: { crumb: string[] }) {
         <kbd>⌘K</kbd>
       </div>
       <div className="topbar-actions">
-        <div className="theme-toggle" aria-hidden="true">
-          <button type="button" className="on" title="Light">
-            <IconSun />
-          </button>
-          <button type="button" title="Dark">
-            <Icon n="moon" />
-          </button>
-        </div>
         <div className="shell-v2-bell-slot">
           <NotificationBell />
         </div>


### PR DESCRIPTION
## Summary
Two UX fixes flagged during manual testing of the live Money Hub on paybacker.co.uk.

### 1. UpcomingWidget empty-state copy
The "Next 7 days" widget was showing **"Connect your bank via Open Banking to track upcoming payments"** even when the user had active bank connections. Root cause: `upcoming_payments` is populated by the Yapily sync job only, so TrueLayer-only users (NatWest/Lloyds etc.) always hit the empty branch of the widget.

- `/api/money-hub/upcoming` now returns `hasBankConnected` and `hasUpcomingCapableBank` alongside the groups.
- The widget picks one of three messages:
  - **No bank:** original "Connect your bank via Open Banking to track upcoming payments."
  - **Bank connected, provider doesn't feed upcoming_payments:** "Upcoming payments are detected via Yapily. Your current bank connection only syncs past transactions."
  - **Bank connected, provider capable, no data yet:** "We'll show direct debits, standing orders and scheduled payments here as your bank reports them."

### 2. Dead Light/Dark toggle
`DashboardShell.tsx` had an `aria-hidden` Light/Dark toggle in the topbar with no handlers, no state, and no dark-mode CSS anywhere in the app. Removed the JSX (kept the `.theme-toggle` CSS as harmless dead-stock for a future real dark-mode implementation).

## Test plan
- [ ] Log in as a user with only a TrueLayer bank → "Next 7 days" shows the new "only syncs past transactions" copy, not the reconnect prompt.
- [ ] Log in as a user with no bank → original "Connect your bank" copy remains.
- [ ] Log in as a user with an active Yapily connection and some upcoming_payments rows → the widget renders the rows as before.
- [ ] Topbar: theme toggle is gone, notification bell still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)