### PR TITLE
fix(watchdog): link inserts hit allowed enum values (Codex P1 on #280/#282)

### DIFF
--- a/src/app/api/disputes/[id]/letter-sent/route.ts
+++ b/src/app/api/disputes/[id]/letter-sent/route.ts
@@ -93,17 +93,26 @@ export async function POST(
       .maybeSingle();
 
     if (emailConn) {
+      // dispute_watchdog_links CHECK constraints require provider ∈
+      // (gmail, outlook, imap) and match_source ∈ (user_confirmed,
+      // auto_domain, auto_ai). email_connections.provider_type uses
+      // 'google' rather than 'gmail', so normalise before insert.
+      const providerMap: Record<string, 'gmail' | 'outlook' | 'imap'> = {
+        google: 'gmail', gmail: 'gmail', outlook: 'outlook', imap: 'imap',
+      };
+      const normalisedProvider = providerMap[emailConn.provider_type as string] ?? 'imap';
+
       const { error: linkErr } = await supabase
         .from('dispute_watchdog_links')
         .insert({
           dispute_id: disputeId,
           user_id: user.id,
           email_connection_id: emailConn.id,
-          provider: emailConn.provider_type,
+          provider: normalisedProvider,
           thread_id: null,
           sender_domain: senderDomain,
           sync_enabled: true,
-          match_source: 'letter_send',
+          match_source: 'auto_domain',
           match_confidence: 0.7,
         });
       if (linkErr) {

--- a/src/app/api/disputes/[id]/route.ts
+++ b/src/app/api/disputes/[id]/route.ts
@@ -73,9 +73,21 @@ export async function GET(
     return c;
   });
 
+  // Flag whether the user has a Gmail connection so the UI can gate
+  // the "Open in Gmail" deep-link — mail.google.com doesn't resolve
+  // message IDs for Outlook users, so showing the button to them
+  // would just land them on their own inbox.
+  const { data: emailConns } = await supabase
+    .from('email_connections')
+    .select('provider_type')
+    .eq('user_id', user.id)
+    .eq('status', 'active');
+  const userHasGmail = (emailConns ?? []).some((c) => c.provider_type === 'google');
+
   return NextResponse.json({
     ...dispute,
     correspondence: enrichedCorrespondence,
+    user_has_gmail: userHasGmail,
   });
 }
 

--- a/src/app/api/subscriptions/[id]/cancellation-sent/route.ts
+++ b/src/app/api/subscriptions/[id]/cancellation-sent/route.ts
@@ -97,17 +97,28 @@ export async function POST(
     const senderDomain = extractDomain(providerEmail);
 
     if (emailConn && senderDomain) {
+      // dispute_watchdog_links constrains provider ∈ (gmail, outlook, imap)
+      // and match_source ∈ (user_confirmed, auto_domain, auto_ai).
+      // email_connections.provider_type stores 'google' rather than
+      // 'gmail', so normalise before insert. 'auto_domain' is the right
+      // semantic here — the link is created automatically, scoped by
+      // domain, without the user confirming a specific thread.
+      const providerMap: Record<string, 'gmail' | 'outlook' | 'imap'> = {
+        google: 'gmail', gmail: 'gmail', outlook: 'outlook', imap: 'imap',
+      };
+      const normalisedProvider = providerMap[emailConn.provider_type as string] ?? 'imap';
+
       const { data: linkRow, error: linkErr } = await supabase
         .from('dispute_watchdog_links')
         .insert({
           dispute_id: dispute.id,
           user_id: user.id,
           email_connection_id: emailConn.id,
-          provider: emailConn.provider_type,
+          provider: normalisedProvider,
           thread_id: null,
           sender_domain: senderDomain,
           sync_enabled: true,
-          match_source: 'cancellation_send',
+          match_source: 'auto_domain',
           match_confidence: 0.7,
         })
         .select('id')

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -44,6 +44,7 @@ interface Dispute {
   latest_snippet?: string | null;
   unread_reply_count?: number;
   last_reply_received_at?: string | null;
+  user_has_gmail?: boolean;
   correspondence?: Correspondence[];
   contract_extractions?: ContractExtraction[];
 }
@@ -1636,7 +1637,7 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                           Reply by email
                         </a>
                       )}
-                      {entry.supplier_message_id && (
+                      {entry.supplier_message_id && dispute.user_has_gmail && (
                         <a
                           href={`https://mail.google.com/mail/u/0/#inbox/${entry.supplier_message_id}`}
                           target="_blank"


### PR DESCRIPTION
Codex caught two P1s on #280 and #282 that meant **every "I've sent it" click was silently failing to create the watchdog link**. The CHECK constraints on \`dispute_watchdog_links\` kept rejecting my inserts — provider='google' and match_source='cancellation_send'/'letter_send' aren't in the allowed enum sets.

## Root cause
\`\`\`
provider     ∈ ('gmail', 'outlook', 'imap')
match_source ∈ ('user_confirmed', 'auto_domain', 'auto_ai')
\`\`\`
I was writing \`emailConn.provider_type\` (which stores 'google') and an invented \`'cancellation_send'\`. Prod confirmed zero rows ever landed.

## Fix
- Normalise provider: google→gmail; outlook/imap/gmail unchanged; unknown→imap
- Use \`match_source='auto_domain'\` — the link is auto-created post-send, scoped by domain, without user confirming a specific thread
- Applied identically in both endpoints

## P2 on #285 — gate "Open in Gmail" to Gmail users
\`mail.google.com\` doesn't resolve message IDs for Outlook users. \`/api/disputes/[id]\` now returns \`user_has_gmail\` so the UI hides the button for non-Gmail users.

## No migration required
The constraint was blocking inserts all along — there are no broken rows to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)