### PR TITLE
fix(dashboard): mobile ergonomics pass on complaints + subscriptions

### DIFF
--- a/src/app/dashboard/complaints/page.tsx
+++ b/src/app/dashboard/complaints/page.tsx
@@ -312,7 +312,7 @@ function LetterModal({ content, title, legalRefs, rightsPills, onClose, disputeI
               );
             })()}
           </div>
-          <button onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1 flex-shrink-0"><X className="h-5 w-5" /></button>
+          <button onClick={onClose} aria-label="Close" className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"><X className="h-5 w-5" /></button>
         </div>
         <div className="flex-1 overflow-y-auto p-6">
           <div className="bg-white rounded-xl p-6 border border-slate-200/50 mb-4">
@@ -475,7 +475,7 @@ function AddCorrespondenceModal({ disputeId, onClose, onAdded }: {
         <form onSubmit={handleSubmit} className="flex flex-col" style={{ maxHeight: 'calc(100vh - env(safe-area-inset-top, 20px) - env(safe-area-inset-bottom, 0px))' }}>
         <div className="flex items-center justify-between p-5 border-b border-slate-200/50 flex-shrink-0">
           <h2 className="text-lg font-bold text-slate-900">Add to your dispute</h2>
-          <button type="button" onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1"><X className="h-5 w-5" /></button>
+          <button type="button" onClick={onClose} aria-label="Close" className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"><X className="h-5 w-5" /></button>
         </div>
         <div className="p-5 space-y-4 overflow-y-auto flex-1 min-h-0"
           style={{ WebkitOverflowScrolling: 'touch' as any }}>
@@ -652,13 +652,13 @@ function ResolveDisputeModal({ disputeId, disputedAmount, onClose, onResolved }:
             <h2 className="text-lg font-bold text-slate-900">Resolve Dispute</h2>
             <p className="text-slate-500 text-sm mt-0.5">Record the outcome of your dispute</p>
           </div>
-          <button onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1"><X className="h-5 w-5" /></button>
+          <button onClick={onClose} aria-label="Close" className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"><X className="h-5 w-5" /></button>
         </div>
         <form onSubmit={handleSubmit} className="p-6 space-y-5">
           {/* Outcome selector */}
           <div>
             <label className="block text-sm font-medium text-slate-600 mb-2">What was the outcome?</label>
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
               {outcomeOptions.map((opt) => (
                 <button
                   key={opt.value}
@@ -891,7 +891,7 @@ function PreviewConfirmModal({ formData, issueLabel, onConfirm, onClose }: {
             <h2 className="text-lg font-bold text-slate-900">Review your dispute</h2>
             <p className="text-slate-600 text-sm mt-0.5">Check the details before we write your letter</p>
           </div>
-          <button onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1">
+          <button onClick={onClose} aria-label="Close" className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors">
             <X className="h-5 w-5" />
           </button>
         </div>
@@ -2235,7 +2235,7 @@ function NewDisputeForm({ onCreated, onCancel }: { onCreated: (id: string) => vo
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-slate-600 mb-2">Amount (£)</label>
               <input
@@ -2797,11 +2797,13 @@ function NewDisputeChooser({
   onScratch, onFromEmail, onClose,
 }: { onScratch: () => void; onFromEmail: () => void; onClose: () => void }) {
   return (
-    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-lg w-full p-6">
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-end sm:items-center justify-center p-0 sm:p-4">
+      <div className="bg-white rounded-t-2xl sm:rounded-2xl shadow-2xl max-w-lg w-full p-6 max-h-[92vh] overflow-y-auto">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-slate-900">Start a new dispute</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 text-xl leading-none">×</button>
+          <button onClick={onClose} aria-label="Close" className="text-slate-500 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors">
+            <X className="h-5 w-5" />
+          </button>
         </div>
         <p className="text-sm text-slate-600 mb-5">How do you want to begin?</p>
         <div className="grid grid-cols-1 gap-3">

--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -1590,7 +1590,7 @@ export default function SubscriptionsPage() {
                     )}
                   </div>
                 </div>
-                <button onClick={() => handleDismissAlert(alert.id)} className="text-slate-500 hover:text-slate-700 p-1 shrink-0">
+                <button onClick={() => handleDismissAlert(alert.id)} aria-label="Dismiss alert" className="text-slate-500 hover:text-slate-700 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors">
                   <X className="h-4 w-4" />
                 </button>
               </div>
@@ -1624,7 +1624,7 @@ export default function SubscriptionsPage() {
                 <Upload className="h-5 w-5 text-emerald-600" />
                 Upload Bill / Contract
               </h2>
-              <button onClick={() => { setBillUploadSubId(null); setBillFile(null); }} className="text-slate-600 hover:text-slate-900 p-1"><X className="h-5 w-5" /></button>
+              <button onClick={() => { setBillUploadSubId(null); setBillFile(null); }} aria-label="Close" className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"><X className="h-5 w-5" /></button>
             </div>
             <div className="p-6 space-y-4">
               <p className="text-slate-600 text-sm">
@@ -2106,12 +2106,12 @@ export default function SubscriptionsPage() {
               <div
                 key={sub.id}
                 data-needs-review={sub.needs_review ? 'true' : undefined}
-                className={`bg-white backdrop-blur-sm border rounded-2xl p-6 transition-all cursor-pointer ${
+                className={`bg-white backdrop-blur-sm border rounded-2xl p-6 transition-all cursor-pointer active:bg-slate-50 ${
                   selectedSub?.id === sub.id
                     ? 'border-emerald-500/50'
                     : sub.needs_review
-                    ? 'border-amber-500/40 hover:border-amber-500/60'
-                    : 'border-slate-200/50 hover:border-slate-200/50'
+                    ? 'border-amber-500/40 hover:border-amber-500/60 active:border-amber-500/70'
+                    : 'border-slate-200/50 hover:border-slate-200/50 active:border-emerald-500/40'
                 }`}
                 onClick={() => {
                   setSelectedSub(sub);
@@ -2174,7 +2174,7 @@ export default function SubscriptionsPage() {
                             <span>{sub.category ? getCategoryLabel(sub.category) : 'Uncategorised'}</span>
                           </button>
                           {inlineRecatSub === sub.id && (
-                            <div className="absolute top-full left-0 mt-1 w-48 bg-white border border-slate-200 rounded-lg shadow-xl z-20 max-h-64 overflow-y-auto">
+                            <div className="absolute top-full left-0 mt-1 w-48 max-w-[calc(100vw-2.5rem)] bg-white border border-slate-200 rounded-lg shadow-xl z-20 max-h-64 overflow-y-auto">
                               {SORTED_CATEGORIES.map(cat => (
                                 <button
                                   key={cat.value}
@@ -2238,8 +2238,9 @@ export default function SubscriptionsPage() {
                           e.stopPropagation();
                           setBillUploadSubId(sub.id);
                         }}
-                        className="text-slate-600 hover:text-purple-400 transition-all p-1"
+                        className="text-slate-600 hover:text-purple-400 inline-flex items-center justify-center h-10 w-10 rounded-lg active:bg-slate-100 transition-all"
                         title="Upload bill to extract contract dates"
+                        aria-label="Upload bill"
                       >
                         <Upload className="h-4 w-4" />
                       </button>
@@ -2248,8 +2249,9 @@ export default function SubscriptionsPage() {
                           e.stopPropagation();
                           openEditModal(sub);
                         }}
-                        className="text-slate-600 hover:text-emerald-600 transition-all p-1"
+                        className="text-slate-600 hover:text-emerald-600 inline-flex items-center justify-center h-10 w-10 rounded-lg active:bg-slate-100 transition-all"
                         title="Edit"
+                        aria-label="Edit"
                       >
                         <Pencil className="h-4 w-4" />
                       </button>
@@ -2258,8 +2260,9 @@ export default function SubscriptionsPage() {
                           e.stopPropagation();
                           setDeleteConfirm(sub.id);
                         }}
-                        className="text-slate-600 hover:text-red-400 transition-all p-1"
+                        className="text-slate-600 hover:text-red-400 inline-flex items-center justify-center h-10 w-10 rounded-lg active:bg-slate-100 transition-all"
                         title="Delete"
+                        aria-label="Delete"
                       >
                         <X className="h-4 w-4" />
                       </button>
@@ -2678,7 +2681,7 @@ export default function SubscriptionsPage() {
                       <p className="text-slate-600 text-sm">{normaliseProviderName(unrecognisedSub.provider_name)} &middot; {formatGBP(unrecognisedSub.amount)}/{unrecognisedSub.billing_cycle}</p>
                     </div>
                   </div>
-                  <button onClick={() => setUnrecognisedSub(null)} className="text-slate-600 hover:text-slate-900 transition-colors p-1">
+                  <button onClick={() => setUnrecognisedSub(null)} aria-label="Close" className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors">
                     <X className="h-5 w-5" />
                   </button>
                 </div>
@@ -2751,7 +2754,7 @@ export default function SubscriptionsPage() {
                       <p className="text-slate-600 text-sm">{formatGBP(unrecognisedSub.amount)} &middot; {unrecognisedSub.bank_description || unrecognisedSub.provider_name}</p>
                     </div>
                   </div>
-                  <button onClick={() => setUnrecognisedSub(null)} className="text-slate-600 hover:text-slate-900 transition-colors p-1">
+                  <button onClick={() => setUnrecognisedSub(null)} aria-label="Close" className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors">
                     <X className="h-5 w-5" />
                   </button>
                 </div>
@@ -2826,7 +2829,7 @@ export default function SubscriptionsPage() {
                 />
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-600 mb-2">Amount (£) *</label>
                   <input
@@ -2853,7 +2856,7 @@ export default function SubscriptionsPage() {
                 </div>
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-600 mb-2">Category</label>
                   <select
@@ -2909,7 +2912,7 @@ export default function SubscriptionsPage() {
                     <p className="text-xs text-slate-500 mt-1">We&apos;ll alert you before this date so you can switch to a better deal</p>
                   </div>
 
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                       <label className="block text-sm font-medium text-slate-600 mb-2">Contract Start Date</label>
                       <input
@@ -2936,7 +2939,7 @@ export default function SubscriptionsPage() {
                     </div>
                   </div>
 
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                       <label className="block text-sm font-medium text-slate-600 mb-2">Contract Type</label>
                       <select
@@ -3087,7 +3090,7 @@ export default function SubscriptionsPage() {
                 />
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-600 mb-2">
                     Amount (£) *
@@ -3121,7 +3124,7 @@ export default function SubscriptionsPage() {
                 </div>
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-600 mb-2">
                     Category
@@ -3203,7 +3206,7 @@ export default function SubscriptionsPage() {
                     <p className="text-xs text-slate-500 mt-1">We&apos;ll alert you before this date so you can switch to a better deal</p>
                   </div>
 
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                       <label className="block text-sm font-medium text-slate-600 mb-2">Contract Start Date</label>
                       <input
@@ -3230,7 +3233,7 @@ export default function SubscriptionsPage() {
                     </div>
                   </div>
 
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                       <label className="block text-sm font-medium text-slate-600 mb-2">Contract Type</label>
                       <select


### PR DESCRIPTION
## Summary
Follow-up to #288 (money-hub). Same audit applied to the two next-most-used dashboard surfaces. 5 HIGH findings fixed in a single pass.

- **Close buttons** (8 instances) — 44×44 tap targets with `active:bg-slate-200` feedback on both modal headers and alert dismiss
- **Subscription card action icons** (upload / edit / delete) — 40×40 tap targets with proper aria-labels; stopped being `p-1` afterthoughts
- **Inline recategorise dropdown** — `w-48` now wrapped in `max-w-[calc(100vw-2.5rem)]` so it can't overflow on 360px viewports
- **NewDisputeChooser modal** — bottom-sheet pattern on mobile (`items-end sm:items-center`, `rounded-t-2xl`) consistent with the other dispute modals
- **10 form grid-cols-2 → grid-cols-1 sm:grid-cols-2** — amount/category/contract-date/contract-type pairs all stop cramming on mobile; stack to single column under 640px
- **Subscription cards** — added `active:bg-slate-50` + active-border states so taps have visible feedback (hover never fires on touch)
- **Dispute outcome radio grid** — same single→double stack so outcome labels don't truncate

## Test plan
- [ ] iPhone 17 Pro Max (430px) — all modal close buttons easily thumb-reachable
- [ ] Tap 3 action icons on a sub card in rapid sequence without mis-hitting
- [ ] Open category dropdown on rightmost sub — stays within viewport
- [ ] Start new dispute → chooser bottom-sheets on mobile, centred modal on desktop
- [ ] Edit subscription → Amount + Category + Contract dates all stack vertically on mobile
- [ ] Tap subscription card — visible press feedback (bg darkens)
- [ ] Desktop (≥640px) unchanged visually

Co-Authored-By: Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)