### PR TITLE
feat(auth): server-side terms-accepted gate

### DIFF
--- a/src/app/auth/accept-terms/page.tsx
+++ b/src/app/auth/accept-terms/page.tsx
@@ -77,8 +77,28 @@ export default function AcceptTermsPage() {
       // Try to auto-drain sessionStorage pending consent for the fresh
       // OAuth signup path. Matches the dashboard-layout guardrails so
       // the two entry points can't disagree.
+      //
+      // Every storage access is individually guarded because Safari
+      // private mode (and enterprise-locked browsers) throw on both
+      // getItem and removeItem. Without these guards, a throw in the
+      // outer catch clause's cleanup call would re-throw and leave the
+      // page stuck on "Checking your account…" indefinitely.
+      const safeRemove = () => {
+        try {
+          sessionStorage.removeItem('pb_pending_consent');
+        } catch {
+          /* storage unavailable — nothing to clean up */
+        }
+      };
+
       try {
-        const raw = sessionStorage.getItem('pb_pending_consent');
+        let raw: string | null = null;
+        try {
+          raw = sessionStorage.getItem('pb_pending_consent');
+        } catch {
+          /* storage unavailable — skip auto-drain, fall through to form */
+        }
+
         if (raw) {
           const pending = JSON.parse(raw) as {
             terms_accepted_at?: string;
@@ -94,7 +114,7 @@ export default function AcceptTermsPage() {
             Number.isFinite(userCreatedMs) && now - userCreatedMs < CONSENT_TTL_MS;
 
           if (!isFreshPayload) {
-            sessionStorage.removeItem('pb_pending_consent');
+            safeRemove();
           } else if (isFreshUser && pending.terms_accepted_at) {
             const { error: updateError } = await supabase.auth.updateUser({
               data: {
@@ -103,7 +123,7 @@ export default function AcceptTermsPage() {
               },
             });
             if (!updateError && !cancelled) {
-              sessionStorage.removeItem('pb_pending_consent');
+              safeRemove();
               router.replace(next);
               return;
             }
@@ -115,10 +135,13 @@ export default function AcceptTermsPage() {
           // records their own consent instead.
         }
       } catch {
-        sessionStorage.removeItem('pb_pending_consent');
+        // JSON.parse failure → payload is corrupt. safeRemove is
+        // guarded so a secondary storage-unavailable exception can't
+        // abort run() before we reach setLoading(false) below.
+        safeRemove();
+      } finally {
+        if (!cancelled) setLoading(false);
       }
-
-      if (!cancelled) setLoading(false);
     };
 
     run();

--- a/src/app/auth/accept-terms/page.tsx
+++ b/src/app/auth/accept-terms/page.tsx
@@ -143,6 +143,16 @@ export default function AcceptTermsPage() {
         },
       });
       if (updateError) throw updateError;
+      // Also clear any pending OAuth blob that may still be in the tab
+      // (e.g. when the gate was entered from /onboarding, which never
+      // hits the dashboard-layout drain). Without this, a stale blob
+      // could auto-drain onto a different account later in the same
+      // 15-min window. Belt-and-braces with the auto-drain branch above.
+      try {
+        sessionStorage.removeItem('pb_pending_consent');
+      } catch {
+        /* storage unavailable — nothing to clean up */
+      }
       router.replace(next);
     } catch (err: unknown) {
       const message =

--- a/src/app/auth/accept-terms/page.tsx
+++ b/src/app/auth/accept-terms/page.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'edge';
+
+import { useEffect, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { MarkNav } from '@/app/blog/_shared';
+import '../../(marketing)/styles.css';
+import '../auth.css';
+
+/**
+ * /auth/accept-terms — server-side consent gate landing page.
+ *
+ * The middleware (src/middleware.ts → updateSession) redirects any
+ * authenticated user without `terms_accepted_at` in user_metadata
+ * here before they can reach /dashboard or /onboarding.
+ *
+ * Two paths through this page:
+ *
+ *   1. FRESH OAuth signup — handleGoogleSignup on /auth/signup stashed
+ *      `{ terms_accepted_at, marketing_opt_in, created_at }` into
+ *      sessionStorage before the OAuth redirect. We auto-drain it on
+ *      mount, write to user_metadata, and bounce straight to `next`.
+ *      The user never sees this page.
+ *
+ *   2. MANUAL consent — legacy accounts with no `terms_accepted_at`,
+ *      users whose sessionStorage drain failed / expired, or anyone
+ *      who reached /dashboard with a bypassed client-side gate. They
+ *      see the consent form and must tick the box to proceed.
+ *
+ * Payload freshness rules mirror the dashboard-layout drain:
+ *   - payload.created_at must be within 15 min (else treat as stale)
+ *   - user.created_at must be within 15 min (else don't apply a
+ *     stashed blob — it belongs to someone else's abandoned signup)
+ */
+
+const CONSENT_TTL_MS = 15 * 60 * 1000;
+
+export default function AcceptTermsPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const supabase = createClient();
+  const rawNext = searchParams.get('next');
+  const next =
+    rawNext && rawNext.startsWith('/') && !rawNext.startsWith('//')
+      ? rawNext
+      : '/dashboard';
+
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [termsAccepted, setTermsAccepted] = useState(false);
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
+  const [error, setError] = useState('');
+
+  // Mount: check auth, then either auto-drain sessionStorage consent
+  // (fresh OAuth signup) or fall through to the manual form.
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        router.replace(`/auth/login?redirect=${encodeURIComponent(next)}`);
+        return;
+      }
+
+      // Already accepted somehow (e.g. race with another tab). Skip the
+      // form and send them on their way — middleware will re-check.
+      if (user.user_metadata?.terms_accepted_at) {
+        router.replace(next);
+        return;
+      }
+
+      // Try to auto-drain sessionStorage pending consent for the fresh
+      // OAuth signup path. Matches the dashboard-layout guardrails so
+      // the two entry points can't disagree.
+      try {
+        const raw = sessionStorage.getItem('pb_pending_consent');
+        if (raw) {
+          const pending = JSON.parse(raw) as {
+            terms_accepted_at?: string;
+            marketing_opt_in?: boolean;
+            created_at?: number;
+          };
+          const now = Date.now();
+          const isFreshPayload =
+            typeof pending?.created_at === 'number' &&
+            now - pending.created_at < CONSENT_TTL_MS;
+          const userCreatedMs = user.created_at ? Date.parse(user.created_at) : NaN;
+          const isFreshUser =
+            Number.isFinite(userCreatedMs) && now - userCreatedMs < CONSENT_TTL_MS;
+
+          if (!isFreshPayload) {
+            sessionStorage.removeItem('pb_pending_consent');
+          } else if (isFreshUser && pending.terms_accepted_at) {
+            const { error: updateError } = await supabase.auth.updateUser({
+              data: {
+                terms_accepted_at: pending.terms_accepted_at,
+                marketing_opt_in: !!pending.marketing_opt_in,
+              },
+            });
+            if (!updateError && !cancelled) {
+              sessionStorage.removeItem('pb_pending_consent');
+              router.replace(next);
+              return;
+            }
+            // If updateError fires, fall through to the manual form —
+            // at least the user can still finish consenting.
+          }
+          // Non-fresh user with a pending blob: leave the blob alone
+          // (TTL will expire it) and show the manual form so the user
+          // records their own consent instead.
+        }
+      } catch {
+        sessionStorage.removeItem('pb_pending_consent');
+      }
+
+      if (!cancelled) setLoading(false);
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [next, router, supabase]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (!termsAccepted) {
+      setError('Please agree to the Terms of Service and Privacy Policy to continue.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const { error: updateError } = await supabase.auth.updateUser({
+        data: {
+          terms_accepted_at: new Date().toISOString(),
+          marketing_opt_in: marketingOptIn,
+        },
+      });
+      if (updateError) throw updateError;
+      router.replace(next);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to record your acceptance. Please try again.';
+      setError(message);
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="m-land-root">
+      <MarkNav />
+      <main className="auth-shell">
+        <div className="auth-wrap">
+          <Link href="/" className="auth-brand">
+            <span className="pay">Pay</span>
+            <span className="backer">backer</span>
+          </Link>
+
+          <div className="auth-head">
+            <h1>One quick thing</h1>
+            <p>
+              We need your acceptance of our Terms &amp; Privacy Policy before
+              you can use Paybacker.
+            </p>
+          </div>
+
+          <div className="auth-card">
+            {loading ? (
+              <p style={{ textAlign: 'center', color: 'var(--text-secondary)', margin: 0 }}>
+                Checking your account…
+              </p>
+            ) : (
+              <form onSubmit={handleSubmit}>
+                <div className="consent" style={{ marginTop: 0 }}>
+                  <label className="consent__row">
+                    <input
+                      type="checkbox"
+                      checked={termsAccepted}
+                      onChange={(e) => setTermsAccepted(e.target.checked)}
+                    />
+                    <span>
+                      I agree to the{' '}
+                      <Link href="/terms-of-service">Terms of Service</Link>
+                      {' '}and{' '}
+                      <Link href="/privacy-policy">Privacy Policy</Link>.
+                    </span>
+                  </label>
+                  <label className="consent__row consent__row--optional">
+                    <input
+                      type="checkbox"
+                      checked={marketingOptIn}
+                      onChange={(e) => setMarketingOptIn(e.target.checked)}
+                    />
+                    <span>
+                      Send me the Paybacker newsletter — savings tips and
+                      product updates (optional, unsubscribe anytime).
+                    </span>
+                  </label>
+                </div>
+
+                {error && <div className="form-error">{error}</div>}
+
+                <button
+                  type="submit"
+                  disabled={submitting || !termsAccepted}
+                  className="auth-submit"
+                >
+                  {submitting ? 'Saving…' : 'Continue'}
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -81,6 +81,26 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
+  // Server-side terms-accepted gate. Any authenticated user without a
+  // recorded `terms_accepted_at` in user_metadata gets bounced to
+  // /auth/accept-terms before they can reach /dashboard or /onboarding.
+  // This is the backstop to the /auth/signup client-side consent
+  // checkbox — it catches OAuth signups that bypassed the gate, legacy
+  // accounts that pre-date the feature, and anyone who edited DOM to
+  // re-enable a disabled button. The accept-terms page auto-drains the
+  // sessionStorage consent blob from fresh OAuth signups, so normal
+  // signups pass through invisibly.
+  const needsTermsGate =
+    user &&
+    !user.user_metadata?.terms_accepted_at &&
+    (request.nextUrl.pathname.startsWith('/dashboard') ||
+      request.nextUrl.pathname.startsWith('/onboarding'));
+  if (needsTermsGate) {
+    const url = new URL('/auth/accept-terms', request.url);
+    url.searchParams.set('next', request.nextUrl.pathname + request.nextUrl.search);
+    return NextResponse.redirect(url);
+  }
+
   // Admin-only path protection
   if (request.nextUrl.pathname.startsWith('/dashboard/admin') && user) {
     const adminEmails = (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com').split(',');
@@ -89,8 +109,13 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  // Redirect authenticated users away from auth pages, honouring any ?redirect= deep link
-  if (request.nextUrl.pathname.startsWith('/auth') && user) {
+  // Redirect authenticated users away from auth pages, honouring any ?redirect= deep link.
+  // Exempt /auth/accept-terms (users must stay here to record consent) and
+  // /auth/callback (OAuth code exchange — interrupting it breaks the session),
+  // otherwise the terms gate above would loop.
+  const isAcceptTermsPage = request.nextUrl.pathname.startsWith('/auth/accept-terms');
+  const isAuthCallback = request.nextUrl.pathname.startsWith('/auth/callback');
+  if (request.nextUrl.pathname.startsWith('/auth') && user && !isAcceptTermsPage && !isAuthCallback) {
     const rawRedirect = request.nextUrl.searchParams.get('redirect');
     const destination = rawRedirect?.startsWith('/') && !rawRedirect.startsWith('//')
       ? rawRedirect


### PR DESCRIPTION
Follow-up to #267. Addresses the remaining Codex concern around client-side consent bypass by adding a proxy-level backstop.

## Summary

Any authenticated user hitting `/dashboard` or `/onboarding` without `user_metadata.terms_accepted_at` gets bounced to a new `/auth/accept-terms` page. That page auto-drains the sessionStorage consent blob from fresh Google OAuth signups (invisible pass-through) or shows a manual consent form for legacy accounts / bypass attempts.

## Why this is the right fix

Codex re-flagged the OAuth consent gap twice on #267 because client-side gating (disabled button + JS handler check) can be bypassed by editing DOM or calling `handleGoogleSignup()` directly from devtools. The only way to *guarantee* no account uses the product without recorded consent is to gate at the **request** layer — which is what this PR does.

## How it behaves

| Path | Behaviour |
|---|---|
| Email/password signup | `terms_accepted_at` written via `supabase.auth.signUp({ options: { data: ... }})` before first dashboard visit. Gate is a no-op. |
| Google OAuth (normal) | `handleGoogleSignup` stashed consent in sessionStorage before OAuth redirect. Proxy redirects to `/auth/accept-terms`, which auto-drains and redirects to `next`. User never sees the page. |
| Legacy account (pre-feature) | No `terms_accepted_at` in metadata. Proxy redirects to `/auth/accept-terms`, user ticks the box, `supabase.auth.updateUser` writes metadata, redirect to `next`. |
| DOM-tampered signup | Even if the disabled Google button is re-enabled via devtools and the client drain fails, the proxy still redirects on `/dashboard`. Can't reach the app without consent on record. |

## Files

- `src/proxy.ts` — new `needsTermsGate` check after the existing auth redirect; exemptions added for `/auth/accept-terms` and `/auth/callback` in the "redirect authed users away from /auth" rule so the gate doesn't loop.
- `src/app/auth/accept-terms/page.tsx` — new blocking page with auto-drain + manual consent form. Mirrors the sessionStorage freshness rules (15-min payload TTL + 15-min user.created_at recency) from the dashboard-layout drain in #267.

## Test plan

- [ ] Log in as an existing user **with** `terms_accepted_at` already set — `/dashboard` loads normally.
- [ ] Open Supabase → manually unset `terms_accepted_at` on a test user → visit `/dashboard` → gets redirected to `/auth/accept-terms?next=/dashboard` → tick checkbox → lands back on `/dashboard` with metadata recorded.
- [ ] Fresh Google OAuth signup on clean browser — should flash through `/auth/accept-terms` invisibly (auto-drain) and land on `/dashboard` with `terms_accepted_at` + `marketing_opt_in` on user_metadata.
- [ ] Expired sessionStorage payload (created > 15 min ago) — accept-terms falls through to manual form; payload gets cleared.
- [ ] Pre-existing user with a foreign sessionStorage blob (edge case) — stale-user check rejects the drain, manual form shown.
- [ ] `/auth/accept-terms` visited directly by an authed user with valid `terms_accepted_at` — auto-redirects to `next` or `/dashboard` immediately.

## Trade-offs

Existing users will see the accept-terms page on their next dashboard visit. For UK GDPR/FCA this is correct and expected — they need to record consent to our current terms. Consider a brief in-app notice announcing "we've added explicit consent capture" if user feedback surfaces friction post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)