### PR TITLE
fix(email): recognise legacy provider_type values when gating deep-links

### DIFF
--- a/src/app/api/disputes/[id]/letter-sent/route.ts
+++ b/src/app/api/disputes/[id]/letter-sent/route.ts
@@ -98,7 +98,9 @@ export async function POST(
       // auto_domain, auto_ai). email_connections.provider_type uses
       // 'google' rather than 'gmail', so normalise before insert.
       const providerMap: Record<string, 'gmail' | 'outlook' | 'imap'> = {
-        google: 'gmail', gmail: 'gmail', outlook: 'outlook', imap: 'imap',
+        google: 'gmail', gmail: 'gmail',
+        outlook: 'outlook', microsoft: 'outlook',
+        imap: 'imap',
       };
       const normalisedProvider = providerMap[emailConn.provider_type as string] ?? 'imap';
 

--- a/src/app/api/disputes/[id]/route.ts
+++ b/src/app/api/disputes/[id]/route.ts
@@ -83,8 +83,14 @@ export async function GET(
     .select('provider_type')
     .eq('user_id', user.id)
     .eq('status', 'active');
-  const userHasGmail = (emailConns ?? []).some((c) => c.provider_type === 'google');
-  const userHasOutlook = (emailConns ?? []).some((c) => c.provider_type === 'outlook');
+  // Handle both the canonical values ('google', 'outlook') and the legacy
+  // aliases ('gmail', 'microsoft') that still exist on older rows — see
+  // providerFromConnection in src/lib/dispute-sync/types.ts for the full
+  // normalisation table.
+  const GMAIL_TYPES = new Set(['google', 'gmail']);
+  const OUTLOOK_TYPES = new Set(['outlook', 'microsoft']);
+  const userHasGmail = (emailConns ?? []).some((c) => GMAIL_TYPES.has(c.provider_type));
+  const userHasOutlook = (emailConns ?? []).some((c) => OUTLOOK_TYPES.has(c.provider_type));
 
   return NextResponse.json({
     ...dispute,

--- a/src/app/api/subscriptions/[id]/cancellation-sent/route.ts
+++ b/src/app/api/subscriptions/[id]/cancellation-sent/route.ts
@@ -104,7 +104,9 @@ export async function POST(
       // semantic here — the link is created automatically, scoped by
       // domain, without the user confirming a specific thread.
       const providerMap: Record<string, 'gmail' | 'outlook' | 'imap'> = {
-        google: 'gmail', gmail: 'gmail', outlook: 'outlook', imap: 'imap',
+        google: 'gmail', gmail: 'gmail',
+        outlook: 'outlook', microsoft: 'outlook',
+        imap: 'imap',
       };
       const normalisedProvider = providerMap[emailConn.provider_type as string] ?? 'imap';
 


### PR DESCRIPTION
Codex P2 on #287 + #289. \`email_connections.provider_type\` has two shapes in prod:
- canonical: \`google\`, \`outlook\`, \`imap\`
- legacy: \`gmail\`, \`microsoft\`

My Gmail/Outlook gates only matched the canonical values, so legacy-row users got no deep-links and the watchdog-link inserts mis-tagged them as IMAP.

Fixed in three spots (sets for readability; mirrors \`providerFromConnection()\` in \`src/lib/dispute-sync/types.ts\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)