### PR TITLE
feat(disputes): Open-in-Email + "I've sent it" for every dispute

### DIFF
--- a/src/app/api/disputes/[id]/letter-sent/route.ts
+++ b/src/app/api/disputes/[id]/letter-sent/route.ts
@@ -1,0 +1,124 @@
+/**
+ * POST /api/disputes/[id]/letter-sent
+ *
+ * Called when a user clicks "I've sent it" after Open-in-Email on a
+ * dispute letter (any dispute type — cancellation, bill dispute,
+ * parking, flight delay, etc.). Mirrors the subscriptions-side
+ * /api/subscriptions/[id]/cancellation-sent endpoint:
+ *
+ *   1. Mark the dispute as sent: status='awaiting_response',
+ *      tracking_status='sent', sent_at=now()
+ *   2. Look up the provider's contact email via the shared
+ *      provider_cancellation_info table (it covers complaint +
+ *      cancellation addresses — same team receives both for most
+ *      providers)
+ *   3. If we resolved an email and the user has an active email
+ *      connection, insert a dispute_watchdog_links row scoped to
+ *      the provider's domain so the Watchdog cron auto-imports any
+ *      reply into this dispute's correspondence timeline
+ *
+ * Body: { providerEmail?: string }  — optional override; the endpoint
+ * will fall back to a DB lookup if not provided.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getCancellationInfo } from '@/lib/cancellation-provider';
+
+export const runtime = 'nodejs';
+
+function extractDomain(email: string | null | undefined): string | null {
+  if (!email) return null;
+  const at = email.indexOf('@');
+  if (at < 0) return null;
+  const domain = email.slice(at + 1).trim().toLowerCase();
+  return domain.length > 0 ? domain : null;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id: disputeId } = await params;
+  const body = await request.json().catch(() => ({}));
+  const overrideEmail = typeof body.providerEmail === 'string' ? body.providerEmail.trim() : null;
+
+  const { data: dispute, error: loadErr } = await supabase
+    .from('disputes')
+    .select('id, provider_name, status')
+    .eq('id', disputeId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (loadErr) return NextResponse.json({ error: loadErr.message }, { status: 500 });
+  if (!dispute) return NextResponse.json({ error: 'Dispute not found' }, { status: 404 });
+
+  // Flip dispute state.
+  const { error: updErr } = await supabase
+    .from('disputes')
+    .update({
+      status: 'awaiting_response',
+      tracking_status: 'sent',
+      sent_at: new Date().toISOString(),
+    })
+    .eq('id', disputeId)
+    .eq('user_id', user.id);
+  if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
+
+  // Resolve provider email — caller override wins, DB lookup fills in.
+  let providerEmail = overrideEmail;
+  if (!providerEmail && dispute.provider_name) {
+    const info = await getCancellationInfo(supabase, dispute.provider_name);
+    providerEmail = info?.email ?? null;
+  }
+  const senderDomain = extractDomain(providerEmail);
+
+  // Auto-link Watchdog when we can. Same pattern as the subscriptions
+  // endpoint: insert a domain-scoped row so the sync-runner polls the
+  // inbox for replies from that domain and imports them as dispute
+  // correspondence. thread_id stays null because the user sent via
+  // their native email client, outside our OAuth.
+  let watchdogLinked = false;
+  if (senderDomain) {
+    const { data: emailConn } = await supabase
+      .from('email_connections')
+      .select('id, provider_type')
+      .eq('user_id', user.id)
+      .eq('status', 'active')
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (emailConn) {
+      const { error: linkErr } = await supabase
+        .from('dispute_watchdog_links')
+        .insert({
+          dispute_id: disputeId,
+          user_id: user.id,
+          email_connection_id: emailConn.id,
+          provider: emailConn.provider_type,
+          thread_id: null,
+          sender_domain: senderDomain,
+          sync_enabled: true,
+          match_source: 'letter_send',
+          match_confidence: 0.7,
+        });
+      if (linkErr) {
+        console.error('[disputes.letter-sent] watchdog link failed:', linkErr.message);
+      } else {
+        watchdogLinked = true;
+      }
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    dispute_id: disputeId,
+    watchdog_link_created: watchdogLinked,
+    sender_domain: senderDomain,
+    provider_email: providerEmail,
+  });
+}

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -206,19 +206,64 @@ function timeAgo(d: string) {
 // ============================================================
 // Letter Modal (reused from before)
 // ============================================================
-function LetterModal({ content, title, legalRefs, rightsPills, onClose }: {
+function LetterModal({ content, title, legalRefs, rightsPills, onClose, disputeId, providerName, onSentMarked }: {
   content: string;
   title: string;
   legalRefs: string[];
   rightsPills?: RightsPill[];
   onClose: () => void;
+  disputeId?: string;
+  providerName?: string;
+  onSentMarked?: () => void;
 }) {
   const [copied, setCopied] = useState(false);
+  const [providerEmail, setProviderEmail] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [sentNote, setSentNote] = useState<string | null>(null);
+
+  // Look up the provider's contact email so the mailto pre-addresses
+  // to them rather than forcing the user to find it themselves.
+  useEffect(() => {
+    if (!providerName) return;
+    let cancelled = false;
+    fetch(`/api/subscriptions/cancel-info?provider=${encodeURIComponent(providerName)}`)
+      .then((r) => r.json())
+      .then((d) => { if (!cancelled) setProviderEmail(d?.info?.email ?? null); })
+      .catch(() => { /* non-fatal — just no pre-addressed mailto */ });
+    return () => { cancelled = true; };
+  }, [providerName]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(content);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleMarkSent = async () => {
+    if (!disputeId) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/api/disputes/${disputeId}/letter-sent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ providerEmail }),
+      });
+      if (res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setSentNote(
+          data?.watchdog_link_created
+            ? "Marked as sent. We'll track the reply in this dispute."
+            : 'Marked as sent. Check this dispute for the reply.',
+        );
+        onSentMarked?.();
+      } else {
+        setSentNote('Could not mark as sent. Try again in a moment.');
+      }
+    } catch {
+      setSentNote('Could not mark as sent. Try again in a moment.');
+    } finally {
+      setSending(false);
+    }
   };
 
   const handlePDF = () => {
@@ -312,14 +357,40 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose }: {
           )}
           <p className="text-[10px] text-slate-600 text-center mt-3 leading-relaxed">{AI_LETTER_DISCLAIMER_HTML}</p>
         </div>
