### PR TITLE
feat(dashboard): next-up banner + KPI grid 2x2 on mobile + copy fixes

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -801,7 +801,7 @@ export default function DashboardPage() {
                 fontSize: 13,
               }}
             >
-              No active alerts yet. Keep your bank and email connected — we&apos;ll flag overcharges and price rises here automatically.
+              Ready to find your first saving? Connect a bank account to scan transactions for forgotten subscriptions and silent price rises — we&apos;ll flag every one automatically.
             </div>
           ) : (
             actionRowsTop.map((r, i) => (
@@ -915,6 +915,95 @@ export default function DashboardPage() {
       {/* ─── Two-column body ───────────────────────────────────────── */}
       <div className="overview-grid">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
+          {/* Next-up banner — surfaces the single most important
+              missing-setup step at the top of the main column, where
+              it's visible on first scroll. The full "Get the most out
+              of Paybacker" checklist still lives on the right rail,
+              but on phones the rail stacks *below* the main column —
+              without this banner, a fresh user on iPhone has to scroll
+              past 1200px of widgets before they see their first
+              setup cue. Only renders while any core step is missing. */}
+          {(!bankConnected || !emailConnected || complaintsGenerated === 0) && (() => {
+            const nextStep = !bankConnected
+              ? { label: 'Connect a bank to unlock price alerts & auto-detected subscriptions', cta: 'Connect bank →', onClick: () => { if (!connectBankDirect()) setShowBankPicker(true); }, href: null }
+              : !emailConnected
+              ? { label: 'Connect an email inbox to catch hidden bills and forgotten subs', cta: 'Connect email →', onClick: null, href: '/dashboard/profile?connect_email=true' }
+              : { label: 'Write your first dispute letter — we\'ll cite the exact UK law', cta: 'Start a letter →', onClick: null, href: '/dashboard/complaints' };
+            return (
+              <div
+                className="card"
+                style={{
+                  background: 'linear-gradient(135deg, var(--mint-wash), #D1FAE5)',
+                  border: '1px solid #86EFAC',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 14,
+                  padding: 16,
+                  minHeight: 68,
+                }}
+              >
+                <div
+                  style={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: 10,
+                    background: '#fff',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                  }}
+                >
+                  <Sparkles className="h-5 w-5" style={{ color: 'var(--mint-deep)' }} />
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--mint-deep)', marginBottom: 2 }}>
+                    Next up
+                  </div>
+                  <div style={{ fontSize: 13.5, fontWeight: 600, color: 'var(--text-1)', lineHeight: 1.35 }}>
+                    {nextStep.label}
+                  </div>
+                </div>
+                {nextStep.href ? (
+                  <Link
+                    href={nextStep.href}
+                    style={{
+                      flexShrink: 0,
+                      padding: '10px 14px',
+                      background: 'var(--mint-deep)',
+                      color: '#fff',
+                      borderRadius: 8,
+                      fontSize: 12.5,
+                      fontWeight: 700,
+                      textDecoration: 'none',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {nextStep.cta}
+                  </Link>
+                ) : (
+                  <button
+                    onClick={nextStep.onClick!}
+                    style={{
+                      flexShrink: 0,
+                      padding: '10px 14px',
+                      background: 'var(--mint-deep)',
+                      color: '#fff',
+                      borderRadius: 8,
+                      fontSize: 12.5,
+                      fontWeight: 700,
+                      border: 'none',
+                      cursor: 'pointer',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {nextStep.cta}
+                  </button>
+                )}
+              </div>
+            );
+          })()}
+
           {/* Savings Opportunity Widget — existing */}
           {dealsLoading ? (
             <SavingsSkeleton />
@@ -978,7 +1067,9 @@ export default function DashboardPage() {
               </h3>
               <p style={{ margin: '-6px 0 10px', fontSize: 12, color: 'var(--text-3)' }}>
                 {emailScanResults !== null
-                  ? `Found ${emailScanResults} opportunities in your inbox.`
+                  ? emailScanResults === 0
+                    ? 'No billing or subscription emails to flag yet.'
+                    : `Found ${emailScanResults} bill${emailScanResults === 1 ? '' : 's'} and subscription${emailScanResults === 1 ? '' : 's'} to review.`
                   : emailAddress
                   ? `Connected: ${emailAddress}${emailLastScanned ? ` · Last scanned ${new Date(emailLastScanned).toLocaleDateString()}` : ''}`
                   : 'Scan your inbox to find bills, overcharges and savings.'}

--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -278,16 +278,25 @@
   .shell-v2 .overview-grid { grid-template-columns: 1fr; }
 }
 
-/* ─── KPI row responsive: c4 collapses 4→2→1 on narrower viewports ─── */
+/* ─── KPI row responsive: c4 collapses 4→2→1 on narrower viewports ───
+   Dashboard landing audit found that jumping straight from 2x2 to a
+   single column at ≤640px broke the "at a glance" property on iPhone
+   viewports — users had to scroll four card-heights to see all four
+   KPIs (a full screen on 430px). Kept 2x2 all the way down to 480px,
+   so a 430px-wide phone still sees 2 cards per row at ~200px each
+   (plenty for the "£0 / Potential savings" text layout). Single
+   column only kicks in below 480px where 2x2 genuinely gets cramped. */
 @media (max-width: 1100px) {
   .shell-v2 .kpi-row.c4 { grid-template-columns: repeat(2, 1fr); }
   .shell-v2 .kpi-row.c3 { grid-template-columns: repeat(2, 1fr); }
 }
-@media (max-width: 640px) {
+@media (max-width: 480px) {
   .shell-v2 .kpi-row.c4,
   .shell-v2 .kpi-row.c3 {
     grid-template-columns: 1fr;
   }
+}
+@media (max-width: 640px) {
   /* Page-title row stacks the CTA cluster below the heading on phones */
   .shell-v2 .page-title-row {
     flex-direction: column;


### PR DESCRIPTION
Highest-impact fixes from a `/dashboard` landing audit. The page is functionally complete but was informationally silent for fresh users — empty KPI cards, empty Action Centre, and on iPhone they had to scroll past ~1200px of widgets before seeing their first setup cue (which lives in the right-rail checklist that stacks *below* main content on mobile).

## Next-up banner

Compact mint-gradient banner at the top of the main column, visible only when any of **bank / email / first-letter** is still missing. Dynamically picks the single most important next step and shows one clear CTA:

| Missing | Copy | CTA |
|---|---|---|
| Bank | "Connect a bank to unlock price alerts & auto-detected subscriptions" | Connect bank → |
| Email | "Connect an email inbox to catch hidden bills and forgotten subs" | Connect email → |
| Letter | "Write your first dispute letter — we'll cite the exact UK law" | Start a letter → |

Reuses `connectBankDirect()` / bank-picker / email OAuth wiring from the existing profile page, so there's no new surface. Self-hides once all three are done.

The full "Get the most out of Paybacker" checklist still lives on the right rail for users who want a progress-at-a-glance view. This banner is the *"just tell me the next thing"* nudge for mobile users who never get as far as the rail.

## KPI grid — 2x2 on mobile (not single column)

Previous breakpoint collapsed the 4-KPI row 2x2 → 1-column at ≤640px. On iPhone 430px that meant 4 stacked cards, so users had to scroll four card-heights (~full screen) to see all four KPIs. Kept 2x2 all the way down to 480px; single-column only below 480px.

## Copy rewrites

- **Empty-state Action Centre:** *"No active alerts yet. Keep your bank and email connected…"* → *"Ready to find your first saving? Connect a bank account to scan transactions for forgotten subscriptions and silent price rises — we'll flag every one automatically."* Active voice + specific direction instead of passive waiting.
- **Email scanner result summary:** *"Found 3 opportunities"* → *"Found 3 bills and subscriptions to review"*. Zero-state handled separately as *"No billing or subscription emails to flag yet."* "Opportunities" was ambiguous — first-time users couldn't tell if it meant bills, savings, or something else.

## Test plan

- [ ] Fresh account on iPhone → land on `/dashboard` → next-up banner renders with "Connect a bank…" + mint CTA as the first thing above the fold
- [ ] Tap the banner CTA → bank picker opens (same flow as the sidebar checklist "Connect →")
- [ ] KPI row shows 2×2 grid on a 430px viewport, not 4 stacked cards
- [ ] Empty Action Centre reads as a directional teaser, not a dead "no alerts yet" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)