### PR TITLE
feat(disputes): Open-in-Outlook parity + wider action-row trigger

### DIFF
--- a/src/app/api/disputes/[id]/route.ts
+++ b/src/app/api/disputes/[id]/route.ts
@@ -17,7 +17,7 @@ export async function GET(
       *,
       correspondence(
         id, entry_type, title, content, summary, attachments, task_id, entry_date, created_at,
-        detected_from_email, sender_address, email_thread_id, supplier_message_id,
+        detected_from_email, sender_address, email_thread_id, supplier_message_id, supplier_web_link,
         ai_respond_needed, ai_urgency, ai_rationale
       ),
       contract_extractions(
@@ -73,21 +73,24 @@ export async function GET(
     return c;
   });
 
-  // Flag whether the user has a Gmail connection so the UI can gate
-  // the "Open in Gmail" deep-link — mail.google.com doesn't resolve
-  // message IDs for Outlook users, so showing the button to them
-  // would just land them on their own inbox.
+  // Flag which mail providers the user has connected so the UI can
+  // gate the "Open in Gmail" / "Open in Outlook" deep-links — those
+  // deep-links only resolve in the matching web mail app, so without
+  // the gate clicking them just lands a signed-in user on their own
+  // empty inbox.
   const { data: emailConns } = await supabase
     .from('email_connections')
     .select('provider_type')
     .eq('user_id', user.id)
     .eq('status', 'active');
   const userHasGmail = (emailConns ?? []).some((c) => c.provider_type === 'google');
+  const userHasOutlook = (emailConns ?? []).some((c) => c.provider_type === 'outlook');
 
   return NextResponse.json({
     ...dispute,
     correspondence: enrichedCorrespondence,
     user_has_gmail: userHasGmail,
+    user_has_outlook: userHasOutlook,
   });
 }
 

--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -45,6 +45,7 @@ interface Dispute {
   unread_reply_count?: number;
   last_reply_received_at?: string | null;
   user_has_gmail?: boolean;
+  user_has_outlook?: boolean;
   correspondence?: Correspondence[];
   contract_extractions?: ContractExtraction[];
 }
@@ -97,6 +98,7 @@ interface Correspondence {
   sender_name?: string | null;
   email_thread_id?: string | null;
   supplier_message_id?: string | null;
+  supplier_web_link?: string | null;
   ai_category?: string | null;
   ai_respond_needed?: boolean | null;
   ai_urgency?: string | null;
@@ -1608,24 +1610,27 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                     <p className="text-sm text-slate-600 whitespace-pre-wrap">{entry.content}</p>
                   )}
 
