### PR TITLE
fix(dashboard): mobile ergonomics pass — profile, settings, contracts, vault, deals

### DIFF
--- a/src/app/dashboard/contract-vault/page.tsx
+++ b/src/app/dashboard/contract-vault/page.tsx
@@ -518,7 +518,7 @@ function ContractCard({ contract, onDelete }: ContractCardProps) {
           <div className="border-t border-slate-200/50"></div>
           <div className="p-4 space-y-4 bg-white/50">
             {/* Key Terms Grid */}
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {contract.contract_start_date && (
                 <div>
                   <p className="text-xs font-semibold text-slate-600 uppercase tracking-wider mb-1">Start Date</p>

--- a/src/app/dashboard/contracts/page.tsx
+++ b/src/app/dashboard/contracts/page.tsx
@@ -527,7 +527,7 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-slate-200/50">
           <h2 className="text-lg font-bold text-slate-900">Add a contract</h2>
-          <button onClick={onClose} className="text-slate-600 hover:text-slate-900 p-1"><X className="h-5 w-5" /></button>
+          <button onClick={onClose} aria-label="Close" className="text-slate-600 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"><X className="h-5 w-5" /></button>
         </div>
 
         {/* Tab switcher */}
@@ -651,7 +651,7 @@ function UploadModal({ subscriptions, onClose, onUploaded, initialProvider }: {
                 />
               </div>
 
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
                   <label className="block text-sm font-medium text-slate-700 mb-2">Start date</label>
                   <input

--- a/src/app/dashboard/deals/page.tsx
+++ b/src/app/dashboard/deals/page.tsx
@@ -257,10 +257,11 @@ function DealCard({ deal, highlight, onDismiss }: { deal: Deal; highlight?: bool
       {onDismiss && (
         <button
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDismiss(); }}
-          className="absolute top-3 right-3 p-1.5 bg-slate-100 hover:bg-slate-50 text-slate-600 hover:text-slate-900 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+          aria-label="Dismiss deal"
+          className="absolute top-2 right-2 inline-flex items-center justify-center h-10 w-10 bg-slate-100 hover:bg-slate-200 active:bg-slate-300 text-slate-600 hover:text-slate-900 rounded-full opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
           title="Not interested"
         >
-          <X className="h-3.5 w-3.5" />
+          <X className="h-4 w-4" />
         </button>
       )}
       {/* Body — grows to fill, pushes footer to bottom */}
@@ -392,12 +393,13 @@ function AffiliatePlanCard({ deal, savingsMonthly, savingsYearly, userProvider, 
   return (
     <div className="group relative bg-white backdrop-blur-sm border border-slate-200/50 rounded-2xl p-5 transition-all flex flex-col overflow-hidden hover:border-slate-200">
       {onDismiss && (
-        <button 
+        <button
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDismiss(); }}
-          className="absolute top-3 right-3 p-1.5 bg-slate-100 hover:bg-slate-50 text-slate-600 hover:text-slate-900 rounded-full opacity-0 group-hover:opacity-100 transition-opacity z-10"
+          aria-label="Dismiss deal"
+          className="absolute top-2 right-2 inline-flex items-center justify-center h-10 w-10 bg-slate-100 hover:bg-slate-200 active:bg-slate-300 text-slate-600 hover:text-slate-900 rounded-full opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity z-10"
           title="Not interested"
         >
-          <X className="h-3.5 w-3.5" />
+          <X className="h-4 w-4" />
         </button>
       )}
       {/* Body — identical to DealCard */}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -282,7 +282,8 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
           <div className="card shadow-2xl w-full max-w-md p-6 relative max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
             <button
               onClick={() => { setShowConnectModal(false); setConnectError(null); setConnectEmail(''); setConnectPassword(''); setImapMode(false); }}
-              className="absolute top-4 right-4 text-slate-500 hover:text-slate-900 transition-all"
+              aria-label="Close"
+              className="absolute top-2 right-2 text-slate-500 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"
             >
               <X className="h-5 w-5" />
             </button>
@@ -301,7 +302,7 @@ function ConnectedAccountsSection({ supabase, searchParams }: { supabase: Return
               {/* Provider selector */}
               <div>
                 <label className="block text-sm font-medium text-slate-700 mb-2">Choose your email provider</label>
-                <div className="grid grid-cols-2 gap-2">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   <button
                      onClick={() => { window.location.href = '/api/auth/google?returnPath=/dashboard/profile'; }}
                     className="flex items-center gap-2 bg-slate-50 border border-slate-200 hover:border-emerald-500/50 rounded-lg px-4 py-3 transition-all text-left"
@@ -838,7 +839,7 @@ export default function ProfilePage() {
           {subscriptionBadge()}
         </div>
 
-        <div className="grid grid-cols-2 gap-6 pt-6 border-t border-slate-200/50">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 pt-6 border-t border-slate-200/50">
           <div>
             <p className="text-sm text-slate-500 mb-1">Member since</p>
             <p className="text-slate-900 font-semibold">{memberSince}</p>

--- a/src/app/dashboard/settings/spaces/page.tsx
+++ b/src/app/dashboard/settings/spaces/page.tsx
@@ -263,7 +263,7 @@ export default function SpacesSettingsPage() {
                   )}
                   <button onClick={() => beginEdit(s)} className="text-xs text-slate-600 hover:text-slate-900 px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200">Edit</button>
                   {!s.is_default && (
-                    <button onClick={() => remove(s.id)} className="p-1.5 text-slate-500 hover:text-red-600 rounded-lg" title="Delete Space">
+                    <button onClick={() => remove(s.id)} aria-label="Delete Space" className="inline-flex items-center justify-center h-10 w-10 text-slate-500 hover:text-red-600 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors" title="Delete Space">
                       <Trash2 className="h-4 w-4" />
                     </button>
                   )}

--- a/src/app/dashboard/settings/telegram/page.tsx
+++ b/src/app/dashboard/settings/telegram/page.tsx
@@ -213,7 +213,7 @@ export default function TelegramSettingsPage() {
               Unlink
             </button>
           </div>
-          <div className="mt-4 pt-4 border-t border-slate-200 grid grid-cols-2 gap-4 text-sm">
+          <div className="mt-4 pt-4 border-t border-slate-200 grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
             <div>
               <span className="text-slate-500">Linked</span>
               <p className="text-slate-700">{formatDate(status.session.linked_at)}</p>


### PR DESCRIPTION
## Summary
Third pass applying the mobile-UX pattern set from PRs #288 and #290. 4 HIGH + 6 MED across five more dashboard surfaces.

### High
- **Profile — Connect Email modal** close button: `p-1` → 44×44 with `active:bg-slate-200`
- **Contracts — Add Contract modal** close button: same treatment
- **Settings/Spaces — Delete Space** icon: 40×40 with `aria-label` and hover/active background
- **Deals — card Dismiss (×2 components)**: was `opacity-0 group-hover:opacity-100` (i.e. **unreachable on touch**) — now `opacity-100 sm:opacity-0 sm:group-hover:opacity-100` so mobile users can actually dismiss deals; tap target upped to 40×40 with `active:bg-slate-300`

### Medium — form grids stacking on mobile
- Profile: email-provider 4-button selector (4 OAuth buttons were cramming at 360px)
- Profile: Member since / Subscription status info grid
- Settings/Telegram: Linked / Last message info grid
- Contracts: Manual-entry Start date / End date pair
- Contract Vault: Key terms grid

## Test plan
- [ ] iPhone 17 Pro Max: Profile → Connect Email modal, close button reachable with thumb
- [ ] Deal card shows the X dismiss on mobile (previously invisible without hover)
- [ ] Tap deal card X — deal dismisses cleanly, no accidental card tap
- [ ] Contracts → Add → Manual tab: Start/End dates stack vertically under 640px
- [ ] Settings → Spaces: delete icon easy to hit without accidentally tapping adjacent Edit
- [ ] Desktop (≥640px) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)