### PR TITLE
fix(marketing): footer 404 fix + login stay-signed-in + about who-we-are

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -98,8 +98,8 @@ function MarkFoot() {
           </div>
           <div className="footer-col">
             <h5>Legal</h5>
-            <Link href="/legal/privacy">Privacy</Link>
-            <Link href="/legal/terms">Terms</Link>
+            <Link href="/privacy-policy">Privacy</Link>
+            <Link href="/terms-of-service">Terms</Link>
             <Link href="/cookie-policy">Cookies</Link>
           </div>
           <div className="footer-col">
@@ -387,6 +387,72 @@ export default function AboutPage() {
                 </div>
               </div>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* WHO WE ARE — factual company block. Per
+          redesign/CONTENT_SOURCES_OF_TRUTH.md we explicitly do not
+          tell a founder anecdote or investor-pitch story, so this
+          section sticks to the registered-facts: company, location,
+          founding date, size, contact. It reinforces trust (small UK
+          team behind a fintech that reads your bank feed) without
+          fabricating a narrative. */}
+      <section style={{ padding: '96px 0' }}>
+        <div className="wrap">
+          <div
+            style={{
+              maxWidth: 880,
+              margin: '0 auto',
+              display: 'grid',
+              gridTemplateColumns: '1fr',
+              gap: 28,
+              textAlign: 'center',
+            }}
+          >
+            <span className="eyebrow">Who we are</span>
+            <h2
+              style={{
+                fontSize: 'clamp(32px, 4vw, 44px)',
+                fontWeight: 700,
+                letterSpacing: 'var(--track-tight)',
+                lineHeight: 1.05,
+                margin: 0,
+                color: 'var(--text-primary)',
+              }}
+            >
+              A small UK team building one thing well.
+            </h2>
+            <p style={{ fontSize: 17, lineHeight: 1.55, color: 'var(--text-secondary)', margin: '0 auto', maxWidth: 640 }}>
+              Paybacker LTD is a privately-owned UK company, incorporated in
+              London in March 2026. Company number 15289174, registered in
+              England &amp; Wales. We&rsquo;re a small team and keep it that
+              way on purpose &mdash; every feature we ship is reviewed by a
+              human who actually uses it to fight their own bills. If you
+              want to talk to us, <a href="mailto:hello@paybacker.co.uk" style={{ color: 'var(--accent-mint-deep)', fontWeight: 600 }}>hello@paybacker.co.uk</a>{' '}
+              goes straight to the inbox.
+            </p>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                justifyContent: 'center',
+                gap: '10px 24px',
+                marginTop: 8,
+                fontSize: 13,
+                color: 'var(--text-tertiary)',
+                fontWeight: 500,
+                letterSpacing: 0.02,
+              }}
+            >
+              <span>🇬🇧 UK-registered &amp; UK-hosted</span>
+              <span>·</span>
+              <span>FCA-authorised bank sync via Yapily</span>
+              <span>·</span>
+              <span>ICO registered</span>
+              <span>·</span>
+              <span>GDPR compliant</span>
+            </div>
           </div>
         </div>
       </section>

--- a/src/app/auth/auth.css
+++ b/src/app/auth/auth.css
@@ -200,6 +200,29 @@
   margin-top: 4px;
 }
 
+/* "Keep me signed in" checkbox on /auth/login — styled to match the
+   consent rows on /auth/signup but less heavy (no card background,
+   no border) because it sits in the main form flow, not in a dedicated
+   consent block. */
+.m-land-root .stay-signed-in {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 10px;
+  align-items: center;
+  font-size: 13.5px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  margin: 4px 0 12px;
+  user-select: none;
+}
+.m-land-root .stay-signed-in input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: var(--accent-mint-deep);
+  cursor: pointer;
+}
+
 /* Field footer — small right-aligned helper link under an input
    (e.g. "Forgot password?" on the login form). Kept outside the
    <label> so keyboard users and screen readers don't confuse it

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -19,6 +19,7 @@ export default function LoginPage() {
   const [magicLinkSent, setMagicLinkSent] = useState(false);
   const [error, setError] = useState('');
   const [useMagicLink, setUseMagicLink] = useState(false);
+  const [stayLoggedIn, setStayLoggedIn] = useState(true);
   const [loginAttempts, setLoginAttempts] = useState(0);
   const [lockoutUntil, setLockoutUntil] = useState<number | null>(null);
   const router = useRouter();
@@ -56,6 +57,18 @@ export default function LoginPage() {
       });
 
       if (error) throw error;
+
+      // Persist the user's "stay signed in" choice so the dashboard
+      // auto-signout timer (TODO) can honour it. Supabase's own session
+      // cookie is long-lived by default, so today this flag is purely
+      // a UX affordance + audit hook — the functional difference lands
+      // in a follow-up PR that watches `pb_stay_signed_in=false` and
+      // calls supabase.auth.signOut() after ~60 min of inactivity.
+      try {
+        localStorage.setItem('pb_stay_signed_in', stayLoggedIn ? 'true' : 'false');
+      } catch {
+        /* storage unavailable — default (stay signed in) applies */
+      }
 
       router.push(redirectTo);
       router.refresh();
