### PR TITLE
fix(money-hub): mobile ergonomics pass across modals and panels

### DIFF
--- a/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
+++ b/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
@@ -196,15 +196,19 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
       <div className="absolute inset-0 bg-white backdrop-blur-sm" onClick={onClose} />
-      <div className="relative card w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-slate-200">
-          <div>
-            <h2 className="text-xl font-bold text-slate-900 capitalize">{displayTitle}</h2>
+      <div className="relative card w-full max-w-2xl max-h-[92vh] sm:max-h-[85vh] flex flex-col shadow-2xl rounded-b-none sm:rounded-2xl">
+        <div className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-200">
+          <div className="min-w-0">
+            <h2 className="text-xl font-bold text-slate-900 capitalize truncate">{displayTitle}</h2>
             <p className="text-slate-500 text-sm mt-1">{selectedMonth ? new Date(`${selectedMonth}-01`).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }) : 'This month'}</p>
           </div>
-          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-2 rounded-lg hover:bg-slate-100 transition-colors">
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-slate-500 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 transition-colors"
+          >
             <X className="h-5 w-5" />
           </button>
         </div>
@@ -218,7 +222,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
           </div>
         )}
 
-        <div className="p-6 overflow-y-auto flex-1 custom-scrollbar">
+        <div className="p-4 sm:p-6 overflow-y-auto flex-1 custom-scrollbar">
           {loading ? (
             <div className="flex items-center justify-center py-20">
               <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
@@ -255,7 +259,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                       </div>
                       
                       {merchantRecatIdx === idx && (
-                        <div className="absolute top-16 right-0 w-56 bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
+                        <div className="absolute top-16 right-0 w-56 max-w-[calc(100vw-2.5rem)] bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
                           {renderReassignOptions(m.merchant)}
                         </div>
                       )}
@@ -288,7 +292,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                         </div>
 
                         {isRecatOpen && (
-                          <div className="absolute top-12 right-4 w-56 bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
+                          <div className="absolute top-12 right-4 w-56 max-w-[calc(100vw-2.5rem)] bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
                             {renderReassignOptions(cleanMerchantName(txn.description || ''))}
                           </div>
                         )}

--- a/src/app/dashboard/money-hub/NetWorthManagementModal.tsx
+++ b/src/app/dashboard/money-hub/NetWorthManagementModal.tsx
@@ -54,12 +54,18 @@ export default function NetWorthManagementModal({ isOpen, onClose, data, onUpdat
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
       <div className="absolute inset-0 bg-white backdrop-blur-sm" onClick={onClose} />
-      <div className="relative card w-full max-w-xl max-h-[85vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-slate-200">
+      <div className="relative card w-full max-w-xl max-h-[92vh] sm:max-h-[85vh] flex flex-col shadow-2xl rounded-b-none sm:rounded-2xl">
+        <div className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-200">
           <h2 className="text-xl font-bold text-slate-900 flex items-center gap-2 pt-1"><PiggyBank className="h-6 w-6 text-mint-400" /> Manage Net Worth</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-2 rounded-lg hover:bg-slate-100 transition-colors"><X className="h-5 w-5" /></button>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-slate-500 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
         </div>
 
         <div className="flex border-b border-slate-200">
@@ -67,13 +73,13 @@ export default function NetWorthManagementModal({ isOpen, onClose, data, onUpdat
           <button onClick={() => setActiveTab('liabilities')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'liabilities' ? 'text-red-400 border-b-2 border-red-400' : 'text-slate-500 hover:text-slate-700'}`}>Liabilities</button>
         </div>
 
-        <div className="p-6 overflow-y-auto custom-scrollbar flex-1">
+        <div className="p-4 sm:p-6 overflow-y-auto custom-scrollbar flex-1">
           {activeTab === 'assets' ? (
             <div className="space-y-6">
               <div className="bg-white p-4 rounded-xl border border-slate-200">
                 <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2"><Building2 className="h-4 w-4 text-green-400" /> Add Asset</h3>
-                <div className="grid grid-cols-2 gap-3 mb-3">
-                  <input type="text" placeholder="Asset Name (e.g. Monzo, House)" value={assetForm.name} onChange={e => setAssetForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none col-span-2" />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
+                  <input type="text" placeholder="Asset Name (e.g. Monzo, House)" value={assetForm.name} onChange={e => setAssetForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none sm:col-span-2" />
                   <select value={assetForm.type} onChange={e => setAssetForm(prev => ({ ...prev, type: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none">
                     <option value="savings">Savings</option><option value="property">Property</option><option value="investment">Investment</option><option value="vehicle">Vehicle</option><option value="crypto">Crypto</option><option value="business">Business</option><option value="pension">Pension</option><option value="other">Other</option>
                   </select>
@@ -94,8 +100,8 @@ export default function NetWorthManagementModal({ isOpen, onClose, data, onUpdat
             <div className="space-y-6">
               <div className="bg-white p-4 rounded-xl border border-slate-200">
                 <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2"><CreditCard className="h-4 w-4 text-red-400" /> Add Liability</h3>
-                <div className="grid grid-cols-2 gap-3 mb-3">
-                  <input type="text" placeholder="Liability Name (e.g. Loan, Mortgage)" value={liabilityForm.name} onChange={e => setLiabilityForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none col-span-2" />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
+                  <input type="text" placeholder="Liability Name (e.g. Loan, Mortgage)" value={liabilityForm.name} onChange={e => setLiabilityForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none sm:col-span-2" />
                   <select value={liabilityForm.type} onChange={e => setLiabilityForm(prev => ({ ...prev, type: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none">
                     <option value="loan">Loan</option><option value="mortgage">Mortgage</option><option value="credit_card">Credit Card</option><option value="car_finance">Car Finance</option><option value="overdraft">Overdraft</option><option value="other">Other</option>
                   </select>

--- a/src/app/dashboard/money-hub/NetWorthPanel.tsx
+++ b/src/app/dashboard/money-hub/NetWorthPanel.tsx
@@ -41,6 +41,18 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
             <div className="text-right"><p className="text-xs text-slate-500">Liabilities</p><p className="text-lg text-slate-900 font-semibold">£---</p></div>
           </div>
         </div>
+      ) : assetsList.length === 0 && liabilitiesList.length === 0 ? (
+        <div className="flex-1 flex flex-col items-center justify-center text-center bg-white border border-slate-200 rounded-xl p-6">
+          <PiggyBank className="h-8 w-8 text-mint-400 mb-3" />
+          <p className="text-slate-900 font-semibold text-sm mb-1">See your true wealth</p>
+          <p className="text-slate-500 text-xs mb-4 max-w-[240px]">Add what you own (savings, property, investments) and what you owe (loans, mortgage) to track your real financial position.</p>
+          <button
+            onClick={() => setModalOpen(true)}
+            className="inline-flex items-center justify-center gap-2 bg-mint-500 hover:bg-mint-600 text-white font-semibold text-sm px-4 h-10 rounded-lg transition-colors"
+          >
+            Add your first entry
+          </button>
+        </div>
       ) : (
         <div className="flex-1 flex flex-col">
           {/* Assets vs Liabilities summary */}
@@ -55,13 +67,15 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
               <p className="text-lg text-red-400 font-semibold">£{fmtNum(liabilities)}</p>
             </div>
           </div>
-          
+
           <div className="space-y-4">
             {/* Top assets */}
             <div>
               <p className="text-xs text-slate-500 uppercase tracking-wider mb-2 font-semibold">Assets</p>
               {assetsList.length === 0 ? (
-                <p className="text-xs text-slate-500">Add assets manually to track net worth.</p>
+                <button onClick={() => setModalOpen(true)} className="text-xs text-mint-600 hover:text-mint-700 underline decoration-dotted">
+                  Add an asset to start tracking
+                </button>
               ) : (
                 assetsList.slice(0, 3).map((a: any) => (
                   <div key={a.id} className="flex justify-between text-sm py-1.5 border-b border-slate-200 last:border-0">
@@ -76,7 +90,9 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
             <div>
               <p className="text-xs text-slate-500 uppercase tracking-wider mb-2 font-semibold">Liabilities</p>
               {liabilitiesList.length === 0 ? (
-                <p className="text-xs text-slate-500">No liabilities tracked.</p>
+                <button onClick={() => setModalOpen(true)} className="text-xs text-mint-600 hover:text-mint-700 underline decoration-dotted">
+                  Add a liability (optional)
+                </button>
               ) : (
                 liabilitiesList.slice(0, 3).map((l: any) => (
                   <div key={l.id} className="flex justify-between text-sm py-1.5 border-b border-slate-200 last:border-0">

--- a/src/app/dashboard/money-hub/OverviewPanel.tsx
+++ b/src/app/dashboard/money-hub/OverviewPanel.tsx
@@ -191,7 +191,7 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
                   return (
                     <div
                       key={entry.type}
-                      className="group cursor-pointer hover:bg-slate-100 p-2 -mx-2 rounded-lg transition-colors"
+                      className="group cursor-pointer hover:bg-slate-100 active:bg-slate-200 p-2 -mx-2 rounded-lg transition-colors"
                       onClick={() => setDrillIncomeType(entry.type)}
                     >
                       <div className="flex items-center justify-between text-sm mb-1">
@@ -247,7 +247,7 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
                   return (
                     <div
                       key={c.category}
-                      className="group cursor-pointer hover:bg-slate-100 p-2 -mx-2 rounded-lg transition-colors"
+                      className="group cursor-pointer hover:bg-slate-100 active:bg-slate-200 p-2 -mx-2 rounded-lg transition-colors"
                       onClick={() => setDrillSpendingCategory(c.category)}
                     >
                       <div className="flex items-center justify-between text-sm mb-1">

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -810,7 +810,8 @@ export default function MoneyHubPage() {
  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
  <span>{spaces.length > 1 ? 'Manage' : 'Spaces'}</span>
  </Link>
- {/* Month nav */}
+ {/* Month nav — grouped so the prev/select/next cluster stays together on mobile wrap */}
+ <div className="inline-flex items-center gap-1">
  <button
  onClick={() => {
  const months = Array.from({ length: 12 }, (_, i) => {
@@ -821,7 +822,8 @@ export default function MoneyHubPage() {
  const next = cur < months.length - 1 ? months[cur + 1] : months[months.length - 1];
  setSelectedMonth(next); refreshData(next); fetchExpectedBills(next);
  }}
- className="text-slate-600 hover:text-slate-900 p-1.5 rounded transition-colors"
+ className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-10 w-10 rounded transition-colors active:bg-slate-100"
+ aria-label="Previous month"
  title="Previous month"
  >
  <ArrowLeft className="h-4 w-4" />
@@ -849,11 +851,13 @@ export default function MoneyHubPage() {
  if (cur > 0) { setSelectedMonth(months[cur - 1]); refreshData(months[cur - 1]); fetchExpectedBills(months[cur - 1]); }
  }}
  disabled={!selectedMonth}
- className="text-slate-600 hover:text-slate-900 p-1.5 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+ className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-10 w-10 rounded transition-colors active:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed"
+ aria-label="Next month"
  title="Next month"
  >
  <ArrowRight className="h-4 w-4" />
  </button>
+ </div>
 
  <button
  onClick={handleSync}


### PR DESCRIPTION
## Summary
Mobile UX audit of `/dashboard/money-hub` surfaced 8 friction points on iPhone viewports. Ship all 8 in one pass.

- **Modal close buttons** — 44×44 tap targets on the Category drill-down + Net Worth modals (was 36px)
- **Modals go bottom-sheet on mobile** — full-width, rounded-top corners, tighter body padding for more content real estate
- **Recategorise dropdowns** — `max-w-[calc(100vw-2.5rem)]` so they never overflow the viewport on narrow rows
- **Net Worth modal grid** — stacks single-column < sm instead of squeezing Type select + Value input into two cramped columns
- **Month nav** — prev/select/next grouped into a sub-flex so the cluster stays together when wrapping; arrow buttons bumped to 40×40 (was 28×28)
- **Overview drill rows** — added `active:bg-slate-200` so there's visible feedback for touch (hover states don't fire on mobile)
- **Net Worth empty state** — replaced the passive "Add assets manually to track net worth" / "No liabilities tracked" with an actionable unified empty card + "Add your first entry" CTA that opens the management modal directly

## Test plan
- [ ] Open Money Hub on iPhone 17 Pro Max (430px) — close buttons reachable with thumb
- [ ] Tap "Recategorise Rule" on top-right merchant — dropdown fits inside viewport
- [ ] Open Net Worth modal → Add Asset form stacks cleanly on mobile
- [ ] Month nav + Sync don't fragment mid-cluster when row wraps
- [ ] Tap any category/income pill in Overview — clear press feedback
- [ ] Fresh Pro user with no assets/liabilities sees actionable CTA, not dead-end copy
- [ ] Desktop (≥640px) unchanged — modals remain centred with original padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)