### PR TITLE
fix(homepage): correct demo scale-fallback padding + extend to iPad range

### DIFF
--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1584,8 +1584,9 @@
 }
 
 /* The wrapper itself must reserve the scaled height so the page
-   layout doesn't collapse around the now-transformed child. */
-@media (max-width: 900px) {
+   layout doesn't collapse around the now-transformed child. Range
+   matches the transform-fallback range (≤1024px) below. */
+@media (max-width: 1024px) {
   .m-v2-root .feature-stage,
   .m-v2-root .demo-slot {
     aspect-ratio: 16 / 10;
@@ -1602,10 +1603,16 @@
    native 980px and clipped against the wrapper. Re-state the same
    transform using `100vw` (which IS reliably available on first
    paint) so the scale lands correctly. The @media rule comes after
-   the @container rule so the cascade hands it the win. The two
-   subtractions account for the .wrap horizontal padding at each
-   breakpoint (24px each side ≤900, 16px each side ≤560). */
-@media (max-width: 900px) {
+   the @container rule so the cascade hands it the win.
+
+   The breakpoint cascade must mirror `.wrap` padding exactly:
+     • default           → 32px each side = 64px total
+     • @media ≤560px     → 16px each side = 32px total
+   Fallback extends to 1024px because the container (.feature-stage
+   / .demo-slot, which fills .wrap's inner width) stays ≤900px up to
+   viewport ≈ 964px — catching iPhone landscape (~932px) and small
+   iPads where the container query can mis-fire on first paint. */
+@media (max-width: 1024px) {
   .m-v2-root .feature-stage > .demo-stage,
   .m-v2-root .demo-slot > .demo-stage {
     width: 980px;
@@ -1614,7 +1621,7 @@
     aspect-ratio: auto;
     margin: 0;
     transform-origin: top left;
-    transform: scale(calc((100vw - 48px) / 980));
+    transform: scale(calc((100vw - 64px) / 980));
   }
 }
 @media (max-width: 560px) {


### PR DESCRIPTION
## Summary

The 7 animated product demos on the homepage (DisputesDemo, PocketAgentDemo, MoneyHubDemo, SubscriptionsDemo, ExportDemo, DealsDemo, McpDemo) were clipping on the right edge on iPhone Pro Max landscape and iPad-class viewports. Two bugs in PR #226's iOS Safari fallback:

1. **Wrong padding subtraction.** The ≤900px fallback subtracted **48px** from `100vw` (24px × 2), but `.wrap` has **32px** horizontal padding each side (64px total) in the 561–900px range. Demos overflowed the wrapper by 16px and got clipped.
2. **Fallback range too narrow.** It only applied at ≤900px. iPhone Pro Max in landscape is ~932px — outside the fallback — but the container width at that viewport is 868px, well within the ≤900px container-query trigger. When iOS Safari mis-fired the container query on first paint, demos rendered at their native 980px, heavily clipped.

## Fix

- Extended both the transform override and the wrapper `aspect-ratio` reservation from ≤900px to **≤1024px**. This covers iPhone landscape and small iPads where the container can still be ≤900px.
- Corrected the subtraction to **64px** (32px × 2), matching `.wrap` padding in that range.
- The ≤560px override (32px subtraction, matching the 16px × 2 padding at that breakpoint) is unchanged.

## Verification

Math verified at multiple breakpoints — scaled demo width equals wrapper inner width exactly:

| viewport | `.wrap` pad × 2 | calc subtracts | scaled demo | wrap inner | Δ |
|---:|---:|---:|---:|---:|---:|
| 1024 | 64 | −64 | 960.0 | 960 | 0 |
| 900  | 64 | −64 | 836.0 | 836 | 0 |
| 700  | 64 | −64 | 636.0 | 636 | 0 |
| 561  | 64 | −64 | 497.0 | 497 | 0 |
| 560  | 32 | −32 | 528.0 | 528 | 0 |
| 440  | 32 | −32 | 408.0 | 408 | 0 |
| 430  | 32 | −32 | 398.0 | 398 | 0 |
| 390  | 32 | −32 | 358.0 | 358 | 0 |

## Test plan

- [ ] Open `/` on iPhone Pro Max (portrait) — demos fit the wrapper with no right-edge clip
- [ ] Rotate to landscape — demos fit the wrapper with no right-edge clip
- [ ] Check on iPad mini (~768px) and iPad (~820–1024px) — demos fit
- [ ] Check on desktop ≥1025px — container-query path still active, no regression
- [ ] Check all 7 demos: Disputes, Pocket Agent, Money Hub, Subscriptions, Export, Deals, MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)