### PR TITLE
fix(dashboard): mobile pass 4 — GoalsAndBudgets modal + leftover grids

### DIFF
--- a/src/app/dashboard/forms/page.tsx
+++ b/src/app/dashboard/forms/page.tsx
@@ -335,7 +335,7 @@ export default function FormsPage() {
                         />
                       </div>
 
-                      <div className="grid grid-cols-2 gap-4">
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                         <div>
                           <label className="block text-sm font-medium text-slate-700 mb-2">Amount (optional)</label>
                           <input

--- a/src/app/dashboard/money-hub/GoalsAndBudgetsModal.tsx
+++ b/src/app/dashboard/money-hub/GoalsAndBudgetsModal.tsx
@@ -94,12 +94,18 @@ export default function GoalsAndBudgetsModal({ isOpen, onClose, data, onUpdated 
 
   return (
     <>
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
       <div className="absolute inset-0 bg-white backdrop-blur-sm" onClick={onClose} />
-      <div className="relative card w-full max-w-xl max-h-[85vh] flex flex-col shadow-2xl">
-        <div className="flex items-center justify-between p-6 border-b border-slate-200">
+      <div className="relative card w-full max-w-xl max-h-[92vh] sm:max-h-[85vh] flex flex-col shadow-2xl rounded-b-none sm:rounded-2xl">
+        <div className="flex items-center justify-between p-4 sm:p-6 border-b border-slate-200">
           <h2 className="text-xl font-bold text-slate-900 flex items-center gap-2 pt-1"><Target className="h-6 w-6 text-green-400" /> Manage Budgets & Goals</h2>
-          <button onClick={onClose} className="text-slate-500 hover:text-slate-900 p-2 rounded-lg hover:bg-slate-100 transition-colors"><X className="h-5 w-5" /></button>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="text-slate-500 hover:text-slate-900 inline-flex items-center justify-center h-11 w-11 shrink-0 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
         </div>
 
         <div className="flex border-b border-slate-200">
@@ -107,12 +113,12 @@ export default function GoalsAndBudgetsModal({ isOpen, onClose, data, onUpdated 
           <button onClick={() => setActiveTab('goals')} className={`flex-1 py-3 text-sm font-semibold transition-colors ${activeTab === 'goals' ? 'text-mint-400 border-b-2 border-mint-400' : 'text-slate-500 hover:text-slate-700'}`}>Savings Goals</button>
         </div>
 
-        <div className="p-6 overflow-y-auto custom-scrollbar flex-1">
+        <div className="p-4 sm:p-6 overflow-y-auto custom-scrollbar flex-1">
           {activeTab === 'budgets' ? (
             <div className="space-y-6">
               <div className="bg-white p-4 rounded-xl border border-slate-200">
                 <h3 className="text-slate-900 font-semibold mb-3 text-sm flex items-center gap-2">Add New Budget</h3>
-                <div className="grid grid-cols-2 gap-3 mb-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
                   <select value={budgetCategory} onChange={e => setBudgetCategory(e.target.value)} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-green-400 focus:outline-none capitalize">
                     {ALL_CATEGORIES.map(c => <option key={c} value={c}>{c.replace(/_/g, ' ')}</option>)}
                   </select>
@@ -124,7 +130,7 @@ export default function GoalsAndBudgetsModal({ isOpen, onClose, data, onUpdated 
                 {budgets.length === 0 ? <p className="text-slate-500 text-sm">No budgets set.</p> : budgets.map((b: any) => (
                   <div key={b.id} className="flex justify-between items-center py-3 border-b border-slate-200 last:border-0">
                     <div><p className="text-slate-900 text-sm capitalize">{b.category.replace(/_/g, ' ')}</p><p className="text-xs text-slate-500">Target: £{fmtNum(b.monthly_limit)}</p></div>
-                    <button onClick={() => handleDeleteBudget(b.id)} disabled={loading} className="text-slate-500 hover:text-red-400"><Trash2 className="h-4 w-4" /></button>
+                    <button onClick={() => handleDeleteBudget(b.id)} disabled={loading} aria-label="Delete budget" className="text-slate-500 hover:text-red-400 inline-flex items-center justify-center h-10 w-10 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"><Trash2 className="h-4 w-4" /></button>
                   </div>
                 ))}
               </div>
@@ -140,7 +146,7 @@ export default function GoalsAndBudgetsModal({ isOpen, onClose, data, onUpdated 
                     ))}
                   </div>
                   <input type="text" placeholder="Goal Name (e.g. Holiday)" value={goalForm.name} onChange={e => setGoalForm(prev => ({ ...prev, name: e.target.value }))} className="w-full mb-2 bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-mint-400 focus:outline-none" />
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     <input type="number" placeholder="Target (£)" value={goalForm.targetAmount} onChange={e => setGoalForm(prev => ({ ...prev, targetAmount: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-mint-400 focus:outline-none" />
                     <input type="number" placeholder="Already saved (£)" value={goalForm.currentAmount} onChange={e => setGoalForm(prev => ({ ...prev, currentAmount: e.target.value }))} className="bg-white border border-slate-200 rounded-lg px-3 py-2 text-sm text-slate-900 focus:border-mint-400 focus:outline-none" />
                   </div>
@@ -156,7 +162,7 @@ export default function GoalsAndBudgetsModal({ isOpen, onClose, data, onUpdated 
                     </div>
                     <div className="flex items-center gap-3">
                       <button onClick={() => handleAddMoneyToGoal(g.id, g.current_amount)} className="text-mint-400 hover:text-mint-300 transition-colors flex items-center gap-1 text-xs font-semibold bg-mint-400/10 px-2 py-1 rounded-full"><PlusCircle className="h-3 w-3" /> Add</button>
-                      <button onClick={() => handleDeleteGoal(g.id)} disabled={loading} className="text-slate-500 hover:text-red-400"><Trash2 className="h-4 w-4" /></button>
+                      <button onClick={() => handleDeleteGoal(g.id)} disabled={loading} aria-label="Delete goal" className="text-slate-500 hover:text-red-400 inline-flex items-center justify-center h-10 w-10 rounded-lg hover:bg-slate-100 active:bg-slate-200 transition-colors"><Trash2 className="h-4 w-4" /></button>
                     </div>
                   </div>
                 ))}

--- a/src/app/dashboard/money-hub/payments/page.tsx
+++ b/src/app/dashboard/money-hub/payments/page.tsx
@@ -193,7 +193,7 @@ function PaymentCard({ payment, type, onCategoryChange, onDelete, onAmountChange
               >
                 <Tag className="h-3 w-3" />
                 {getCategoryLabel(payment.category)}
-                <ChevronDown className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                <ChevronDown className="h-3 w-3 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity" />
               </button>
             </div>
             <div className="text-right flex-shrink-0 ml-2">

--- a/src/app/dashboard/spending/page.tsx
+++ b/src/app/dashboard/spending/page.tsx
@@ -206,7 +206,7 @@ export default function SpendingPage() {
                 {/* Expanded detail with individual payments */}
                 {isExpanded && isPaid && (
                   <div className="ml-12 mt-2 mb-3 bg-slate-50 rounded-lg p-4 border border-slate-200">
-                    <div className="grid grid-cols-3 gap-4 mb-4">
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
                       <div>
                         <p className="text-slate-500 text-xs">Total ({summary.months_analysed}mo)</p>
                         <p className="text-slate-900 font-semibold">£{cat.total.toLocaleString()}</p>


### PR DESCRIPTION
## Summary
Final mobile pass after ripgrepping the entire dashboard for the established pattern set. 4 real fixes.

- **GoalsAndBudgetsModal** (money-hub) — was missed in #288. Same treatment as Net Worth modal now: bottom-sheet on mobile, 44×44 close with `active:bg-slate-200`, `p-4 sm:p-6` body, budget+goal 2-col form grids stack on mobile, Trash delete buttons get 40×40 tap targets + aria-labels
- **money-hub/payments category chevron** — was `opacity-0 group-hover:opacity-100` — touch users couldn't see the hint that tapping a category opens the picker. Now visible on mobile, desktop behaviour unchanged
- **forms/page** Amount + Reference inputs now stack under 640px
- **spending/page** expanded-detail stat row (Total / Monthly avg / Share) now stacks under 640px — previously three cells crammed inside an `ml-12` container

No new issues found on notifications / rewards / tutorials / export / pocket-agent — they were already patterned correctly.

## Test plan
- [ ] iPhone: Money Hub → Goals & Budgets modal bottom-sheets; close button 44×44; can delete a budget/goal without accidentally tapping adjacent row
- [ ] Money Hub payments list → tap category label; now visibly hints at interactivity on mobile via always-visible chevron
- [ ] forms/page: Amount and Reference inputs each get full row under 640px
- [ ] spending/page expanded detail: three stats each own full row on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)