### PR TITLE
fix(mcp): security hardening for Paybacker Assistant

### DIFF
--- a/src/app/api/mcp/tokens/route.ts
+++ b/src/app/api/mcp/tokens/route.ts
@@ -46,6 +46,15 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  // Pro gate — same rule as mint + runtime auth, so the settings UI never
+  // needs to duplicate the "what counts as Pro?" logic client-side.
+  const plan = await getUserPlan(user.id);
+  const isPro = plan.tier === 'pro' && plan.isActive;
+
+  if (!isPro) {
+    return NextResponse.json({ isPro: false, tokens: [] as TokenRow[] });
+  }
+
   const { data, error } = await admin()
     .from('mcp_tokens')
     .select(
@@ -59,7 +68,7 @@ export async function GET() {
     return NextResponse.json({ error: 'Failed to load tokens' }, { status: 500 });
   }
 
-  return NextResponse.json({ tokens: (data ?? []) as TokenRow[] });
+  return NextResponse.json({ isPro: true, tokens: (data ?? []) as TokenRow[] });
 }
 
 export async function POST(req: NextRequest) {

--- a/src/app/api/mcp/transactions/route.ts
+++ b/src/app/api/mcp/transactions/route.ts
@@ -39,7 +39,16 @@ export async function GET(req: NextRequest) {
 
   if (since) q = q.gte('timestamp', since);
   if (until) q = q.lte('timestamp', until);
-  if (category) q = q.or(`user_category.eq.${category},category.eq.${category}`);
+  if (category) {
+    // PostgREST .or() takes a raw filter string, so strip anything that could
+    // break out of the expression (comma splits the disjunction list, parens
+    // open sub-groups, % / * are ilike wildcards). The outer user_id eq still
+    // constrains results to the caller, but defence in depth is cheap.
+    const safeCategory = category.replace(/[,*%()]/g, '').slice(0, 80);
+    if (safeCategory) {
+      q = q.or(`user_category.eq.${safeCategory},category.eq.${safeCategory}`);
+    }
+  }
 
   const { data, error } = await q;
   if (error) {

--- a/src/app/dashboard/settings/mcp/page.tsx
+++ b/src/app/dashboard/settings/mcp/page.tsx
@@ -10,7 +10,6 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { createClient } from '@/lib/supabase/client';
 import {
   Terminal,
   Copy,
@@ -24,7 +23,12 @@ import {
   Zap,
   AlertCircle,
   KeyRound,
+  FileJson,
 } from 'lucide-react';
+
+// Auto-hide the freshly-minted token banner so the plaintext doesn't sit on
+// screen if the tab is left open or shared over screen-sharing.
+const JUST_MINTED_TTL_MS = 5 * 60 * 1000;
 
 interface TokenRow {
   id: string;
@@ -39,8 +43,6 @@ interface TokenRow {
 }
 
 export default function McpSettingsPage() {
-  const supabase = createClient();
-
   const [isPro, setIsPro] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(true);
   const [tokens, setTokens] = useState<TokenRow[]>([]);
@@ -50,57 +52,41 @@ export default function McpSettingsPage() {
   const [newName, setNewName] = useState('Paybacker Assistant');
   const [creating, setCreating] = useState(false);
   const [justMinted, setJustMinted] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
 
   // revoke flow
   const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [confirmRevokeId, setConfirmRevokeId] = useState<string | null>(null);
 
-  const loadTokens = useCallback(async () => {
+  const loadPlanAndTokens = useCallback(async () => {
     try {
       const res = await fetch('/api/mcp/tokens');
       if (res.status === 401) {
         setError('Please sign in.');
+        setIsPro(false);
         return;
       }
       if (!res.ok) throw new Error('Failed to load tokens');
       const data = await res.json();
-      setTokens(data.tokens ?? []);
+      setIsPro(!!data.isPro);
+      setTokens((data.tokens ?? []) as TokenRow[]);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unknown error');
+      setIsPro(false);
     }
   }, []);
 
   useEffect(() => {
-    const init = async () => {
-      try {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        if (!user) {
-          setLoading(false);
-          return;
-        }
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('subscription_tier, subscription_status, stripe_subscription_id')
-          .eq('id', user.id)
-          .single();
-        const tier = profile?.subscription_tier;
-        const status = profile?.subscription_status;
-        const hasStripe = !!profile?.stripe_subscription_id;
-        const pro =
-          tier === 'pro' &&
-          (hasStripe
-            ? ['active', 'trialing'].includes(status ?? '')
-            : status === 'trialing' || status === 'active');
-        setIsPro(pro);
-        if (pro) await loadTokens();
-      } finally {
-        setLoading(false);
-      }
-    };
-    init();
-  }, [supabase, loadTokens]);
+    loadPlanAndTokens().finally(() => setLoading(false));
+  }, [loadPlanAndTokens]);
+
+  // Auto-hide the plaintext token after a short window so it doesn't hang
+  // around on a screen-shared or unattended tab.
+  useEffect(() => {
+    if (!justMinted) return;
+    const t = setTimeout(() => setJustMinted(null), JUST_MINTED_TTL_MS);
+    return () => clearTimeout(t);
+  }, [justMinted]);
 
   const handleCreate = async () => {
     setCreating(true);
@@ -118,7 +104,7 @@ export default function McpSettingsPage() {
       }
       setJustMinted(body.token as string);
       setNewName('Paybacker Assistant');
-      await loadTokens();
+      await loadPlanAndTokens();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unknown error');
     } finally {
@@ -126,14 +112,13 @@ export default function McpSettingsPage() {
     }
   };
 
-  const handleCopy = async (value: string) => {
+  const handleCopy = async (key: string, value: string) => {
     await navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1800);
+    setCopied(key);
+    setTimeout(() => setCopied(null), 1800);
   };
 
-  const handleRevoke = async (id: string, name: string) => {
-    if (!confirm(`Revoke "${name}"? Any AI assistant session using this token will stop working immediately.`)) return;
+  const handleRevoke = async (id: string) => {
     setRevokingId(id);
     try {
       const res = await fetch(`/api/mcp/tokens/${id}`, { method: 'DELETE' });
@@ -141,13 +126,29 @@ export default function McpSettingsPage() {
         const body = await res.json();
         throw new Error(body.error ?? 'Failed to revoke');
       }
-      await loadTokens();
+      setConfirmRevokeId(null);
+      await loadPlanAndTokens();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unknown error');
     } finally {
       setRevokingId(null);
     }
   };
+
+  const configSnippet = (token: string) =>
+    JSON.stringify(
+      {
+        mcpServers: {
+          paybacker: {
+            command: 'npx',
+            args: ['-y', '@paybacker/mcp'],
+            env: { PAYBACKER_TOKEN: token },
+          },
+        },
+      },
+      null,
+      2,
+    );
 
   const formatDate = (iso: string) =>
     new Date(iso).toLocaleDateString('en-GB', {
@@ -288,13 +289,43 @@ export default function McpSettingsPage() {
                   {justMinted}
                 </code>
                 <button
-                  onClick={() => handleCopy(justMinted)}
+                  onClick={() => handleCopy('token', justMinted)}
                   className="inline-flex items-center gap-1.5 px-3 py-2 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-medium rounded-lg text-sm transition-colors"
                 >
-                  {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                  {copied ? 'Copied' : 'Copy'}
+                  {copied === 'token' ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                  {copied === 'token' ? 'Copied' : 'Copy'}
                 </button>
               </div>
+              <details className="mt-4 group">
+                <summary className="cursor-pointer text-xs font-medium text-emerald-800 hover:text-emerald-900 inline-flex items-center gap-1.5">
+                  <FileJson className="h-3.5 w-3.5" />
+                  Prefer to paste the JSON config yourself?
+                </summary>
+                <div className="mt-2">
+                  <p className="text-xs text-emerald-700/80 mb-2">
+                    Open your Claude Desktop config and merge this block under{' '}
+                    <code className="font-mono">mcpServers</code>:
+                  </p>
+                  <pre className="bg-slate-900 text-emerald-200 rounded-lg p-3 text-xs overflow-x-auto font-mono">
+                    {configSnippet(justMinted)}
+                  </pre>
+                  <div className="mt-2 flex items-center gap-2">
+                    <button
+                      onClick={() => handleCopy('snippet', configSnippet(justMinted))}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-emerald-500 hover:bg-emerald-600 text-slate-900 text-xs font-medium rounded-lg transition-colors"
+                    >
+                      {copied === 'snippet' ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                      {copied === 'snippet' ? 'Copied' : 'Copy config'}
+                    </button>
+                    <span className="text-xs text-emerald-700/70">
+                      macOS: <code className="font-mono">~/Library/Application Support/Claude/claude_desktop_config.json</code>
+                    </span>
+                  </div>
+                </div>
+              </details>
+              <p className="mt-3 text-[11px] text-emerald-700/70">
+                This token will auto-hide after 5 minutes so it doesn&rsquo;t sit on screen.
+              </p>
             </div>
             <button
               onClick={() => setJustMinted(null)}
@@ -345,37 +376,66 @@ export default function McpSettingsPage() {
         {active.length > 0 && (
           <ul className="divide-y divide-slate-200">
             {active.map((t) => (
-              <li key={t.id} className="p-5 flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="text-sm font-medium text-slate-900 truncate">{t.name}</span>
-                    <code className="font-mono text-xs text-slate-600 bg-slate-100 px-2 py-0.5 rounded">
-                      {t.token_prefix}…
-                    </code>
+              <li key={t.id} className="p-5 flex flex-col gap-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium text-slate-900 truncate">{t.name}</span>
+                      <code className="font-mono text-xs text-slate-600 bg-slate-100 px-2 py-0.5 rounded">
+                        {t.token_prefix}…
+                      </code>
+                    </div>
+                    <div className="mt-1 text-xs text-slate-500 flex flex-wrap gap-x-3 gap-y-0.5">
+                      <span>Created {formatDate(t.created_at)}</span>
+                      <span>Expires {formatDate(t.expires_at)}</span>
+                      <span>
+                        {t.use_count === 0
+                          ? 'Never used'
+                          : `${t.use_count} call${t.use_count === 1 ? '' : 's'}`}
+                        {t.last_used_at ? ` · last ${formatDate(t.last_used_at)}` : ''}
+                      </span>
+                    </div>
                   </div>
-                  <div className="mt-1 text-xs text-slate-500 flex flex-wrap gap-x-3 gap-y-0.5">
-                    <span>Created {formatDate(t.created_at)}</span>
-                    <span>Expires {formatDate(t.expires_at)}</span>
-                    <span>
-                      {t.use_count === 0
-                        ? 'Never used'
-                        : `${t.use_count} call${t.use_count === 1 ? '' : 's'}`}
-                      {t.last_used_at ? ` · last ${formatDate(t.last_used_at)}` : ''}
-                    </span>
-                  </div>
-                </div>
-                <button
-                  onClick={() => handleRevoke(t.id, t.name)}
-                  disabled={revokingId === t.id}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-red-600 hover:text-red-700 border border-red-200 hover:border-red-300 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50 flex-shrink-0"
-                >
-                  {revokingId === t.id ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Trash2 className="h-3.5 w-3.5" />
+                  {confirmRevokeId !== t.id && (
+                    <button
+                      onClick={() => setConfirmRevokeId(t.id)}
+                      disabled={revokingId === t.id}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-red-600 hover:text-red-700 border border-red-200 hover:border-red-300 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50 flex-shrink-0"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                      Revoke
+                    </button>
                   )}
-                  Revoke
-                </button>
+                </div>
+                {confirmRevokeId === t.id && (
+                  <div className="bg-red-50 border border-red-200 rounded-lg p-3 flex items-center justify-between gap-3">
+                    <p className="text-xs text-red-800">
+                      Revoke <span className="font-semibold">{t.name}</span>? Any assistant using
+                      this token will stop working immediately.
+                    </p>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <button
+                        onClick={() => setConfirmRevokeId(null)}
+                        disabled={revokingId === t.id}
+                        className="px-3 py-1.5 text-xs text-slate-700 hover:text-slate-900 border border-slate-300 rounded-lg disabled:opacity-50"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={() => handleRevoke(t.id)}
+                        disabled={revokingId === t.id}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-white bg-red-600 hover:bg-red-700 rounded-lg disabled:opacity-50"
+                      >
+                        {revokingId === t.id ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-3.5 w-3.5" />
+                        )}
+                        Revoke now
+                      </button>
+                    </div>
+                  </div>
+                )}
               </li>
             ))}
           </ul>

--- a/src/app/dashboard/settings/mcp/page.tsx
+++ b/src/app/dashboard/settings/mcp/page.tsx
@@ -71,8 +71,11 @@ export default function McpSettingsPage() {
       setIsPro(!!data.isPro);
       setTokens((data.tokens ?? []) as TokenRow[]);
     } catch (e) {
+      // Don't flip isPro on transient fetch/parse errors — that would hide the
+      // token manager from actual Pro users exactly when the API is flaky.
+      // Surface the error banner and leave the Pro state unchanged so the
+      // existing UI (or the loading state, on first load) is preserved.
       setError(e instanceof Error ? e.message : 'Unknown error');
-      setIsPro(false);
     }
   }, []);
 

--- a/src/lib/mcp-auth.ts
+++ b/src/lib/mcp-auth.ts
@@ -1,16 +1,15 @@
 // src/lib/mcp-auth.ts
 // Bearer-token auth for the Paybacker MCP HTTP layer.
 //
-// Every /api/mcp/* endpoint (except the token-management ones, which use the
-// browser session) calls `authenticateMcp(req)` first. It:
-//   1. Pulls the Bearer token from Authorization or ?token=…
+// Every /api/mcp/* data endpoint (the token-management ones use the browser
+// session instead) calls `authenticateMcp(req)` first. It:
+//   1. Pulls the Bearer token from the Authorization header (header-only —
+//      query-string tokens leak through access logs / Referer)
 //   2. Hashes it (SHA-256) and looks up a non-revoked, non-expired row
-//   3. Verifies the owning user still has an active Pro plan
-//   4. Bumps last_used_at / use_count on the token (best-effort)
-//   5. Returns { userId, tokenId } or a NextResponse error
-//
-// Rate limiting is deliberately simple for v1: 10 active tokens per user +
-// Pro gate + revocable. We can layer a token-bucket on top later.
+//   3. Applies a per-token rate limit (120/min per serverless instance)
+//   4. Verifies the owning user still has an active Pro plan
+//   5. Bumps last_used_at / use_count on the token (best-effort)
+//   6. Returns { userId, tokenId } or a NextResponse error
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createAdmin } from '@supabase/supabase-js';
@@ -37,16 +36,37 @@ function admin() {
   );
 }
 
+// Tokens must travel in the Authorization header only. Query params leak into
+// Vercel access logs, Referer headers and browser history — that's how
+// credentials get quietly exfiltrated.
 function extractToken(req: NextRequest): string | null {
-  const auth = req.headers.get('authorization') ?? req.headers.get('Authorization');
-  if (auth) {
-    const match = auth.match(/^Bearer\s+(.+)$/i);
-    if (match) return match[1].trim();
+  const auth = req.headers.get('authorization');
+  if (!auth) return null;
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+// Per-token rate limit — best-effort, in-memory, per serverless instance.
+// MCP traffic is interactive (one question = handful of calls); 120/min is
+// well above normal Claude Desktop usage and caps runaway or leaked tokens.
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 120;
+const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+
+function checkTokenRateLimit(tokenId: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(tokenId);
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(tokenId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    // Opportunistic cleanup — prevents the map growing unbounded under churn.
+    if (rateLimitMap.size > 10_000) {
+      for (const [k, v] of rateLimitMap) if (now > v.resetAt) rateLimitMap.delete(k);
+    }
+    return true;
   }
-  // Fallback — query param lets curl users test without headers
-  const q = req.nextUrl.searchParams.get('token');
-  if (q) return q.trim();
-  return null;
+  if (entry.count >= RATE_LIMIT_MAX) return false;
+  entry.count++;
+  return true;
 }
 
 /**
@@ -76,16 +96,26 @@ export async function authenticateMcp(
     console.error('[mcp-auth] lookup failed:', error.message);
     return NextResponse.json({ error: 'Auth lookup failed' }, { status: 500 });
   }
-  if (!row) {
+  // Don't tell the caller whether the token is merely unknown or revoked —
+  // an attacker with a list of leaked tokens shouldn't be able to tell which
+  // state each is in. Genuinely expired tokens get a distinct message because
+  // that's a legitimate user needing to rotate.
+  if (!row || row.revoked_at) {
     return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
-  }
-  if (row.revoked_at) {
-    return NextResponse.json({ error: 'Token revoked' }, { status: 401 });
   }
   if (new Date(row.expires_at) <= new Date()) {
     return NextResponse.json(
       { error: 'Token expired. Generate a new one at /dashboard/settings/mcp.' },
       { status: 401 },
+    );
+  }
+
+  // Per-token rate limit — capped *before* the Pro gate so we don't run plan
+  // lookups for abusive callers.
+  if (!checkTokenRateLimit(row.id)) {
+    return NextResponse.json(
+      { error: 'Rate limit exceeded. Try again in a minute.' },
+      { status: 429 },
     );
   }
 

--- a/src/lib/mcp-tokens.ts
+++ b/src/lib/mcp-tokens.ts
@@ -27,10 +27,16 @@ export function mintToken(): {
   tokenHash: string;
   tokenPrefix: string;
 } {
-  const bytes = randomBytes(SECRET_LEN);
+  // Rejection sampling — a plain `byte % 30` would bias the last 6 alphabet
+  // symbols because 256 is not a multiple of 30. We only accept bytes in
+  // [0, MAX_VALID) where MAX_VALID is the largest multiple of 30 ≤ 256.
+  const MAX_VALID = 256 - (256 % ALPHABET.length); // 240
   let secret = '';
-  for (let i = 0; i < SECRET_LEN; i++) {
-    secret += ALPHABET[bytes[i] % ALPHABET.length];
+  while (secret.length < SECRET_LEN) {
+    const buf = randomBytes(SECRET_LEN);
+    for (let i = 0; i < buf.length && secret.length < SECRET_LEN; i++) {
+      if (buf[i] < MAX_VALID) secret += ALPHABET[buf[i] % ALPHABET.length];
+    }
   }
   const plaintext = `${PREFIX}${secret}`;
   const tokenHash = createHash('sha256').update(plaintext).digest('hex');


### PR DESCRIPTION
## Summary

Defence-in-depth hardening on the Paybacker Assistant MCP (Pro-only read-only endpoint at `/api/mcp/*` that powers `@paybacker/mcp`). User-scoping was already correct on every route; these are fixes around token transport, rate limiting, settings UX and a latent PostgREST-injection risk.

### Security
- **Drop `?token=` fallback** in `mcp-auth.ts`. Tokens in query strings leak through Vercel access logs, CDN logs and Referer headers. `Authorization: Bearer` only now.
- **Per-token rate limit** (120/min per serverless instance) on every `/api/mcp/*` data route. Leaked tokens could previously pull unlimited data.
- **Sanitise `category`** before `.or()` in the transactions route — matches the existing search-route pattern. Outer `user_id` eq still scoped results, but raw interpolation into `.or()` was a latent PostgREST-injection footgun.
- **Rejection-sample** the token alphabet instead of `byte % 30`. Removes a slight bias on the last 6 alphabet symbols; 155+ bits of entropy either way.
- **Merge `Invalid token` + `Token revoked`** into one error so a holder of leaked tokens can't learn which are revoked.

### UX
- **Server-gate `GET /api/mcp/tokens` on Pro** so the settings page trusts the server's plan verdict instead of duplicating the logic client-side.
- **Replace browser `confirm()`** on revoke with an inline styled confirmation row.
- **Auto-hide the plaintext token** on the settings page after 5 minutes so it doesn't sit on a shared/unattended tab.
- **Inline "Copy JSON config"** on the minted-token banner so non-CLI users can paste it into `claude_desktop_config.json` directly.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Manual: probe prod post-deploy with `?token=` (should 401), with valid Pro token on transactions?category=valid (should work), with `category=foo,bar` (should silently strip to `foobar` or drop)
- [ ] Manual: settings page — free user sees upgrade gate, Pro user sees token list, revoke shows inline confirm (no browser dialog), just-minted banner disappears after 5 min
- [ ] Manual: mint a token and verify "Copy config" produces valid JSON that Claude Desktop accepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)