### PR TITLE
feat(onboarding): dual-connect choice on step 1 + adaptive step 2

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -12,7 +12,10 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { ArrowRight, Check, Loader2, Mail, CreditCard, Sparkles } from 'lucide-react';
 
-const STEPS = ['Account', 'Connect bank', 'Scan inbox', 'First win'] as const;
+// Step labels reflect the user choice on step 1: they pick bank OR email
+// (OR both). Step 2 then becomes the other, conditionally. Naming stays
+// neutral so the sidebar reads sensibly whichever path the user took.
+const STEPS = ['Account', 'Connect', 'Complete set-up', 'First win'] as const;
 
 interface OnboardingState {
   hasAccount: boolean;
@@ -57,13 +60,21 @@ function OnboardingInner() {
     })();
   }, [router, supabase]);
 
+  // Derived step in the NEW dual-connect flow:
+  //   0 = Account (pre-signup shouldn't reach here, but fallback)
+  //   1 = Connect (show both bank+email choice — user has connected NEITHER)
+  //   2 = Complete set-up (show whichever is missing — user has ONE of the two)
+  //   3 = First win (both connected, OR scan complete, OR user chose to skip)
+  // Users can always move forward with Skip buttons even if a step's
+  // underlying data isn't set — skipping resets derivedStep back to this
+  // cell on refresh, but the ?step= URL param overrides it below.
   const derivedStep = useMemo(() => {
     if (!state) return 0;
     if (!state.hasAccount) return 0;
-    if (!state.hasBank) return 1;
-    if (!state.hasEmail) return 2;
+    if (!state.hasBank && !state.hasEmail) return 1;
+    if (!state.hasBank || !state.hasEmail) return 2;
     if (!state.hasScan) return 3;
-    return 3; // max — "First win"
+    return 3;
   }, [state]);
 
   const requestedStep = parseInt(searchParams.get('step') ?? '', 10);
