### PR TITLE
feat(dashboard): connection-health banner for broken email connections

### DIFF
--- a/src/app/api/connections/health/route.ts
+++ b/src/app/api/connections/health/route.ts
@@ -1,0 +1,57 @@
+/**
+ * GET /api/connections/health
+ *
+ * Returns any of the current user's email connections that need the
+ * user's attention. Used by <ConnectionHealthBanner /> on the
+ * dashboard layout so silent OAuth expiry or IMAP auth failures
+ * surface as a "your sync is paused" callout rather than the
+ * Watchdog cron quietly stopping.
+ *
+ * Archived rows are excluded — the user explicitly removed them.
+ *
+ * Banner shows a connection when either:
+ *   - status is not 'active' (e.g. 'needs_reauth', 'expired',
+ *     'disconnected', set by fetchers.ts / Watchdog on auth failure)
+ *   - OR last_error was recorded in the last 24h and status is still
+ *     marked active (covers transient failures that haven't tripped
+ *     the status flip yet)
+ */
+
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const RECENT_ERROR_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { data: emailConns } = await supabase
+    .from('email_connections')
+    .select('id, email_address, provider_type, status, last_error, last_error_at')
+    .eq('user_id', user.id)
+    .is('archived_at', null);
+
+  const now = Date.now();
+  const unhealthyEmail = (emailConns ?? []).filter((c) => {
+    if (c.status !== 'active') return true;
+    if (!c.last_error || !c.last_error_at) return false;
+    return now - new Date(c.last_error_at).getTime() < RECENT_ERROR_WINDOW_MS;
+  }).map((c) => ({
+    id: c.id,
+    email_address: c.email_address,
+    provider_type: c.provider_type,
+    status: c.status,
+    // Strip stack traces / long tokens from the error string — the banner
+    // shows a compact summary, not raw output.
+    last_error: (c.last_error ?? '').slice(0, 120),
+  }));
+
+  return NextResponse.json({
+    unhealthy_email: unhealthyEmail,
+  });
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import TrialBanner from '@/components/TrialBanner';
+import ConnectionHealthBanner from '@/components/ConnectionHealthBanner';
 import DashboardShell, { type UserSummary } from '@/components/dashboard/DashboardShell';
 import './shell-v2.css';
 import './dashboard.css';
@@ -184,10 +185,18 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     trialDaysLeft,
   };
 
