### PR TITLE
fix(mcp): schema bugs + 401 sign-in UX

### DIFF
--- a/src/app/api/mcp/budget/route.ts
+++ b/src/app/api/mcp/budget/route.ts
@@ -32,7 +32,7 @@ export async function GET(req: NextRequest) {
   const [budgetsRes, txnsRes] = await Promise.all([
     admin()
       .from('money_hub_budgets')
-      .select('id, category, monthly_limit, alerts_enabled, created_at')
+      .select('id, category, monthly_limit, rollover, created_at')
       .eq('user_id', auth.userId),
     admin()
       .from('bank_transactions')
@@ -67,7 +67,7 @@ export async function GET(req: NextRequest) {
       remaining_gbp: parseFloat((Number(b.monthly_limit ?? 0) - spent).toFixed(2)),
       percentage_used: parseFloat(pct.toFixed(1)),
       status: pct > 100 ? 'over_budget' : pct > 80 ? 'warning' : 'on_track',
-      alerts_enabled: !!b.alerts_enabled,
+      rollover: !!b.rollover,
     };
   });
 

--- a/src/app/api/mcp/disputes/route.ts
+++ b/src/app/api/mcp/disputes/route.ts
@@ -26,7 +26,7 @@ export async function GET(req: NextRequest) {
   let q = admin()
     .from('disputes')
     .select(
-      'id, provider_name, issue_type, issue_summary, desired_outcome, status, amount, created_at, updated_at',
+      'id, provider_name, provider_type, issue_type, issue_summary, desired_outcome, status, disputed_amount, currency, created_at, updated_at',
     )
     .eq('user_id', auth.userId)
     .order('created_at', { ascending: false })
@@ -40,7 +40,7 @@ export async function GET(req: NextRequest) {
   if (error) return mcpJson({ error: error.message }, { status: 500 });
 
   const rows = data ?? [];
-  const totalDisputedGbp = rows.reduce((s, r) => s + Number(r.amount ?? 0), 0);
+  const totalDisputedGbp = rows.reduce((s, r) => s + Number(r.disputed_amount ?? 0), 0);
 
   return mcpJson({
     count: rows.length,

--- a/src/app/dashboard/settings/mcp/page.tsx
+++ b/src/app/dashboard/settings/mcp/page.tsx
@@ -44,6 +44,7 @@ interface TokenRow {
 
 export default function McpSettingsPage() {
   const [isPro, setIsPro] = useState<boolean | null>(null);
+  const [needsSignIn, setNeedsSignIn] = useState(false);
   const [loading, setLoading] = useState(true);
   const [tokens, setTokens] = useState<TokenRow[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -62,12 +63,15 @@ export default function McpSettingsPage() {
     try {
       const res = await fetch('/api/mcp/tokens');
       if (res.status === 401) {
-        setError('Please sign in.');
-        setIsPro(false);
+        // Auth failure ≠ plan failure. Render a sign-in prompt instead of
+        // the Pro upsell, otherwise a real Pro user with an expired session
+        // gets told to upgrade.
+        setNeedsSignIn(true);
         return;
       }
       if (!res.ok) throw new Error('Failed to load tokens');
       const data = await res.json();
+      setNeedsSignIn(false);
       setIsPro(!!data.isPro);
       setTokens((data.tokens ?? []) as TokenRow[]);
     } catch (e) {
@@ -164,6 +168,30 @@ export default function McpSettingsPage() {
     return (
       <div className="flex items-center justify-center min-h-[300px]">
         <Loader2 className="h-8 w-8 text-emerald-600 animate-spin" />
+      </div>
+    );
+  }
+
+  if (needsSignIn) {
+    return (
+      <div className="max-w-2xl mx-auto p-6">
+        <div className="bg-white border border-slate-200 shadow-sm rounded-2xl p-8 text-center">
+          <div className="bg-emerald-50 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+            <KeyRound className="h-8 w-8 text-emerald-600" />
+          </div>
+          <h2 style={{fontSize:18,fontWeight:700,letterSpacing:"-.01em",margin:"0 0 10px"}}>
+            Please sign in
+          </h2>
+          <p className="text-slate-600 mb-6">
+            Your session has expired. Sign in again to manage your Paybacker Assistant tokens.
+          </p>
+          <Link
+            href="/login?next=/dashboard/settings/mcp"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-500 hover:bg-emerald-600 text-slate-900 font-semibold rounded-xl transition-colors"
+          >
+            Sign in
+          </Link>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Two follow-up fixes surfaced during end-to-end UAT and Codex re-review of #250.

### Schema bugs (existing, not from #250)
End-to-end UAT against a real Pro account surfaced two MCP endpoints returning 500 for everyone since the MCP data routes first shipped (5572f4a):
- `/api/mcp/budget` selected `alerts_enabled` on `money_hub_budgets` — column doesn't exist on that table (lives on `subscriptions`). Replaced with `rollover`, which is the actual boolean on the budgets row.
- `/api/mcp/disputes` selected and summed `amount`, but the column is `disputed_amount`. Also now surfaces `provider_type` and `currency` for Claude's context.

### 401 sign-in UX (Codex P2 on #250)
When `/api/mcp/tokens` returned 401 (expired session), the settings page set `isPro=false` and fell into the Pro upsell — misclassifying an auth failure as a plan downgrade. A real Pro user with an expired cookie was told to upgrade.

Introduced a distinct `needsSignIn` state and a sign-in CTA that preserves the return path via `?next=/dashboard/settings/mcp`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Pre-fix: reproduced both 500s against prod using `/tmp/mcp_uat.sh` as a real Pro user
- [ ] Post-deploy: rerun UAT, confirm budget + disputes return 200
- [ ] Post-deploy: hit `/dashboard/settings/mcp` with an expired session and confirm sign-in prompt (not upgrade gate) renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)