### PR TITLE
fix(uat): re-apply bank-health endpoint + mobile tier badge

### DIFF
--- a/src/app/api/connections/health/route.ts
+++ b/src/app/api/connections/health/route.ts
@@ -1,20 +1,28 @@
 /**
  * GET /api/connections/health
  *
- * Returns any of the current user's email connections that need the
- * user's attention. Used by <ConnectionHealthBanner /> on the
- * dashboard layout so silent OAuth expiry or IMAP auth failures
- * surface as a "your sync is paused" callout rather than the
- * Watchdog cron quietly stopping.
+ * Returns any of the current user's email AND bank connections that
+ * need attention. Used by <ConnectionHealthBanner /> on the dashboard
+ * layout so silent OAuth expiry or IMAP / TrueLayer / Yapily consent
+ * expiry surfaces as a "your sync is paused" callout, instead of the
+ * background cron quietly stopping with no UI trace.
  *
- * Archived rows are excluded — the user explicitly removed them.
+ * Archived + soft-deleted rows are excluded — the user explicitly
+ * removed them.
  *
- * Banner shows a connection when either:
- *   - status is not 'active' (e.g. 'needs_reauth', 'expired',
- *     'disconnected', set by fetchers.ts / Watchdog on auth failure)
+ * Email unhealthy when:
+ *   - status is not 'active' (needs_reauth / expired / disconnected,
+ *     set by fetchers.ts / Watchdog on auth failure)
  *   - OR last_error was recorded in the last 24h and status is still
  *     marked active (covers transient failures that haven't tripped
  *     the status flip yet)
+ *
+ * Bank unhealthy when:
+ *   - status ∈ (expired, expired_legacy, token_expired) — the consent
+ *     window has closed and the cron can't renew without the user
+ *   - 'expiring_soon' stays out of here because the existing
+ *     ConsentRenewalBanner handles that advance-warning case
+ *   - 'revoked' stays out — user explicitly disconnected
  */
 
 import { NextResponse } from 'next/server';
@@ -30,14 +38,22 @@ export async function GET() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const { data: emailConns } = await supabase
-    .from('email_connections')
-    .select('id, email_address, provider_type, status, last_error, last_error_at')
-    .eq('user_id', user.id)
-    .is('archived_at', null);
+  const [emailRes, bankRes] = await Promise.all([
+    supabase
+      .from('email_connections')
+      .select('id, email_address, provider_type, status, last_error, last_error_at')
+      .eq('user_id', user.id)
+      .is('archived_at', null),
+    supabase
+      .from('bank_connections')
+      .select('id, bank_name, provider, status')
+      .eq('user_id', user.id)
+      .is('deleted_at', null)
+      .in('status', ['expired', 'expired_legacy', 'token_expired']),
+  ]);
 
   const now = Date.now();
