### PR TITLE
fix(mobile): iOS input zoom prevention + onboarding UX wins

### DIFF
--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -317,6 +317,37 @@
 }
 .shell-v2 .cta-danger:hover { background: #FEE2E2; }
 
+/* ─── iOS Safari input auto-zoom prevention ───────────────────────────────
+   Mobile Safari auto-zooms any text input whose font-size is < 16px on
+   focus, and often doesn't zoom back out when the keyboard closes —
+   leaving the entire dashboard pinched-out until the user manually
+   pinch-zooms. The dashboard has dozens of forms using Tailwind's
+   `text-sm` (14px) and `text-xs` (12px) on inputs, textareas and
+   selects, so rather than hunt each one down we enforce the 16px
+   minimum globally at ≤768px via a high-specificity selector.
+
+   Paul reported this as "first page is zoomed in after login and I
+   have to pinch to zoom out" — same root cause as the auth pages
+   input fix in PR #270. */
+@media (max-width: 768px) {
+  .shell-v2 input[type="text"],
+  .shell-v2 input[type="email"],
+  .shell-v2 input[type="password"],
+  .shell-v2 input[type="number"],
+  .shell-v2 input[type="tel"],
+  .shell-v2 input[type="search"],
+  .shell-v2 input[type="url"],
+  .shell-v2 input[type="date"],
+  .shell-v2 input[type="datetime-local"],
+  .shell-v2 input[type="month"],
+  .shell-v2 input[type="time"],
+  .shell-v2 input:not([type]),
+  .shell-v2 textarea,
+  .shell-v2 select {
+    font-size: 16px;
+  }
+}
+
 /* ─── Mobile overflow safeguards ──────────────────────────────────────────
    Pages were rendering with horizontal scroll on iPhone-class viewports
    because:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,3 +100,31 @@ body {
     opacity: 1;
   }
 }
+
+/* ─── iOS Safari input auto-zoom prevention (global backstop) ──────────────
+   Mobile Safari auto-zooms any text input whose font-size is < 16px on
+   focus, and frequently doesn't zoom back out when the keyboard closes.
+   Result: the whole page is stuck pinched-out until the user manually
+   pinch-zooms. Paul hit this after login and reported "first page is
+   slightly too zoomed in". The dashboard fix lives in shell-v2.css; this
+   global rule catches every other client surface (admin pages mounted
+   outside the shell, auth flows, marketing forms, etc.) and enforces
+   the 16px minimum on mobile. Desktop styles are unaffected (@media gate). */
+@media (max-width: 768px) {
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="number"],
+  input[type="tel"],
+  input[type="search"],
+  input[type="url"],
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="month"],
+  input[type="time"],
+  input:not([type]),
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -234,6 +234,51 @@ function OnboardingInner() {
             width: '100%',
           }}
         >