@@ -299,174 +310,383 @@ function OnboardingInner() {
               icon="👋"
               iconGradient="linear-gradient(135deg,#DCFCE7,#BBF7D0)"
               title={`Welcome${state.userEmail ? `, ${state.userEmail.split('@')[0]}` : ''}.`}
-              subtitle="Your account is live. Next up: plug in a bank so we can find the money suppliers owe you back."
+              subtitle="Your account is live. Next: connect your bank, your email inbox, or both — so we can start finding money your suppliers owe you back."
             >
               <button
                 onClick={() => gotoStep(1)}
                 className="cta"
                 style={{ padding: '12px 18px', fontSize: 14 }}
               >
-                Connect my bank <ArrowRight style={{ width: 14, height: 14 }} />
+                Let&rsquo;s get started <ArrowRight style={{ width: 14, height: 14 }} />
               </button>
             </StepWrap>
           )}
 
           {activeStep === 1 && (
             <StepWrap
-              icon="🏦"
-              iconGradient="linear-gradient(135deg,#DBEAFE,#BFDBFE)"
-              title="Connect a bank"
-              subtitle="Read-only access via TrueLayer (FCA-authorised). We spot silent price rises, forgotten subscriptions, and unfair charges in your transaction history."
+              icon="🔌"
+              iconGradient="linear-gradient(135deg,#DCFCE7,#86EFAC)"
+              title="Connect your data"
+              subtitle="We need at least one connection to start finding you money. Bank gets the most wins; email catches the bills banks miss. Most users connect both."
             >
-              <a
-                href="/api/auth/truelayer"
-                className="cta"
+              {/* Dual-connect choice — bank and email side-by-side.
+                  Bank is highlighted as "Recommended" (it's where ~80%
+                  of wins come from per product data), but email isn't
+                  demoted — users who aren't ready to share bank access
+                  can still get real value from inbox scanning alone.
+                  Whichever they pick first, step 2 surfaces the other
+                  one as "also connect". */}
+              <div
+                className="connect-choice-grid"
                 style={{
-                  padding: '14px 18px',
-                  fontSize: 14.5,
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 8,
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 1fr',
+                  gap: 14,
+                  width: '100%',
+                  maxWidth: 620,
+                  marginBottom: 16,
                 }}
               >
-                <CreditCard style={{ width: 16, height: 16 }} /> Connect bank via TrueLayer
-              </a>
-              <p style={{ fontSize: 12.5, color: '#6B7280', marginTop: 10, maxWidth: 440, lineHeight: 1.5 }}>
-                You&rsquo;ll be securely redirected to your bank&rsquo;s own login screen via TrueLayer. No password ever touches Paybacker. You&rsquo;ll bounce straight back here when you&rsquo;re done.
+                {/* BANK card — highlighted */}
+                <div
+                  style={{
+                    padding: 20,
+                    border: '2px solid #86EFAC',
+                    borderRadius: 14,
+                    background: 'linear-gradient(135deg,#F0FDF4,#DCFCE7)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 10,
+                    position: 'relative',
+                  }}
+                >
+                  <span
+                    style={{
+                      position: 'absolute',
+                      top: 12,
+                      right: 12,
+                      fontSize: 10,
+                      fontWeight: 700,
+                      letterSpacing: '.08em',
+                      textTransform: 'uppercase',
+                      background: '#059669',
+                      color: '#fff',
+                      padding: '3px 8px',
+                      borderRadius: 999,
+                    }}
+                  >
+                    Recommended
+                  </span>
+                  <div
+                    style={{
+                      width: 44,
+                      height: 44,
+                      borderRadius: 10,
+                      background: '#059669',
+                      color: '#fff',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                    }}
+                  >
+                    <CreditCard style={{ width: 22, height: 22 }} />
+                  </div>
+                  <div style={{ fontSize: 16, fontWeight: 800, color: '#0B1220', letterSpacing: '-.01em' }}>
+                    Your bank
+                  </div>
+                  <p style={{ fontSize: 13, color: '#374151', lineHeight: 1.45, margin: 0, flex: 1 }}>
+                    We read your transactions to spot forgotten subscriptions, silent price rises, and overcharges. <strong>Most savings come from here.</strong>
+                  </p>
+                  <a
+                    href="/api/auth/truelayer"
+                    style={{
+                      marginTop: 4,
+                      padding: '11px 14px',
+                      background: '#0B1220',
+                      color: '#fff',
+                      borderRadius: 9,
+                      fontSize: 13,
+                      fontWeight: 700,
+                      textDecoration: 'none',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: 6,
+                    }}
+                  >
+                    Connect bank &rarr;
+                  </a>
+                  <p style={{ fontSize: 11.5, color: '#6B7280', margin: 0, lineHeight: 1.4 }}>
+                    Read-only via TrueLayer (FCA-authorised). No password ever touches Paybacker.
+                  </p>
+                </div>
+
+                {/* EMAIL card — equal weight, no demotion */}
+                <div
+                  style={{
+                    padding: 20,
+                    border: '1px solid #E5E7EB',
+                    borderRadius: 14,
+                    background: '#fff',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 10,
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 44,
+                      height: 44,
+                      borderRadius: 10,
+                      background: '#F59E0B',
+                      color: '#fff',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0,
+                    }}
+                  >
+                    <Mail style={{ width: 22, height: 22 }} />
+                  </div>
+                  <div style={{ fontSize: 16, fontWeight: 800, color: '#0B1220', letterSpacing: '-.01em' }}>
+                    Your email
+                  </div>
+                  <p style={{ fontSize: 13, color: '#374151', lineHeight: 1.45, margin: 0, flex: 1 }}>
+                    We read receipts, invoices and billing emails to catch PDF bills, trial conversions, and parking tickets &mdash; things that never show up as bank transactions.
+                  </p>
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginTop: 4 }}>
+                    <a
+                      href="/api/auth/google"
+                      style={{
+                        padding: '10px 8px',
+                        background: '#fff',
+                        color: '#0B1220',
+                        border: '1px solid #E5E7EB',
+                        borderRadius: 9,
+                        fontSize: 12.5,
+                        fontWeight: 700,
+                        textDecoration: 'none',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 6,
+                      }}
+                    >
+                      <span style={{ width: 16, height: 16, borderRadius: 4, background: '#EA4335', color: '#fff', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, fontWeight: 800 }}>G</span>
+                      Gmail
+                    </a>
+                    <a
+                      href="/api/auth/microsoft"
+                      style={{
+                        padding: '10px 8px',
+                        background: '#fff',
+                        color: '#0B1220',
+                        border: '1px solid #E5E7EB',
+                        borderRadius: 9,
+                        fontSize: 12.5,
+                        fontWeight: 700,
+                        textDecoration: 'none',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 6,
+                      }}
+                    >
+                      <span style={{ width: 16, height: 16, borderRadius: 4, background: '#0078D4', color: '#fff', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 10, fontWeight: 800 }}>O</span>
+                      Outlook
+                    </a>
+                  </div>
+                  <p style={{ fontSize: 11.5, color: '#6B7280', margin: 0, lineHeight: 1.4 }}>
+                    Read-only via OAuth. We only scan receipts and billing senders &mdash; never personal mail.
+                  </p>
+                </div>
+              </div>
+
+              <p style={{ fontSize: 12.5, color: '#6B7280', marginTop: 4, maxWidth: 540, lineHeight: 1.5, textAlign: 'center' }}>
+                Connect one, both, or skip for now &mdash; you can always add the other later from Profile &rarr; Connected accounts.
               </p>
