### PR TITLE
fix(email): record price-increase email sends in rate-limit tracker

### DIFF
--- a/src/app/api/cron/price-increases/route.ts
+++ b/src/app/api/cron/price-increases/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { detectPriceIncreases } from '@/lib/price-increase-detector';
 import { buildPriceIncreaseEmail } from '@/lib/email/price-increase-alerts';
-import { canSendEmail } from '@/lib/email-rate-limit';
+import { canSendEmail, markEmailSent } from '@/lib/email-rate-limit';
 import { sendNotification } from '@/lib/notifications/dispatch';
 
 export const maxDuration = 60;
@@ -128,7 +128,10 @@ export async function GET(request: NextRequest) {
           telegram: { text: telegramText },
           push: { title: 'Price hike detected', body: headline.replace(/\*/g, '') },
         });
-        if (result.delivered.includes('email')) totalEmailsSent++;
+        if (result.delivered.includes('email')) {
+          totalEmailsSent++;
+          await markEmailSent(supabase, userId, 'price_increase_alert', `Price increase alert: ${newIncreases.length} merchant${newIncreases.length === 1 ? '' : 's'}`);
+        }
       }
     } catch (err) {
       errors.push(`Error processing user ${userId}: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
Rescue of the work from #247 onto current master (which was 52 commits behind).

## The bug
\`/api/cron/price-increases\` called \`canSendEmail()\` before delivery but never called \`markEmailSent()\` after. Net effect: a price-increase email went out successfully but wasn't recorded against the user's daily email cap, so subsequent marketing / alert emails could push them over without the cap noticing.

## Fix
Import \`markEmailSent\` alongside \`canSendEmail\` and call it with \`type='price_increase_alert'\` after \`sendNotification\` reports the email delivered.

\`price_increase_alert\` is already an allowed \`type\` on the \`tasks\` CHECK constraint (shipped in migration 20260424030000_tasks_email_types.sql / PR #248) so the insert lands cleanly.

Closes #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)