### PR TITLE
fix(cancel-info): skip loan/credit providers in discovery + admin preview

### DIFF
--- a/src/app/api/admin/cancel-info/route.ts
+++ b/src/app/api/admin/cancel-info/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createAdminClient } from '@supabase/supabase-js';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { isFinanceProvider } from '@/lib/subscriptions/active-count';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -100,6 +101,10 @@ export async function GET(request: NextRequest) {
   }
 
   const uncovered = Array.from(userCountByName.entries())
+    // Skip finance providers — debts, not cancellable. Matches the
+    // discovery cron's own filter so this preview reflects what the
+    // cron will actually process, not a superset.
+    .filter(([name]) => !isFinanceProvider(name))
     .filter(([name]) => !hasCoverage(name))
     .map(([name, users]) => ({ provider_name: name, user_count: users.size }))
     .sort((a, b) => b.user_count - a.user_count)

--- a/src/app/api/cron/refresh-cancellation-info/route.ts
+++ b/src/app/api/cron/refresh-cancellation-info/route.ts
@@ -26,6 +26,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { isFinanceProvider } from '@/lib/subscriptions/active-count';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -264,7 +265,14 @@ export async function GET(request: NextRequest) {
       ),
     );
 
-    const uncovered = distinctNames.filter((name) => !hasExistingCoverage(name, rows));
+    // Skip loan/mortgage/credit-card names — they're debts the user
+    // can't "cancel" in the consumer-rights sense, so spending a
+    // Perplexity call on them is wasted quota and the result would
+    // be a generic "contact your lender" message the UI already
+    // handles with the fallback.
+    const uncovered = distinctNames
+      .filter((name) => !isFinanceProvider(name))
+      .filter((name) => !hasExistingCoverage(name, rows));
 
     for (const name of uncovered.slice(0, MAX_DISCOVERY_PER_RUN)) {
       const answer = await askPerplexity(name);

--- a/src/lib/subscriptions/active-count.ts
+++ b/src/lib/subscriptions/active-count.ts
@@ -50,7 +50,14 @@ const CREDIT_KEYWORDS = [
   'credit card',
 ];
 
-function isFinanceProvider(name: string | null | undefined): boolean {
+/**
+ * True when the merchant name looks like a loan / mortgage / credit
+ * card rather than a cancellable subscription. Reused by the admin
+ * cancel-info uncovered-providers list and the Perplexity discovery
+ * cron so we don't waste a call researching "how to cancel a Santander
+ * loan" — that's a debt, not a subscription.
+ */
+export function isFinanceProvider(name: string | null | undefined): boolean {
   if (!name) return false;
   const lower = name.toLowerCase();
   return DEBT_KEYWORDS.some((k) => lower.includes(k)) || CREDIT_KEYWORDS.some((k) => lower.includes(k));


### PR DESCRIPTION
Loans, mortgages and credit cards aren't cancellable subscriptions — they're debts. Routing them through Perplexity wastes quota and the result would be unhelpful ("contact your lender").

## Changes
- Export the existing \`isFinanceProvider\` helper (was module-local)
- Discovery cron now filters it out before \`hasExistingCoverage\`
- Admin uncovered-providers preview applies the same filter so the list reflects what the cron will actually process

## Impact on current prod data
Removes from the uncovered list: CA Auto Finance, NatWest Loan, Santander Loans, Novuna Personal Finance, Skipton Building Society, Barclaycard. Keeps the real gaps: Test Valley Borough Council, Dial Direct Insurance, Loqbox, London Borough of Hounslow, SmarTrack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)