-        <div className="flex gap-3 p-6 border-t border-slate-200/50 flex-shrink-0">
-          <button onClick={handleCopy} className="flex-1 flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-900 py-3 rounded-lg transition-all font-medium">
-            {copied ? <CheckCircle className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
-            {copied ? 'Copied!' : 'Copy Letter'}
-          </button>
-          <button onClick={handlePDF} className="flex-1 flex items-center justify-center gap-2 cta py-3 rounded-lg transition-all font-semibold">
-            <Download className="h-4 w-4" /> Download PDF
-          </button>
+        <div className="flex flex-col gap-3 p-6 border-t border-slate-200/50 flex-shrink-0">
+          {sentNote && (
+            <div className="bg-emerald-500/10 border border-emerald-500/30 rounded-lg p-3 flex items-center gap-2 text-sm text-emerald-700">
+              <CheckCircle2 className="h-4 w-4 shrink-0" />
+              {sentNote}
+            </div>
+          )}
+          <div className="flex flex-wrap gap-3">
+            <button onClick={handleCopy} className="flex-1 min-w-[120px] flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-900 py-3 rounded-lg transition-all font-medium">
+              {copied ? <CheckCircle className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+              {copied ? 'Copied!' : 'Copy Letter'}
+            </button>
+            <button onClick={handlePDF} className="flex-1 min-w-[120px] flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-900 py-3 rounded-lg transition-all font-medium">
+              <Download className="h-4 w-4" /> Download PDF
+            </button>
+            {providerEmail && (
+              <a
+                href={`mailto:${providerEmail}?subject=${encodeURIComponent(title)}&body=${encodeURIComponent(content)}`}
+                className="flex-1 min-w-[160px] flex items-center justify-center gap-2 cta py-3 rounded-lg transition-all font-semibold"
+              >
+                <Mail className="h-4 w-4" /> Open in Email
+              </a>
+            )}
+          </div>
+          {disputeId && !sentNote && (
+            <button
+              onClick={handleMarkSent}
+              disabled={sending}
+              className="w-full flex items-center justify-center gap-2 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-700 border border-emerald-500/30 py-3 rounded-lg transition-all font-medium disabled:opacity-60"
+            >
+              {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
+              I&apos;ve sent it — track the reply
+            </button>
+          )}
         </div>
       </div>
     </div>
@@ -1039,6 +1110,9 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
           title={letterModal.title}
           legalRefs={letterModal.refs}
           rightsPills={letterModal.pills}
+          disputeId={disputeId}
+          providerName={dispute?.provider_name}
+          onSentMarked={fetchDispute}
           onClose={() => setLetterModal(null)}
         />
       )}

--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -2504,10 +2504,10 @@ export default function SubscriptionsPage() {
                         await fetchSubscriptions();
                         setBankToast(
                           data.watchdog_link_created
-                            ? `Tracking replies from ${data.sender_domain} in Disputes`
-                            : `Marked as sent — link a reply thread in Disputes if no confirmation arrives`,
+                            ? "Marked as sent. We'll track the reply in Disputes."
+                            : "Marked as sent. Check Disputes for the reply.",
                         );
-                        setTimeout(() => setBankToast(null), 5500);
+                        setTimeout(() => setBankToast(null), 5000);
                       } else {
                         setBankToast('Failed to update — try again');
                         setTimeout(() => setBankToast(null), 5000);


### PR DESCRIPTION
Generalises the send-and-track handoff from subscription cancellations to **every dispute type**. Any letter generated in the Disputes tool — bill dispute, parking appeal, flight delay, overcharge, energy / broadband complaint, etc. — now offers the same Open-in-Email → "I've sent it" → Watchdog tracks flow.

## What changes
- **LetterModal** gains two buttons next to Copy + Download:
  - **Open in Email** (only when we can resolve a provider email)
  - **I've sent it — track the reply**
- **New endpoint \`POST /api/disputes/\[id\]/letter-sent\`** — mirrors the subscription-side one
- **Provider email lookup** reuses \`provider_cancellation_info\`

## Copy cleanup
Subscriptions toast no longer leaks the technical domain. Now reads: *"Marked as sent. We'll track the reply in Disputes."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)