### PR TITLE
fix(pricing/auth): mobile readability on comparison table + tactile tap states

### DIFF
--- a/src/app/auth/auth.css
+++ b/src/app/auth/auth.css
@@ -79,6 +79,10 @@
   box-shadow: var(--shadow-sm);
   transform: translateY(-1px);
 }
+.m-land-root .oauth-btn:active:not(:disabled) {
+  background: #E5E7EB;
+  transform: translateY(0) scale(0.98);
+}
 .m-land-root .oauth-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -269,6 +273,10 @@
 .m-land-root .auth-submit:hover:not(:disabled) {
   transform: translateY(-1px);
   background: #2CC48A;
+}
+.m-land-root .auth-submit:active:not(:disabled) {
+  transform: translateY(0) scale(0.98);
+  background: #1FA878;
 }
 .m-land-root .auth-submit:disabled {
   opacity: 0.55;

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -341,6 +341,7 @@ export default function PricingPage() {
             </h2>
           </div>
           <div
+            className="compare-table-wrap"
             style={{
               background: '#fff',
               border: '1px solid var(--divider)',

--- a/src/app/pricing/styles.css
+++ b/src/app/pricing/styles.css
@@ -337,4 +337,24 @@
 @media (max-width: 480px) {
   .m-pricing-root .wrap { padding: 0 20px; }
   .m-pricing-root .pricing-section { padding: 80px 0; }
+  /* Comparison table: horizontal scroll with a minimum row width so the
+   * four columns stay readable instead of squishing at 360–430px. */
+  .m-pricing-root .compare-table-wrap {
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+  .m-pricing-root .compare-table-head,
+  .m-pricing-root .compare-table-row {
+    min-width: 540px;
+    padding: 12px 16px !important;
+    font-size: 13px !important;
+  }
+  /* Billing toggle: let it wrap the save badge to a second line gracefully
+   * rather than blowing out the pill width on small screens. */
+  .m-pricing-root .billing-toggle__opt { padding: 8px 14px; }
+  .m-pricing-root .billing-toggle__save { font-size: 10px; padding: 2px 6px; }
 }
+
+/* Tactile active states — tap feedback for mobile, matches the dashboard mobile-pass pattern */
+.m-pricing-root .billing-toggle__opt:active { transform: scale(0.97); }
+.m-pricing-root .btn:active { transform: scale(0.98); }


### PR DESCRIPTION
## Summary
Acquisition-funnel mobile pass following the dashboard sweep (#288, #290, #294, #296). Two high-impact areas, small change.

### Pricing
- **Comparison table** — was squishing the 4 columns to ~70px each at 360px, making feature rows multi-line and unreadable. Now at `≤480px` the table horizontally scrolls with `min-width: 540px`, keeping tier columns legible. Users swipe to compare — familiar mobile pattern.
- **Billing toggle** — tightened `.billing-toggle__opt` padding and shrunk the "save ~25%" badge so the pill fits cleanly on 360px without wrapping mid-word.
- **`.btn` + toggle** now have `:active scale()` for tactile press feedback.

### Auth
- **OAuth + submit buttons** had only `:hover` states (which don't fire on touch). Added `:active` — darker background + subtle scale so the press is visibly acknowledged.

## Test plan
- [ ] iPhone: /pricing comparison table swipes horizontally cleanly, no vertical squeeze
- [ ] /pricing billing toggle fits on one row at 360px without wrapping mid-word
- [ ] Tap pricing CTA — visible press scale
- [ ] Tap "Continue with Google" on signup — visible press scale
- [ ] Desktop (≥481px) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)