### PR TITLE
fix(codex): #300/#302/#313 follow-ups + cancellation issue_type CHECK

### DIFF
--- a/src/app/api/admin/cancel-info/route.ts
+++ b/src/app/api/admin/cancel-info/route.ts
@@ -48,6 +48,13 @@ export async function GET(request: NextRequest) {
 
   if (infoRes.error) return NextResponse.json({ error: infoRes.error.message }, { status: 500 });
 
+  // Codex P2 #300: a failed subscriptions lookup would silently
+  // produce an empty `uncovered` list, which renders as "good news,
+  // every provider is covered" — misleading. Fall through with
+  // uncovered=null + the error message so the UI can distinguish
+  // "actually empty" from "couldn't compute".
+  const subsLookupError = subsRes.error?.message ?? null;
+
   const rows = infoRes.data ?? [];
 
   // Quick freshness buckets for the UI header.
@@ -110,7 +117,12 @@ export async function GET(request: NextRequest) {
     .sort((a, b) => b.user_count - a.user_count)
     .slice(0, 50);
 
-  return NextResponse.json({ rows, stats, uncovered });
+  return NextResponse.json({
+    rows,
+    stats,
+    uncovered: subsLookupError ? null : uncovered,
+    uncovered_error: subsLookupError,
+  });
 }
 
 export async function PATCH(request: NextRequest) {

--- a/src/app/api/disputes/[id]/route.ts
+++ b/src/app/api/disputes/[id]/route.ts
@@ -209,24 +209,22 @@ export async function PATCH(
         console.error('Failed to resolve dispute:', error);
         return NextResponse.json({ error: 'Failed to resolve dispute' }, { status: 500 });
       }
-      // Same subscription auto-cancel as the RPC path — see the
-      // comment further down. Duplicated here because this branch
-      // fires when resolve_dispute isn't available; the fix should
-      // still land on the subscription either way.
-      if (body.outcome === 'won' && data?.provider_name) {
-        try {
-          await supabase
-            .from('subscriptions')
-            .update({
-              status: 'cancelled',
-              cancelled_at: new Date().toISOString(),
-              notes: `Auto-cancelled on dispute resolution (${id.slice(0, 8)})`,
-            })
-            .eq('user_id', user.id)
-            .eq('status', 'pending_cancellation')
-            .ilike('provider_name', data.provider_name);
-        } catch (err) {
-          console.error('[disputes.resolve.fallback] subscription auto-cancel failed:', err);
+      // Same subscription auto-cancel as the RPC path — same guards:
+      // outcome='won' AND issue_type='cancellation'. See the longer
+      // comment below for rationale.
+      if (body.outcome === 'won' && data?.provider_name && data?.issue_type === 'cancellation') {
+        const { error: cancelErr } = await supabase
+          .from('subscriptions')
+          .update({
+            status: 'cancelled',
+            cancelled_at: new Date().toISOString(),
+            notes: `Auto-cancelled on dispute resolution (${id.slice(0, 8)})`,
+          })
+          .eq('user_id', user.id)
+          .eq('status', 'pending_cancellation')
+          .ilike('provider_name', data.provider_name);
+        if (cancelErr) {
+          console.error('[disputes.resolve.fallback] subscription auto-cancel failed:', cancelErr.message);
         }
       }
       return NextResponse.json(data);
@@ -240,37 +238,40 @@ export async function PATCH(
       .eq('user_id', user.id)
       .single();
 
-    // Close the cancellation loop. When a dispute started from a
-    // subscription cancellation resolves as "won", the matching
-    // subscription is still sitting at pending_cancellation because
-    // nothing else progresses it. Flip it to cancelled + stamp
+    // Close the cancellation loop. When a dispute that was opened
+    // specifically to cancel a subscription resolves as "won", the
+    // matching subscription is still sitting at pending_cancellation
+    // because nothing else progresses it. Flip it to cancelled + stamp
     // cancelled_at so Money Hub, subscription counts and the
     // Subscriptions UI all catch up without the user having to mark
     // two things manually.
     //
-    // Only fires on outcome='won' — 'partial' could be a reduced-
-    // rate deal the user kept, 'lost' means the cancellation was
-    // refused, 'withdrawn' means the user cancelled the dispute.
-    // Only 'won' = provider confirmed cancellation.
-    if (body.outcome === 'won' && resolved?.provider_name) {
-      try {
-        const { data: matched } = await supabase
-          .from('subscriptions')
-          .update({
-            status: 'cancelled',
-            cancelled_at: new Date().toISOString(),
-            notes: `Auto-cancelled on dispute resolution (${id.slice(0, 8)})`,
-          })
-          .eq('user_id', user.id)
-          .eq('status', 'pending_cancellation')
-          .ilike('provider_name', resolved.provider_name)
-          .select('id, provider_name');
-        if (matched && matched.length > 0) {
-          console.log(`[disputes.resolve] auto-cancelled ${matched.length} subscription(s) for ${resolved.provider_name}`);
-        }
-      } catch (err) {
-        // Non-fatal — dispute is resolved, this is a convenience.
-        console.error('[disputes.resolve] subscription auto-cancel failed:', err);
+    // GUARDS:
+    //  - outcome must be 'won' — 'partial' = reduced-rate deal kept,
+    //    'lost' = cancellation refused, 'withdrawn' = user backed out.
+    //  - dispute issue_type must be 'cancellation' — Codex P1: a 'won'
+    //    energy/refund dispute against the same provider as an active
+    //    subscription must NOT auto-cancel that subscription. Only
+    //    cancellation-flow disputes signal cancel intent.
+    if (body.outcome === 'won' && resolved?.provider_name && resolved?.issue_type === 'cancellation') {
+      const { data: matched, error: cancelErr } = await supabase
+        .from('subscriptions')
+        .update({
+          status: 'cancelled',
+          cancelled_at: new Date().toISOString(),
+          notes: `Auto-cancelled on dispute resolution (${id.slice(0, 8)})`,
+        })
+        .eq('user_id', user.id)
+        .eq('status', 'pending_cancellation')
+        .ilike('provider_name', resolved.provider_name)
+        .select('id, provider_name');
+      if (cancelErr) {
+        // Codex P2 — surface the error rather than just throwing past
+        // it. Still non-fatal so the dispute resolution response
+        // returns OK; admins can see the failure in the logs.
+        console.error('[disputes.resolve] subscription auto-cancel failed:', cancelErr.message);
+      } else if (matched && matched.length > 0) {
+        console.log(`[disputes.resolve] auto-cancelled ${matched.length} subscription(s) for ${resolved.provider_name}`);
       }
     }
 

--- a/src/app/dashboard/admin/cancel-info/page.tsx
+++ b/src/app/dashboard/admin/cancel-info/page.tsx
@@ -66,6 +66,7 @@ export default function AdminCancelInfoPage() {
   const [rows, setRows] = useState<Row[]>([]);
   const [stats, setStats] = useState<Stats | null>(null);
   const [uncovered, setUncovered] = useState<UncoveredRow[]>([]);
+  const [uncoveredError, setUncoveredError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [query, setQuery] = useState('');
@@ -90,6 +91,7 @@ export default function AdminCancelInfoPage() {
       setRows(data.rows ?? []);
       setStats(data.stats ?? null);
       setUncovered(data.uncovered ?? []);
+      setUncoveredError(data.uncovered_error ?? null);
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Failed to load');
     } finally {
@@ -382,7 +384,12 @@ export default function AdminCancelInfoPage() {
           Monday discovery cron processes up to 5 of these per run, so
           this list is a preview of what it'll pick up next + an
           indication of the highest-impact gaps by user count. */}
-      {uncovered.length > 0 && (
+      {uncoveredError && (
+        <div className="mt-8 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-700">
+          Couldn&apos;t compute the uncovered-providers preview — {uncoveredError}. The seeded coverage table above is unaffected.
+        </div>
+      )}
+      {!uncoveredError && uncovered.length > 0 && (
         <div className="mt-8">
           <div className="flex items-baseline justify-between mb-3">
             <h2 className="text-lg font-semibold text-slate-900">Providers seen but not covered</h2>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -218,8 +218,14 @@ export default function DashboardPage() {
             // Only allow one refresh per 6 hours unless the cache is
             // genuinely empty.
             const REFRESH_COOLDOWN_MS = 6 * 60 * 60 * 1000;
+            // Scope the cooldown key to the current user — Codex P2 #313:
+            // shared devices (family laptop, internet cafe) shouldn't
+            // inherit a previous user's "we just refreshed" timer and
+            // skip the new user's first-load fetch.
+            const { data: { user: userForKey } } = await supabase.auth.getUser();
+            const cooldownKey = `pb_compare_last_refresh_${userForKey?.id ?? 'anon'}`;
             let lastRefreshAt = 0;
-            try { lastRefreshAt = Number(localStorage.getItem('pb_compare_last_refresh') || '0'); } catch { /* private mode */ }
+            try { lastRefreshAt = Number(localStorage.getItem(cooldownKey) || '0'); } catch { /* private mode */ }
             const cooldownActive = Date.now() - lastRefreshAt < REFRESH_COOLDOWN_MS;
             const cacheEmpty = compared === 0 || filteredCount === 0;
             const shouldRefresh = cacheEmpty || (
@@ -238,7 +244,7 @@ export default function DashboardPage() {
               setComparisonDeals(dealsList);
               const r = await fetch('/api/subscriptions/compare', { method: 'POST' });
               if (r.ok) {
-                try { localStorage.setItem('pb_compare_last_refresh', String(Date.now())); } catch { /* ignore */ }
+                try { localStorage.setItem(cooldownKey, String(Date.now())); } catch { /* ignore */ }
                 const freshData = await r.json();
                 const { saving: freshSaving, count: freshCount, deals: freshDeals } = parseComparisonDeals(freshData);
                 setComparisonSaving(freshSaving);

--- a/supabase/migrations/20260427010000_disputes_issue_type_cancellation.sql
+++ b/supabase/migrations/20260427010000_disputes_issue_type_cancellation.sql
@@ -1,0 +1,34 @@
+-- Add 'cancellation' to the disputes.issue_type allow-list.
+--
+-- create_dispute_from_subscription RPC defaults p_issue_type to
+-- 'cancellation', and the subscriptions-page cancellation flow calls
+-- it without overriding. The current CHECK constraint forbids
+-- 'cancellation', so every cancellation-flow attempt to create a
+-- dispute silently fails — the letter generates but no dispute row
+-- is written, which means /api/subscriptions/[id]/cancellation-sent
+-- can't link a watchdog row (no dispute to link to) and the auto-
+-- track-reply flow never fires for cancellations.
+--
+-- Additive change: drop and recreate the CHECK with 'cancellation'
+-- added. Existing rows are unaffected because none of them use the
+-- new value yet.
+
+ALTER TABLE public.disputes
+  DROP CONSTRAINT IF EXISTS disputes_issue_type_check;
+
+ALTER TABLE public.disputes
+  ADD CONSTRAINT disputes_issue_type_check
+  CHECK (issue_type = ANY (ARRAY[
+    'complaint',
+    'cancellation',
+    'energy_dispute',
+    'broadband_complaint',
+    'flight_compensation',
+    'parking_appeal',
+    'debt_dispute',
+    'refund_request',
+    'hmrc_tax_rebate',
+    'council_tax_band',
+    'dvla_vehicle',
+    'nhs_complaint'
+  ]));


### PR DESCRIPTION
Bundle of Codex review findings + a critical CHECK-constraint mismatch surfaced while reviewing #302.

## CRITICAL — disputes.issue_type CHECK didn't allow 'cancellation'
\`create_dispute_from_subscription\` RPC defaults to \`'cancellation'\` but the CHECK constraint forbade it. Every cancellation-flow attempt to create a dispute was silently failing the CHECK — letter generated, but no dispute row, which broke the watchdog auto-track-reply chain (#287, #298). Migration 20260427010000 widens the allow-list. Already applied to prod.

## Codex P1 #302 — restrict auto-cancel to cancellation-typed disputes
A "won" energy/refund dispute against the same provider as an active sub used to auto-cancel that sub. Now requires \`issue_type === 'cancellation'\` to fire. Combined with the CHECK fix above, this means auto-cancel only triggers for explicitly-opened cancellation flows.

## Codex P2 #302 — surface auto-cancel errors
Bare try/catch swallowed the Supabase update error. Now destructures \`{ error }\` and logs the message.

## Codex P2 #300 — guard subscriptions query failure on admin cancel-info
A failed sub lookup made the uncovered list render as "good news, all covered" — misleading. Now returns \`uncovered=null + uncovered_error\` and the UI shows a red explanatory banner.

## Codex P2 #313 — scope compare-cooldown by user
Single localStorage key shared across users on a device → second user inherited first user's cooldown. Key is now \`pb_compare_last_refresh_<userId>\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)