### PR TITLE
chore(admin): instrument test-notification with direct-fire control

### DIFF
--- a/src/app/api/admin/test-notification/route.ts
+++ b/src/app/api/admin/test-notification/route.ts
@@ -7,8 +7,11 @@
  * target email so we can fire it to any user, defaulting to
  * ADMIN_EMAIL.
  *
- * Uses the `support_reply` event as the dispatch event type because
- * it has sensible channel defaults and a low false-positive cost.
+ * Also direct-fires the same message via the user bot as a control,
+ * so a failure in the dispatcher path doesn't leave us blind —
+ * `direct.ok=true` means the token + chat_id work end-to-end, and
+ * `dispatch.delivered=['telegram']` is what we expect from the
+ * unified routing.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -42,25 +45,49 @@ export async function POST(request: NextRequest) {
     .maybeSingle();
   if (!user) return NextResponse.json({ error: `User ${targetEmail} not found` }, { status: 404 });
 
+  const { data: session } = await admin
+    .from('telegram_sessions')
+    .select('telegram_chat_id, is_active')
+    .eq('user_id', user.id)
+    .eq('is_active', true)
+    .maybeSingle();
+
   const stamp = new Date().toLocaleTimeString('en-GB', { timeZone: 'Europe/London' });
-  // Use `price_increase` — defaults email + telegram + push all on,
-  // and allowed channels include telegram (unlike support_reply which
-  // only permits email + push, leaving this endpoint silently
-  // no-opping on the telegram channel).
-  const result = await sendNotification(admin as any, {
+  const text = `🧪 *Paybacker test alert*\n\nIf you\'re reading this in the *Paybacker* bot (not Paybacker Assistant), the dispatcher routing fix is live.\n\nSent at ${stamp} BST.`;
+
+  const dispatch = await sendNotification(admin as any, {
     userId: user.id,
     event: 'price_increase',
-    telegram: {
-      text: `🧪 *Paybacker test alert*\n\nIf you\'re reading this in the *Paybacker* bot (not Paybacker Assistant), the dispatcher routing fix is live.\n\nSent at ${stamp} BST.`,
-    },
+    telegram: { text },
     bypassQuietHours: true,
   });
+
+  // Control path: fire directly via the user bot, same precedence
+  // as dispatch.sendTelegram, so we can see whether the token + chat
+  // pair work irrespective of the dispatcher.
+  const token = process.env.TELEGRAM_USER_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
+  let direct: { ok: boolean; status?: number; error?: string } = { ok: false, error: 'no chat_id or token' };
+  if (token && session?.telegram_chat_id) {
+    try {
+      const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: session.telegram_chat_id, text, parse_mode: 'Markdown' }),
+      });
+      direct = { ok: res.ok, status: res.status };
+    } catch (err) {
+      direct = { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
 
   return NextResponse.json({
     ok: true,
     target: user.email,
     sentAt: stamp,
-    result,
+    sessionPresent: !!session,
+    chatId: session?.telegram_chat_id ?? null,
     whichToken: process.env.TELEGRAM_USER_BOT_TOKEN ? 'TELEGRAM_USER_BOT_TOKEN' : 'TELEGRAM_BOT_TOKEN (fallback)',
+    dispatch,
+    direct,
   });
 }


### PR DESCRIPTION
Diagnostic pass — surface session state and fire a control message directly through the user bot so we can pinpoint why the dispatcher returns `delivered=[]`. Drop-in when the routing bug is identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)