### PR TITLE
fix(money-hub): reverse-sync recategorisation + Pro-gate exports

### DIFF
--- a/src/app/api/export/csv/route.ts
+++ b/src/app/api/export/csv/route.ts
@@ -47,6 +47,18 @@ export async function GET(_req: NextRequest) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
   }
 
+  // CSV export is Pro-only per plan-limits.ts. Previously the route only
+  // gated on auth, so any authenticated user with the URL could download
+  // their full ledger regardless of tier.
+  const { getEffectiveTier } = await import('@/lib/plan-limits')
+  const tier = await getEffectiveTier(user.id)
+  if (tier !== 'pro') {
+    return NextResponse.json(
+      { error: 'CSV export is available on the Pro plan.' },
+      { status: 403 },
+    )
+  }
+
   // Pull the user's bank connections so we can map account_id -> bank/account name.
   const { data: bankConns } = await supabase
     .from('bank_connections')

--- a/src/app/api/export/xlsx/route.ts
+++ b/src/app/api/export/xlsx/route.ts
@@ -102,6 +102,18 @@ export async function GET(_req: NextRequest) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
   }
 
+  // XLSX export is Pro-only per plan-limits.ts. Previously the route
+  // only gated on auth, so any authenticated user with the URL could
+  // download their full ledger regardless of tier.
+  const { getEffectiveTier } = await import('@/lib/plan-limits')
+  const tier = await getEffectiveTier(user.id)
+  if (tier !== 'pro') {
+    return NextResponse.json(
+      { error: 'XLSX export is available on the Pro plan.' },
+      { status: 403 },
+    )
+  }
+
   // Load bank connections + build account_id -> {bank, account} map.
   const { data: bankConns } = await supabase
     .from('bank_connections')

--- a/src/app/api/money-hub/recategorise/route.ts
+++ b/src/app/api/money-hub/recategorise/route.ts
@@ -189,6 +189,25 @@ export async function POST(request: NextRequest) {
         userId: user.id,
       }).catch((e) => console.error('Learn error (non-fatal):', e.message));
 
+      // 4. Reverse-sync to subscriptions: if the user recategorised a
+      // merchant in Money Hub, the matching subscription row was
+      // stuck on its old category — the subscriptions PATCH path
+      // goes subs→Money Hub, but this endpoint was one-way. That
+      // meant "Test Valley" could be council_tax in bank_transactions
+      // but still 'other' on the Subscriptions page. Keeps the two
+      // stores aligned regardless of which screen the user corrects
+      // from.
+      try {
+        const { error: subSyncErr } = await admin.from('subscriptions')
+          .update({ category: newCategory })
+          .eq('user_id', user.id)
+          .is('dismissed_at', null)
+          .or(`provider_name.ilike.%${overridePattern}%,bank_description.ilike.%${overridePattern}%`);
+        if (subSyncErr) console.error('Sub reverse-sync failed (non-fatal):', subSyncErr.message);
+      } catch (e) {
+        console.error('Sub reverse-sync threw:', e);
+      }
+
       return NextResponse.json({
         success: true,
         updated,


### PR DESCRIPTION
Two gaps surfaced while investigating "Test Valley not consistent across Subs + Money Hub".

## Recategorisation was one-way
Subs-page edit propagated to Money Hub via \`apply_subscription_category_correction\` RPC. Money-Hub-page edit did NOT propagate back — the subscription row stayed on its old category. Added a reverse-sync UPDATE on matching \`subscriptions\` rows in \`/api/money-hub/recategorise\`.

## Export API not tier-gated
\`plan-limits.ts\` marks CSV + XLSX as Pro-only; the UI hides the button; but \`/api/export/{csv,xlsx}\` only checked auth. Direct URL → any user got a full ledger download. Added \`getEffectiveTier\` → 403 on !Pro.

MCP routes were audited and all already gated (either via \`authenticateMcp\` or \`getUserPlan\` on the browser-session endpoints).

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Recategorise a merchant on Money Hub → matching subscription row flips to the same category
- [ ] Free user GET /api/export/csv → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)