### PR TITLE
fix(tier): stop silent demotion when Stripe status is past_due

### DIFF
--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -687,11 +687,15 @@ export default function ProfilePage() {
     }
   };
 
-  // Fetch saved reports for Pro users
+  // Fetch saved reports for Pro users. Per CLAUDE.md, paid tiers are
+  // only demoted by explicit webhook-driven statuses; past_due /
+  // unpaid / incomplete are Stripe retry states and must still count
+  // as Pro so the user doesn't lose access while their card retries.
   useEffect(() => {
-    const isPro = profile?.subscription_tier &&
-      profile.subscription_tier === 'pro' &&
-      ['active', 'trialing'].includes(profile?.subscription_status ?? '');
+    const tier = profile?.subscription_tier;
+    const status = profile?.subscription_status ?? '';
+    const terminated = ['canceled', 'cancelled', 'expired', 'incomplete_expired'].includes(status);
+    const isPro = tier === 'pro' && !terminated;
     if (profile && isPro) {
       fetchSavedReports();
     }
@@ -709,13 +713,18 @@ export default function ProfilePage() {
     ? new Date(profile.created_at).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
     : 'Unknown';
 
-  // Trust the DB tier — covers both Stripe-paying and manually upgraded users
-  const hasActiveSubscription = profile?.subscription_tier && profile.subscription_tier !== 'free' &&
-    ['active', 'trialing'].includes(profile?.subscription_status ?? '');
+  // Trust the DB tier unless the webhook has explicitly marked the
+  // subscription as terminated. past_due / unpaid / incomplete are
+  // retry states — the user keeps their tier while Stripe reattempts
+  // the payment, matching CLAUDE.md's "demotion is webhook-driven"
+  // rule and getEffectiveTier in plan-limits.ts.
+  const status = profile?.subscription_status ?? '';
+  const terminated = ['canceled', 'cancelled', 'expired', 'incomplete_expired'].includes(status);
   const hasActiveStripe = !!profile?.stripe_subscription_id;
-  const effectiveTier = hasActiveSubscription
-    ? (profile.subscription_tier || 'free')
+  const effectiveTier = (profile?.subscription_tier && !terminated)
+    ? profile.subscription_tier
     : 'free';
+  const isPastDue = ['past_due', 'unpaid', 'incomplete'].includes(status);
 
   const subscriptionBadge = () => {
     const colors = {

--- a/src/lib/claude-rate-limit.ts
+++ b/src/lib/claude-rate-limit.ts
@@ -34,28 +34,25 @@ function getLimit(tier: string): number {
 
 /**
  * Fetch a user's subscription tier from their profile.
- * Verifies active Stripe subscription for paid tiers.
+ *
+ * Trusts `profile.subscription_tier` per CLAUDE.md — demotion is
+ * webhook-driven only. Transitional Stripe states (past_due, unpaid,
+ * incomplete) do NOT demote — the webhook writes 'canceled' on an
+ * actual termination. Previously we demoted on anything other than
+ * active/trialing, which silently flipped past_due Pro users to Free.
  */
 export async function getUserTier(userId: string): Promise<string> {
   const admin = getAdmin();
   const { data } = await admin
     .from('profiles')
-    .select('subscription_tier, subscription_status, stripe_subscription_id, trial_ends_at')
+    .select('subscription_tier, subscription_status')
     .eq('id', userId)
     .single();
 
   const tier = (data?.subscription_tier as string) ?? 'free';
-  const isPaid = tier !== 'free';
-  const hasActiveStripe =
-    data?.stripe_subscription_id &&
-    ['active', 'trialing'].includes(data?.subscription_status ?? '');
-
-  // Founding member trial: tier != free, status = trialing, no Stripe, valid trial_ends_at
-  const isFoundingTrial = isPaid && !data?.stripe_subscription_id &&
-    data?.subscription_status === 'trialing' &&
-    data?.trial_ends_at && new Date(data.trial_ends_at) > new Date();
-
-  return isPaid && !hasActiveStripe && !isFoundingTrial ? 'free' : tier;
+  const status = data?.subscription_status ?? 'free';
+  const terminated = ['canceled', 'cancelled', 'expired', 'incomplete_expired'].includes(status);
+  return terminated ? 'free' : tier;
 }
 
 /**

--- a/src/lib/get-user-plan.ts
+++ b/src/lib/get-user-plan.ts
@@ -7,6 +7,7 @@ export interface UserPlan {
   status: string;
   isActive: boolean;
   isTrial: boolean;
+  isPastDue: boolean;
   trialDaysLeft: number | null;
 }
 
@@ -17,9 +18,25 @@ function getAdmin() {
   );
 }
 
+// Statuses that Stripe (or our webhook) write when the subscription has
+// actually ended. Anything outside this set — including `past_due`,
+// `incomplete`, `unpaid` — is a retry state, not a termination, and
+// must NOT demote the stored tier. Per CLAUDE.md: demotion is
+// webhook-driven only (customer.subscription.deleted → 'canceled').
+const TERMINATED_STATUSES = new Set(['canceled', 'cancelled', 'expired', 'incomplete_expired']);
+
 /**
- * Single source of truth for a user's effective plan.
- * Handles: Stripe subscribers, founding member trials, and free users.
+ * Single source of truth for a user's effective plan tier.
+ *
+ * Rule (matches CLAUDE.md + getEffectiveTier in plan-limits.ts): the
+ * stored `profile.subscription_tier` is authoritative. We only demote
+ * when the status column is in TERMINATED_STATUSES (written by the
+ * Stripe webhook). Transitional states like past_due keep the user on
+ * their paid tier; they just get an `isPastDue` flag so the UI can
+ * surface a "payment retrying" banner instead of silently downgrading.
+ *
+ * Onboarding trials upgrade the user to Pro for the trial window even
+ * if the stored tier is Free.
  */
 export async function getUserPlan(userId: string): Promise<UserPlan> {
   const admin = getAdmin();
@@ -30,47 +47,36 @@ export async function getUserPlan(userId: string): Promise<UserPlan> {
     .eq('id', userId)
     .single();
 
-  const tier = (profile?.subscription_tier as PlanTier) ?? 'free';
+  const storedTier = (profile?.subscription_tier as PlanTier) ?? 'free';
   const status = profile?.subscription_status ?? 'free';
-  const hasStripe = !!profile?.stripe_subscription_id;
+  const isPastDue = status === 'past_due' || status === 'unpaid' || status === 'incomplete';
 
-  // Stripe subscriber — use their tier directly
-  if (hasStripe && ['active', 'trialing'].includes(status)) {
-    return { tier, status, isActive: true, isTrial: status === 'trialing', trialDaysLeft: null };
-  }
-
-  // Onboarding trial: trial_ends_at in the future, not yet converted or expired → treat as pro
+  // Onboarding trial override — grant Pro while the trial window is open.
   const trialEnd = profile?.trial_ends_at ? new Date(profile.trial_ends_at) : null;
   const now = new Date();
-  const isOnboardingTrial = trialEnd &&
-    trialEnd > now &&
-    !profile?.trial_converted_at &&
-    !profile?.trial_expired_at;
+  const onboardingTrialActive = !!trialEnd
+    && trialEnd > now
+    && !profile?.trial_converted_at
+    && !profile?.trial_expired_at;
 
-  if (!hasStripe && isOnboardingTrial) {
+  if (onboardingTrialActive) {
     const daysLeft = Math.ceil((trialEnd!.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-    return { tier: 'pro', status: 'trialing', isActive: true, isTrial: true, trialDaysLeft: daysLeft };
+    return { tier: 'pro', status: 'trialing', isActive: true, isTrial: true, isPastDue: false, trialDaysLeft: daysLeft };
   }
 
-  // Founding member trial (no Stripe, but tier=pro/essential + trialing)
-  if (tier !== 'free' && status === 'trialing' && !hasStripe) {
-    if (trialEnd && trialEnd > now) {
-      const daysLeft = Math.ceil((trialEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-      return { tier, status: 'trialing', isActive: true, isTrial: true, trialDaysLeft: daysLeft };
-    }
-    // Trial expired — treat as free
-    return { tier: 'free', status: 'expired', isActive: false, isTrial: false, trialDaysLeft: 0 };
+  // Explicit termination → demote. This is the only path that can flip a
+  // paid user to Free; everything else trusts the stored tier.
+  if (TERMINATED_STATUSES.has(status)) {
+    return { tier: 'free', status, isActive: false, isTrial: false, isPastDue: false, trialDaysLeft: null };
   }
 
-  // Manually granted active status (lifetime or admin granted)
-  if (tier !== 'free' && status === 'active' && !hasStripe) {
-    return { tier, status, isActive: true, isTrial: false, trialDaysLeft: null };
-  }
-
-  // Paid tier but no active Stripe, not manually active, and not trialing — downgrade
-  if (tier !== 'free' && !hasStripe) {
-    return { tier: 'free', status, isActive: false, isTrial: false, trialDaysLeft: null };
-  }
-
-  return { tier, status, isActive: tier !== 'free', isTrial: false, trialDaysLeft: null };
+  const isTrial = status === 'trialing';
+  return {
+    tier: storedTier,
+    status,
+    isActive: storedTier !== 'free',
+    isTrial,
+    isPastDue,
+    trialDaysLeft: null,
+  };
 }


### PR DESCRIPTION
## Bug
Sidebar showed **Pro**, profile showed **Free**, yearly report 403'd with "Pro plan required" — all for the same paying user.

Root cause: \`getUserPlan\`, \`getUserTier\`, and the profile page's \`effectiveTier\` all demoted to Free on anything outside \`status ∈ {active, trialing}\`. That includes \`past_due\` (card retrying) and \`unpaid\` (retry in flight). CLAUDE.md says demotion is webhook-driven — the webhook writes \`canceled\` on actual termination.

## Fix
Three helpers now demote only on explicit termination (\`canceled\`, \`cancelled\`, \`expired\`, \`incomplete_expired\`). \`past_due\` / \`unpaid\` / \`incomplete\` keep the tier; \`getUserPlan\` surfaces them as \`isPastDue\` so a follow-up can render a "payment retrying" banner instead of silently downgrading.

\`getEffectiveTier\` in plan-limits.ts was already right — it's the authoritative source per CLAUDE.md. The other three now match it.

## Scope
- \`src/lib/get-user-plan.ts\` — used by reports/generate
- \`src/lib/claude-rate-limit.ts\` \`getUserTier\` — used by complaint rate limiter
- \`src/app/dashboard/profile/page.tsx\` — \`effectiveTier\` + savedReports gate

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] User with tier=pro + status=past_due: sidebar AND profile both show Pro; yearly report generates
- [ ] User with tier=pro + status=canceled: demoted to Free (webhook path unchanged)
- [ ] Onboarding trial: still grants Pro for the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)