-                  {/* Action row for company replies — Draft AI response,
-                      open the original in the user's inbox, or start a
-                      blank reply via mailto. Covers the "I just want to
-                      reply in Gmail" case without forcing the user to
-                      dig through their inbox to find the thread. */}
-                  {isFromCompany && !isResolved(dispute.status) && (
+                  {/* Action row — Draft AI response, open the original
+                      in the user's webmail, or start a blank reply via
+                      mailto. Broader than isFromCompany so classifier
+                      false-positives (auto-replies tagged as user_note
+                      etc.) still surface the send/reply actions as long
+                      as we know who sent it. */}
+                  {(isFromCompany || entry.detected_from_email || entry.sender_address) && !isResolved(dispute.status) && (
                     <div className="mt-3 pt-3 border-t border-slate-200/30 flex flex-wrap gap-2">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          generateFollowUp();
-                        }}
-                        disabled={generating}
-                        className="flex items-center gap-2 px-4 py-2 bg-amber-100 hover:bg-amber-200 text-amber-600 rounded-lg text-sm transition-all border border-amber-200 font-medium"
-                      >
-                        {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
-                        Draft response to this
-                      </button>
+                      {isFromCompany && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            generateFollowUp();
+                          }}
+                          disabled={generating}
+                          className="flex items-center gap-2 px-4 py-2 bg-amber-100 hover:bg-amber-200 text-amber-600 rounded-lg text-sm transition-all border border-amber-200 font-medium"
+                        >
+                          {generating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+                          Draft response to this
+                        </button>
+                      )}
                       {entry.sender_address && (
                         <a
                           href={`mailto:${entry.sender_address}?subject=${encodeURIComponent('Re: ' + (entry.title || dispute.issue_summary || dispute.provider_name || ''))}`}
@@ -1637,6 +1642,10 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                           Reply by email
                         </a>
                       )}
+                      {/* Gmail deep-link — only for Gmail users. Uses
+                          the Gmail internal message ID we store as
+                          supplier_message_id; mail.google.com accepts
+                          that in the #inbox/<id> fragment. */}
                       {entry.supplier_message_id && dispute.user_has_gmail && (
                         <a
                           href={`https://mail.google.com/mail/u/0/#inbox/${entry.supplier_message_id}`}
@@ -1644,10 +1653,28 @@ function DisputeDetail({ disputeId, onBack }: { disputeId: string; onBack: () =>
                           rel="noopener noreferrer"
                           onClick={(e) => e.stopPropagation()}
                           className="flex items-center gap-2 px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 border border-slate-200 rounded-lg text-sm transition-all font-medium"
-                          title="Open this message in Gmail (uses the Gmail internal message ID)"
+                          title="Open this message in Gmail"
                         >
                           <ArrowRight className="h-4 w-4" />
                           Open in Gmail
+                        </a>
+                      )}
+                      {/* Outlook deep-link — Microsoft Graph hands us a
+                          per-message webLink that opens OWA. Captured
+                          at sync time; older rows imported before
+                          migration 20260424090000 have it null so this
+                          gracefully hides. */}
+                      {entry.supplier_web_link && dispute.user_has_outlook && (
+                        <a
+                          href={entry.supplier_web_link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="flex items-center gap-2 px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 border border-slate-200 rounded-lg text-sm transition-all font-medium"
+                          title="Open this message in Outlook"
+                        >
+                          <ArrowRight className="h-4 w-4" />
+                          Open in Outlook
                         </a>
                       )}
                     </div>

--- a/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
+++ b/src/app/dashboard/money-hub/CategoryDrillDownModal.tsx
@@ -196,15 +196,19 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
       <div className="absolute inset-0 bg-white backdrop-blur-sm" onClick={onClose} />
-      <div className="relative card w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-slate-200">
-          <div>
-            <h2 className="text-xl font-bold text-slate-900 capitalize">{displayTitle}</h2>
+      <div className="relative card w-full max-w-2xl max-h-[92vh] sm:max-h-[85vh] flex flex-col shadow-2xl rounded-b-none sm:rounded-2xl">
+        <div className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-200">
+          <div className="min-w-0">
+            <h2 className="text-xl font-bold text-slate-900 capitalize truncate">{displayTitle}</h2>
             <p className="text-slate-500 text-sm mt-1">{selectedMonth ? new Date(`${selectedMonth}-01`).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }) : 'This month'}</p>
           </div>
-          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-2 rounded-lg hover:bg-slate-100 transition-colors">
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-slate-500 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 transition-colors"
+          >
             <X className="h-5 w-5" />
           </button>
         </div>
@@ -218,7 +222,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
           </div>
         )}
 
