### PR TITLE
feat(admin): surface providers seen-but-not-covered on cancel-info page

### DIFF
--- a/src/app/api/admin/cancel-info/route.ts
+++ b/src/app/api/admin/cancel-info/route.ts
@@ -32,17 +32,25 @@ export async function GET(request: NextRequest) {
   if (!auth.ok) return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
 
   const admin = getAdmin();
-  const { data, error } = await admin
-    .from('provider_cancellation_info')
-    .select('id, provider, display_name, category, method, email, phone, url, tips, data_source, confidence, auto_cancel_support, last_verified_at, updated_at')
-    .order('last_verified_at', { ascending: true, nullsFirst: true })
-    .order('provider', { ascending: true });
+  const [infoRes, subsRes] = await Promise.all([
+    admin
+      .from('provider_cancellation_info')
+      .select('id, provider, display_name, category, method, email, phone, url, tips, data_source, confidence, auto_cancel_support, last_verified_at, updated_at, aliases')
+      .order('last_verified_at', { ascending: true, nullsFirst: true })
+      .order('provider', { ascending: true }),
+    admin
+      .from('subscriptions')
+      .select('provider_name, user_id')
+      .eq('status', 'active')
+      .is('dismissed_at', null),
+  ]);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (infoRes.error) return NextResponse.json({ error: infoRes.error.message }, { status: 500 });
+
+  const rows = infoRes.data ?? [];
 
   // Quick freshness buckets for the UI header.
   const now = Date.now();
-  const rows = data ?? [];
   const stats = {
     total: rows.length,
     verified_30d: rows.filter((r) => r.last_verified_at && (now - new Date(r.last_verified_at).getTime()) < 30 * 86_400_000).length,
@@ -60,7 +68,44 @@ export async function GET(request: NextRequest) {
     },
   };
 
-  return NextResponse.json({ rows, stats });
+  // Providers seen on a user's subscriptions but not yet covered by any
+  // row in provider_cancellation_info (neither canonical nor alias
+  // match). Mirrors the fuzzy-match logic the discovery leg of the
+  // Perplexity cron uses, so this is a preview of what Monday's run
+  // will consider. Ranked by user count descending so the highest-
+  // impact gaps float to the top.
+  const normalise = (s: string) => (s ?? '').toLowerCase().replace(/[^a-z0-9\s]/g, '').trim();
+  const hasCoverage = (name: string): boolean => {
+    const search = normalise(name);
+    if (!search) return true;
+    const first = search.split(/\s+/)[0];
+    for (const r of rows) {
+      if (search.includes(r.provider) || r.provider.includes(first)) return true;
+      for (const a of r.aliases ?? []) {
+        const alias = (a ?? '').toLowerCase();
+        if (!alias) continue;
+        if (search.includes(alias) || alias.includes(first)) return true;
+      }
+    }
+    return false;
+  };
+
+  const userCountByName = new Map<string, Set<string>>();
+  for (const s of subsRes.data ?? []) {
+    const name = (s.provider_name as string | null)?.trim();
+    if (!name || name.length < 3) continue;
+    const set = userCountByName.get(name) ?? new Set<string>();
+    set.add(s.user_id as string);
+    userCountByName.set(name, set);
+  }
+
+  const uncovered = Array.from(userCountByName.entries())
+    .filter(([name]) => !hasCoverage(name))
+    .map(([name, users]) => ({ provider_name: name, user_count: users.size }))
+    .sort((a, b) => b.user_count - a.user_count)
+    .slice(0, 50);
+
+  return NextResponse.json({ rows, stats, uncovered });
 }
 
 export async function PATCH(request: NextRequest) {

--- a/src/app/dashboard/admin/cancel-info/page.tsx
+++ b/src/app/dashboard/admin/cancel-info/page.tsx
@@ -35,6 +35,11 @@ interface Stats {
   by_source: Record<DataSource, number>;
 }
 
+interface UncoveredRow {
+  provider_name: string;
+  user_count: number;
+}
+
 function freshnessLabel(v: string | null): { text: string; tone: 'ok' | 'warn' | 'stale' } {
   if (!v) return { text: 'Never verified', tone: 'stale' };
   const days = Math.floor((Date.now() - new Date(v).getTime()) / 86_400_000);
@@ -60,6 +65,7 @@ const SOURCE_COLOR: Record<DataSource, string> = {
 export default function AdminCancelInfoPage() {
   const [rows, setRows] = useState<Row[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);
+  const [uncovered, setUncovered] = useState<UncoveredRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [query, setQuery] = useState('');
@@ -83,6 +89,7 @@ export default function AdminCancelInfoPage() {
       const data = await res.json();
       setRows(data.rows ?? []);
       setStats(data.stats ?? null);
+      setUncovered(data.uncovered ?? []);
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Failed to load');
     } finally {
@@ -364,6 +371,41 @@ export default function AdminCancelInfoPage() {
                     </td>
                   </tr>
                 )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Uncovered providers — merchant names that appear on a user's
+          subscriptions but have no match in the cancel-info table. The
+          Monday discovery cron processes up to 5 of these per run, so
+          this list is a preview of what it'll pick up next + an
+          indication of the highest-impact gaps by user count. */}
+      {uncovered.length > 0 && (
+        <div className="mt-8">
+          <div className="flex items-baseline justify-between mb-3">
+            <h2 className="text-lg font-semibold text-slate-900">Providers seen but not covered</h2>
+            <span className="text-xs text-slate-500">{uncovered.length} — top {Math.min(uncovered.length, 50)} by user count</span>
+          </div>
+          <p className="text-xs text-slate-500 mb-3">
+            Merchant names from active subscriptions that don&apos;t match any row above — neither by canonical name nor alias. Discovery cron adds up to 5 per week, highest user-count first.
+          </p>
+          <div className="card p-0 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 text-slate-600 text-xs uppercase tracking-wide">
+                <tr>
+                  <th className="text-left px-4 py-2">Provider name</th>
+                  <th className="text-right px-4 py-2 w-32">Users</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {uncovered.map((u) => (
+                  <tr key={u.provider_name} className="hover:bg-slate-50/50">
+                    <td className="px-4 py-2 text-slate-900">{u.provider_name}</td>
+                    <td className="px-4 py-2 text-right text-slate-600">{u.user_count}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
Preview of what the Monday Perplexity discovery cron will pick up next, ranked by user impact.

## Behaviour
- \`/api/admin/cancel-info\` now also returns \`uncovered[]\` — distinct \`subscription.provider_name\` values not matching any canonical provider or alias. Uses the same fuzzy match the discovery leg of the refresh cron uses, so this is a faithful preview
- Ranked by \`user_count desc\`, capped at 50
- Admin page renders them in a compact table below the main coverage table

## Real gaps it surfaces in prod right now
- Skipton Building Society (3 users)
- Test Valley Borough Council (3 users)
- Dial Direct Insurance (2 users)
- Loqbox, NatWest Loan, Santander Loans, Novuna Personal Finance (2 users each)
- London Borough of Hounslow, SmarTrack, BANK OF SCOTLAND (1–2 users)

Finance-product names (loans, credit) in the list are a known false-positive — they're debts, not subscriptions with a cancellation flow. Possible follow-up to skip finance categories in the discovery cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)