### PR TITLE
fix(ui): demo scale unit bug (THE bug), chat transparency, iOS login zoom

### DIFF
--- a/src/app/auth/auth.css
+++ b/src/app/auth/auth.css
@@ -174,7 +174,12 @@
   width: 100%;
   padding: 12px 14px;
   padding-left: 38px;
-  font-size: 15px;
+  /* Must be ≥16px on mobile — iOS Safari auto-zooms any text input
+     with font-size < 16px on focus, and then doesn't always zoom
+     back out, leaving the whole /auth/login and /auth/signup pages
+     stuck in a pinched-out state until the user manually pinch-zooms.
+     Reported post-#269 on /auth/login. */
+  font-size: 16px;
   color: var(--text-primary);
   background: #fff;
   border: 1px solid var(--divider);

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -1648,13 +1648,21 @@
     aspect-ratio: auto;
     margin: 0;
     transform-origin: top left;
-    transform: scale(min(1, calc((100vw - 72px) / 980)));
+    /* CRITICAL: divisor MUST be `980px` (length / length = number),
+       not `980` (length / number = length, rejected by scale()).
+       Safari strict-rejected the invalid declaration through PRs
+       #226/#265/#267/#269, leaving every demo rendered at its
+       native 980×612.5 and clipped by the parent's overflow —
+       exactly what the user's post-#269 screenshot shows. Chrome
+       was lenient and treated the length as unitless, so desktop
+       math testing never surfaced the bug. */
+    transform: scale(min(1, calc((100vw - 72px) / 980px)));
   }
 }
 @media (max-width: 560px) {
   .m-v2-root .feature-stage > .demo-stage,
   .m-v2-root .demo-slot > .demo-stage {
-    transform: scale(min(1, calc((100vw - 40px) / 980)));
+    transform: scale(min(1, calc((100vw - 40px) / 980px)));
   }
 }
 

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -294,7 +294,7 @@ export default function ChatWidget() {
 
       {/* Chat panel */}
       {open && (
-        <div className="fixed bottom-16 right-4 z-50 w-[380px] max-w-[calc(100vw-2rem)] h-[460px] max-h-[calc(100vh-8rem)] card shadow-2xl flex flex-col overflow-hidden md:bottom-6 md:right-6 md:h-[520px] md:max-h-[calc(100vh-6rem)]">
+        <div className="fixed bottom-16 right-4 z-50 w-[380px] max-w-[calc(100vw-2rem)] h-[460px] max-h-[calc(100vh-8rem)] bg-white border border-slate-200 rounded-2xl shadow-2xl flex flex-col overflow-hidden md:bottom-6 md:right-6 md:h-[520px] md:max-h-[calc(100vh-6rem)]">
           {/* Header */}
           <div className="flex items-center justify-between px-4 py-3 bg-slate-100 border-b border-slate-200">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
Three user-reported mobile bugs from post-#269 testing. The first one is the actual root cause of the "demo cut off on iPhone" issue that we've been chasing through PRs #226 / #265 / #267 / #269.

## 1. Demo video CSS scale unit bug — THE real culprit

`transform: scale(calc((100vw - 72px) / 980))` was the defensive fallback I added in #269. Per CSS calc() typing rules:

| Operation | Result |
|---|---|
| `length / number` | `length` ← **invalid argument to `scale()`** |
| `length / length` | `number` ← valid |

The divisor was **`980`** (unitless), so the calc yielded a length (e.g. `0.4px`), and Safari strictly rejected the whole `transform` declaration. Every demo then rendered at its native 980×612.5 and got clipped by the parent's overflow — exactly what the user's post-#269 screenshot showed (MoneyHub demo with only its Tesco/Virgin Media left panel visible, right panel off-screen).

Chrome was lenient and treated `length / number` as unitless in `scale()` context, which is why this went undetected through PRs #226, #265, #267, and #269 — every round of desktop-Chrome math testing worked.

**Fix:** one-character change per rule: `980` → `980px`. Division becomes `length / length = number`, which `scale()` accepts.

## 2. Chat widget transparent on homepage

`ChatWidget.tsx` opened panel had `className="card"`. The `.card` rule is scoped to `.shell-v2 .card` in `dashboard/shell-v2.css`, so on the homepage (outside the dashboard shell) the class did nothing — the panel rendered with no background and text showed through. Replaced with explicit Tailwind `bg-white border border-slate-200 rounded-2xl`.

## 3. /auth/login iPhone zoom-in

iOS Safari auto-zooms any text input whose font-size is `<16px` when focused, and often doesn't auto-zoom back out when the keyboard closes. Auth inputs were at 15px → login/signup stuck pinched-out on iPhone. Bumped to 16px.

## Test plan

- [ ] Hard-refresh `paybacker.co.uk` on iPhone 17 Pro Max (private tab to skip cache)
- [ ] Every demo fits the wrapper with visible breathing room on both edges, in both portrait and landscape
- [ ] Click the green chat bubble → panel has a solid white background, readable text
- [ ] Visit `/auth/login` → page does not zoom in when the email field is tapped → zoom remains normal after keyboard closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)