### PR TITLE
fix(money-hub): drop Yapily-specific line from Upcoming empty-state

### DIFF
--- a/src/app/dashboard/money-hub/UpcomingWidget.tsx
+++ b/src/app/dashboard/money-hub/UpcomingWidget.tsx
@@ -110,12 +110,9 @@ export default function UpcomingWidget() {
 
   if (!data || flat.length === 0) {
     const hasBank = data?.hasBankConnected ?? false;
-    const upcomingCapable = data?.hasUpcomingCapableBank ?? false;
     const subtitle = !hasBank
       ? 'Connect your bank via Open Banking to track upcoming payments.'
-      : !upcomingCapable
-        ? 'Upcoming payments are detected via Yapily. Your current bank connection only syncs past transactions.'
-        : "We'll show direct debits, standing orders and scheduled payments here as your bank reports them.";
+      : "We'll show direct debits, standing orders and scheduled payments here as your bank reports them.";
     return (
       <div className="card" style={{ padding: 18 }}>
         <div className="k-label" style={{ marginBottom: 8 }}>


### PR DESCRIPTION
Per user feedback, remove the 'Your current bank connection only syncs past transactions' branch from the UpcomingWidget empty state. Connected users now just see the generic 'We'll show direct debits, standing orders and scheduled payments here as your bank reports them.' copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)