+
               <div style={{ display: 'flex', gap: 12, marginTop: 16 }}>
                 <button
-                  onClick={() => gotoStep(2)}
+                  onClick={() => gotoStep(3)}
                   className="onboarding-skip"
                 >
-                  Skip for now — I&rsquo;ll do it later
+                  Skip for now &mdash; use Paybacker without data connections
                 </button>
               </div>
             </StepWrap>
           )}
 
-          {activeStep === 2 && (
-            <StepWrap
-              icon="📧"
-              iconGradient="linear-gradient(135deg,#FEF3C7,#FDE68A)"
-              title="Scan your inbox for subscriptions"
-              subtitle="We'll find every receipt, subscription, and free-trial-turned-paid in your email. Takes about 90 seconds."
-            >
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: '1fr 1fr',
-                  gap: 10,
-                  width: '100%',
-                  maxWidth: 520,
-                  marginBottom: 14,
-                }}
-                className="onboarding-provider-grid"
-              >
-                {[
-                  { t: 'Gmail', bg: '#EA4335', initial: 'G', href: '/api/auth/google', popular: true },
-                  { t: 'Outlook', bg: '#0078D4', initial: 'O', href: '/api/auth/microsoft', popular: true },
-                ].map((p) => (
+          {activeStep === 2 && (() => {
+            // Dynamic "complete set-up": shows whichever connection is
+            // still missing, framed as a reinforcing add-on rather than
+            // a forced second step. If both are somehow already set
+            // (user clicked back/forward), auto-advance to step 3.
+            if (state.hasBank && state.hasEmail) {
+              return (
+                <StepWrap
+                  icon="✓"
+                  iconGradient="linear-gradient(135deg,#DCFCE7,#86EFAC)"
+                  title="Both connections are live"
+                  subtitle="Bank and email are both scanning in the background. You&rsquo;re in the best position to find every bit of money you&rsquo;re owed."
+                >
+                  <button
+                    onClick={() => gotoStep(3)}
+                    className="cta"
+                    style={{ padding: '12px 18px', fontSize: 14 }}
+                  >
+                    See my first win <ArrowRight style={{ width: 14, height: 14 }} />
+                  </button>
+                </StepWrap>
+              );
+            }
+
+            const missingBank = !state.hasBank;
+
+            if (missingBank) {
+              // User connected email only — invite bank second.
+              return (
+                <StepWrap
+                  icon="🏦"
+                  iconGradient="linear-gradient(135deg,#DBEAFE,#BFDBFE)"
+                  title="Also add your bank?"
+                  subtitle="Your inbox is connected — nice. A bank connection is where we find the big wins though: silent price rises, duplicate charges, forgotten subscriptions still going out months after you cancelled. Skip if you&rsquo;re not ready; you can add it any time."
+                >
                   <a
-                    key={p.t}
-                    href={p.href}
+                    href="/api/auth/truelayer"
+                    className="cta"
                     style={{
-                      padding: 14,
-                      border: '1px solid #E5E7EB',
-                      borderRadius: 11,
-                      textDecoration: 'none',
-                      color: 'inherit',
-                      display: 'flex',
+                      padding: '14px 18px',
+                      fontSize: 14.5,
+                      display: 'inline-flex',
                       alignItems: 'center',
-                      gap: 10,
-                      background: '#fff',
+                      gap: 8,
                     }}
                   >
-                    <div
-                      style={{
-                        width: 36,
-                        height: 36,
-                        borderRadius: 9,
-                        background: p.bg,
-                        color: '#fff',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        fontWeight: 800,
-                        fontSize: 14,
-                      }}
-                    >
-                      {p.initial}
-                    </div>
-                    <div style={{ flex: 1 }}>
-                      <div style={{ fontSize: 13.5, fontWeight: 700 }}>Connect {p.t}</div>
-                      <div style={{ fontSize: 11, color: '#9CA3AF', marginTop: 1 }}>
-                        OAuth — no password needed
-                      </div>
-                    </div>
-                    {p.popular && (
-                      <span
-                        style={{
-                          fontSize: 10,
-                          fontWeight: 700,
-                          padding: '2px 6px',
-                          borderRadius: 4,
-                          letterSpacing: '.04em',
-                          background: '#DCFCE7',
-                          color: '#059669',
-                          textTransform: 'uppercase',
-                        }}
-                      >
-                        Popular
-                      </span>
-                    )}
+                    <CreditCard style={{ width: 16, height: 16 }} /> Connect bank via TrueLayer
                   </a>
-                ))}
-              </div>
+                  <p style={{ fontSize: 12.5, color: '#6B7280', marginTop: 10, maxWidth: 440, lineHeight: 1.5, textAlign: 'center' }}>
+                    You&rsquo;ll be securely redirected to your bank&rsquo;s own login screen via TrueLayer (FCA-authorised). No password ever touches Paybacker.
+                  </p>
+                  <button
+                    onClick={() => gotoStep(3)}
+                    className="onboarding-skip"
+                  >
+                    Skip for now &mdash; I&rsquo;ll add my bank later
+                  </button>
+                </StepWrap>
+              );
+            }
 
-              <p style={{ fontSize: 12.5, color: '#6B7280', marginTop: 4, maxWidth: 440, lineHeight: 1.5, textAlign: 'center' }}>
-                You&rsquo;ll authorise read-only inbox access on your provider&rsquo;s own sign-in page. We never see your password and you can revoke access any time.
-              </p>
-
-              <button
-                onClick={() => gotoStep(3)}
-                className="onboarding-skip"
-              >
-                Skip for now — I&rsquo;ll do it later
-              </button>
-
-              <div
-                style={{
-                  marginTop: 36,
-                  width: '100%',
-                  maxWidth: 520,
-                  padding: 16,
-                  background: '#fff',
-                  border: '1px solid #E5E7EB',
-                  borderRadius: 12,
-                  fontSize: 12.5,
-                  color: '#4B5563',
-                  lineHeight: 1.55,
-                }}
+            // User connected bank only — invite email second.
+            return (
+              <StepWrap
+                icon="📧"
+                iconGradient="linear-gradient(135deg,#FEF3C7,#FDE68A)"
+                title="Also scan your inbox?"
+                subtitle="Your bank is connected — brilliant, that&rsquo;s where most wins come from. An email connection catches the rest: PDF invoices, free-trial conversions, parking tickets, and anything billed via a company card rather than direct debit. Takes about 90 seconds."
               >
                 <div
                   style={{
-                    fontSize: 11,
-                    fontWeight: 700,
-                    color: '#9CA3AF',
-                    letterSpacing: '.08em',
-                    textTransform: 'uppercase',
-                    marginBottom: 6,
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gap: 10,
+                    width: '100%',
+                    maxWidth: 520,
+                    marginBottom: 14,
+                  }}
+                  className="onboarding-provider-grid"
+                >
+                  {[
+                    { t: 'Gmail', bg: '#EA4335', initial: 'G', href: '/api/auth/google' },
+                    { t: 'Outlook', bg: '#0078D4', initial: 'O', href: '/api/auth/microsoft' },
+                  ].map((p) => (
+                    <a
+                      key={p.t}
+                      href={p.href}
+                      style={{
+                        padding: 14,
+                        border: '1px solid #E5E7EB',
+                        borderRadius: 11,
+                        textDecoration: 'none',
+                        color: 'inherit',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 10,
+                        background: '#fff',
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: 36,
+                          height: 36,
+                          borderRadius: 9,
+                          background: p.bg,
+                          color: '#fff',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontWeight: 800,
+                          fontSize: 14,
+                        }}
+                      >
+                        {p.initial}
+                      </div>
+                      <div style={{ flex: 1 }}>
+                        <div style={{ fontSize: 13.5, fontWeight: 700 }}>Connect {p.t}</div>
+                        <div style={{ fontSize: 11, color: '#9CA3AF', marginTop: 1 }}>
+                          OAuth &mdash; no password needed
+                        </div>
+                      </div>
+                    </a>
+                  ))}
+                </div>
+
+                <p style={{ fontSize: 12.5, color: '#6B7280', marginTop: 4, maxWidth: 440, lineHeight: 1.5, textAlign: 'center' }}>
+                  You&rsquo;ll authorise read-only inbox access on your provider&rsquo;s own sign-in page. We never see your password and you can revoke access any time.
+                </p>
+
+                <button
+                  onClick={() => gotoStep(3)}
+                  className="onboarding-skip"
+                >
+                  Skip for now &mdash; I&rsquo;ll add my inbox later
+                </button>
+
+                <div
+                  style={{
+                    marginTop: 36,
+                    width: '100%',
+                    maxWidth: 520,
+                    padding: 16,
+                    background: '#fff',
+                    border: '1px solid #E5E7EB',
+                    borderRadius: 12,
+                    fontSize: 12.5,
+                    color: '#4B5563',
+                    lineHeight: 1.55,
                   }}
                 >
-                  What we'll read
+                  <div
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 700,
+                      color: '#9CA3AF',
+                      letterSpacing: '.08em',
+                      textTransform: 'uppercase',
+                      marginBottom: 6,
+                    }}
+                  >
+                    What we&rsquo;ll read
+                  </div>
+                  Only senders matching receipt patterns &mdash; <code style={{ background: '#F3F4F6', padding: '1px 5px', borderRadius: 4, fontSize: 11 }}>receipt@</code>
+                  , <code style={{ background: '#F3F4F6', padding: '1px 5px', borderRadius: 4, fontSize: 11 }}>no-reply@</code>
+                  , <code style={{ background: '#F3F4F6', padding: '1px 5px', borderRadius: 4, fontSize: 11 }}>billing@</code> &mdash; plus 143 known providers. Personal mail is never opened.
                 </div>
-                Only senders matching receipt patterns — <code style={{ background: '#F3F4F6', padding: '1px 5px', borderRadius: 4, fontSize: 11 }}>receipt@</code>
-                , <code style={{ background: '#F3F4F6', padding: '1px 5px', borderRadius: 4, fontSize: 11 }}>no-reply@</code>
-                , <code style={{ background: '#F3F4F6', padding: '1px 5px', borderRadius: 4, fontSize: 11 }}>billing@</code> — plus 143 known providers. Personal mail is never opened.
-              </div>
-            </StepWrap>
-          )}
+              </StepWrap>
+            );
+          })()}
 
           {activeStep === 3 && (
             <StepWrap
@@ -674,6 +894,10 @@ function OnboardingInner() {
           :global(.onboarding-grid) { grid-template-columns: 1fr !important; }
           :global(.onboarding-grid aside) { border-right: none !important; border-bottom: 1px solid #E5E7EB; }
           :global(.onboarding-provider-grid) { grid-template-columns: 1fr !important; }
+          /* Dual-connect cards stack on tablets and phones — side-by-side
+             needs ~620px of horizontal room to fit the "Most savings come
+             from here" copy without overflow. */
+          :global(.connect-choice-grid) { grid-template-columns: 1fr !important; }
         }
         /* ≤480px: compact rail — hide the marketing headers and the
            privacy reassurance block (both duplicated elsewhere in the


### PR DESCRIPTION
Restructures the onboarding flow so users pick **bank OR email OR both** up-front, instead of being forced down a rigid bank-first sequential path.

## Why

Bank is the primary data source — ~80% of savings come from transaction scanning (silent price rises, forgotten subscriptions, duplicate charges). Email is important too — it catches bills that *never* show up as bank transactions: PDF invoices, trial-conversion emails, parking tickets.

But some users won't share bank access on day one. The old flow forced bank first, showed a tiny grey "skip" link, and lost those users before they even saw the product work.

New flow: **recommend the best path, respect the genuine choice.**

## Step 1 — dual-choice screen

Two cards side-by-side:

| Card | Visual | Copy |
|---|---|---|
| **Bank** | Mint gradient, "Recommended" badge | *"Most savings come from spotting forgotten subs and silent price rises in your transactions. Read-only via TrueLayer (FCA-authorised)."* |
| **Email** | White, neutral weight | *"Catches PDF invoices, trial conversions, parking tickets — bills that never show up as bank transactions."* |

Below both: *"Connect one, both, or skip for now — you can always add the other later from Profile → Connected accounts."*

## Step 2 — "Also add [the other]"

Dynamically branches on live state:

- **Bank connected, email missing** → *"Also scan your inbox?"* with Gmail + Outlook CTAs and warmer framing ("brilliant, that's where most wins come from; email catches the rest")
- **Email connected, bank missing** → *"Also add your bank?"* with specific value prop about what bank catches that email doesn't
- **Both already connected** (back/forward nav) → success card "Both connections are live" + Continue CTA to step 3

Skip affordance stays prominent on every branch — no coercion.

## Sidebar labels

`STEPS = ['Account', 'Connect', 'Complete set-up', 'First win']` — neutral names that read sensibly whichever path the user took.

## derivedStep

```
0 → no account (unreachable in practice)
1 → no bank AND no email  → first-connection screen
2 → one of the two        → adaptive "complete set-up" screen
3 → both connected        → first win
```

`?step=N` URL param still overrides so deep links keep working.

## Test plan

- [ ] Fresh signup → lands on step 0 → "Let's get started" → step 1 shows both cards
- [ ] Connect bank only on step 1 → OAuth return lands on step 2 showing "Also scan your inbox?"
- [ ] Connect email only on step 1 → OAuth return lands on step 2 showing "Also add your bank?"
- [ ] Connect both before moving on → step 2 auto-shows "Both connections are live" + Continue
- [ ] Skip step 1 entirely → lands on step 3 "You're ready to find wins"
- [ ] Cards stack to single column on iPhone (≤820px)
- [ ] `/onboarding?error=bank_auth_failed` still shows the red recoverable banner above the cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)