-  const unhealthyEmail = (emailConns ?? []).filter((c) => {
+  const unhealthyEmail = (emailRes.data ?? []).filter((c) => {
     if (c.status !== 'active') return true;
     if (!c.last_error || !c.last_error_at) return false;
     return now - new Date(c.last_error_at).getTime() < RECENT_ERROR_WINDOW_MS;
@@ -51,7 +67,15 @@ export async function GET() {
     last_error: (c.last_error ?? '').slice(0, 120),
   }));
 
+  const unhealthyBank = (bankRes.data ?? []).map((c) => ({
+    id: c.id,
+    bank_name: c.bank_name ?? 'Bank',
+    provider: c.provider,
+    status: c.status,
+  }));
+
   return NextResponse.json({
     unhealthy_email: unhealthyEmail,
+    unhealthy_bank: unhealthyBank,
   });
 }

--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -236,6 +236,18 @@
   .shell-v2-mob-header .brand .brand-name { font-weight: 800; font-size: 16px; }
   .shell-v2-mob-header .brand .brand-name span { color: var(--mint-deep); }
   .shell-v2-mob-actions { display: flex; align-items: center; gap: 6px; }
+  /* Mobile tier pill — color-coded by plan, mirrors the sidebar pill
+     on desktop so users can see what plan they're on without opening
+     the menu drawer. */
+  .shell-v2-mob-tier {
+    display: inline-flex; align-items: center;
+    padding: 4px 10px; border-radius: 999px;
+    font-size: 11px; font-weight: 700; letter-spacing: .02em;
+    border: 1px solid transparent; white-space: nowrap;
+  }
+  .shell-v2-mob-tier[data-tier="pro"] { background: #FAF5FF; color: #7C3AED; border-color: #E9D5FF; }
+  .shell-v2-mob-tier[data-tier="essential"] { background: #ECFDF5; color: #047857; border-color: #A7F3D0; }
+  .shell-v2-mob-tier[data-tier="free"] { background: #F1F5F9; color: #475569; border-color: #CBD5E1; }
 
   .shell-v2-drawer-backdrop {
     display: block;

--- a/src/components/ConnectionHealthBanner.tsx
+++ b/src/components/ConnectionHealthBanner.tsx
@@ -26,6 +26,13 @@ interface UnhealthyEmail {
   last_error: string;
 }
 
+interface UnhealthyBank {
+  id: string;
+  bank_name: string;
+  provider: string;
+  status: string;
+}
+
 const DISMISS_KEY = 'connection-health-banner-dismissed';
 
 function reconnectPath(providerType: string): string {
@@ -46,7 +53,8 @@ function readableStatus(status: string, lastError: string): string {
 }
 
 export default function ConnectionHealthBanner() {
-  const [unhealthy, setUnhealthy] = useState<UnhealthyEmail[]>([]);
+  const [email, setEmail] = useState<UnhealthyEmail[]>([]);
+  const [bank, setBank] = useState<UnhealthyBank[]>([]);
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
@@ -60,25 +68,43 @@ export default function ConnectionHealthBanner() {
       .then((r) => r.ok ? r.json() : null)
       .then((d) => {
         if (cancelled || !d) return;
-        setUnhealthy(d.unhealthy_email ?? []);
+        setEmail(d.unhealthy_email ?? []);
+        setBank(d.unhealthy_bank ?? []);
       })
       .catch(() => { /* silent — banner just won't render */ });
 
     return () => { cancelled = true; };
   }, []);
 
-  if (dismissed || unhealthy.length === 0) return null;
+  const total = email.length + bank.length;
+  if (dismissed || total === 0) return null;
 
   const handleDismiss = () => {
     setDismissed(true);
     try { sessionStorage.setItem(DISMISS_KEY, '1'); } catch { /* ignore */ }
   };
 
-  // One or many — different copy so a single expiry doesn't read as "they all broke".
-  const primary = unhealthy[0];
-  const headline = unhealthy.length === 1
-    ? `${primary.email_address} — ${readableStatus(primary.status, primary.last_error)}`
-    : `${unhealthy.length} email connections need attention`;
+  // Headline adapts to whether it's email, banks, or a mix — so a single
+  // expired bank doesn't read as "all your accounts broke".
+  let headline: string;
+  if (total === 1) {
+    if (email.length === 1) {
+      headline = `${email[0].email_address} — ${readableStatus(email[0].status, email[0].last_error)}`;
+    } else {
+      headline = `${bank[0].bank_name} — ${bank[0].status.replace(/_/g, ' ')}`;
+    }
+  } else if (email.length > 0 && bank.length > 0) {
+    headline = `${email.length} email + ${bank.length} bank connection${bank.length === 1 ? '' : 's'} need attention`;
+  } else if (email.length > 0) {
+    headline = `${email.length} email connections need attention`;
+  } else {
+    headline = `${bank.length} bank connections need attention`;
+  }
+
+  const explain =
+    email.length > 0 && bank.length === 0 ? "Watchdog has paused — dispute replies, renewal reminders and cancellation confirmations won't come through until you reconnect."
+    : bank.length > 0 && email.length === 0 ? "Transaction sync has stopped — Money Hub and price-increase detection won't see new activity until you reconnect."
+    : "Email + bank sync is paused — alerts, replies and transactions won't update until each connection is reconnected.";
 
   return (
     <div className="bg-amber-50 border-b border-amber-200 px-4 py-3">
@@ -86,13 +112,9 @@ export default function ConnectionHealthBanner() {
         <AlertTriangle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold text-amber-900">{headline}</p>
-          <p className="text-xs text-amber-700 mt-0.5">
-            Watchdog has paused on {unhealthy.length === 1 ? 'this account' : 'these accounts'} — dispute replies,
-            renewal reminders and cancellation confirmations won&apos;t come through
-            until you reconnect.
-          </p>
+          <p className="text-xs text-amber-700 mt-0.5">{explain}</p>
           <div className="mt-2 flex flex-wrap gap-2">
-            {unhealthy.slice(0, 3).map((c) => (
+            {email.slice(0, 2).map((c) => (
               <Link
                 key={c.id}
                 href={reconnectPath(c.provider_type)}
@@ -101,12 +123,21 @@ export default function ConnectionHealthBanner() {
                 Reconnect {c.email_address}
               </Link>
             ))}
-            {unhealthy.length > 3 && (
+            {bank.slice(0, 2).map((c) => (
+              <Link
+                key={c.id}
+                href="/dashboard/subscriptions?connectBank=true"
+                className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-amber-600 hover:bg-amber-700 text-white transition-colors"
+              >
+                Reconnect {c.bank_name}
+              </Link>
+            ))}
+            {total > 4 && (
               <Link
                 href="/dashboard/profile"
                 className="inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-white border border-amber-300 text-amber-700 hover:bg-amber-100 transition-colors"
               >
-                View all {unhealthy.length} in Profile
+                View all {total} in Profile
               </Link>
             )}
           </div>

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -200,6 +200,16 @@ export default function DashboardShell({
           </div>
         </Link>
         <div className="shell-v2-mob-actions">
+          {/* Tier pill on mobile — desktop has it inside the sidebar
+              card, but mobile hides the sidebar so users had no way
+              to see what plan they're on without opening the menu. */}
+          <span
+            className="shell-v2-mob-tier"
+            title="Tap menu to manage your plan"
+            data-tier={user.tier ?? 'free'}
+          >
+            {tierLabel(user.tier, user.isTrial, user.trialDaysLeft)}
+          </span>
           <NotificationBell />
           <button
             type="button"


### PR DESCRIPTION
Ran a Playwright UAT against prod with founder credentials. Two real findings:

## 1. \`/api/connections/health\` was missing \`unhealthy_bank\` from the response
A concurrent session reverted PR #298. Re-applied: Promise.all email + bank queries, bank unhealthy when \`status ∈ (expired, expired_legacy, token_expired)\` AND \`deleted_at IS NULL\`. Banner re-extended with copy that adapts to email-only / bank-only / mixed.

## 2. Mobile dashboard had no tier badge
Desktop sidebar shows "Pro Plan", but mobile hid the sidebar AND didn't carry the tier into the mob-header. Mobile users couldn't see which plan they were on without opening the drawer. Added a colour-coded pill to the mob-header left of the bell. Pro=purple, Essential=emerald, Free=slate. Reuses \`tierLabel()\`.

## UAT outcome
12/14 pre-fix. Money Hub mobile networkidle timeout still outstanding (separate hung-request investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)