### PR TITLE
feat(admin): run cancel-info refresh on demand

### DIFF
--- a/src/app/api/cron/refresh-cancellation-info/route.ts
+++ b/src/app/api/cron/refresh-cancellation-info/route.ts
@@ -25,6 +25,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -143,10 +144,11 @@ function scoreConfidence(answer: PerplexityAnswer): 'high' | 'medium' | 'low' {
 }
 
 export async function GET(request: NextRequest) {
-  const auth = request.headers.get('authorization');
-  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  // Two legitimate callers: Vercel cron (Bearer CRON_SECRET) and the
+  // founder firing an ad-hoc run from /dashboard/admin/cancel-info.
+  // authorizeAdminOrCron handles both paths uniformly.
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
 
   const admin = getAdmin();
   const staleCutoff = new Date(Date.now() - STALE_DAYS * 86_400_000).toISOString();

--- a/src/app/dashboard/admin/cancel-info/page.tsx
+++ b/src/app/dashboard/admin/cancel-info/page.tsx
@@ -67,6 +67,8 @@ export default function AdminCancelInfoPage() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [draft, setDraft] = useState<Partial<Row>>({});
   const [saving, setSaving] = useState(false);
+  const [runningRefresh, setRunningRefresh] = useState(false);
+  const [refreshResult, setRefreshResult] = useState<{ ok: boolean; summary: string } | null>(null);
 
   const load = async () => {
     setLoading(true);
@@ -206,7 +208,53 @@ export default function AdminCancelInfoPage() {
         >
           <RefreshCw className="h-4 w-4" /> Reload
         </button>
+        {/* Fire the Perplexity refresh cron on-demand so we can validate
+            it end-to-end without waiting for the Monday 03:00 UTC run.
+            Calls the same endpoint Vercel cron hits; admin-session auth
+            is accepted alongside the bearer path. */}
+        <button
+          onClick={async () => {
+            setRunningRefresh(true);
+            setRefreshResult(null);
+            try {
+              const res = await fetch('/api/cron/refresh-cancellation-info');
+              const data = await res.json();
+              if (!res.ok) {
+                setRefreshResult({ ok: false, summary: data.error || `Failed (${res.status})` });
+              } else {
+                const parts = [
+                  `${data.updated ?? 0} updated`,
+                  `${data.unchanged ?? 0} unchanged`,
+                  `${data.discovered ?? 0} discovered`,
+                  `${(data.failed ?? 0) + (data.discovery_failed ?? 0)} failed`,
+                ];
+                setRefreshResult({ ok: true, summary: parts.join(' · ') });
+                await load();
+              }
+            } catch (e) {
+              setRefreshResult({ ok: false, summary: e instanceof Error ? e.message : 'Request failed' });
+            } finally {
+              setRunningRefresh(false);
+            }
+          }}
+          disabled={runningRefresh}
+          className="flex items-center gap-2 px-3 py-2 bg-emerald-500/10 border border-emerald-500/30 rounded-lg text-sm text-emerald-700 hover:bg-emerald-500/20 disabled:opacity-60"
+          title="Runs the weekly refresh cron now — up to 10 stale rows refreshed + 5 new providers discovered via Perplexity."
+        >
+          {runningRefresh ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+          {runningRefresh ? 'Running refresh…' : 'Run refresh now'}
+        </button>
       </div>
+
+      {refreshResult && (
+        <div className={`mb-4 rounded-lg px-4 py-3 text-sm border ${
+          refreshResult.ok
+            ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-700'
+            : 'bg-red-500/10 border-red-500/30 text-red-700'
+        }`}>
+          {refreshResult.ok ? 'Refresh complete — ' : 'Refresh failed — '}{refreshResult.summary}
+        </div>
+      )}
 
       {err && (
         <div className="card p-4 border-red-500/30 bg-red-500/10 text-red-700 mb-4 flex items-center gap-2">


### PR DESCRIPTION
Small follow-up to #292 — adds a **Run refresh now** button so you can fire the Perplexity refresh cron from the admin page instead of waiting for Monday 03:00 UTC.

- \`/api/cron/refresh-cancellation-info\` now accepts admin-session auth alongside the \`Bearer CRON_SECRET\` path via the shared \`authorizeAdminOrCron\` helper
- Button + result banner on \`/dashboard/admin/cancel-info\` shows \`N updated / unchanged / discovered / failed\` from the cron response, then reloads the table

Same \`MAX_PER_RUN=10\` and \`MAX_DISCOVERY_PER_RUN=5\` caps as the scheduled run — spending is bounded even if the button is clicked repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)