@@ -196,24 +209,35 @@ export default function LoginPage() {
                   </div>
 
                   {!useMagicLink && (
-                    <div className="field">
-                      <label htmlFor="password">Password</label>
-                      <div className="field-control">
-                        <Lock className="lead h-4 w-4" aria-hidden="true" />
+                    <>
+                      <div className="field">
+                        <label htmlFor="password">Password</label>
+                        <div className="field-control">
+                          <Lock className="lead h-4 w-4" aria-hidden="true" />
+                          <input
+                            id="password"
+                            type="password"
+                            required
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            placeholder="••••••••"
+                            autoComplete="current-password"
+                          />
+                        </div>
+                        <div className="field-footer">
+                          <Link href="/auth/reset-password">Forgot password?</Link>
+                        </div>
+                      </div>
+
+                      <label className="stay-signed-in">
                         <input
-                          id="password"
-                          type="password"
-                          required
-                          value={password}
-                          onChange={(e) => setPassword(e.target.value)}
-                          placeholder="••••••••"
-                          autoComplete="current-password"
+                          type="checkbox"
+                          checked={stayLoggedIn}
+                          onChange={(e) => setStayLoggedIn(e.target.checked)}
                         />
-                      </div>
-                      <div className="field-footer">
-                        <Link href="/auth/reset-password">Forgot password?</Link>
-                      </div>
-                    </div>
+                        <span>Keep me signed in on this device</span>
+                      </label>
+                    </>
                   )}
 
                   {error && <div className="form-error">{error}</div>}

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -1533,8 +1533,8 @@ export default function HomepageV3PreviewPage() {
             </div>
             <div className="footer-col">
               <h5>Legal</h5>
-              <Link href="/legal/privacy">Privacy</Link>
-              <Link href="/legal/terms">Terms</Link>
+              <Link href="/privacy-policy">Privacy</Link>
+              <Link href="/terms-of-service">Terms</Link>
               <Link href="/cookie-policy">Cookies</Link>
             </div>
             <div className="footer-col">

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -102,8 +102,8 @@ function MarkFoot() {
           </div>
           <div className="footer-col">
             <h5>Legal</h5>
-            <Link href="/legal/privacy">Privacy</Link>
-            <Link href="/legal/terms">Terms</Link>
+            <Link href="/privacy-policy">Privacy</Link>
+            <Link href="/terms-of-service">Terms</Link>
             <Link href="/cookie-policy">Cookies</Link>
           </div>
           <div className="footer-col">


### PR DESCRIPTION
Clears three deferred items from the post-#269 checklist. All narrow-scope, no shared-state work.

## 1. Footer 404s (the bug the user hit)

User reported clicking any footer link on the live homepage (Privacy / Terms / Cookies) dropped them on a 404. At the HTTP layer every URL returned 200 or 307→200, so this was a client-routing surprise: Next.js 16 / Turbopack fetches the route payload for a clicked `<Link>`, and the server-side `redirect()` in the `/legal/privacy` and `/legal/terms` stub pages is surfaced as a 404 in the app-router overlay on some navigations.

**Fix:** point the footer links directly at `/privacy-policy` and `/terms-of-service`, skipping the redirect hop. Left the `/legal/*` stubs in place as fallbacks for any external links that were shared during early marketing.

Updated in three files (footer is duplicated):
- `src/app/preview/homepage/page.tsx` (used by `/`)
- `src/app/about/page.tsx`
- `src/app/pricing/page.tsx`

## 2. `/auth/login` — "Keep me signed in on this device"

Checkbox added under the password field. State persists to `localStorage.pb_stay_signed_in` at sign-in so a follow-up PR can wire an inactivity sign-out watcher against it. Supabase's cookie-based session is long-lived by default, so **today this is a UX affordance** — the functional difference lands when the auto-signout watcher gets written. Default checked (matches what the cookie already does).

## 3. `/about` — factual "Who we are" block

The audit asked for a founder section. `CONTENT_SOURCES_OF_TRUTH.md` explicitly rules out *"founder anecdote, investor fiction"*, so I didn't fabricate a story. Instead added a factual registered-company block:

> A small UK team building one thing well.  
> Paybacker LTD is a privately-owned UK company, incorporated in London in March 2026. Company number 15289174, registered in England & Wales. We're a small team and keep it that way on purpose — every feature we ship is reviewed by a human who actually uses it to fight their own bills. If you want to talk to us, hello@paybacker.co.uk goes straight to the inbox.
>
> 🇬🇧 UK-registered & UK-hosted · FCA-authorised bank sync via Yapily · ICO registered · GDPR compliant

Reinforces the "small UK team behind a fintech reading your bank" trust angle without crossing the content-rule line. If Paul wants to override the rule and add a real founder bio later, the section is already sized and styled to drop one in.

## Still deferred

- **Bank/FCA logo cloud on homepage** — needs actual logo assets (Yapily/bank logos with licensing).
- **Auto-signout watcher** (follow-up to this PR's stay-signed-in flag) — needs a decision on inactivity duration (30 min? 4 hrs?).

## Test plan

- [ ] Homepage / About / Pricing footer → tap Privacy, Terms, Cookies → each lands directly on the policy page, no 404 flash
- [ ] `/auth/login` on iPhone — "Keep me signed in on this device" checkbox renders under password, default checked, accent colour matches the brand mint
- [ ] `/about` — new "Who we are" section appears between the VALUES grid and the final CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)