### PR TITLE
fix(email): price-increase emails now count toward daily rate limit

### DIFF
--- a/shared-context/active-sessions.md
+++ b/shared-context/active-sessions.md
@@ -1,3 +1,14 @@
+# Active Sessions — Last Updated 24 Apr 2026 (dev-sprint-runner)
+
+## Latest: Dev Sprint Runner — 24 Apr 2026
+- Audited all SKILL.md critical tasks — most already implemented (Savings Rate card, monthly RPCs, routing redirects, auto-categorise, spending totals all done)
+- Found genuine bug: price-increases cron called `canSendEmail()` but never `markEmailSent()` — daily email cap was being bypassed
+- Fix: added `markEmailSent` call after confirmed email delivery in `price-increases/route.ts`
+- Created PR #247: https://github.com/airpau/lifeadmin-ai/pull/247
+- Supabase/Telegram notification attempted — network blocked in local environment; logged to shared-context instead
+
+---
+
 # Active Sessions — Last Updated 22 Apr 2026 18:00 UTC
 
 ## Latest: Business Monitor — 22 Apr 2026 (evening)

--- a/shared-context/handoff-notes.md
+++ b/shared-context/handoff-notes.md
@@ -1,3 +1,33 @@
+# Handoff Notes — Last Updated 24 Apr 2026
+
+## Session: Dev Sprint Runner — Email Rate Limit Fix (24 Apr 2026)
+
+### What was done
+Fixed bug in `src/app/api/cron/price-increases/route.ts`. The cron called `canSendEmail()` to check the daily email cap but never called `markEmailSent()` after a successful send. The tasks table had no record of price-increase emails, so deal-alerts and targeted-deals would see 0 marketing emails that day and bypass `MAX_MARKETING_EMAILS_PER_DAY=1`.
+
+PR #247 created: https://github.com/airpau/lifeadmin-ai/pull/247
+
+### SKILL.md task audit
+Most critical tasks in the sprint SKILL.md are already done:
+- Savings Rate card (OverviewPanel has it, no Net Position card)
+- get_monthly_spending/income RPCs (already called in /api/money-hub/route.ts)
+- localStorage dismiss replaced (uses dismiss_expected_bill RPC already)
+- auto_categorise called after bank sync (already in sync-now and bank-sync cron)
+- URL routing 404s (disputes/ and overview/ redirects already exist)
+- Spending category totals (already shown in OverviewPanel)
+
+Remaining unimplemented SKILL.md tasks needing new Supabase functions:
+- Task 6: `get_subscriptions_with_actions` RPC (doesn't exist yet)
+- Task 7: `dismiss_subscription` / `cancel_subscription` RPCs (don't exist yet)
+
+### Next steps
+1. **Merge PR #247** — small, safe, single-file fix
+2. **Also merge PR #99** — email rate limit types fix (still open)
+3. For next sprint: create `get_subscriptions_with_actions` SQL migration + update subscriptions page
+4. Next URGENT email task: consolidate deal-alerts + targeted-deals + price-increases into single daily digest
+
+---
+
 # Handoff Notes — Last Updated 17 Apr 2026
 
 ## Session: Cowork Desktop — Agent Reality Audit + CLAUDE.md Correction (17 Apr 2026)

--- a/shared-context/task-queue.md
+++ b/shared-context/task-queue.md
@@ -14,6 +14,7 @@
 
 ## URGENT - Email Spam Fix
 - [~PR#99] Implement global email rate limiter (max 2 emails per user per day) — rate limiter exists in email-rate-limit.ts; PR#99 fixes missing types (contract_expiry_alert, contract_end_alert, overcharge_alert) that were bypassing the cap (PR created 2026-04-20)
+- [~PR#247] Fix: price-increase cron now records sends in rate-limit tracker so daily email cap is enforced (PR created 2026-04-24)
 - [ ] Consolidate deal alerts + targeted deals + price increases into single daily digest
 - [ ] Add user email preference settings (daily digest / weekly / off)
 - [ ] Audit and restructure all 11 email cron triggers (see email-audit below)

--- a/src/app/api/cron/price-increases/route.ts
+++ b/src/app/api/cron/price-increases/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { detectPriceIncreases } from '@/lib/price-increase-detector';
 import { buildPriceIncreaseEmail } from '@/lib/email/price-increase-alerts';
-import { canSendEmail } from '@/lib/email-rate-limit';
+import { canSendEmail, markEmailSent } from '@/lib/email-rate-limit';
 import { sendNotification } from '@/lib/notifications/dispatch';
 
 export const maxDuration = 60;
@@ -128,7 +128,10 @@ export async function GET(request: NextRequest) {
           telegram: { text: telegramText },
           push: { title: 'Price hike detected', body: headline.replace(/\*/g, '') },
         });
-        if (result.delivered.includes('email')) totalEmailsSent++;
+        if (result.delivered.includes('email')) {
+          totalEmailsSent++;
+          await markEmailSent(supabase, userId, 'price_increase_alert', `Price increase alert: ${newIncreases.length} merchant${newIncreases.length === 1 ? '' : 's'}`);
+        }
       }
     } catch (err) {
       errors.push(`Error processing user ${userId}: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## What
- Import `markEmailSent` in `src/app/api/cron/price-increases/route.ts`
- Call `markEmailSent` immediately after a price-increase email is successfully delivered

## Why
The daily email rate limiter (`canSendEmail`) works by counting rows in the `tasks` table for the current day. All other marketing-email crons (deal-alerts, targeted-deals, contract-expiry-alerts, etc.) insert a tasks record after sending. The price-increases cron was the only one that checked the limit but never recorded the send.

Result: on any day where a price increase alert fired first (8am), the tasks table showed 0 marketing emails → deal-alerts (9am Mon) and targeted-deals (9am Wed) would both pass their rate-limit check and send a second/third email to the same user, bypassing the `MAX_MARKETING_EMAILS_PER_DAY = 1` cap.

## Test plan
- [ ] Deploy to preview; check Supabase `tasks` table after cron runs — should see a `price_increase_alert` row for each user who received a price-increase email
- [ ] Confirm deal-alerts cron skips those users on the same day (check cron logs for "Daily limit reached")
- [ ] Confirm no regression in Telegram/push delivery (those channels are unaffected)

From task queue: URGENT - Email Spam Fix
🤖 Paybacker Dev Sprint Runner
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>