### PR TITLE
feat(disputes): Reply-by-email + Open-in-Gmail on provider replies

### DIFF
--- a/src/app/api/disputes/[id]/route.ts
+++ b/src/app/api/disputes/[id]/route.ts
@@ -17,7 +17,8 @@ export async function GET(
       *,
       correspondence(
         id, entry_type, title, content, summary, attachments, task_id, entry_date, created_at,
-        detected_from_email, sender_address, email_thread_id
+        detected_from_email, sender_address, email_thread_id, supplier_message_id,
+        ai_respond_needed, ai_urgency, ai_rationale
       ),
       contract_extractions(
         id, file_url, file_name, provider_name, contract_start_date, contract_end_date,

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -95,6 +95,7 @@ interface Correspondence {
   sender_address?: string | null;
   sender_name?: string | null;
   email_thread_id?: string | null;
+  supplier_message_id?: string | null;
   ai_category?: string | null;
   ai_respond_needed?: boolean | null;
   ai_urgency?: string | null;
@@ -372,14 +373,17 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose, disputeI
             <button onClick={handlePDF} className="flex-1 min-w-[120px] flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-900 py-3 rounded-lg transition-all font-medium">
               <Download className="h-4 w-4" /> Download PDF
             </button>
-            {providerEmail && (
-              <a
-                href={`mailto:${providerEmail}?subject=${encodeURIComponent(title)}&body=${encodeURIComponent(content)}`}
-                className="flex-1 min-w-[160px] flex items-center justify-center gap-2 cta py-3 rounded-lg transition-all font-semibold"
-              >
-                <Mail className="h-4 w-4" /> Open in Email
-              </a>
-            )}
+            {/* Always offer Open-in-Email. When we know the provider
+                address the mailto pre-addresses to them; when we don't,
+                the To field opens empty for the user to fill in. Better
+                than forcing them back to copy-paste into a fresh draft. */}
+            <a
+              href={`mailto:${providerEmail ?? ''}?subject=${encodeURIComponent(title)}&body=${encodeURIComponent(content)}`}
+              className="flex-1 min-w-[160px] flex items-center justify-center gap-2 cta py-3 rounded-lg transition-all font-semibold"
+            >
+              <Mail className="h-4 w-4" />
+              {providerEmail ? 'Open in Email' : 'Open in Email (add recipient)'}
+            </a>
           </div>
           {disputeId && !sentNote && (
             <button
@@ -1603,9 +1607,13 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                     <p className="text-sm text-slate-600 whitespace-pre-wrap">{entry.content}</p>
                   )}
 
-                  {/* Draft response button — shown on company responses */}
+                  {/* Action row for company replies — Draft AI response,
+                      open the original in the user's inbox, or start a
+                      blank reply via mailto. Covers the "I just want to
+                      reply in Gmail" case without forcing the user to
+                      dig through their inbox to find the thread. */}
                   {isFromCompany && !isResolved(dispute.status) && (
-                    <div className="mt-3 pt-3 border-t border-slate-200/30">
+                    <div className="mt-3 pt-3 border-t border-slate-200/30 flex flex-wrap gap-2">
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1617,6 +1625,30 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                         {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
                         Draft response to this
                       </button>
+                      {entry.sender_address && (
+                        <a
+                          href={`mailto:${entry.sender_address}?subject=${encodeURIComponent('Re: ' + (entry.title || dispute.issue_summary || dispute.provider_name || ''))}`}
+                          onClick={(e) => e.stopPropagation()}
+                          className="flex items-center gap-2 px-4 py-2 bg-white hover:bg-slate-50 text-slate-900 border border-slate-200 rounded-lg text-sm transition-all font-medium"
+                          title={`Reply to ${entry.sender_address}`}
+                        >
+                          <Mail className="h-4 w-4" />
+                          Reply by email
+                        </a>
+                      )}
+                      {entry.supplier_message_id && (
+                        <a
+                          href={`https://mail.google.com/mail/u/0/#inbox/${entry.supplier_message_id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="flex items-center gap-2 px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 border border-slate-200 rounded-lg text-sm transition-all font-medium"
+                          title="Open this message in Gmail (uses the Gmail internal message ID)"
+                        >
+                          <ArrowRight className="h-4 w-4" />
+                          Open in Gmail
+                        </a>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
Fixes the gap found in your testing: opening an existing dispute showed the provider's reply but had no way to launch it in Gmail or reply directly.

## New actions on every provider-reply card
- **Reply by email** — mailto to \`sender_address\` with \`Re: <subject>\` pre-filled. Works in any mail client.
- **Open in Gmail** — deep-link using the Gmail internal message ID we already store as \`supplier_message_id\`. Gmail users land on the original thread; Outlook users just use Reply-by-email.

## Supporting plumbing
- \`/api/disputes/[id]\` now selects \`supplier_message_id\` and the classifier fields (\`ai_respond_needed\`, etc.) that were referenced in render but not returned
- \`Correspondence\` TS interface gains \`supplier_message_id\`
- LetterModal \`Open in Email\` now shows unconditionally — when the provider isn't in cancel-info, the mailto opens with an empty To for manual entry

## Test plan
- [x] \`npx tsc --noEmit\` clean on touched files
- [ ] Open a dispute with an imported provider reply → new action buttons appear
- [ ] Reply-by-email → mailto opens with sender + Re:-prefixed subject
- [ ] Open in Gmail → opens that thread in Gmail (Gmail users only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)