### PR TITLE
feat(e2e): Playwright UAT suite + comprehensive UX audit

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,17 @@
+# Copy to .env.e2e and fill in. Never commit the real file.
+# Ignored by .gitignore. Used by playwright.config.ts and fixtures/auth.ts.
+
+# Target URL. Default is localhost (dev server boots automatically).
+# Override with a deployed URL to smoke prod — when you do, BASE_URL
+# matching /paybacker\.co\.uk/ also suppresses the local dev server boot.
+BASE_URL=http://localhost:3000
+
+# Account credentials for the authenticated specs. The existing fixtures
+# log in via email+password (signup/login page), not OAuth.
+E2E_EMAIL=
+E2E_PASSWORD=
+
+# Gate destructive tests (creating disputes, deleting subscriptions).
+# Unset or empty = destructive tests are skipped. Only set to 1 when
+# running against a dev/staging DB you're happy to mutate.
+DESTRUCTIVE=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+# Allow example env templates — they contain no secrets
+!.env*.example
 
 # vercel
 .vercel
@@ -42,3 +44,9 @@ next-env.d.ts
 TASK.md
 TASK2.md
 .env*.local
+
+# playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/
+/.auth/

--- a/_handoff/UX_AUDIT.md
+++ b/_handoff/UX_AUDIT.md
@@ -47,6 +47,13 @@ Several icon buttons across the dashboard were caught and fixed in #288/#290/#29
 `STATUS_CONFIG` patterns in complaints, subscriptions, deals all convey state purely by color (amber/green/red). Fails for colorblind users and monochrome printing.
 **Fix:** pair every color with either an icon, label, or distinctive shape (✓ for done, ⏸ for pending, ⚠ for attention).
 
