### PR TITLE
fix(bank): respect deleted_at everywhere + keep loan credit in trends

### DIFF
--- a/src/app/api/auth/callback/truelayer/route.ts
+++ b/src/app/api/auth/callback/truelayer/route.ts
@@ -112,6 +112,10 @@ export async function GET(request: NextRequest) {
       bank_name: bankName,
       status: 'active',
       connected_at: new Date().toISOString(),
+      // Clear any prior soft-delete so reconnecting an existing
+      // provider brings the row back to life instead of staying
+      // hidden by the deleted_at filters in Money Hub / Telegram.
+      deleted_at: null,
     }, { onConflict: 'user_id,provider_id' })
     .select()
     .single();

--- a/src/app/api/auth/truelayer/route.ts
+++ b/src/app/api/auth/truelayer/route.ts
@@ -22,7 +22,8 @@ export async function GET(request: Request) {
     .from('bank_connections')
     .select('id')
     .eq('user_id', user.id)
-    .eq('status', 'active');
+    .eq('status', 'active')
+    .is('deleted_at', null);
 
   const connectionCount = existingConnections?.length || 0;
 

--- a/src/app/api/auth/yapily/route.ts
+++ b/src/app/api/auth/yapily/route.ts
@@ -49,7 +49,8 @@ export async function GET(request: NextRequest) {
     .from('bank_connections')
     .select('id')
     .eq('user_id', user.id)
-    .eq('status', 'active');
+    .eq('status', 'active')
+    .is('deleted_at', null);
 
   const connectionCount = existingConnections?.length || 0;
 

--- a/src/app/api/cron/bank-sync/route.ts
+++ b/src/app/api/cron/bank-sync/route.ts
@@ -122,6 +122,7 @@ export async function GET(request: NextRequest) {
     .in('status', ['active', 'token_expired'])
     .in('provider', ['truelayer', 'yapily'])
     .is('archived_at', null)
+    .is('deleted_at', null)
     .in('user_id', orderedUserIds.length > 0 ? orderedUserIds : ['00000000-0000-0000-0000-000000000000']);
 
   if (connError || !connections || connections.length === 0) {

--- a/src/app/api/money-hub/route.ts
+++ b/src/app/api/money-hub/route.ts
@@ -146,6 +146,7 @@ export async function GET(request: Request) {
       .from('bank_connections')
       .select('id, bank_name, status, last_synced_at, last_manual_sync_at, account_ids, account_display_names')
       .eq('user_id', user.id)
+      .is('deleted_at', null)
       .neq('status', 'revoked');
     if (connectionFilter) {
       connQuery = connQuery.in('id', connectionFilter);

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -1652,7 +1652,11 @@ export function isTransferLike(t: {
   const rawCat = (t.category ?? '').toString().toUpperCase();
   if (rawCat === 'TRANSFER') return true;
   if (userCat === 'transfers') return true;
-  if (incomeType === 'transfer' || incomeType === 'credit_loan') return true;
+  // Only pure transfers are excluded. credit_loan / loan_repayment
+  // contribute to income totals via migration 20260423020000 — they
+  // surface as "Loan Credit" in the Money Hub UI, so dropping them
+  // here would make Telegram trends diverge downward from the web.
+  if (incomeType === 'transfer') return true;
   return false;
 }
 
@@ -1857,7 +1861,10 @@ async function getMonthlyTrends(
 
     if (amt > 0) {
       if (userCat === 'transfers') return;
-      if (incomeType === 'transfer' || incomeType === 'credit_loan') return;
+      // Keep credit_loan / loan_repayment — the income RPC includes
+      // them since migration 20260423020000; dropping them here would
+      // make the bot trend short by real loan drawdowns.
+      if (incomeType === 'transfer') return;
       monthlyData[key].income += amt;
     } else if (amt < 0) {
       if (userCat === 'transfers' || userCat === 'income') return;


### PR DESCRIPTION
Codex follow-ups to #260 / #261.

## Changes
- Money Hub route + bank-sync cron + tier-limit counters all filter \`deleted_at IS NULL\` — a removed connection now fully disappears
- TrueLayer callback clears \`deleted_at\` on reconnect so a soft-deleted row can come back to life
- \`isTransferLike\` + \`getMonthlyTrends\` stop excluding \`credit_loan\`. Migration 20260423020000 made the income RPC include loan drawdowns ("Loan Credit"); the bot's JS filter was silently undoing that

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Remove a connection → Money Hub + Telegram + cron all ignore it
- [ ] Reconnect the same provider → row re-appears on both surfaces
- [ ] User with a loan drawdown: bot monthly trends match Money Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)