-  const topBanner =
-    isTrial || trialExpired ? (
-      <TrialBanner daysLeft={trialDaysLeft} trialExpired={trialExpired} />
-    ) : null;
+  // Stacked banners — trial status (when active) then the connection
+  // health banner (only renders if any email connection is broken).
+  // Order matters: billing/trial is the more urgent signal so it sits
+  // above any sync-health nagging.
+  const topBanner = (
+    <>
+      {(isTrial || trialExpired) && (
+        <TrialBanner daysLeft={trialDaysLeft} trialExpired={trialExpired} />
+      )}
+      <ConnectionHealthBanner />
+    </>
+  );
 
   return (
     <DashboardShell

--- a/src/components/ConnectionHealthBanner.tsx
+++ b/src/components/ConnectionHealthBanner.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+/**
+ * Dashboard-wide banner surfaced when any of the user's email
+ * connections is in a broken state — OAuth token expiry, IMAP auth
+ * failure, or a recent error recorded by the Watchdog fetchers.
+ *
+ * Without this the user sees no sign that their alerts have stopped
+ * flowing. Hitting "Reconnect" takes them to the appropriate OAuth
+ * flow (or the IMAP profile tab for app-password connections).
+ *
+ * Dismissal is session-scoped (sessionStorage) — it reappears on the
+ * next tab, because the underlying problem hasn't been fixed by
+ * dismissing.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { AlertTriangle, X } from 'lucide-react';
+
+interface UnhealthyEmail {
+  id: string;
+  email_address: string;
+  provider_type: string;
+  status: string;
+  last_error: string;
+}
+
+const DISMISS_KEY = 'connection-health-banner-dismissed';
+
+function reconnectPath(providerType: string): string {
+  // Canonical + legacy aliases — matches the provider-gate sets in
+  // /api/disputes/[id] so we're consistent across the codebase.
+  const p = (providerType ?? '').toLowerCase();
+  if (p === 'google' || p === 'gmail') return '/api/auth/google?reconnect=1';
+  if (p === 'outlook' || p === 'microsoft') return '/api/auth/microsoft?reconnect=1';
+  return '/dashboard/profile?connect_email=true';
+}
+
+function readableStatus(status: string, lastError: string): string {
+  if (status === 'needs_reauth') return 'Sign-in expired';
+  if (status === 'expired') return 'Access expired';
+  if (status === 'disconnected') return 'Disconnected';
+  if (lastError) return 'Sync error';
+  return 'Needs attention';
+}
+
+export default function ConnectionHealthBanner() {
+  const [unhealthy, setUnhealthy] = useState<UnhealthyEmail[]>([]);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    // Respect a session-scoped dismiss.
+    try {
+      if (sessionStorage.getItem(DISMISS_KEY) === '1') setDismissed(true);
+    } catch { /* private mode — fall through */ }
+
+    let cancelled = false;
+    fetch('/api/connections/health', { credentials: 'include' })
+      .then((r) => r.ok ? r.json() : null)
+      .then((d) => {
+        if (cancelled || !d) return;
+        setUnhealthy(d.unhealthy_email ?? []);
+      })
+      .catch(() => { /* silent — banner just won't render */ });
+
+    return () => { cancelled = true; };
+  }, []);
+
+  if (dismissed || unhealthy.length === 0) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    try { sessionStorage.setItem(DISMISS_KEY, '1'); } catch { /* ignore */ }
+  };
+
+  // One or many — different copy so a single expiry doesn't read as "they all broke".
+  const primary = unhealthy[0];
+  const headline = unhealthy.length === 1
+    ? `${primary.email_address} — ${readableStatus(primary.status, primary.last_error)}`
+    : `${unhealthy.length} email connections need attention`;
+
+  return (
+    <div className="bg-amber-50 border-b border-amber-200 px-4 py-3">
+      <div className="max-w-7xl mx-auto flex items-start gap-3">
+        <AlertTriangle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-amber-900">{headline}</p>
+          <p className="text-xs text-amber-700 mt-0.5">
+            Watchdog has paused on {unhealthy.length === 1 ? 'this account' : 'these accounts'} — dispute replies,
+            renewal reminders and cancellation confirmations won&apos;t come through
+            until you reconnect.
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {unhealthy.slice(0, 3).map((c) => (
+              <Link
+                key={c.id}
+                href={reconnectPath(c.provider_type)}
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-amber-600 hover:bg-amber-700 text-white transition-colors"
+              >
+                Reconnect {c.email_address}
+              </Link>
+            ))}
+            {unhealthy.length > 3 && (
+              <Link
+                href="/dashboard/profile"
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-white border border-amber-300 text-amber-700 hover:bg-amber-100 transition-colors"
+              >
+                View all {unhealthy.length} in Profile
+              </Link>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="text-amber-700 hover:text-amber-900 p-1 flex-shrink-0"
+          title="Dismiss for this session"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Silent OAuth expiry / IMAP auth failures used to mean Watchdog quietly stopped polling — dispute replies, renewal reminders, cancellation confirmations just stopped arriving and the dashboard looked fine.

Fetchers already record \`status='needs_reauth'\` + \`last_error\` when auth fails (\`src/lib/dispute-sync/fetchers.ts\`). We've just never surfaced it.

## New
- \`GET /api/connections/health\` — returns the user's unhealthy email connections (non-active status OR error within the last 24h)
- \`<ConnectionHealthBanner />\` — amber top-of-dashboard banner. Per-connection Reconnect buttons routing to the correct OAuth flow (or Profile for IMAP). Session-dismissible; reappears next tab because hiding it doesn't fix it
- Wired into \`dashboard/layout.tsx\` below the TrialBanner

Provider routing covers canonical (\`google\`, \`outlook\`) + legacy (\`gmail\`, \`microsoft\`) \`provider_type\` values, matching the gate logic aligned in #291.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Artificially flip an email connection to \`status='needs_reauth'\` in prod → banner appears with Reconnect CTA
- [ ] Click Reconnect → lands on Google/Microsoft OAuth → on success, status returns to active and banner disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)