-        <div className="p-6 overflow-y-auto flex-1 custom-scrollbar">
+        <div className="p-4 sm:p-6 overflow-y-auto flex-1 custom-scrollbar">
           {loading ? (
             <div className="flex items-center justify-center py-20">
               <Loader2 className="h-8 w-8 text-mint-400 animate-spin" />
@@ -255,7 +259,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                       </div>
                       
                       {merchantRecatIdx === idx && (
-                        <div className="absolute top-16 right-0 w-56 bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
+                        <div className="absolute top-16 right-0 w-56 max-w-[calc(100vw-2.5rem)] bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
                           {renderReassignOptions(m.merchant)}
                         </div>
                       )}
@@ -288,7 +292,7 @@ export default function CategoryDrillDownModal({ isOpen, onClose, category, inco
                         </div>
 
                         {isRecatOpen && (
-                          <div className="absolute top-12 right-4 w-56 bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
+                          <div className="absolute top-12 right-4 w-56 max-w-[calc(100vw-2.5rem)] bg-slate-100 border border-slate-200 rounded-xl shadow-xl z-20 overflow-hidden">
                             {renderReassignOptions(cleanMerchantName(txn.description || ''))}
                           </div>
                         )}

--- a/src/app/dashboard/money-hub/NetWorthManagementModal.tsx
+++ b/src/app/dashboard/money-hub/NetWorthManagementModal.tsx
@@ -54,12 +54,18 @@ export default function NetWorthManagementModal({ isOpen, onClose, data, onUpdat
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
       <div className="absolute inset-0 bg-white backdrop-blur-sm" onClick={onClose} />
-      <div className="relative card w-full max-w-xl max-h-[85vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-slate-200">
+      <div className="relative card w-full max-w-xl max-h-[92vh] sm:max-h-[85vh] flex flex-col shadow-2xl rounded-b-none sm:rounded-2xl">
+        <div className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-200">
           <h2 className="text-xl font-bold text-slate-900 flex items-center gap-2 pt-1"><PiggyBank className="h-6 w-6 text-mint-400" /> Manage Net Worth</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-2 rounded-lg hover:bg-slate-100 transition-colors"><X className="h-5 w-5" /></button>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-slate-500 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
         </div>
 
         <div className="flex border-b border-slate-200">
@@ -67,13 +73,13 @@ export default function NetWorthManagementModal({ isOpen, onClose, data, onUpdat
           <button onClick={() => setActiveTab('liabilities')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'liabilities' ? 'text-red-400 border-b-2 border-red-400' : 'text-slate-500 hover:text-slate-700'}`}>Liabilities</button>
         </div>
 
-        <div className="p-6 overflow-y-auto custom-scrollbar flex-1">
+        <div className="p-4 sm:p-6 overflow-y-auto custom-scrollbar flex-1">
           {activeTab === 'assets' ? (
             <div className="space-y-6">
               <div className="bg-white p-4 rounded-xl border border-slate-200">
                 <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2"><Building2 className="h-4 w-4 text-green-400" /> Add Asset</h3>
-                <div className="grid grid-cols-2 gap-3 mb-3">
-                  <input type="text" placeholder="Asset Name (e.g. Monzo, House)" value={assetForm.name} onChange={e => setAssetForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none col-span-2" />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
+                  <input type="text" placeholder="Asset Name (e.g. Monzo, House)" value={assetForm.name} onChange={e => setAssetForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none sm:col-span-2" />
                   <select value={assetForm.type} onChange={e => setAssetForm(prev => ({ ...prev, type: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none">
                     <option value="savings">Savings</option><option value="property">Property</option><option value="investment">Investment</option><option value="vehicle">Vehicle</option><option value="crypto">Crypto</option><option value="business">Business</option><option value="pension">Pension</option><option value="other">Other</option>
                   </select>
@@ -94,8 +100,8 @@ export default function NetWorthManagementModal({ isOpen, onClose, data, onUpdat
             <div className="space-y-6">
               <div className="bg-white p-4 rounded-xl border border-slate-200">
                 <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2"><CreditCard className="h-4 w-4 text-red-400" /> Add Liability</h3>
-                <div className="grid grid-cols-2 gap-3 mb-3">
-                  <input type="text" placeholder="Liability Name (e.g. Loan, Mortgage)" value={liabilityForm.name} onChange={e => setLiabilityForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none col-span-2" />
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
+                  <input type="text" placeholder="Liability Name (e.g. Loan, Mortgage)" value={liabilityForm.name} onChange={e => setLiabilityForm(prev => ({ ...prev, name: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none sm:col-span-2" />
                   <select value={liabilityForm.type} onChange={e => setLiabilityForm(prev => ({ ...prev, type: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-red-400 focus:outline-none">
                     <option value="loan">Loan</option><option value="mortgage">Mortgage</option><option value="credit_card">Credit Card</option><option value="car_finance">Car Finance</option><option value="overdraft">Overdraft</option><option value="other">Other</option>
                   </select>

--- a/src/app/dashboard/money-hub/NetWorthPanel.tsx
+++ b/src/app/dashboard/money-hub/NetWorthPanel.tsx
@@ -41,6 +41,18 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
             <div className="text-right"><p className="text-xs text-slate-500">Liabilities</p><p className="text-lg text-slate-900 font-semibold">£---</p></div>
           </div>
         </div>
+      ) : assetsList.length === 0 && liabilitiesList.length === 0 ? (
+        <div className="flex-1 flex flex-col items-center justify-center text-center bg-white border border-slate-200 rounded-xl p-6">
+          <PiggyBank className="h-8 w-8 text-mint-400 mb-3" />
+          <p className="text-slate-900 font-semibold text-sm mb-1">See your true wealth</p>
+          <p className="text-slate-500 text-xs mb-4 max-w-[240px]">Add what you own (savings, property, investments) and what you owe (loans, mortgage) to track your real financial position.</p>
+          <button
+            onClick={() => setModalOpen(true)}
+            className="inline-flex items-center justify-center gap-2 bg-mint-500 hover:bg-mint-600 text-white font-semibold text-sm px-4 h-10 rounded-lg transition-colors"
+          >
+            Add your first entry
+          </button>
+        </div>
       ) : (
         <div className="flex-1 flex flex-col">
           {/* Assets vs Liabilities summary */}
@@ -55,13 +67,15 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
               <p className="text-lg text-red-400 font-semibold">£{fmtNum(liabilities)}</p>
             </div>
           </div>
-          
+
           <div className="space-y-4">
             {/* Top assets */}
             <div>
               <p className="text-xs text-slate-500 uppercase tracking-wider mb-2 font-semibold">Assets</p>
               {assetsList.length === 0 ? (
-                <p className="text-xs text-slate-500">Add assets manually to track net worth.</p>
+                <button onClick={() => setModalOpen(true)} className="text-xs text-mint-600 hover:text-mint-700 underline decoration-dotted">
+                  Add an asset to start tracking
+                </button>
               ) : (
                 assetsList.slice(0, 3).map((a: any) => (
                   <div key={a.id} className="flex justify-between text-sm py-1.5 border-b border-slate-200 last:border-0">
@@ -76,7 +90,9 @@ export default function NetWorthPanel({ data, isPro, refreshData }: { data: any,
             <div>
               <p className="text-xs text-slate-500 uppercase tracking-wider mb-2 font-semibold">Liabilities</p>
               {liabilitiesList.length === 0 ? (
-                <p className="text-xs text-slate-500">No liabilities tracked.</p>
+                <button onClick={() => setModalOpen(true)} className="text-xs text-mint-600 hover:text-mint-700 underline decoration-dotted">
+                  Add a liability (optional)
+                </button>
               ) : (
                 liabilitiesList.slice(0, 3).map((l: any) => (
                   <div key={l.id} className="flex justify-between text-sm py-1.5 border-b border-slate-200 last:border-0">

--- a/src/app/dashboard/money-hub/OverviewPanel.tsx
+++ b/src/app/dashboard/money-hub/OverviewPanel.tsx
@@ -191,7 +191,7 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
                   return (
                     <div
                       key={entry.type}
-                      className="group cursor-pointer hover:bg-slate-100 p-2 -mx-2 rounded-lg transition-colors"
+                      className="group cursor-pointer hover:bg-slate-100 active:bg-slate-200 p-2 -mx-2 rounded-lg transition-colors"
                       onClick={() => setDrillIncomeType(entry.type)}
                     >
                       <div className="flex items-center justify-between text-sm mb-1">
@@ -247,7 +247,7 @@ export default function OverviewPanel({ data, refreshData, selectedMonth }: { da
                   return (
                     <div
                       key={c.category}
-                      className="group cursor-pointer hover:bg-slate-100 p-2 -mx-2 rounded-lg transition-colors"
+                      className="group cursor-pointer hover:bg-slate-100 active:bg-slate-200 p-2 -mx-2 rounded-lg transition-colors"
                       onClick={() => setDrillSpendingCategory(c.category)}
                     >
                       <div className="flex items-center justify-between text-sm mb-1">

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -810,7 +810,8 @@ export default function MoneyHubPage() {
  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
  <span>{spaces.length > 1 ? 'Manage' : 'Spaces'}</span>
  </Link>
- {/* Month nav */}
+ {/* Month nav — grouped so the prev/select/next cluster stays together on mobile wrap */}
+ <div className="inline-flex items-center gap-1">
  <button
  onClick={() => {
  const months = Array.from({ length: 12 }, (_, i) => {
@@ -821,7 +822,8 @@ export default function MoneyHubPage() {
  const next = cur < months.length - 1 ? months[cur + 1] : months[months.length - 1];
  setSelectedMonth(next); refreshData(next); fetchExpectedBills(next);
  }}
- className="text-slate-600 hover:text-slate-900 p-1.5 rounded transition-colors"
+ className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-10 w-10 rounded transition-colors active:bg-slate-100"
+ aria-label="Previous month"
  title="Previous month"
  >
  <ArrowLeft className="h-4 w-4" />
@@ -849,11 +851,13 @@ export default function MoneyHubPage() {
  if (cur > 0) { setSelectedMonth(months[cur - 1]); refreshData(months[cur - 1]); fetchExpectedBills(months[cur - 1]); }
  }}
  disabled={!selectedMonth}
- className="text-slate-600 hover:text-slate-900 p-1.5 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+ className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-10 w-10 rounded transition-colors active:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed"
+ aria-label="Next month"
  title="Next month"
  >
  <ArrowRight className="h-4 w-4" />
  </button>
+ </div>
 
  <button
  onClick={handleSync}

--- a/src/lib/dispute-sync/fetchers.ts
+++ b/src/lib/dispute-sync/fetchers.ts
@@ -54,6 +54,8 @@ interface GraphMessage {
   bodyPreview?: string;
   from?: { emailAddress?: { address?: string; name?: string } };
   body?: { contentType?: 'text' | 'html'; content?: string };
+  /** Ready-to-use OWA deep-link Graph issues per-message. */
+  webLink?: string;
 }
 
 // -----------------------------------------------------------------------------
@@ -300,7 +302,7 @@ async function fetchOutlookConversation(
   url.searchParams.set('$top', '50');
   url.searchParams.set(
     '$select',
-    'id,conversationId,subject,from,receivedDateTime,bodyPreview,body',
+    'id,conversationId,subject,from,receivedDateTime,bodyPreview,body,webLink',
   );
 
   const res = await fetch(url.toString(), {
@@ -333,6 +335,7 @@ async function fetchOutlookConversation(
       receivedAt: new Date(m.receivedDateTime),
       snippet: makeSnippet(bodyText || m.bodyPreview || ''),
       body: bodyText.slice(0, 8000),
+      webLink: m.webLink,
     });
   }
   return messages;
@@ -465,7 +468,7 @@ export async function fetchDomainMessages(
     url.searchParams.set('$top', '20');
     url.searchParams.set(
       '$select',
-      'id,conversationId,subject,from,receivedDateTime,bodyPreview,body',
+      'id,conversationId,subject,from,receivedDateTime,bodyPreview,body,webLink',
     );
     const res = await fetch(url.toString(), {
       headers: { Authorization: `Bearer ${token}` },
@@ -498,6 +501,7 @@ export async function fetchDomainMessages(
         receivedAt: received,
         snippet: makeSnippet(bodyText || m.bodyPreview || ''),
         body: bodyText.slice(0, 8000),
+        webLink: m.webLink,
       });
     }
     return out.sort((a, b) => a.receivedAt.getTime() - b.receivedAt.getTime());

--- a/src/lib/dispute-sync/sync-runner.ts
+++ b/src/lib/dispute-sync/sync-runner.ts
@@ -313,6 +313,7 @@ export async function syncLinkedThread(
         sender_address: m.fromAddress,
         sender_name: m.fromName || null,
         supplier_message_id: m.messageId,
+        supplier_web_link: m.webLink ?? null,
         detected_from_email: true,
         email_thread_id: link.id,
         entry_date: m.receivedAt.toISOString(),

--- a/src/lib/dispute-sync/types.ts
+++ b/src/lib/dispute-sync/types.ts
@@ -30,6 +30,14 @@ export interface FetchedMessage {
   snippet: string;
   /** Plain-text body, HTML stripped, capped to 8000 chars. */
   body: string;
+  /**
+   * Provider-supplied deep-link that opens this message in their web UI.
+   * Microsoft Graph returns this as `webLink` on /me/messages and it's
+   * the only reliable way to open an Outlook message from us. Gmail
+   * doesn't expose an equivalent field — constructed client-side for
+   * Gmail users, so this stays undefined for Gmail-imported rows.
+   */
+  webLink?: string;
 }
 
 /**

--- a/supabase/migrations/20260424090000_correspondence_supplier_web_link.sql
+++ b/supabase/migrations/20260424090000_correspondence_supplier_web_link.sql
@@ -1,0 +1,17 @@
+-- Capture the provider's ready-to-use deep-link URL at import time so
+-- the dispute UI can offer "Open in Outlook" (and eventually "Open in
+-- Gmail" if we migrate to Gmail's rfc822 URLs).
+--
+-- Microsoft Graph's /me/messages resource exposes `webLink` — a pre-
+-- signed OWA URL that opens the message in the user's Outlook Web.
+-- We were dropping it on import because the $select clause didn't ask
+-- for it; now we'll capture it and store it alongside the existing
+-- supplier_message_id.
+--
+-- Gmail API doesn't have an equivalent webLink field — Gmail deep-
+-- links are constructed client-side from the message id. So this
+-- column stays NULL for Gmail-imported rows, and the UI falls back
+-- to the existing Gmail URL format when supplier_web_link IS NULL.
+
+ALTER TABLE public.correspondence
+  ADD COLUMN IF NOT EXISTS supplier_web_link text;


### PR DESCRIPTION
Follow-up to the Gmail gating from #287. Two real improvements the user flagged while testing:

## 1. Outlook parity via Graph \`webLink\`
Microsoft Graph hands us a per-message \`webLink\` that opens the original in OWA — we just weren't asking for it in \`\$select\`. Now we capture + persist it, and the dispute UI shows **Open in Outlook** for any imported Outlook message when the user has an Outlook connection.

- Migration 20260424090000: \`correspondence.supplier_web_link text\` (applied to prod)
- Both Outlook fetchers request \`webLink\` in \`\$select\`
- \`sync-runner\` writes it on insert
- \`/api/disputes/[id]\` returns \`user_has_outlook\` alongside \`user_has_gmail\`

Gmail side unchanged — Gmail API has no equivalent, but the existing \`#inbox/<id>\` URL works fine.

## 2. Wider action-row trigger
Old condition was \`isFromCompany && !isResolved\` which hid Reply/Gmail/Outlook on any row the classifier misfiled (auto-replies tagged \`user_note\`, etc.). Now any row with \`detected_from_email\` or a \`sender_address\` surfaces the reply buttons. "Draft AI response" stays gated on \`isFromCompany\` so we don't AI-reply to misclassified content.

## Backfill
Not needed. Existing rows have \`supplier_web_link=null\` and the button hides. Next Watchdog cycle populates it for new Outlook imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)