### PR TITLE
fix(admin): test-notification uses price_increase event

### DIFF
--- a/src/app/api/admin/test-notification/route.ts
+++ b/src/app/api/admin/test-notification/route.ts
@@ -43,9 +43,13 @@ export async function POST(request: NextRequest) {
   if (!user) return NextResponse.json({ error: `User ${targetEmail} not found` }, { status: 404 });
 
   const stamp = new Date().toLocaleTimeString('en-GB', { timeZone: 'Europe/London' });
+  // Use `price_increase` — defaults email + telegram + push all on,
+  // and allowed channels include telegram (unlike support_reply which
+  // only permits email + push, leaving this endpoint silently
+  // no-opping on the telegram channel).
   const result = await sendNotification(admin as any, {
     userId: user.id,
-    event: 'support_reply',
+    event: 'price_increase',
     telegram: {
       text: `🧪 *Paybacker test alert*\n\nIf you\'re reading this in the *Paybacker* bot (not Paybacker Assistant), the dispatcher routing fix is live.\n\nSent at ${stamp} BST.`,
     },


### PR DESCRIPTION
## Summary
- Change event from \`support_reply\` (allowedChannels email+push, no telegram) to \`price_increase\` (all three channels on by default)
- Unblocks PR #249 verification — endpoint was returning \`delivered=[]\` because the dispatcher was correctly filtering telegram out

## Test plan
- [x] curl endpoint after deploy → expect \`delivered: ['telegram']\`
- [x] Message lands in Paybacker bot (not Paybacker Assistant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)