+### A8. Cookie consent banner intercepts clicks on auth forms — `HIGH`
+`CookieConsentBanner.tsx:59` uses `fixed bottom-0 inset-x-0 z-[9999]` covering the entire bottom of the viewport. At typical desktop heights (<900px) and most mobile heights, the banner covers the "Sign in" submit button on `/auth/login` and "Create account" on `/auth/signup`. First-time visitors must dismiss the banner before they can finish authenticating — **discovered by the E2E suite on first run**, but a real user on a mid-sized laptop will hit this too.
+**Fix:**
+1. At minimum, reserve bottom padding on the page body equal to the banner height so the submit button never sits under the banner.
+2. Better: render the banner as a centered card/toast rather than a full-width bottom sticky.
+3. Ideal: pre-accept-essential on auth pages (GDPR-compliant in the UK since essential cookies don't need consent), defer the full preferences banner until after the user reaches the dashboard.
+
 ---
 
 ## `/` (homepage via `preview/homepage/page.tsx`)

--- a/_handoff/UX_AUDIT.md
+++ b/_handoff/UX_AUDIT.md
@@ -1,0 +1,421 @@
+# Paybacker UX Audit — April 2026
+
+Comprehensive code-level UX review across the Paybacker public site and authenticated dashboard. Captures accessibility, error/loading/empty states, form validation, copy, interaction feedback, navigation, and information-architecture issues. Companion to the Playwright E2E suite in `/e2e`.
+
+**Methodology:** Static analysis of every page file in `/src/app/` against the ui-ux-pro-max pattern set (priority 1–10: Accessibility, Touch, Performance, Style, Layout, Typography/Color, Animation, Forms, Navigation, Charts). Runtime/visual testing was not possible in this pass — findings that require live verification are marked `runtime-check`.
+
+**Severity key:**
+- `HIGH` — blocks a primary task, data loss risk, or accessibility-critical
+- `MED`  — friction, confusion, or accessibility-important
+- `LOW`  — polish, consistency, or accessibility-niceties
+
+Reference numbers like [#288] map to shipped PRs that already addressed related patterns.
+
+---
+
+## Global patterns (apply across every route)
+
+### A1. No global error boundary — `HIGH`
+A runtime error in any dashboard route crashes the whole page with no user-facing fallback. Next.js App Router error.tsx conventions aren't in use at the route-group level.
+**Fix:** add `src/app/dashboard/error.tsx` with a friendly "Something went wrong — [reload] [contact support]" card that captures and posts to Sentry/PostHog.
+
+### A2. Skeleton loaders not consistent — `HIGH`
+Several routes show a blank container → data pop-in (FOUC) rather than skeletons. Money Hub, Subscriptions, and Complaints all have this pattern. Users on slow connections see empty UI for several seconds.
+**Fix:** use `loading.tsx` route-group files with matching skeleton shapes per surface.
+
+### A3. Submit buttons don't disable during async — `HIGH`
+Forms across signup, login, complaint-new, subscription-edit allow double-click submission. Backend usually idempotency-keys, but the UI should prevent it.
+**Fix:** every submit button that triggers a mutation must spread `disabled={submitting}` + show a spinner (lucide `Loader2` + `animate-spin` is already imported everywhere).
+
+### A4. Generic error copy — `MED`
+"Failed to sign in", "Something went wrong", "Please try again" — these appear across auth, complaints, money-hub sync. Users don't get actionable next steps.
+**Fix:** write an error-copy ladder:
+- Network: "Can't reach Paybacker — check your connection."
+- Auth: "Email or password doesn't match any account."
+- Rate-limited: "Too many tries. Try again in 60 seconds."
+- Server (5xx): "Our end — we're on it. [Retry] [Contact support]."
+
+### A5. No skip-to-main-content link — `MED`
+Keyboard and screen-reader users must tab through the full dashboard sidebar on every page.
+**Fix:** add a visually-hidden `<a href="#main-content">Skip to content</a>` in `layout.tsx`.
+
+### A6. Icon-only buttons without `aria-label` — `MED`
+Several icon buttons across the dashboard were caught and fixed in #288/#290/#294/#296 mobile passes (close, dismiss, delete, month nav). A full sweep is still needed on: notifications list actions, rewards page, tutorials, export page, admin pages.
+**Fix:** grep for `<button[^>]*>\s*<[A-Z]\w+\s+className=` across the repo to find remaining candidates, add `aria-label` to each.
+
+### A7. Color-only status indication — `MED`
+`STATUS_CONFIG` patterns in complaints, subscriptions, deals all convey state purely by color (amber/green/red). Fails for colorblind users and monochrome printing.
+**Fix:** pair every color with either an icon, label, or distinctive shape (✓ for done, ⏸ for pending, ⚠ for attention).
+
+---
+
+## `/` (homepage via `preview/homepage/page.tsx`)
+
+### H1. StickyCTA `aria-hidden` but still tabbable — `MED`
+Line 782: the fixed bottom CTA fades out but keeps pointer-events + tab order, so a keyboard user can focus an invisible button.
+**Fix:** toggle `inert` or conditionally `display: none`.
+
+### H2. HeroDemo "Generate" has no validation feedback — `MED`
+Lines 503–646. Clicking the button with an empty issue description silently disables the button with no inline error. User assumes nothing happened.
+**Fix:** inline helper text on the textarea "Describe what went wrong (e.g. 'unexpected £40 charge on my energy bill')", and flash a toast/error if submitted empty.
+
+### H3. Anchor scroll has no smooth behavior — `LOW`
+Jumps feel jarring on mobile when tapping `#how`, `#features`, etc.
+**Fix:** `html { scroll-behavior: smooth }` or use Framer's `scroll` helper if respecting `prefers-reduced-motion`.
+
+---
+
+## `/auth/signup`
+
+### S1. Server errors only at top of form — `HIGH`
+Line 460. "Email already in use" shows in a banner at top, not inline below the email input. Violates the "error near field" UX rule (ui-ux-pro-max #8).
+**Fix:** lift server validation errors into a `fieldErrors: { email?: string, password?: string }` map and render each beside its field.
+
+### S2. Submit button: text-only loading — `MED`
+Line 467. Text flips to "Creating account…" but no spinner. Unclear if system is working.
+**Fix:** use `<Loader2 className="animate-spin h-4 w-4" />` alongside the text.
+
+### S3. Password strength aria-live announces full checklist — `MED`
+Line 441. Screen reader re-reads the whole 3-rule list on each keystroke.
+**Fix:** split each rule into its own `aria-live="polite"` region so only the rule that flipped is announced.
+
+### S4. Password help text mismatches live checklist — `LOW`
+Line 138 error says "8 chars + letter + number" but the live checklist shows 3 rules. User ticks all 3 and still sees "missing something" error if server validation trips.
+**Fix:** single source of truth for password rules; import the same list into both the checklist and the error message.
+
+### S5. Inconsistent "required" / "optional" signalling — `LOW`
+Phone marked `(optional)`, first-name not marked as required. Users must guess.
+**Fix:** label required with subtle asterisk; optional fields show "(optional)" in muted text.
+
+---
+
+## `/auth/login`
+
+### L1. Lockout message has no escape — `MED`
+Lines 76–86. After 5 failed attempts user sees a 60s lockout but nothing tells them what to do if they're locked out repeatedly (password reset link, support contact).
+**Fix:** lockout message should include "Forgot password?" link prominently.
+
+### L2. Generic "Failed to sign in" — `MED`
+Line 83. No indication of why — wrong password, unknown email, network error, captcha? User can't fix what they can't diagnose.
+**Fix:** map Supabase error codes to specific user-facing copy (see A4 above).
+
+### L3. No inline email-format validation — `LOW`
+Line 201. User can submit `notanemail` and only learn it's wrong after round-trip.
+**Fix:** `onBlur` regex check with inline error.
+
+### L4. Tab group focus unclear — `MED`
+Lines 177–192. Magic-link vs. password tabs have no visible focus ring; Tab-key users can't see which is focused.
+**Fix:** `:focus-visible` outline of 2–4px (matches ui-ux-pro-max accessibility rule `focus-states`).
+
+---
+
+## `/auth/accept-terms`
+
+### AT1. "Checking your account…" shows no spinner — `MED`
+Line 209. Static text, no animation. Page feels frozen.
+**Fix:** `<Loader2 className="animate-spin" />` paired with the text.
+
+### AT2. No context for why user is here — `LOW`
+Users auto-redirected by the middleware terms-gate [PR #268] land here with no explanation of why they can't get to the dashboard.
+**Fix:** above the consent form, add: "Before you continue, please accept our updated terms."
+
+---
+
+## `/auth/reset-password`
+
+### RP1. Weak email validation — `MED`
+Line 24. `email.includes('@')` accepts `a@.com`.
+**Fix:** standard email regex or HTML `type="email"` which covers most cases.
+
+### RP2. Emoji-as-icon without alt — `MED`
+Lines 79–85. 🔑 rendered without `role="img" aria-label="Password reset"`.
+**Fix:** wrap in `<span role="img" aria-label="Password reset">🔑</span>` — or better, replace with a lucide `<KeyRound />`.
+
+### RP3. "60 minutes" → "1 hour" — `LOW`
+Line 69. Shorter is clearer. Also mention checking spam folder.
+
+---
+
+## `/onboarding`
+
+### O1. Loading spinner with no text — `MED`
+Lines 93–96. Is it loading the page or checking account state? User can't tell.
+
+### O2. "Skip" button affordance changes type — `MED`
+Lines 829–843. On step 0, "Back" becomes a text link "Skip onboarding"; on later steps it's a `<button>`. Inconsistent click target size and visual weight.
+**Fix:** always use a button with a clear label; change the label, not the element.
+
+### O3. Skip-to-step-3 isn't obvious — `LOW`
+Lines 517–518. Clicking "Skip for now — use Paybacker without data connections" jumps to step 3 (final). No breadcrumb feedback that user has jumped ahead.
+**Fix:** visual step indicator already exists — add "(skipped connections)" subtitle on step 3 if connection data is missing.
+
+### O4. Example-win is hard-coded Spotify — `MED`
+Lines 711–798. If user connects a bank but has no subscriptions, they still see the Spotify £11.99 example card. Disappointing when they hit the real dashboard and find nothing.
+**Fix:** if actual scan results exist, render the top one; else render the example with a clearer "This is what a win will look like" badge.
+
+### O5. Choice cards lack hover state — `MED`
+Lines 338–504. Bank / Email choice cards on desktop don't elevate or show pointer feedback. Users unsure they're clickable.
+**Fix:** add `transition-shadow shadow-sm hover:shadow-md cursor-pointer` to each card.
+
+---
+
+## `/pricing`
+
+### P1. Billing toggle wrong ARIA role — `MED`
+`PricingGrid.tsx` line 30. `role="radiogroup"` with buttons, but buttons don't carry `role="radio"`. Screen reader announces "group" but no items.
+**Fix:** either add `role="radio"` and `aria-checked` to each button, or switch the whole thing to a native `<input type="radio">` with visually-styled labels.
+
+### P2. FAQ `<summary>` has no focus outline — `MED`
+Line 442. Keyboard users can't see when an FAQ item is focused.
+**Fix:** `summary:focus-visible { outline: 2px solid var(--accent-mint); }`
+
+### P3. FAQ expand/collapse is instant — `LOW`
+No transition, jarring UX.
+**Fix:** `details[open] summary ~ *` animate with `interpolate-size: allow-keywords` (or use framer-motion with `AnimatePresence` if you need cross-browser).
+
+### P4. "Save £14.89 vs monthly" copy is ambiguous — `LOW`
+Unclear whether the £44.99 is after discount or the same annual total. Reword: "Annual billing saves you £14.89 vs paying monthly."
+
+---
+
+## `/about`
+
+### AB1. Step numbers have no semantic meaning — `MED`
+Line 382. "01", "02", "03", "04" styled with `fontFamily: 'JetBrains Mono'` but rendered in plain divs.
+**Fix:** wrap content in `<ol>` or mark each section with `aria-labelledby` pointing at a heading; the numbers become CSS counters.
+
+### AB2. Sticky timeline breaks on mobile — `LOW`
+Line 268. `position: sticky` on desktop collides with fixed headers on mobile.
+**Fix:** gate with `@media (min-width: 768px) { position: sticky; }`.
+
+---
+
+## `/dashboard` (overview)
+
+### DB1. Single large spinner for 12 data regions — `HIGH`
+Lines 27–133. Whole dashboard hangs on a single `loading` flag. Slow bank sync means user sees nothing for 10+ seconds.
+**Fix:** independent loading states per region; skeletons per card.
+
+### DB2. Browser `confirm()` for bank disconnect — `MED`
+Lines 71–92. Uses native `confirm()` which looks out of place with the app's design. Can't style, can't add context.
+**Fix:** custom confirm modal matching `.shell-v2` aesthetics with "Disconnect [bank name]? You'll stop getting daily sync and new alerts."
+
+### DB3. Optimistic remove but no rollback on failure — `HIGH`
+Lines 82–88. State removes the bank before server confirms. If server fails, UI shows bank removed but it's actually still there.
+**Fix:** move the state update inside the `.then()` callback, OR implement proper optimistic pattern with rollback on error.
+
+### DB4. Toasts have no auto-dismiss — `MED`
+Errors stick until manually dismissed (or may disappear on route change). Inconsistent behaviour.
+**Fix:** success toasts auto-dismiss in 3s; errors in 8s (or stay until dismissed if destructive).
+
+### DB5. No empty-state CTA if user hasn't connected anything — `MED`
+Fresh user with no bank / email / subs sees a grid of empty cards.
+**Fix:** if every connection is absent, render a single large "Let's connect your first account" CTA.
+
+---
+
+## `/dashboard/money-hub`
+
+### MH1. Multiple loading flags with no skeleton — `HIGH`
+Lines 105–150. `loading`, `syncing`, `switching` all trigger different states but none show skeleton cards.
+**Fix:** per-panel skeletons (Income card, Spending card, Net Worth card, Contracts card).
+
+### MH2. Scan caption has no timeout — `HIGH`
+Lines 148–150. If `scanning` hangs (network failure), the rotating message never recovers.
+**Fix:** timeout after 60s → error toast with retry button.
+
+### MH3. No CTA for no-bank-connected state — `MED`
+Lines 128–130. Expected bills empty with no explanation.
+**Fix:** "Connect a bank to see upcoming bills automatically" link.
+
+### MH4. Collapsible panels don't announce state — `MED`
+Keyboard users tab into Goals/Contracts panels but don't hear "expanded"/"collapsed".
+**Fix:** `<button aria-expanded={isOpen} aria-controls="goals-panel">` pattern.
+
+---
+
+## `/dashboard/complaints`
+
+### C1. No error boundary — `HIGH`
+If disputes API fails, the page appears blank or crashes.
+**Fix:** `src/app/dashboard/complaints/error.tsx`.
+
+### C2. Loading state hangs on large threads — `HIGH`
+A dispute with 50+ emails blocks the whole correspondence section.
+**Fix:** paginate or virtualise the correspondence list; show first 10, "Load more" below.
+
+### C3. 3-dot menu button no hover/focus — `MED`
+`MoreVertical` icon appears dead.
+**Fix:** `hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-emerald-500`.
+
+### C4. Form modals don't show submit spinner — `MED`
+Edit-dispute and add-note modals' submit buttons go silent during the API call.
+
+### C5. No breadcrumb on `/dashboard/complaints/[id]` — `LOW`
+User has to use browser back to return to list.
+**Fix:** `‹ All disputes` link at top-left of detail view.
+
+---
+
+## `/dashboard/subscriptions`
+
+### SB1. Blank list while fetching — `HIGH`
+Line 116. No skeleton — empty page for seconds.
+
+### SB2. Empty state lacks prominent CTA — `MED`
+"No subscriptions yet" is easy to miss; the "Add subscription" button should dominate the empty state.
+
+### SB3. Form fields no inline validation — `MED`
+Edit form only validates on submit.
+
+### SB4. Error state not rendered — `MED`
+Lines 140–142. `cancellationError` stored in state but no visible render location found in excerpt. Either error is invisible or it's rendered somewhere not easily found.
+**Fix:** standardise on a `<FormError>` component used across every form.
+
+### SB5. Optimistic delete without rollback — `MED`
+Same pattern as DB3. Subscription disappears before server confirms.
+
+---
+
+## `/dashboard/contracts` & `/dashboard/contract-vault`
+
+### CT1. Upload progress not visible — `MED`
+Users uploading a PDF contract have no progress bar or "Reading your contract…" feedback; the page just waits.
+**Fix:** progress bar + status copy.
+
+### CT2. Extracted-terms grid was fixed [#294] but the "edit terms" flow isn't reviewed here — `runtime-check`
+Haven't verified the edit modal works at mobile widths post-extraction.
+
+### CT3. Contract end-date reminders: unclear cadence copy — `LOW`
+"We'll remind you at 30, 14, 7 days" on pricing page, but no visible indicator on the contract itself of next reminder date.
+
+---
+
+## `/dashboard/deals`
+
+### D1. Deal card dismiss was hover-gated [#294] — fixed
+Still worth a runtime check that the dismiss actually POSTs to `/api/deals/dismiss` with the right id.
+**Fix in e2e:** add a destructive test behind `DESTRUCTIVE=1`.
+
+### D2. No active state on deal card click — `MED`
+Cards have hover but no active press feedback.
+
+### D3. Deal card "Not for me" vs dismiss X — `LOW`
+Potential confusion between the two actions; the X is actually "not interested" but the copy on the in-card link may also say "not relevant".
+**Fix:** unify copy; pick one word (suggest "Hide").
+
+---
+
+## `/dashboard/settings` (+ /spaces, /notifications, /telegram)
+
+### ST1. No confirmation on destructive Space delete — `HIGH`
+`settings/spaces/page.tsx:266` delete icon fires immediately. No confirm step. A mistap loses the Space and its grouping.
+**Fix:** `window.confirm` at minimum; ideally a styled confirm modal with "Type SPACE-NAME to confirm" for destructive.
+
+### ST2. Telegram unlink error copy — `MED`
+`settings/telegram/page.tsx` Unlink button doesn't explain what unlinking loses (bot commands, alerts).
+**Fix:** copy near button: "Unlinking stops all Telegram alerts but keeps your account data."
+
+### ST3. Quiet-hours inputs missing helper text — `LOW`
+`settings/notifications/page.tsx:156`. Start/End time inputs have no "timezone: UK" clarification. User abroad may not know which timezone these apply to.
+
+---
+
+## `/dashboard/profile`
+
+### PR1. "Connect Email" modal provider cards now stack [#294] — verified
+No further action.
+
+### PR2. Subscription status (Member-since / Tier) shows no upgrade CTA if on Free — `MED`
+User on Free tier sees their tier but no prominent upgrade button on the profile page.
+**Fix:** if `tier === 'free'`, show an "Upgrade to Essential" CTA with the same styling as pricing page.
+
+### PR3. Account deletion flow — `runtime-check`
+Haven't verified the account-deletion page structure is accessible (I noticed `src/app/account-deletion/` appeared during a fetch but wasn't in scope).
+
+---
+
+## `/dashboard/rewards`
+
+### RW1. Locked badge state low contrast — `MED`
+Line 473: locked badges use `opacity: 40%` which on slate-50 backgrounds falls below 3:1 contrast for large text.
+**Fix:** raise to `opacity-60` or switch to a grayscale treatment that still meets contrast.
+
+### RW2. "Show all challenges" no active state — `LOW`
+Line 571. Hover only.
+**Fix:** add `active:text-emerald-800`.
+
+### RW3. Redemption options grid cramped at 430px — `LOW`
+Line 423 `grid-cols-2 md:grid-cols-3 lg:grid-cols-5`. 2-col is fine for short cards but the Redemption cards have long titles ("£5 Amazon voucher", "1 free month Essential") that truncate.
+**Fix:** `grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5` — single col below 480px.
+
+---
+
+## `/dashboard/notifications`
+
+### N1. Row onClick without keyboard handler — `HIGH`
+`notifications/page.tsx:185`. Each row is a `<div>` with `onClick` but no `role="button"`, `tabIndex={0}`, or `onKeyDown`. Keyboard users can't open notifications.
+**Fix:** change to `<button>` or add the three required attributes.
+
+### N2. No active state on row — `MED`
+Inline styles with no active pseudo-class.
+
+### N3. Unread indicator relies on `background: #FEFDF7` — `MED`
+Color-only signal. Colorblind users won't see it.
+**Fix:** add a small `•` unread dot next to the title.
+
+---
+
+## `/dashboard/forms`
+
+### F1. `Amount` + `Reference` now stacks on mobile [#296] — verified
+
+### F2. No character count on issue textarea — `LOW`
+Users typing their complaint don't know if there's a limit.
+**Fix:** show `0 / 2000` counter below the textarea.
+
+### F3. "Generate letter" button has no loading copy — `MED`
+Just goes to the preview modal with no "Writing your letter…" feedback during the 10–30s Claude API call.
+**Fix:** intermediate modal: "We're drafting your complaint letter using UK Consumer Rights Act…" with a spinner.
+
+---
+
+## `/dashboard/export`
+
+### EX1. Format selection not reviewed — `runtime-check`
+Export supports CSV / PDF per pricing page. Haven't reviewed the page for:
+- date range picker ergonomics on mobile
+- download feedback
+- error state if export fails
+
+---
+
+## `/dashboard/tutorials` & `/dashboard/pocket-agent` & `/dashboard/upgrade`
+
+Not flagged for issues in this pass — they're mostly static content pages. Recommend a dedicated pass when these have more interactive elements.
+
+---
+
+## Summary
+
+**HIGH severity** (11 items): A1, A2, A3, DB1, DB3, MH1, MH2, C1, C2, SB1, N1, ST1
+
+These block a primary task, risk data loss, or fail accessibility-critical criteria. Recommend scheduling these as a single "UX foundation" sprint.
+
+**MED severity** (~40 items): bulk of the polish work. Bundle by theme:
+- Error-copy ladder (A4 + L1 + L2 + RP1 + …)
+- Skeleton loaders (A2 expansion across every async region)
+- Button loading states (A3 expansion)
+- Empty-state CTAs (DB5, SB2, MH3, …)
+- Accessibility pass (A5, A6, A7, L4, P1, RP2, N1, …)
+
+**LOW severity** (~15 items): can be folded into regular feature work.
+
+## Next recommended action
+
+1. Ship an `error.tsx` + skeleton primitives per route group (A1 + A2) — one PR, high leverage.
+2. Standardise button-loading + error-copy patterns (A3 + A4) — single component library update.
+3. Accessibility pass: icon-button `aria-label`, skip-link, focus rings (A5 + A6 + L4 + P1 + N1) — grep-driven PR.
+4. Empty-state CTA pattern applied across dashboard (DB5, SB2, MH3, +deals, +complaints).
+
+After that, individual-route polish (the MED bucket) can be parallelised across agents.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,51 @@
+# Paybacker E2E UAT Suite
+
+Playwright suite covering acquisition funnel + authenticated dashboard flows.
+Two projects: `desktop-chromium` (default) and `iphone-17-pro-max` (430×932).
+
+## First run
+
+```bash
+# 1. Copy creds template and fill in
+cp .env.e2e.example .env.e2e
+
+# 2. Install browsers (once)
+npx playwright install chromium
+
+# 3. Run — boots the dev server on :3000 automatically
+npm run test:e2e
+```
+
+## Useful commands
+
+| Command                            | What it does                                                   |
+| ---------------------------------- | -------------------------------------------------------------- |
+| `npm run test:e2e`                 | Full suite, headless, both projects                            |
+| `npm run test:e2e:headed`          | Watch the browser drive the tests                              |
+| `npm run test:e2e:ui`              | Playwright's interactive UI runner                             |
+| `npm run test:e2e:mobile`          | Only the mobile viewport project                               |
+| `npm run test:e2e:desktop`         | Only desktop                                                   |
+| `npm run test:e2e:prod`            | Run against https://paybacker.co.uk (read-only, no dev server) |
+| `npm run test:e2e:report`          | Open the HTML report after a run                               |
+
+## Scope
+
+| Spec                         | Covers                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `auth.spec.ts`               | Login/signup page shape, invalid creds, successful login                 |
+| `dashboard-routes.spec.ts`   | Every authenticated dashboard route loads without runtime error          |
+| `money-hub.spec.ts`          | Tabs, month nav tap targets, drill-down modal, Net Worth Pro states      |
+| `subscriptions.spec.ts`      | List, Add modal, card action tap targets; add/delete gated on DESTRUCTIVE |
+| `complaints.spec.ts`         | New dispute chooser shows both entry points; scratch form fields mount    |
+| `profile.spec.ts`            | Profile info visible; Connect Email modal opens + close target is 44×44   |
+| `mobile.spec.ts`             | No horizontal scroll on any route at 430px; deal dismiss visible on touch |
+
+## Safety
+
+- **Destructive tests are opt-in.** `DESTRUCTIVE=1 npm run test:e2e` is required to run the add-then-delete subscription flow. Running `test:e2e:prod` without that flag is read-only.
+- **Credentials stay local.** `.env.e2e` is gitignored. Never commit real passwords.
+- **No OAuth driving.** Google OAuth in tests would require real interstitials; we only assert the buttons exist and are tappable.
+
+## Updating when UI changes
+
+Most specs use accessible-name locators (`getByRole`, `getByLabel`) so they're stable across copy tweaks. If a test breaks after a UI change, first check whether the test's accessibility assumption still holds — missing `aria-label`s are often the real issue, not the test.

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, loginViaForm, hasCreds } from './fixtures/auth';
+import { test, expect, loginViaForm, hasCreds, dismissCookieBanner } from './fixtures/auth';
 
 /**
  * Auth UAT — login flow, invalid creds, session persistence.
@@ -10,7 +10,7 @@ test.describe('Auth', () => {
     await page.goto('/auth/login');
     await expect(page.getByRole('heading', { name: /log in|sign in|welcome/i })).toBeVisible();
     await expect(page.getByLabel(/email/i).first()).toBeVisible();
-    await expect(page.getByLabel(/password/i).first()).toBeVisible();
+    await expect(page.locator('input#password')).toBeVisible();
     await expect(page.getByRole('button', { name: /log in|sign in/i })).toBeVisible();
     // "Forgot password" link should exist and be reachable
     await expect(page.getByRole('link', { name: /forgot/i })).toBeVisible();
@@ -31,9 +31,12 @@ test.describe('Auth', () => {
 
   test('invalid credentials show an error', async ({ page }) => {
     await page.goto('/auth/login');
-    await page.getByLabel(/email/i).first().fill('invalid-e2e@example.com');
-    await page.getByLabel(/password/i).first().fill('wrong-password-12345');
-    await page.getByRole('button', { name: /log in|sign in/i }).click();
+    // Wait for form to be fully mounted
+    await page.locator('input#email').waitFor({ state: 'visible' });
+    await page.locator('input#email').fill('invalid-e2e@example.com');
+    await page.locator('input#password').fill('wrong-password-12345');
+    // Submit via Enter on password field (avoids cookie-banner click-intercept at bottom)
+    await page.locator('input#password').press('Enter');
     // Expect an error message; wording is permissive since it might be
     // "Invalid credentials" or "Email or password is incorrect"
     await expect(
@@ -43,8 +46,8 @@ test.describe('Auth', () => {
     await expect(page).toHaveURL(/\/auth\/login/);
   });
 
-  test.skip(!hasCreds, 'E2E creds not set');
   test('valid credentials authenticate and land on dashboard or gate', async ({ page }) => {
+    test.skip(!hasCreds, 'E2E_EMAIL / E2E_PASSWORD not set in .env.e2e');
     await loginViaForm(page);
     const url = new URL(page.url());
     expect(

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, loginViaForm, hasCreds } from './fixtures/auth';
+
+/**
+ * Auth UAT — login flow, invalid creds, session persistence.
+ * Read-only. Doesn't touch OAuth (would require real Google interaction).
+ */
+
+test.describe('Auth', () => {
+  test('login page loads with all required fields', async ({ page }) => {
+    await page.goto('/auth/login');
+    await expect(page.getByRole('heading', { name: /log in|sign in|welcome/i })).toBeVisible();
+    await expect(page.getByLabel(/email/i).first()).toBeVisible();
+    await expect(page.getByLabel(/password/i).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /log in|sign in/i })).toBeVisible();
+    // "Forgot password" link should exist and be reachable
+    await expect(page.getByRole('link', { name: /forgot/i })).toBeVisible();
+    // OAuth button present
+    await expect(page.getByRole('button', { name: /google/i })).toBeVisible();
+  });
+
+  test('signup page loads with consent checkboxes', async ({ page }) => {
+    await page.goto('/auth/signup');
+    await expect(page.getByRole('heading', { name: /sign up|create|join/i })).toBeVisible();
+    // Terms + privacy consent checkbox is mandatory
+    const consentCheckbox = page.getByRole('checkbox').first();
+    await expect(consentCheckbox).toBeVisible();
+    // Must NOT be able to submit without checking it
+    const submit = page.getByRole('button', { name: /sign up|create account/i });
+    await expect(submit).toBeDisabled();
+  });
+
+  test('invalid credentials show an error', async ({ page }) => {
+    await page.goto('/auth/login');
+    await page.getByLabel(/email/i).first().fill('invalid-e2e@example.com');
+    await page.getByLabel(/password/i).first().fill('wrong-password-12345');
+    await page.getByRole('button', { name: /log in|sign in/i }).click();
+    // Expect an error message; wording is permissive since it might be
+    // "Invalid credentials" or "Email or password is incorrect"
+    await expect(
+      page.getByText(/invalid|incorrect|wrong|not found/i).first(),
+    ).toBeVisible({ timeout: 10_000 });
+    // Must stay on login page
+    await expect(page).toHaveURL(/\/auth\/login/);
+  });
+
+  test.skip(!hasCreds, 'E2E creds not set');
+  test('valid credentials authenticate and land on dashboard or gate', async ({ page }) => {
+    await loginViaForm(page);
+    const url = new URL(page.url());
+    expect(
+      ['/dashboard', '/onboarding', '/auth/accept-terms'].some((prefix) =>
+        url.pathname.startsWith(prefix),
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/e2e/complaints.spec.ts
+++ b/e2e/complaints.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect, hasCreds } from './fixtures/auth';
+
+test.describe('Complaints / Disputes', () => {
+  test.skip(!hasCreds, 'E2E creds not set');
+  test.beforeEach(async ({ loggedInPage }) => {
+    await loggedInPage.goto('/dashboard/complaints');
+    await expect(
+      loggedInPage.getByRole('heading', { name: /complaints|disputes/i }).first(),
+    ).toBeVisible();
+  });
+
+  test('NewDisputeChooser opens with both "from email" and "from scratch" options', async ({
+    loggedInPage,
+  }) => {
+    const newBtn = loggedInPage
+      .getByRole('button', { name: /new dispute|start a new dispute|\+ new|new complaint/i })
+      .first();
+    if (!(await newBtn.isVisible().catch(() => false))) {
+      test.skip(true, 'New dispute CTA not visible on this surface');
+    }
+    await newBtn.click();
+
+    await expect(loggedInPage.getByRole('heading', { name: /start a new dispute/i })).toBeVisible();
+    await expect(loggedInPage.getByText(/from an email in my inbox/i)).toBeVisible();
+    await expect(loggedInPage.getByText(/from scratch/i)).toBeVisible();
+
+    // Close button is the upgraded 44×44 (post-#290)
+    const close = loggedInPage.getByRole('button', { name: /close/i }).first();
+    const box = await close.boundingBox();
+    expect(box?.width).toBeGreaterThanOrEqual(40);
+    await close.click();
+    await expect(loggedInPage.getByRole('heading', { name: /start a new dispute/i })).not.toBeVisible();
+  });
+
+  test('From-scratch form loads required fields', async ({ loggedInPage }) => {
+    const newBtn = loggedInPage
+      .getByRole('button', { name: /new dispute|start a new dispute|\+ new|new complaint/i })
+      .first();
+    if (!(await newBtn.isVisible().catch(() => false))) test.skip(true, 'CTA missing');
+    await newBtn.click();
+
+    // Choose "from scratch" path
+    const fromScratch = loggedInPage.getByText(/from scratch/i);
+    if (await fromScratch.isVisible().catch(() => false)) {
+      await fromScratch.click();
+    }
+
+    // At least a company + issue + outcome field should be visible
+    const hasCompany = await loggedInPage.getByLabel(/company|provider|business/i).first().isVisible().catch(() => false);
+    const hasIssue = await loggedInPage.getByLabel(/issue|what happened|describe/i).first().isVisible().catch(() => false);
+    expect(hasCompany || hasIssue).toBeTruthy();
+  });
+});

--- a/e2e/dashboard-routes.spec.ts
+++ b/e2e/dashboard-routes.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, hasCreds } from './fixtures/auth';
+
+/**
+ * Smoke sweep: every authenticated dashboard route should render without
+ * a Next.js error boundary and without 4xx/5xx responses. This is the
+ * "does it boot" test — deeper behaviour lives in per-feature specs.
+ */
+
+const DASHBOARD_ROUTES = [
+  '/dashboard',
+  '/dashboard/money-hub',
+  '/dashboard/subscriptions',
+  '/dashboard/complaints',
+  '/dashboard/contracts',
+  '/dashboard/contract-vault',
+  '/dashboard/deals',
+  '/dashboard/spending',
+  '/dashboard/rewards',
+  '/dashboard/pocket-agent',
+  '/dashboard/notifications',
+  '/dashboard/profile',
+  '/dashboard/settings',
+  '/dashboard/settings/spaces',
+  '/dashboard/settings/notifications',
+  '/dashboard/settings/telegram',
+  '/dashboard/forms',
+  '/dashboard/export',
+  '/dashboard/tutorials',
+  '/dashboard/upgrade',
+] as const;
+
+test.describe('Dashboard route smoke', () => {
+  test.skip(!hasCreds, 'E2E creds not set');
+
+  test.beforeEach(async ({ loggedInPage }) => {
+    // warm session via fixture
+    void loggedInPage;
+  });
+
+  for (const route of DASHBOARD_ROUTES) {
+    test(`${route} renders without crash`, async ({ loggedInPage }) => {
+      const errors: string[] = [];
+      loggedInPage.on('pageerror', (err) => errors.push(err.message));
+      loggedInPage.on('response', (res) => {
+        if (res.status() >= 500 && new URL(res.url()).pathname === route) {
+          errors.push(`${route} → ${res.status()}`);
+        }
+      });
+
+      const response = await loggedInPage.goto(route);
+      // Either 2xx (render) or 3xx (intentional redirect — e.g. /disputes → /complaints)
+      expect(response?.status(), `${route} HTTP status`).toBeLessThan(400);
+
+      // Next.js error overlay usually mounts a role="dialog" with "Application error"
+      await expect(
+        loggedInPage.getByText(/application error|unhandled runtime error/i),
+      ).not.toBeVisible();
+
+      expect(errors, `${route} runtime errors`).toEqual([]);
+    });
+  }
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -18,6 +18,24 @@ export const E2E_PASSWORD = process.env.E2E_PASSWORD || '';
 
 export const hasCreds = Boolean(E2E_EMAIL && E2E_PASSWORD);
 
+/**
+ * The cookie consent banner (`CookieConsentBanner.tsx`) is `fixed bottom-0
+ * inset-x-0 z-[9999]` — at typical viewport heights it covers the bottom of
+ * the auth forms, including the submit button. Dismiss it up-front so tests
+ * can interact with the form below. This is also a real UX issue (see
+ * `_handoff/UX_AUDIT.md` § auth banner blocks submit).
+ */
+export const dismissCookieBanner = async (page: Page) => {
+  const banner = page.locator('.fixed.bottom-0.inset-x-0').first();
+  if (await banner.isVisible().catch(() => false)) {
+    const accept = page.getByRole('button', { name: /accept|ok|got it|continue/i }).first();
+    if (await accept.isVisible().catch(() => false)) {
+      await accept.click().catch(() => {});
+      await banner.waitFor({ state: 'hidden', timeout: 2_000 }).catch(() => {});
+    }
+  }
+};
+
 export const loginViaForm = async (page: Page) => {
   if (!hasCreds) {
     throw new Error(
@@ -25,8 +43,9 @@ export const loginViaForm = async (page: Page) => {
     );
   }
   await page.goto('/auth/login');
+  await dismissCookieBanner(page);
   await page.getByLabel(/email/i).first().fill(E2E_EMAIL);
-  await page.getByLabel(/password/i).first().fill(E2E_PASSWORD);
+  await page.locator('input#password').fill(E2E_PASSWORD);
   await page.getByRole('button', { name: /log in|sign in/i }).click();
   // Settle on either dashboard or the terms gate, depending on account state.
   await page.waitForURL(

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,48 @@
+import { test as base, expect, Page } from '@playwright/test';
+
+/**
+ * Auth fixture. Logs in via email+password on /auth/login and hands the
+ * authenticated Page to the test. Session state is persisted per worker to
+ * a shared storage-state file so follow-up tests don't re-login every time.
+ *
+ * Credentials come from .env.e2e (E2E_EMAIL / E2E_PASSWORD). Tests that
+ * require auth will fail fast with a clear message if those aren't set.
+ */
+
+type Fixtures = {
+  loggedInPage: Page;
+};
+
+export const E2E_EMAIL = process.env.E2E_EMAIL || '';
+export const E2E_PASSWORD = process.env.E2E_PASSWORD || '';
+
+export const hasCreds = Boolean(E2E_EMAIL && E2E_PASSWORD);
+
+export const loginViaForm = async (page: Page) => {
+  if (!hasCreds) {
+    throw new Error(
+      'E2E_EMAIL / E2E_PASSWORD not set in .env.e2e — cannot run authenticated tests.',
+    );
+  }
+  await page.goto('/auth/login');
+  await page.getByLabel(/email/i).first().fill(E2E_EMAIL);
+  await page.getByLabel(/password/i).first().fill(E2E_PASSWORD);
+  await page.getByRole('button', { name: /log in|sign in/i }).click();
+  // Settle on either dashboard or the terms gate, depending on account state.
+  await page.waitForURL(
+    (url) =>
+      url.pathname.startsWith('/dashboard') ||
+      url.pathname.startsWith('/onboarding') ||
+      url.pathname.startsWith('/auth/accept-terms'),
+    { timeout: 20_000 },
+  );
+};
+
+export const test = base.extend<Fixtures>({
+  loggedInPage: async ({ page }, use) => {
+    await loginViaForm(page);
+    await use(page);
+  },
+});
+
+export { expect };

--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, hasCreds } from './fixtures/auth';
+
+/**
+ * Mobile-specific regression suite — runs under the iphone-17-pro-max project.
+ * The acceptance criterion from PRs #288/#290/#294/#296: no route causes
+ * horizontal scroll and no fixed-width element exceeds the viewport width.
+ *
+ * Destructive mutations stay in subscriptions.spec.ts behind DESTRUCTIVE=1.
+ */
+
+test.describe('Mobile viewport regressions (430px)', () => {
+  test.skip(!hasCreds, 'E2E creds not set');
+
+  test.beforeEach(({}, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'iphone-17-pro-max',
+      'Mobile regressions only run under the iphone-17-pro-max project',
+    );
+  });
+  const MOBILE_ROUTES = [
+    '/dashboard',
+    '/dashboard/money-hub',
+    '/dashboard/subscriptions',
+    '/dashboard/complaints',
+    '/dashboard/profile',
+    '/dashboard/settings',
+    '/dashboard/deals',
+    '/dashboard/contracts',
+  ];
+
+  for (const route of MOBILE_ROUTES) {
+    test(`${route} has no horizontal scroll`, async ({ loggedInPage }) => {
+      await loggedInPage.goto(route);
+      // Wait for at least one main heading to guarantee the page laid out
+      await loggedInPage.waitForLoadState('networkidle');
+
+      const overflow = await loggedInPage.evaluate(() => {
+        const body = document.body;
+        const html = document.documentElement;
+        return {
+          scrollWidth: Math.max(body.scrollWidth, html.scrollWidth),
+          clientWidth: Math.max(body.clientWidth, html.clientWidth),
+        };
+      });
+
+      expect(overflow.scrollWidth, `${route} horizontal scroll`).toBeLessThanOrEqual(
+        overflow.clientWidth + 1, // subpixel tolerance
+      );
+    });
+  }
+
+  test('pricing page comparison table scrolls horizontally at 430px', async ({ loggedInPage }) => {
+    await loggedInPage.goto('/pricing');
+    await loggedInPage.waitForLoadState('networkidle');
+
+    // The table wrapper should be overflow-x:auto with rows ≥ 540px (from #299).
+    const wrapper = loggedInPage.locator('.compare-table-wrap').first();
+    if (await wrapper.isVisible().catch(() => false)) {
+      const overflow = await wrapper.evaluate(
+        (el) => el.scrollWidth > el.clientWidth + 1,
+      );
+      expect(overflow).toBeTruthy();
+    }
+
+    // Outer body must NOT horizontally scroll
+    const bodyOverflow = await loggedInPage.evaluate(() => {
+      const html = document.documentElement;
+      return html.scrollWidth - html.clientWidth;
+    });
+    expect(bodyOverflow).toBeLessThanOrEqual(1);
+  });
+
+  test('deal card dismiss button is visible on mobile (was opacity-0 group-hover before #294)', async ({
+    loggedInPage,
+  }) => {
+    await loggedInPage.goto('/dashboard/deals');
+    await loggedInPage.waitForLoadState('networkidle');
+    const dismiss = loggedInPage.getByRole('button', { name: /dismiss deal/i }).first();
+    if (!(await dismiss.isVisible().catch(() => false))) {
+      test.skip(true, 'No deals rendered — either no personalised deals yet or user is not on Pro');
+    }
+    // opacity should be effectively 1 on mobile (the #294 fix)
+    const opacity = await dismiss.evaluate((el) => getComputedStyle(el).opacity);
+    expect(parseFloat(opacity)).toBeGreaterThanOrEqual(0.9);
+  });
+});

--- a/e2e/money-hub.spec.ts
+++ b/e2e/money-hub.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect, hasCreds } from './fixtures/auth';
+
+test.describe('Money Hub', () => {
+  test.skip(!hasCreds, 'E2E creds not set');
+  test.beforeEach(async ({ loggedInPage }) => {
+    await loggedInPage.goto('/dashboard/money-hub');
+    await expect(loggedInPage.getByRole('heading', { name: /money hub/i })).toBeVisible();
+  });
+
+  test('tabs / panels render core regions', async ({ loggedInPage }) => {
+    // Overview, Spending, Contracts, Net Worth — these are the primary panels.
+    const overviewText = loggedInPage.getByText(/income|spending|net worth/i).first();
+    await expect(overviewText).toBeVisible();
+  });
+
+  test('month nav buttons are reachable tap targets', async ({ loggedInPage }) => {
+    const prev = loggedInPage.getByRole('button', { name: /previous month/i });
+    const next = loggedInPage.getByRole('button', { name: /next month/i });
+    await expect(prev).toBeVisible();
+    await expect(next).toBeVisible();
+
+    // 44px guideline for primary close / nav; we use 40×40 on inline row actions.
+    const prevBox = await prev.boundingBox();
+    expect(prevBox?.width).toBeGreaterThanOrEqual(36);
+    expect(prevBox?.height).toBeGreaterThanOrEqual(36);
+  });
+
+  test('Category drill-down modal opens and closes cleanly', async ({ loggedInPage }) => {
+    // Click any category row that has tap-feedback (we added active:bg-slate-200
+    // on both income + spending rows in #288/#296). Pick by class instead of
+    // content — any drill row has `cursor-pointer` with a percentage label.
+    const anyRow = loggedInPage.locator('[class*="cursor-pointer"]').filter({
+      hasText: /%/,
+    }).first();
+    if (!(await anyRow.isVisible().catch(() => false))) {
+      test.skip(true, 'No income/spending rows available on this account yet');
+    }
+
+    await anyRow.click();
+    const modal = loggedInPage.getByRole('heading').filter({ hasText: /transaction|search/i }).first();
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+
+    // Close button should be 44×44 (the #288 fix) with aria-label="Close"
+    const close = loggedInPage.getByRole('button', { name: /close/i }).first();
+    const box = await close.boundingBox();
+    expect(box?.width).toBeGreaterThanOrEqual(40);
+    expect(box?.height).toBeGreaterThanOrEqual(40);
+
+    await close.click();
+    await expect(modal).not.toBeVisible();
+  });
+
+  test('Net Worth Pro section either shows data or a clear upgrade CTA', async ({
+    loggedInPage,
+  }) => {
+    const netWorth = loggedInPage.getByRole('heading', { name: /net worth/i });
+    await expect(netWorth).toBeVisible();
+
+    // Exactly one of these three must be true: shows data, shows "upgrade"
+    // lock, or shows the empty-state CTA from #288.
+    const hasData = await loggedInPage.getByText(/£[0-9]/).first().isVisible().catch(() => false);
+    const hasUpgrade = await loggedInPage
+      .getByRole('link', { name: /view plans/i })
+      .first()
+      .isVisible()
+      .catch(() => false);
+    const hasEmptyCta = await loggedInPage
+      .getByRole('button', { name: /add your first entry/i })
+      .first()
+      .isVisible()
+      .catch(() => false);
+    expect(hasData || hasUpgrade || hasEmptyCta).toBeTruthy();
+  });
+});

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect, hasCreds } from './fixtures/auth';
+
+test.describe('Profile', () => {
+  test.skip(!hasCreds, 'E2E creds not set');
+  test('profile page renders and shows member-since / subscription info', async ({ loggedInPage }) => {
+    await loggedInPage.goto('/dashboard/profile');
+    await expect(loggedInPage.getByRole('heading', { name: /profile|account/i }).first()).toBeVisible();
+    await expect(loggedInPage.getByText(/member since/i)).toBeVisible();
+    await expect(loggedInPage.getByText(/subscription status/i)).toBeVisible();
+  });
+
+  test('Connect Email modal opens + close button is 44×44', async ({ loggedInPage }) => {
+    await loggedInPage.goto('/dashboard/profile');
+    const connectBtn = loggedInPage.getByRole('button', { name: /connect email|add email/i }).first();
+    if (!(await connectBtn.isVisible().catch(() => false))) {
+      test.skip(true, 'Connect Email CTA not visible — probably already at plan limit');
+    }
+    await connectBtn.click();
+    await expect(loggedInPage.getByRole('heading', { name: /connect email/i })).toBeVisible();
+
+    // Four OAuth provider cards (Gmail/Outlook/Yahoo/iCloud/IMAP) should be tappable
+    const providerButtons = await loggedInPage.getByRole('button', { name: /gmail|outlook|yahoo|icloud|imap/i }).all();
+    expect(providerButtons.length).toBeGreaterThanOrEqual(2);
+
+    // Close button enlarged in #294
+    const close = loggedInPage.getByRole('button', { name: /close/i }).first();
+    const box = await close.boundingBox();
+    expect(box?.width).toBeGreaterThanOrEqual(40);
+    expect(box?.height).toBeGreaterThanOrEqual(40);
+    await close.click();
+  });
+});

--- a/e2e/subscriptions.spec.ts
+++ b/e2e/subscriptions.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, hasCreds } from './fixtures/auth';
+
+const DESTRUCTIVE = process.env.DESTRUCTIVE === '1';
+
+test.describe('Subscriptions', () => {
+  test.skip(!hasCreds, 'E2E creds not set');
+  test.beforeEach(async ({ loggedInPage }) => {
+    await loggedInPage.goto('/dashboard/subscriptions');
+    await expect(loggedInPage.getByRole('heading', { name: /subscriptions/i })).toBeVisible();
+  });
+
+  test('list renders either subscriptions or the empty-state CTA', async ({ loggedInPage }) => {
+    const hasSubs = await loggedInPage.locator('[data-needs-review], article, .sub-card').first().isVisible().catch(() => false);
+    const hasEmpty = await loggedInPage.getByText(/no subscriptions/i).first().isVisible().catch(() => false);
+    expect(hasSubs || hasEmpty).toBeTruthy();
+  });
+
+  test('Add subscription modal opens + closes without mutations', async ({ loggedInPage }) => {
+    const addBtn = loggedInPage.getByRole('button', { name: /add|new subscription|\+ add/i }).first();
+    if (!(await addBtn.isVisible().catch(() => false))) {
+      test.skip(true, 'Add button not visible on this account');
+    }
+    await addBtn.click();
+
+    // Modal should mount — heading or Amount field indicates the form is there.
+    await expect(loggedInPage.getByLabel(/amount/i).first()).toBeVisible();
+
+    // Close via the header X (44×44 after #290)
+    const close = loggedInPage.getByRole('button', { name: /close/i }).first();
+    const box = await close.boundingBox();
+    expect(box?.width).toBeGreaterThanOrEqual(40);
+    await close.click();
+  });
+
+  test('subscription card action icons are ≥36px tap targets', async ({ loggedInPage }) => {
+    const anyEditBtn = loggedInPage.getByRole('button', { name: /^edit$/i }).first();
+    if (!(await anyEditBtn.isVisible().catch(() => false))) {
+      test.skip(true, 'No subscription cards to exercise action buttons on');
+    }
+    const box = await anyEditBtn.boundingBox();
+    expect(box?.width).toBeGreaterThanOrEqual(36);
+    expect(box?.height).toBeGreaterThanOrEqual(36);
+  });
+
+  test.describe('Destructive', () => {
+    test.skip(!DESTRUCTIVE, 'DESTRUCTIVE=1 not set — skipping mutation tests');
+
+    test('can add then delete a throwaway subscription', async ({ loggedInPage }) => {
+      const unique = `E2E-${Date.now()}`;
+      const addBtn = loggedInPage.getByRole('button', { name: /add|new subscription|\+ add/i }).first();
+      await addBtn.click();
+
+      await loggedInPage.getByLabel(/provider|name/i).first().fill(unique);
+      await loggedInPage.getByLabel(/amount/i).first().fill('1.00');
+      await loggedInPage.getByRole('button', { name: /save|add/i }).last().click();
+
+      await expect(loggedInPage.getByText(unique)).toBeVisible({ timeout: 10_000 });
+
+      // Delete — locate the card then its Delete icon
+      const card = loggedInPage.getByText(unique).locator('xpath=ancestor::*[contains(@class,"rounded-2xl")][1]');
+      await card.getByRole('button', { name: /^delete$/i }).click();
+
+      // Confirm dialog, if present
+      const confirm = loggedInPage.getByRole('button', { name: /confirm|yes|delete/i }).last();
+      if (await confirm.isVisible().catch(() => false)) {
+        await confirm.click();
+      }
+
+      await expect(loggedInPage.getByText(unique)).not.toBeVisible({ timeout: 10_000 });
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,11 +40,13 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.0",
         "tailwindcss": "^4",
@@ -2383,6 +2385,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@posthog/core": {
@@ -5794,9 +5812,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -7435,6 +7453,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/fstream": {
       "version": "1.0.12",
@@ -10984,6 +11016,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,14 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:mobile": "playwright test --project=iphone-17-pro-max",
+    "test:e2e:desktop": "playwright test --project=desktop-chromium",
+    "test:e2e:prod": "BASE_URL=https://paybacker.co.uk playwright test",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
@@ -41,11 +48,13 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.0",
     "tailwindcss": "^4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,64 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+
+/**
+ * Paybacker E2E UAT suite.
+ *
+ * Defaults to a local dev server on :3000 — set BASE_URL to a deployed URL
+ * (e.g. https://paybacker.co.uk) for smoke-testing production. Credentials
+ * come from .env.e2e (see .env.e2e.example); never commit them.
+ *
+ * Destructive mutations (creating disputes, deleting subscriptions) are gated
+ * behind DESTRUCTIVE=1 so a bare `npm run test:e2e` against prod can't delete
+ * real data.
+ */
+
+require('dotenv').config({ path: path.resolve(__dirname, '.env.e2e') });
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const IS_PROD = /paybacker\.co\.uk/i.test(BASE_URL);
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+  },
+
+  projects: [
+    {
+      name: 'desktop-chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'iphone-17-pro-max',
+      use: {
+        ...devices['iPhone 14 Pro Max'],
+        viewport: { width: 430, height: 932 },
+      },
+    },
+  ],
+
+  // Only boot the dev server when running against localhost. Skip if BASE_URL
+  // points at a deployed environment — we don't want to double-start Next.
+  webServer: IS_PROD
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: BASE_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});


### PR DESCRIPTION
## Summary

Two deliverables in one PR, covering both runtime testing and static code review:

### 1. Playwright E2E UAT Suite (`/e2e`)

92 tests across 7 spec files and 2 projects (`desktop-chromium`, `iphone-17-pro-max @ 430×932`).

- `auth.spec.ts` — login + signup page shape, invalid creds, successful login
- `dashboard-routes.spec.ts` — all 20 authenticated routes load without runtime errors or 5xx
- `money-hub.spec.ts` — tabs, month nav tap target sizes, drill-down modal, Net Worth states (Free/Pro/empty)
- `subscriptions.spec.ts` — list + Add modal; card action tap targets; add/delete gated on `DESTRUCTIVE=1`
- `complaints.spec.ts` — NewDisputeChooser (both entry points), from-scratch form fields
- `profile.spec.ts` — Connect Email modal opens, 44×44 close, provider cards
- `mobile.spec.ts` — no horizontal scroll on 8 routes; pricing comparison table scrolls; deal-dismiss visibility regression guard (the #294 fix)

Usage:

```bash
cp .env.e2e.example .env.e2e   # fill in E2E_EMAIL / E2E_PASSWORD
npm run test:e2e               # local, auto-boots dev server
npm run test:e2e:prod          # against https://paybacker.co.uk, read-only
npm run test:e2e:mobile        # only the iPhone project
npm run test:e2e:ui            # Playwright UI runner
```

Credentials stay local (`.env.e2e` is gitignored). Destructive tests opt-in via `DESTRUCTIVE=1` so production smoke runs can never delete real data.

### 2. UX Audit (`_handoff/UX_AUDIT.md`)

Full code-level audit: 11 HIGH, ~40 MED, ~15 LOW findings organised by route. Categories: accessibility, error states, loading states, empty states, form validation, copy, interaction feedback, navigation, information architecture.

Top of the doc surfaces **7 global patterns** that recur everywhere — tackling those is the highest-leverage first sprint:

1. No global error boundary (Next.js `error.tsx` missing)
2. Skeleton loaders inconsistent (Money Hub / Subs / Complaints all show FOUC)
3. Submit buttons don't disable during mutation (double-submit risk)
4. Generic error copy ("Something went wrong") with no actionable next step
5. No skip-to-main-content link
6. Icon-only buttons still missing `aria-label` in some surfaces (rewards/tutorials/export untouched by recent mobile passes)
7. Color-only status indication (complaints, subs, deals)

Closes with a recommended fix order and ties every finding back to already-shipped PRs so the next sprint doesn't duplicate work.

## Test plan
- [ ] `npm run test:e2e -- --list` lists 92 tests
- [ ] Set `.env.e2e` with test account, `npm run test:e2e:headed` runs auth + dashboard-routes green on localhost
- [ ] `npm run test:e2e:mobile` — iPhone project runs, no-horizontal-scroll tests pass
- [ ] Open `_handoff/UX_AUDIT.md` in a markdown preview; all routes covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)