### PR TITLE
fix(subscriptions): dedup detected rows + align counts across page

### DIFF
--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -1534,8 +1534,8 @@ export default function SubscriptionsPage() {
       {tierLoaded && userTier === 'free' && bankConnections.length > 0 && baseSubscriptions.filter(s => s.status === 'active').length > 0 && (
         <UpgradeTrigger
           type="bank_scan"
-          subscriptionCount={baseSubscriptions.filter(s => s.status === 'active').length}
-          monthlyCost={flexibleTotalMonthly + statutoryTotalMonthly}
+          subscriptionCount={rpcTotals?.subscriptions_count ?? baseSubscriptions.filter(s => s.status === 'active').length}
+          monthlyCost={rpcTotals?.subscriptions_monthly ?? (flexibleTotalMonthly + statutoryTotalMonthly)}
           userTier={userTier ?? undefined}
           className="mb-6"
         />
@@ -1672,10 +1672,15 @@ export default function SubscriptionsPage() {
           Flagged = count of detected + review-needed subs;
           Potential savings reads from the inline comparison CTA state below. */}
       {(() => {
+        // Single source of truth: get_subscription_total RPC. Using the
+        // RPC's count + monthly on both the KPI header and the
+        // UpgradeTrigger banner below means users no longer see two
+        // different numbers for the same thing ("we found 34 @ £3,431"
+        // vs "43 active · £1,208" — same user, same page).
         const monthly = rpcTotals?.subscriptions_monthly ?? 0;
         const yearly = monthly * 12;
         const flaggedCount = (detectedSubs?.length || 0) + subscriptions.filter(s => (s as any).needs_review).length;
-        const activeCount = subscriptions.filter(s => s.status === 'active').length;
+        const activeCount = rpcTotals?.subscriptions_count ?? baseSubscriptions.filter(s => s.status === 'active').length;
         return (
           <>
             <div className="page-title-row">

--- a/src/lib/detect-recurring.ts
+++ b/src/lib/detect-recurring.ts
@@ -283,7 +283,16 @@ export async function detectRecurring(
     });
 
     if (insertError) {
-      console.error(`Failed to create subscription for ${displayName}:`, insertError);
+      // Partial unique index on (user_id, lower(provider_name), round(amount,2))
+      // guards against concurrent bank-sync runs — when two crons both see no
+      // Patreon row and both try to insert, the second one lands here with
+      // PG error 23505. That's the expected path, not a failure: silently
+      // skip so we don't noisy-log or double-count.
+      if ((insertError as { code?: string }).code === '23505') {
+        // Already inserted by a parallel run — nothing to do.
+      } else {
+        console.error(`Failed to create subscription for ${displayName}:`, insertError);
+      }
     } else {
       newRecurringCount++;
       console.log(`Detected recurring: ${finalDisplayName} £${avgAmount.toFixed(2)}/${cycle} [${category}]${rule ? ' (from merchant rules)' : ''}`);

--- a/supabase/migrations/20260424060000_subscription_dedup.sql
+++ b/supabase/migrations/20260424060000_subscription_dedup.sql
@@ -1,0 +1,60 @@
+-- One subscription per (user, provider, amount) — collapse accumulated
+-- duplicates and prevent the next concurrent cron run from re-creating them.
+--
+-- Background: detect-recurring's in-JS dedup (src/lib/detect-recurring.ts:207)
+-- reads `allUserSubs`, checks for a matching row, then inserts if none.
+-- That check is not atomic — two bank-sync runs starting within seconds of
+-- each other both see no Patreon row and both insert. Result: some users
+-- accumulated 10+ identical rows for the same provider (Patreon, EE, etc.),
+-- each still `needs_review=true`, so the "flagged for review" counter
+-- appears to never drain no matter how many the user resolves.
+--
+-- Fix: (a) collapse existing dupes so the user's counter reflects reality,
+--      (b) partial unique index over the rest so INSERT-on-conflict can
+--          be idempotent from the application layer.
+
+-- ─── 1. Collapse existing dupes (idempotent; safe to re-run) ──────────
+-- Keep one canonical row per (user, lower(provider), round(amount,2))
+-- that's still active + not dismissed. Preference order:
+--   1. needs_review = false (user has already actioned it)
+--   2. non-null category (has been classified)
+--   3. earliest created_at (the original, not the stray copies)
+-- The losers are soft-deleted via dismissed_at — we never hard-delete
+-- subscription rows (bank_transactions may reference them).
+WITH ranked AS (
+  SELECT
+    id, user_id, provider_name, amount, status, dismissed_at, needs_review,
+    category, created_at,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_id,
+                   LOWER(COALESCE(provider_name, '')),
+                   ROUND(COALESCE(amount, 0)::numeric, 2)
+      ORDER BY
+        (CASE WHEN needs_review = false THEN 0 ELSE 1 END),
+        (CASE WHEN category IS NOT NULL AND category <> '' THEN 0 ELSE 1 END),
+        created_at ASC
+    ) AS keep_rank
+  FROM subscriptions
+  WHERE status = 'active'
+    AND dismissed_at IS NULL
+)
+UPDATE subscriptions s
+   SET dismissed_at = NOW(),
+       notes = COALESCE(s.notes || E'\n', '')
+               || 'Auto-dismissed as duplicate during 2026-04-24 cleanup'
+  FROM ranked r
+ WHERE s.id = r.id
+   AND r.keep_rank > 1;
+
+-- ─── 2. Partial unique index ──────────────────────────────────────────
+-- Cover only the live set so cancelled / dismissed rows don't block a
+-- legitimate re-subscription. round(amount, 2) so penny-level jitter in
+-- bank data doesn't defeat the constraint — Patreon at £6.00 and a
+-- future £10.00 tier stay distinct, but two £6.00 rows can't coexist.
+CREATE UNIQUE INDEX IF NOT EXISTS subscriptions_live_one_per_provider_amount
+  ON subscriptions (
+    user_id,
+    LOWER(COALESCE(provider_name, '')),
+    ROUND(COALESCE(amount, 0)::numeric, 2)
+  )
+  WHERE status = 'active' AND dismissed_at IS NULL;


### PR DESCRIPTION
Two coupled bugs, one PR.

## Bug 1 — count mismatch

Same page showed both "we found 34 subscriptions totalling £3,431/mo" (UpgradeTrigger banner) and "43 active · £1,208/mo" (KPI header). The banner summed client-side from subscription.amount; the header used \`rpcTotals.subscriptions_monthly\` (authoritative \`get_subscription_total\` RPC that uses real bank ledger data + bucket exclusions). Now both read from the RPC.

## Bug 2 — "1 flagged for review" after resolving

User's account had **14 Patreon rows** + 20 EE rows + 9 London-parking rows, all active duplicates, most still \`needs_review=true\`. Each bank-sync cron created another copy within seconds of the previous, so resolving one surfaced the next on the subsequent refresh.

Root cause: \`detect-recurring.ts:207\` does in-JS dedup — non-atomic. Two cron runs overlapping by 2-3 seconds both read \`allUserSubs\` before either has inserted, so both insert.

## Fix

### Migration \`20260424060000_subscription_dedup.sql\` (already applied to prod)
- Collapse existing dupes: keep the row with \`needs_review=false\` / non-null category / earliest created, soft-dismiss the rest
- Partial unique index on \`(user_id, lower(provider_name), round(amount, 2))\` WHERE status='active' AND dismissed_at IS NULL. Allows £6 + £10 Patreon tiers to coexist; forbids identical duplicates

### \`src/lib/detect-recurring.ts\`
- Keep the in-JS dedup as a fast-path (avoids DB round-trip in the common case)
- Silently swallow PG 23505 so the unique-index backstop absorbs concurrent-run races without log spam

### \`src/app/dashboard/subscriptions/page.tsx\`
- KPI header: read count from RPC
- UpgradeTrigger: read count + monthlyCost from RPC

## Test plan
- [x] Migration applied (35 duplicate rows collapsed for the reporter)
- [x] \`npx tsc --noEmit\` clean
- [ ] Next bank-sync cron doesn't create a 15th Patreon row
- [ ] "Flagged for review" count actually drains as user resolves rows
- [ ] Banner + KPI show the same £ figure

🤖 Generated with [Claude Code](https://claude.com/claude-code)