+          {/* OAuth error banner — the bank / Gmail / Outlook callbacks
+              route back here with ?error=<code> when they fail. Before
+              this, the user just saw the same step reload with no
+              explanation and quietly bounced off the flow. Now we
+              surface a clear recoverable message with a "try again"
+              affordance (staying on the same step) so they can retry
+              or skip without abandoning onboarding. */}
+          {(() => {
+            const errorCode = searchParams.get('error');
+            if (!errorCode) return null;
+            const errorMessages: Record<string, string> = {
+              bank_auth_failed:
+                'We couldn’t complete the bank connection. No data was shared. You can try again or skip this step.',
+              gmail_auth_failed:
+                'We couldn’t connect your Gmail inbox. No data was shared. You can try again or skip this step.',
+              outlook_auth_failed:
+                'We couldn’t connect your Outlook inbox. No data was shared. You can try again or skip this step.',
+              access_denied:
+                'You cancelled the authorisation. That’s fine — you can try again or skip this step.',
+            };
+            const message =
+              errorMessages[errorCode] ??
+              'Something went wrong with the connection. Your data is safe. Try again or skip this step.';
+            return (
+              <div
+                role="alert"
+                style={{
+                  width: '100%',
+                  maxWidth: 560,
+                  padding: '14px 16px',
+                  marginBottom: 24,
+                  background: '#FEF2F2',
+                  border: '1px solid #FECACA',
+                  borderRadius: 10,
+                  color: '#991B1B',
+                  fontSize: 13.5,
+                  lineHeight: 1.5,
+                }}
+              >
+                <strong style={{ display: 'block', marginBottom: 2 }}>Connection didn&rsquo;t complete</strong>
+                {message}
+              </div>
+            );
+          })()}
+
           {activeStep === 0 && (
             <StepWrap
               icon="👋"
@@ -271,12 +316,15 @@ function OnboardingInner() {
               >
                 <CreditCard style={{ width: 16, height: 16 }} /> Connect bank via TrueLayer
               </a>
-              <div style={{ display: 'flex', gap: 12, marginTop: 12 }}>
+              <p style={{ fontSize: 12.5, color: '#6B7280', marginTop: 10, maxWidth: 440, lineHeight: 1.5 }}>
+                You&rsquo;ll be securely redirected to your bank&rsquo;s own login screen via TrueLayer. No password ever touches Paybacker. You&rsquo;ll bounce straight back here when you&rsquo;re done.
+              </p>
+              <div style={{ display: 'flex', gap: 12, marginTop: 16 }}>
                 <button
                   onClick={() => gotoStep(2)}
-                  style={{ fontSize: 13, color: '#6B7280', background: 'transparent', border: 'none', cursor: 'pointer', fontWeight: 500 }}
+                  className="onboarding-skip"
                 >
-                  Skip for now — I'll do it later
+                  Skip for now — I&rsquo;ll do it later
                 </button>
               </div>
             </StepWrap>
@@ -361,11 +409,15 @@ function OnboardingInner() {
                 ))}
               </div>
 
+              <p style={{ fontSize: 12.5, color: '#6B7280', marginTop: 4, maxWidth: 440, lineHeight: 1.5, textAlign: 'center' }}>
+                You&rsquo;ll authorise read-only inbox access on your provider&rsquo;s own sign-in page. We never see your password and you can revoke access any time.
+              </p>
+
               <button
                 onClick={() => gotoStep(3)}
-                style={{ fontSize: 13, color: '#9CA3AF', background: 'transparent', border: 'none', cursor: 'pointer', fontWeight: 500 }}
+                className="onboarding-skip"
               >
-                Skip for now — I'll do it later
+                Skip for now — I&rsquo;ll do it later
               </button>
 
               <div
@@ -484,6 +536,26 @@ function OnboardingInner() {
           align-items: center;
           gap: 6px;
           font-family: inherit;
+        }
+        /* Skip button — promoted from a barely-visible grey link to a
+           proper outlined button so users who don't want to grant OAuth
+           scope can see their out without abandoning the whole flow.
+           Same tap-target size as the primary CTA. */
+        :global(.onboarding-skip) {
+          padding: 12px 16px;
+          font-size: 13.5px;
+          font-weight: 600;
+          color: #334155;
+          background: #fff;
+          border: 1px solid #E5E7EB;
+          border-radius: 10px;
+          cursor: pointer;
+          font-family: inherit;
+          transition: background 150ms ease, border-color 150ms ease;
+        }
+        :global(.onboarding-skip:hover) {
+          background: #F8FAFC;
+          border-color: #CBD5E1;
         }
         @media (max-width: 820px) {
           :global(.onboarding-grid) { grid-template-columns: 1fr !important; }


### PR DESCRIPTION
Two separate fixes bundled in one PR, both low-risk and narrow-scope.

## 1. iOS input auto-zoom (the login→dashboard pinch-zoom bug)

User reported "first page after login is zoomed in, I have to pinch to zoom out". Same root cause as the auth-pages fix in #270: iOS Safari auto-zooms any text input with font-size < 16px on focus, and often doesn't zoom back out when the keyboard closes.

The dashboard has **dozens** of forms using Tailwind's `text-sm` (14px) and `text-xs` (12px) on inputs — money-hub, profile, settings, forms, contracts, subscriptions, admin, complaints. Fixing each file individually is infeasible. Added two scoped CSS overrides:

1. **`src/app/dashboard/shell-v2.css`** — high-specificity mobile rule at `≤768px` forcing every text-like `<input>`, `<textarea>`, `<select>` inside `.shell-v2` to 16px.
2. **`src/app/globals.css`** — sitewide backstop at `≤768px` covering admin pages mounted outside the shell, marketing forms, and any future client surface.

Types listed explicitly: `text / email / password / number / tel / search / url / date / datetime-local / month / time / (no type) / textarea / select`. Non-text inputs (checkbox, radio, file, button, submit) don't trigger iOS auto-zoom. Desktop (>768px) is untouched.

## 2. Onboarding first-run UX wins

Three highest-impact fixes from an onboarding-flow UX audit:

### OAuth pre-departure copy (steps 1 and 2)
The connect-bank / connect-inbox buttons dropped users onto an unfamiliar OAuth screen with zero context. Added a 12.5px sub-copy under each CTA: *"You'll be securely redirected to your bank's own login screen via TrueLayer. No password ever touches Paybacker. You'll bounce straight back here when you're done."*

### Promoted skip buttons
The "Skip for now — I'll do it later" links were near-invisible grey text at 13px, making users think they were forced to grant OAuth scope. Promoted to proper outlined `.onboarding-skip` buttons matching the primary CTA's tap target.

### OAuth error banner
The bank / Gmail / Outlook callbacks route back to `/onboarding?error=<code>` when they fail, but the wizard had no UI for that. User saw the same step reload with no feedback and bounced. Added a recoverable `role="alert"` banner mapping known error codes to clear messages:

| Code | Message |
|---|---|
| `bank_auth_failed` | We couldn't complete the bank connection. No data was shared. You can try again or skip this step. |
| `gmail_auth_failed` | We couldn't connect your Gmail inbox. No data was shared. You can try again or skip this step. |
| `outlook_auth_failed` | We couldn't connect your Outlook inbox. No data was shared. You can try again or skip this step. |
| `access_denied` | You cancelled the authorisation. That's fine — you can try again or skip this step. |

## Deferred

- Step 4 showing a real "first win" instead of just copy (needs design)
- Mobile sidebar layout below 820px (needs wider rework)
- Bank/inbox flow-choice on step 1 (architectural)

## Test plan

- [ ] Log in on iPhone — dashboard no longer zooms in when any input is tapped; zoom stays normal after the keyboard closes
- [ ] Every form field across money-hub, profile, settings, forms, subscriptions, contracts renders at ≥16px on mobile
- [ ] `/onboarding` on iPhone — the two OAuth explainers render under the CTAs at step 1 and step 2
- [ ] Skip buttons at steps 1 and 2 are visually prominent (outlined, not barely-visible grey)
- [ ] `/onboarding?error=bank_auth_failed` shows the red recoverable banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)