### PR TITLE
fix(marketing): homepage + pricing + auth + about UX improvements

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -188,7 +188,11 @@ export default function AboutPage() {
         style={{ '--glow-opacity': 0.18, paddingTop: 140, paddingBottom: 80 } as CSSVarProperties}
       >
         <div className="wrap">
-          <span className="eyebrow">About · Paybacker LTD · Launched March 2026</span>
+          <span className="eyebrow">
+            About · Paybacker LTD · Launched March 2026
+            <span className="eyebrow-dot" aria-hidden="true"> · </span>
+            <span className="eyebrow-trust">ICO registered · FCA-authorised via Yapily</span>
+          </span>
           <h1
             style={{
               fontSize: 'var(--fs-display)',
@@ -216,7 +220,7 @@ export default function AboutPage() {
           </p>
           <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
             <Link className="btn btn-mint" href={SIGNUP_HREF}>
-              Start free 14-day trial →
+              Start free — no card needed →
             </Link>
             <Link className="btn btn-ghost" href="/careers">
               We&apos;re hiring — see roles

--- a/src/app/about/styles.css
+++ b/src/app/about/styles.css
@@ -82,6 +82,13 @@
   font-weight: 600;
 }
 .m-about-root .eyebrow.on-ink { color: var(--accent-mint); }
+.m-about-root .eyebrow .eyebrow-trust {
+  color: var(--text-tertiary);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+.m-about-root .eyebrow .eyebrow-dot { color: var(--text-tertiary); opacity: 0.5; }
 
 .m-about-root .btn {
   display: inline-flex; align-items: center; gap: 8px;

--- a/src/app/auth/auth.css
+++ b/src/app/auth/auth.css
@@ -74,10 +74,14 @@
   cursor: pointer;
   transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
 }
-.m-land-root .oauth-btn:hover {
+.m-land-root .oauth-btn:hover:not(:disabled) {
   background: #F8FAFC;
   box-shadow: var(--shadow-sm);
   transform: translateY(-1px);
+}
+.m-land-root .oauth-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* OR divider -------------------------------------------------------- */

--- a/src/app/auth/auth.css
+++ b/src/app/auth/auth.css
@@ -191,6 +191,23 @@
   margin-top: 4px;
 }
 
+/* Field footer — small right-aligned helper link under an input
+   (e.g. "Forgot password?" on the login form). Kept outside the
+   <label> so keyboard users and screen readers don't confuse it
+   with the field caption. */
+.m-land-root .field .field-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6px;
+  font-size: 13px;
+}
+.m-land-root .field .field-footer a {
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+  text-decoration: none;
+}
+.m-land-root .field .field-footer a:hover { text-decoration: underline; }
+
 /* Form error -------------------------------------------------------- */
 .m-land-root .form-error {
   margin: 10px 0 4px;
@@ -252,6 +269,80 @@
 .m-land-root .auth-finepr a {
   color: var(--text-secondary);
   text-decoration: underline;
+}
+
+/* Password strength checklist (real-time feedback) ------------------ */
+.m-land-root .pw-checklist {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: grid;
+  gap: 4px;
+  font-size: 12.5px;
+  color: var(--text-tertiary);
+}
+.m-land-root .pw-checklist li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: color 150ms ease;
+}
+.m-land-root .pw-checklist li.ok { color: var(--accent-mint-deep); }
+.m-land-root .pw-checklist li.todo { color: var(--text-tertiary); }
+.m-land-root .pw-checklist__mark {
+  display: inline-grid;
+  place-items: center;
+  width: 16px; height: 16px;
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+.m-land-root .pw-checklist li.ok .pw-checklist__mark {
+  background: var(--accent-mint-wash);
+  color: var(--accent-mint-deep);
+}
+.m-land-root .pw-checklist li.todo .pw-checklist__mark {
+  background: transparent;
+  color: var(--text-tertiary);
+  border: 1px solid var(--divider);
+}
+
+/* Consent checkboxes (required T&Cs + optional marketing) ----------- */
+.m-land-root .consent {
+  margin: 14px 0 4px;
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--divider);
+  border-radius: var(--r-input);
+  background: #FAFAF7;
+}
+.m-land-root .consent__row {
+  display: grid;
+  grid-template-columns: 20px 1fr;
+  gap: 10px;
+  align-items: start;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.m-land-root .consent__row input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  margin: 2px 0 0;
+  accent-color: var(--accent-mint-deep);
+  cursor: pointer;
+}
+.m-land-root .consent__row a {
+  color: var(--accent-mint-deep);
+  font-weight: 600;
+  text-decoration: underline;
+}
+.m-land-root .consent__row--optional {
+  color: var(--text-tertiary);
+  font-size: 12.5px;
 }
 
 /* Check / sent screens --------------------------------------------- */

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -197,10 +197,7 @@ export default function LoginPage() {
 
                   {!useMagicLink && (
                     <div className="field">
-                      <label htmlFor="password">
-                        Password
-                        <Link href="/auth/reset-password">Forgot password?</Link>
-                      </label>
+                      <label htmlFor="password">Password</label>
                       <div className="field-control">
                         <Lock className="lead h-4 w-4" aria-hidden="true" />
                         <input
@@ -212,6 +209,9 @@ export default function LoginPage() {
                           placeholder="••••••••"
                           autoComplete="current-password"
                         />
+                      </div>
+                      <div className="field-footer">
+                        <Link href="/auth/reset-password">Forgot password?</Link>
                       </div>
                     </div>
                   )}

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -63,15 +63,56 @@ export default function SignupPage() {
       router.replace('/');
       return;
     }
-    // Redirect to dashboard if already logged in
-    supabase.auth.getUser().then(({ data: { user } }) => {
-      if (user) router.replace(redirectTo || '/dashboard');
+    // Redirect to dashboard if already logged in. If they landed back here
+    // via the OAuth callback and had pre-accepted the Terms / opted into
+    // marketing, drain that from localStorage onto the new user before
+    // routing them onwards so the audit trail is consistent with the
+    // email/password path.
+    supabase.auth.getUser().then(async ({ data: { user } }) => {
+      if (!user) return;
+      try {
+        const raw = localStorage.getItem('pb_pending_consent');
+        if (raw) {
+          const pending = JSON.parse(raw) as {
+            terms_accepted_at?: string;
+            marketing_opt_in?: boolean;
+          };
+          if (pending?.terms_accepted_at && !user.user_metadata?.terms_accepted_at) {
+            await supabase.auth.updateUser({
+              data: {
+                terms_accepted_at: pending.terms_accepted_at,
+                marketing_opt_in: !!pending.marketing_opt_in,
+              },
+            });
+          }
+          localStorage.removeItem('pb_pending_consent');
+        }
+      } catch {
+        localStorage.removeItem('pb_pending_consent');
+      }
+      router.replace(redirectTo || '/dashboard');
     });
     if (searchParams.get('verify') === 'true') setVerifyMode(true);
   }, [searchParams, router]);
 
   const handleGoogleSignup = async () => {
+    // Same consent gate as the email/password path — don't start the
+    // OAuth redirect without explicit T&Cs acceptance, otherwise we'd
+    // end up with Google accounts that skipped the checkbox entirely.
+    if (!termsAccepted) {
+      setError('Please agree to the Terms of Service and Privacy Policy to continue.');
+      return;
+    }
     try {
+      // Stash consent choices for /auth/callback → the useEffect above
+      // drains them onto user_metadata once the session is established.
+      localStorage.setItem(
+        'pb_pending_consent',
+        JSON.stringify({
+          terms_accepted_at: new Date().toISOString(),
+          marketing_opt_in: marketingOptIn,
+        })
+      );
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
@@ -276,10 +317,43 @@ export default function SignupPage() {
               </div>
             ) : (
               <>
+                {/* Consent gate — sits above both signup paths so Google
+                    OAuth and email/password both respect the same T&Cs
+                    checkbox. Without this, Google skipped consent entirely
+                    and `terms_accepted_at` only landed on email users. */}
+                <div className="consent">
+                  <label className="consent__row">
+                    <input
+                      type="checkbox"
+                      checked={termsAccepted}
+                      onChange={(e) => setTermsAccepted(e.target.checked)}
+                    />
+                    <span>
+                      I agree to the{' '}
+                      <Link href="/terms-of-service">Terms of Service</Link>
+                      {' '}and{' '}
+                      <Link href="/privacy-policy">Privacy Policy</Link>.
+                    </span>
+                  </label>
+                  <label className="consent__row consent__row--optional">
+                    <input
+                      type="checkbox"
+                      checked={marketingOptIn}
+                      onChange={(e) => setMarketingOptIn(e.target.checked)}
+                    />
+                    <span>
+                      Send me the Paybacker newsletter — savings tips and
+                      product updates (optional, unsubscribe anytime).
+                    </span>
+                  </label>
+                </div>
+
                 <button
                   type="button"
                   onClick={handleGoogleSignup}
                   className="oauth-btn"
+                  disabled={!termsAccepted}
+                  aria-disabled={!termsAccepted}
                 >
                   <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
@@ -397,37 +471,13 @@ export default function SignupPage() {
                     </ul>
                   </div>
 
-                  <div className="consent">
-                    <label className="consent__row">
-                      <input
-                        type="checkbox"
-                        required
-                        checked={termsAccepted}
-                        onChange={(e) => setTermsAccepted(e.target.checked)}
-                      />
-                      <span>
-                        I agree to the{' '}
-                        <Link href="/terms-of-service">Terms of Service</Link>
-                        {' '}and{' '}
-                        <Link href="/privacy-policy">Privacy Policy</Link>.
-                      </span>
-                    </label>
-                    <label className="consent__row consent__row--optional">
-                      <input
-                        type="checkbox"
-                        checked={marketingOptIn}
-                        onChange={(e) => setMarketingOptIn(e.target.checked)}
-                      />
-                      <span>
-                        Send me the Paybacker newsletter — savings tips and
-                        product updates (optional, unsubscribe anytime).
-                      </span>
-                    </label>
-                  </div>
-
                   {error && <div className="form-error">{error}</div>}
 
-                  <button type="submit" disabled={loading} className="auth-submit">
+                  <button
+                    type="submit"
+                    disabled={loading || !termsAccepted}
+                    className="auth-submit"
+                  >
                     {loading ? 'Creating account…' : 'Create account'}
                   </button>
                 </form>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -63,34 +63,14 @@ export default function SignupPage() {
       router.replace('/');
       return;
     }
-    // Redirect to dashboard if already logged in. If they landed back here
-    // via the OAuth callback and had pre-accepted the Terms / opted into
-    // marketing, drain that from localStorage onto the new user before
-    // routing them onwards so the audit trail is consistent with the
-    // email/password path.
-    supabase.auth.getUser().then(async ({ data: { user } }) => {
-      if (!user) return;
-      try {
-        const raw = localStorage.getItem('pb_pending_consent');
-        if (raw) {
-          const pending = JSON.parse(raw) as {
-            terms_accepted_at?: string;
-            marketing_opt_in?: boolean;
-          };
-          if (pending?.terms_accepted_at && !user.user_metadata?.terms_accepted_at) {
-            await supabase.auth.updateUser({
-              data: {
-                terms_accepted_at: pending.terms_accepted_at,
-                marketing_opt_in: !!pending.marketing_opt_in,
-              },
-            });
-          }
-          localStorage.removeItem('pb_pending_consent');
-        }
-      } catch {
-        localStorage.removeItem('pb_pending_consent');
-      }
-      router.replace(redirectTo || '/dashboard');
+    // Redirect to dashboard if already logged in. Pending OAuth consent
+    // (stashed before the Google redirect) is drained in the dashboard
+    // layout — we deliberately don't drain here because this branch also
+    // fires for users who are just revisiting /auth/signup in a new tab,
+    // and at that point we can't tell whether the pending blob belongs
+    // to them or to an abandoned signup on the same origin.
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) router.replace(redirectTo || '/dashboard');
     });
     if (searchParams.get('verify') === 'true') setVerifyMode(true);
   }, [searchParams, router]);
@@ -104,13 +84,19 @@ export default function SignupPage() {
       return;
     }
     try {
-      // Stash consent choices for /auth/callback → the useEffect above
-      // drains them onto user_metadata once the session is established.
-      localStorage.setItem(
+      // Stash consent choices in sessionStorage so they're tab-scoped
+      // (avoids leaking onto a different user who later signs in on a
+      // shared browser — localStorage would persist across tab lifetimes).
+      // The dashboard layout drains this onto user_metadata once the
+      // OAuth callback establishes a session, but only for users who
+      // themselves were just created (server-side created_at check),
+      // and only deletes the blob after a confirmed successful write.
+      sessionStorage.setItem(
         'pb_pending_consent',
         JSON.stringify({
           terms_accepted_at: new Date().toISOString(),
           marketing_opt_in: marketingOptIn,
+          created_at: Date.now(),
         })
       );
       const { error } = await supabase.auth.signInWithOAuth({

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -14,15 +14,29 @@ import { MarkNav } from '@/app/blog/_shared';
 import '../../(marketing)/styles.css';
 import '../auth.css';
 
+// Password strength helpers — used to drive the live checklist below the
+// password field. Same rules Supabase will enforce server-side so the
+// user gets immediate feedback instead of a post-submit bounce.
+const PW_RULES = [
+  { id: 'length', label: 'At least 8 characters', test: (v: string) => v.length >= 8 },
+  { id: 'letter', label: 'Contains a letter', test: (v: string) => /[A-Za-z]/.test(v) },
+  { id: 'number', label: 'Contains a number', test: (v: string) => /\d/.test(v) },
+] as const;
+
 export default function SignupPage() {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [mobile, setMobile] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [termsAccepted, setTermsAccepted] = useState(false);
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [verifyMode, setVerifyMode] = useState(false);
+
+  const passedRules = PW_RULES.filter((r) => r.test(password));
+  const passwordValid = passedRules.length === PW_RULES.length;
   const router = useRouter();
   const searchParams = useSearchParams();
   const supabase = createClient();
@@ -93,6 +107,18 @@ export default function SignupPage() {
       }
     }
 
+    if (!passwordValid) {
+      setError('Password must be at least 8 characters and include a letter and a number.');
+      setLoading(false);
+      return;
+    }
+
+    if (!termsAccepted) {
+      setError('Please agree to the Terms of Service and Privacy Policy to continue.');
+      setLoading(false);
+      return;
+    }
+
     const fullName = `${firstName.trim()} ${lastName.trim()}`.trim();
 
     try {
@@ -105,6 +131,8 @@ export default function SignupPage() {
             first_name: firstName.trim(),
             last_name: lastName.trim(),
             mobile_number: mobile.trim() || null,
+            terms_accepted_at: new Date().toISOString(),
+            marketing_opt_in: marketingOptIn,
           },
           emailRedirectTo: `${window.location.origin}/auth/callback`,
         },
@@ -325,6 +353,7 @@ export default function SignupPage() {
                       <input
                         id="signup-mobile"
                         type="tel"
+                        inputMode="tel"
                         value={mobile}
                         onChange={(e) => setMobile(e.target.value)}
                         placeholder="+44 7700 900000"
@@ -346,9 +375,54 @@ export default function SignupPage() {
                         onChange={(e) => setPassword(e.target.value)}
                         placeholder="••••••••"
                         autoComplete="new-password"
+                        aria-describedby="password-requirements"
                       />
                     </div>
-                    <p className="hint">Minimum 8 characters.</p>
+                    <ul
+                      id="password-requirements"
+                      className={`pw-checklist ${password.length === 0 ? 'is-idle' : ''}`}
+                      aria-live="polite"
+                    >
+                      {PW_RULES.map((rule) => {
+                        const ok = rule.test(password);
+                        return (
+                          <li key={rule.id} className={ok ? 'ok' : 'todo'}>
+                            <span className="pw-checklist__mark" aria-hidden="true">
+                              {ok ? '✓' : '○'}
+                            </span>
+                            {rule.label}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+
+                  <div className="consent">
+                    <label className="consent__row">
+                      <input
+                        type="checkbox"
+                        required
+                        checked={termsAccepted}
+                        onChange={(e) => setTermsAccepted(e.target.checked)}
+                      />
+                      <span>
+                        I agree to the{' '}
+                        <Link href="/terms-of-service">Terms of Service</Link>
+                        {' '}and{' '}
+                        <Link href="/privacy-policy">Privacy Policy</Link>.
+                      </span>
+                    </label>
+                    <label className="consent__row consent__row--optional">
+                      <input
+                        type="checkbox"
+                        checked={marketingOptIn}
+                        onChange={(e) => setMarketingOptIn(e.target.checked)}
+                      />
+                      <span>
+                        Send me the Paybacker newsletter — savings tips and
+                        product updates (optional, unsubscribe anytime).
+                      </span>
+                    </label>
                   </div>
 
                   {error && <div className="form-error">{error}</div>}
@@ -365,12 +439,6 @@ export default function SignupPage() {
                   >
                     Sign in
                   </Link>
-                </div>
-
-                <div className="auth-finepr">
-                  By creating an account, you agree to our{' '}
-                  <Link href="/terms-of-service">Terms of Service</Link> and{' '}
-                  <Link href="/privacy-policy">Privacy Policy</Link>.
                 </div>
               </>
             )}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -32,6 +32,31 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       setUserEmail(user.email || null);
       setAuthChecked(true);
 
+      // OAuth signup path leaves Terms/marketing consent in localStorage
+      // (the signup page can't write to user_metadata before the OAuth
+      // redirect). Drain it here so Google-signup users have the same
+      // audit trail as email/password users.
+      try {
+        const raw = localStorage.getItem('pb_pending_consent');
+        if (raw && !user.user_metadata?.terms_accepted_at) {
+          const pending = JSON.parse(raw) as {
+            terms_accepted_at?: string;
+            marketing_opt_in?: boolean;
+          };
+          if (pending?.terms_accepted_at) {
+            await supabase.auth.updateUser({
+              data: {
+                terms_accepted_at: pending.terms_accepted_at,
+                marketing_opt_in: !!pending.marketing_opt_in,
+              },
+            });
+          }
+        }
+        localStorage.removeItem('pb_pending_consent');
+      } catch {
+        localStorage.removeItem('pb_pending_consent');
+      }
+
       const { data } = await supabase
         .from('profiles')
         .select('first_name, full_name, subscription_tier, subscription_status, stripe_subscription_id, trial_ends_at')

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -32,29 +32,63 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       setUserEmail(user.email || null);
       setAuthChecked(true);
 
-      // OAuth signup path leaves Terms/marketing consent in localStorage
+      // OAuth signup path leaves Terms/marketing consent in sessionStorage
       // (the signup page can't write to user_metadata before the OAuth
-      // redirect). Drain it here so Google-signup users have the same
-      // audit trail as email/password users.
+      // redirect). Drain it here for Google-signup users. Guardrails:
+      //   1. sessionStorage is tab-scoped — can't leak to other users
+      //      who later sign in from the same browser profile.
+      //   2. The payload carries `created_at`; we reject > 15 min old
+      //      blobs as stale (e.g. abandoned OAuth flows).
+      //   3. The CURRENT user must themselves be newly created
+      //      (auth.users.created_at within 15 min). This prevents the
+      //      same-tab hand-off a legacy account would need to inherit
+      //      someone else's abandoned consent blob.
+      //   4. The key is only removed AFTER a confirmed write (or when
+      //      it's stale / already applied) — transient network errors
+      //      leave the blob in place so a retry can still recover it.
+      const CONSENT_TTL_MS = 15 * 60 * 1000;
       try {
-        const raw = localStorage.getItem('pb_pending_consent');
+        const raw = sessionStorage.getItem('pb_pending_consent');
         if (raw && !user.user_metadata?.terms_accepted_at) {
           const pending = JSON.parse(raw) as {
             terms_accepted_at?: string;
             marketing_opt_in?: boolean;
+            created_at?: number;
           };
-          if (pending?.terms_accepted_at) {
-            await supabase.auth.updateUser({
+          const now = Date.now();
+          const isFreshPayload =
+            typeof pending?.created_at === 'number' &&
+            now - pending.created_at < CONSENT_TTL_MS;
+          const userCreatedMs = user.created_at ? Date.parse(user.created_at) : NaN;
+          const isFreshUser =
+            Number.isFinite(userCreatedMs) && now - userCreatedMs < CONSENT_TTL_MS;
+
+          if (!isFreshPayload) {
+            sessionStorage.removeItem('pb_pending_consent');
+          } else if (!isFreshUser) {
+            // Don't apply a stashed consent blob to a pre-existing user
+            // — the pending blob belongs to an abandoned OAuth signup.
+            // Leave the blob in place; it'll expire on TTL above.
+          } else if (pending.terms_accepted_at) {
+            const { error: updateError } = await supabase.auth.updateUser({
               data: {
                 terms_accepted_at: pending.terms_accepted_at,
                 marketing_opt_in: !!pending.marketing_opt_in,
               },
             });
+            if (!updateError) {
+              sessionStorage.removeItem('pb_pending_consent');
+            }
+            // If updateError (transient 5xx, network), keep the blob so
+            // the next dashboard hit can retry.
           }
+        } else if (raw && user.user_metadata?.terms_accepted_at) {
+          // User already has consent recorded — safe to clear.
+          sessionStorage.removeItem('pb_pending_consent');
         }
-        localStorage.removeItem('pb_pending_consent');
       } catch {
-        localStorage.removeItem('pb_pending_consent');
+        // JSON.parse error → payload is corrupt, safe to remove.
+        sessionStorage.removeItem('pb_pending_consent');
       }
 
       const { data } = await supabase

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -811,9 +811,9 @@ export default function HomepageV3PreviewPage() {
             <Reveal className="hero-copy">
               <span className="eyebrow">Free forever tier · No card required</span>
               <h1>
-                <span className="l1">Find Hidden Overcharges.</span>
-                <span className="l2">Fight Unfair Bills.</span>
-                <span className="l3">Get Your Money Back.</span>
+                <span className="l1">Find the £1,000+</span>
+                <span className="l2">you&rsquo;re overpaying.</span>
+                <span className="l3">Get your money back.</span>
               </h1>
               <p className="hero-sub">
                 Paybacker scans your bank and email to spot overcharges, forgotten
@@ -822,7 +822,7 @@ export default function HomepageV3PreviewPage() {
               </p>
               <div className="hero-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup">
-                  Sign up for free →
+                  Start free — 3 AI letters included →
                 </Link>
                 <a className="btn btn-ghost" href="#how">
                   See how it works
@@ -1484,7 +1484,7 @@ export default function HomepageV3PreviewPage() {
           </Reveal>
           <Reveal className="fc-btn-row">
             <Link className="btn btn-mint" href="/auth/signup">
-              Sign up for free →
+              Find my money — free →
             </Link>
           </Reveal>
           <p className="fine">No card. Cancel anytime. Your data stays in the UK.</p>

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -226,7 +226,7 @@
 
 .m-v2-root .nav-cta-row { display: flex; align-items: center; gap: 6px; }
 
-.m-v2-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 8px 14px; }
+.m-v2-root .nav-signin { font-size: 14px; font-weight: 500; color: var(--text-primary); text-decoration: none; padding: 12px 16px; min-height: 44px; display: inline-flex; align-items: center; }
 
 .m-v2-root .nav-start {
   background: var(--accent-mint); color: #052E1C;
@@ -1958,10 +1958,10 @@
    ============================================================ */
 .m-v2-root .nav-burger {
   display: none;
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   border: 1px solid var(--divider, #E5E7EB);
-  border-radius: 10px;
+  border-radius: 12px;
   background: #fff;
   cursor: pointer;
   padding: 0;
@@ -2021,8 +2021,8 @@
   border-bottom: 1px solid var(--divider, #E5E7EB);
 }
 .m-v2-root .nav-drawer-close {
-  width: 36px;
-  height: 36px;
+  width: 44px;
+  height: 44px;
   border: 0;
   background: transparent;
   cursor: pointer;

--- a/src/app/pricing/PricingGrid.tsx
+++ b/src/app/pricing/PricingGrid.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+/**
+ * PricingGrid — client-side pricing cards with a monthly/annual toggle.
+ *
+ * Replaces the three inline <div className="price-card"> blocks on page.tsx.
+ * Annual price IDs are already wired into PricingCTA (billingCycle='yearly'),
+ * so the toggle only needs to drive (a) displayed price + cadence label and
+ * (b) the billingCycle prop passed to PricingCTA.
+ *
+ * Pricing copy pinned to CLAUDE.md §PRICING:
+ *   - Essential £4.99/mo · £44.99/year (saves £14.89)
+ *   - Pro       £9.99/mo · £94.99/year (saves £24.89)
+ * CTAs deliberately avoid any "14-day trial" language — per CLAUDE.md the
+ * Pro trial was removed because it produced silent downgrades at expiry.
+ */
+
+import { useState } from 'react';
+import PricingCTA from './PricingCTA';
+
+type Cycle = 'monthly' | 'yearly';
+
+export default function PricingGrid() {
+  const [cycle, setCycle] = useState<Cycle>('monthly');
+  const isYearly = cycle === 'yearly';
+
+  return (
+    <>
+      <div className="billing-toggle-wrap">
+        <div className="billing-toggle" role="radiogroup" aria-label="Billing period">
+          <button
+            type="button"
+            role="radio"
+            aria-checked={!isYearly}
+            className={`billing-toggle__opt ${!isYearly ? 'is-active' : ''}`}
+            onClick={() => setCycle('monthly')}
+          >
+            Monthly
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={isYearly}
+            className={`billing-toggle__opt ${isYearly ? 'is-active' : ''}`}
+            onClick={() => setCycle('yearly')}
+          >
+            Yearly <span className="billing-toggle__save">save ~25%</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="pricing-grid">
+        <div className="price-card">
+          <div className="tier">Free</div>
+          <div className="price">
+            £0<span className="per">/forever</span>
+          </div>
+          <div className="founding" style={{ visibility: 'hidden' }}>—</div>
+          <ul>
+            <li>3 AI dispute letters / month</li>
+            <li>Manual subscription tracker</li>
+            <li>Public deals marketplace</li>
+          </ul>
+          <PricingCTA
+            plan="free"
+            className="btn btn-ghost cta"
+            style={{ justifyContent: 'center' }}
+          >
+            Start free →
+          </PricingCTA>
+        </div>
+
+        <div className="price-card featured">
+          <span className="ribbon">Most popular</span>
+          <div className="tier">Essential</div>
+          <div className="price">
+            {isYearly ? '£44.99' : '£4.99'}
+            <span className="per">{isYearly ? '/year' : '/month'}</span>
+          </div>
+          <div className="founding">
+            {isYearly ? 'Saves £14.89 vs monthly' : 'Founding member · locked-in forever'}
+          </div>
+          <ul>
+            <li>Unlimited AI dispute letters</li>
+            <li>Bank sync — 2 accounts</li>
+            <li>Email inbox scan</li>
+            <li>Pocket Agent in Telegram</li>
+          </ul>
+          <PricingCTA
+            plan="essential"
+            billingCycle={cycle}
+            className="btn btn-mint cta"
+            style={{ justifyContent: 'center' }}
+          >
+            Start Essential →
+          </PricingCTA>
+        </div>
+
+        <div className="price-card">
+          <div className="tier">Pro</div>
+          <div className="price">
+            {isYearly ? '£94.99' : '£9.99'}
+            <span className="per">{isYearly ? '/year' : '/month'}</span>
+          </div>
+          <div className="founding">
+            {isYearly ? 'Saves £24.89 vs monthly' : 'Founding member · locked-in forever'}
+          </div>
+          <ul>
+            <li>Everything in Essential</li>
+            <li>Unlimited bank &amp; email connections</li>
+            <li>Deal alerts on bill changes</li>
+            <li>Priority human review on complex disputes</li>
+          </ul>
+          <PricingCTA
+            plan="pro"
+            billingCycle={cycle}
+            className="btn btn-ghost cta"
+            style={{ justifyContent: 'center' }}
+          >
+            Start Pro →
+          </PricingCTA>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
+import PricingGrid from './PricingGrid';
 import './styles.css';
 
 /**
@@ -221,58 +222,16 @@ export default function PricingPage() {
       {/* PRICING GRID */}
       <section className="pricing-section" style={{ paddingTop: 40 }}>
         <div className="wrap">
-          <div className="pricing-grid">
-            <div className="price-card">
-              <div className="tier">Free</div>
-              <div className="price">
-                £0<span className="per">/forever</span>
-              </div>
-              <div className="founding" style={{ visibility: 'hidden' }}>—</div>
-              <ul>
-                <li>3 AI dispute letters / month</li>
-                <li>Manual subscription tracker</li>
-                <li>Public deals marketplace</li>
-              </ul>
-              <Link className="btn btn-ghost cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
-                Start free →
-              </Link>
-            </div>
-
-            <div className="price-card featured">
-              <span className="ribbon">Most popular</span>
-              <div className="tier">Essential</div>
-              <div className="price">
-                £4.99<span className="per">/month</span>
-              </div>
-              <div className="founding">Founding member · locked-in forever</div>
-              <ul>
-                <li>Unlimited AI dispute letters</li>
-                <li>Bank sync — 2 accounts</li>
-                <li>Email inbox scan</li>
-                <li>Pocket Agent in Telegram</li>
-              </ul>
-              <Link className="btn btn-mint cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
-                Start 14-day trial →
-              </Link>
-            </div>
-
-            <div className="price-card">
-              <div className="tier">Pro</div>
-              <div className="price">
-                £9.99<span className="per">/month</span>
-              </div>
-              <div className="founding">Founding member · locked-in forever</div>
-              <ul>
-                <li>Everything in Essential</li>
-                <li>Unlimited bank &amp; email connections</li>
-                <li>Deal alerts on bill changes</li>
-                <li>Priority human review on complex disputes</li>
-              </ul>
-              <Link className="btn btn-ghost cta" href={SIGNUP_HREF} style={{ justifyContent: 'center' }}>
-                Go Pro →
-              </Link>
-            </div>
-          </div>
+          <p className="trust-row" aria-label="Plan guarantees">
+            <span>No card for Free</span>
+            <span className="trust-row__dot">·</span>
+            <span>Cancel anytime</span>
+            <span className="trust-row__dot">·</span>
+            <span>0% success fee, ever</span>
+            <span className="trust-row__dot">·</span>
+            <span>Your data stays in the UK</span>
+          </p>
+          <PricingGrid />
           <p className="compare-link">
             <a href="#compare">See the full feature comparison ↓</a>
           </p>
@@ -521,7 +480,7 @@ export default function PricingPage() {
               style={{ color: 'var(--accent-mint)', borderColor: 'rgba(52,211,153,.3)' }}
               href={SIGNUP_HREF}
             >
-              Try Essential 14 days free →
+              Start Essential — £4.99/mo →
             </Link>
           </div>
           <p style={{ textAlign: 'center', marginTop: 20, color: 'var(--text-on-ink-dim)', fontSize: 13 }}>

--- a/src/app/pricing/styles.css
+++ b/src/app/pricing/styles.css
@@ -258,6 +258,73 @@
 }
 .m-pricing-root .footer-socials a:hover { background: rgba(255,255,255,0.06); }
 
+/* Trust row above pricing grid ------------------------------------- */
+.m-pricing-root .trust-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 6px 14px;
+  margin: 0 auto 32px;
+  padding: 0 16px;
+  max-width: 720px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  text-align: center;
+}
+.m-pricing-root .trust-row__dot {
+  color: var(--text-tertiary);
+  opacity: 0.6;
+}
+
+/* Monthly / Yearly billing toggle ---------------------------------- */
+.m-pricing-root .billing-toggle-wrap {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 28px;
+}
+.m-pricing-root .billing-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  padding: 4px;
+  background: #F3F4F6;
+  border-radius: 999px;
+  border: 1px solid var(--divider);
+  max-width: 100%;
+}
+.m-pricing-root .billing-toggle__opt {
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 600;
+  padding: 10px 20px;
+  border-radius: 999px;
+  cursor: pointer;
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: background 150ms ease, color 150ms ease, box-shadow 150ms ease;
+  white-space: nowrap;
+}
+.m-pricing-root .billing-toggle__opt.is-active {
+  background: #fff;
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}
+.m-pricing-root .billing-toggle__save {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent-mint-deep);
+  background: var(--accent-mint-wash);
+  padding: 3px 8px;
+  border-radius: 999px;
+}
 /* Responsive --------------------------------------------------------- */
 @media (max-width: 980px) {
   .m-pricing-root .pricing-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
Re-opened after #265 merged (GitHub auto-closed the original PR #266 when its base branch was deleted). All six commits are unchanged on the `fix/marketing-site-ux` branch — the pre-squash demo-scaling commit (`d84f0c4`) was auto-dropped by rebase since master already has it as `eea0650`.

## Summary

Marketing-surface UX sweep — homepage, pricing, auth, about. Six focused commits.

## Commits

| Commit | Page | Changes |
|---|---|---|
| `7587901` | `/` homepage | Hero headline leads with £1,000+ quantified · CTAs differentiated ("Start free — 3 AI letters included", "Find my money — free") · nav/burger/drawer-close bumped to 44–48px tap targets |
| `b8d90e4` | `/pricing` | New `PricingGrid` client component with **monthly/annual toggle** (£4.99/mo ↔ £44.99/yr, £9.99/mo ↔ £94.99/yr) · trust row above cards · removed misleading "14-day trial" copy · wired `PricingCTA` so logged-in users go straight to Stripe |
| `1799797` | `/auth/signup` + `/auth/login` | Explicit T&Cs consent checkbox (required) + optional marketing opt-in · live password strength checklist · `inputMode="tel"` on mobile field · "Forgot password?" moved to dedicated `.field-footer` under password input |
| `384a4c6` | `/about` | "ICO registered · FCA-authorised via Yapily" added to hero eyebrow · 14-day trial copy fix |
| `419daac` | `/auth/signup` + `/app/dashboard/layout.tsx` | **Codex P1 round 1**: Google OAuth path now also gates on consent — button `disabled={!termsAccepted}`, handler short-circuits on miss, consent stashed in localStorage pre-OAuth and drained in dashboard layout post-OAuth |
| `bb3cc56` | `/auth/signup` + `/app/dashboard/layout.tsx` | **Codex P1 round 2**: hardened OAuth consent carry — sessionStorage (tab-scoped) instead of localStorage · 15-min TTL on payload · user.created_at recency check so a pre-existing user can't inherit an abandoned consent blob · only delete the key after confirmed successful write (transient errors leave blob for retry) |

## Known tension with Codex

Codex re-flagged the consent-on-OAuth issue on round 3 even though the client-side gate is in place. The correct architectural fix is a **server-side terms-accepted gate** on the dashboard layout (redirect to `/auth/accept-terms` if `!user.user_metadata.terms_accepted_at`) which makes it impossible to use the product without recorded consent — worth doing as a follow-up PR once the rest is shipped.

## Deferred (flagged in audit)

- Founder story on `/about` — page comment rules out founder anecdote, wants Paul's call
- Signup post-verify screen still shows the full form — bigger refactor
- "Stay signed in" on login — Supabase session-length change
- Bank/FCA logo cloud on homepage — needs logo assets
- Server-side terms-accepted gate (see above)

## Test plan

- [ ] `/` on iPhone 17 Pro Max, portrait + landscape
- [ ] `/pricing` toggle switches £/mo ↔ £/yr; CTAs route to Stripe when logged in
- [ ] `/auth/signup` — Google button disabled until T&Cs ticked; email submit blocked same way; check `auth.users.user_metadata` contains `terms_accepted_at` + `marketing_opt_in` after Google signup on a fresh user
- [ ] `/auth/login` — Forgot password link visible below password field
- [ ] `/about` — hero eyebrow shows "ICO registered · FCA-authorised via Yapily"

🤖 Generated with [Claude Code](https://claude.com/claude-code)