### PR TITLE
feat(billing): 7-day payment-grace + auto-demote to free

### DIFF
--- a/src/app/api/cron/process-payment-grace/route.ts
+++ b/src/app/api/cron/process-payment-grace/route.ts
@@ -1,0 +1,149 @@
+/**
+ * GET /api/cron/process-payment-grace
+ *
+ * Daily cron that processes the 7-day payment-grace state set by the
+ * Stripe `invoice.payment_failed` webhook. See
+ * supabase/migrations/20260427020000_payment_grace_columns.sql for the
+ * column contract.
+ *
+ * Two passes per run:
+ *   1. T-3 reminder — for any profile with past_due_grace_ends_at
+ *      between (now+0, now+72h] and no past_due_final_warning_sent_at,
+ *      send the final warning and stamp the timestamp.
+ *   2. Demotion — for any profile with past_due_grace_ends_at <= now
+ *      and tier in ('pro','essential'), demote to 'free', clear all
+ *      grace columns, then call openDowngradeEvent() so existing
+ *      bank/email overage gets archived (NOT deleted — data preserved
+ *      via archived_at).
+ *
+ * Idempotent: once a row is demoted past_due_grace_ends_at is null, so
+ * the next run skips it. Founding members are excluded — same rule as
+ * the existing customer.subscription.deleted handler.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { sendFinalGraceWarning, sendDemotionConfirmation } from '@/lib/notifications/payment-grace';
+import { openDowngradeEvent } from '@/lib/plan-downgrade';
+import type { PlanTier } from '@/lib/plan-limits';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+interface GraceRow {
+  id: string;
+  subscription_tier: string | null;
+  subscription_status: string | null;
+  past_due_grace_ends_at: string | null;
+  past_due_final_warning_sent_at: string | null;
+  founding_member: boolean | null;
+}
+
+export async function GET(request: NextRequest) {
+  const auth = request.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const supabase = getAdmin();
+  const now = new Date();
+  const t3 = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
+
+  const { data: rows, error } = await supabase
+    .from('profiles')
+    .select('id, subscription_tier, subscription_status, past_due_grace_ends_at, past_due_final_warning_sent_at, founding_member')
+    .not('past_due_grace_ends_at', 'is', null);
+  if (error) {
+    console.error('process-payment-grace: query failed', error.message);
+    return NextResponse.json({ error: 'query failed' }, { status: 500 });
+  }
+
+  const finalsSent: string[] = [];
+  const demoted: string[] = [];
+  const errors: Array<{ userId: string; reason: string }> = [];
+
+  for (const row of (rows ?? []) as GraceRow[]) {
+    if (row.founding_member) continue;
+    if (!row.past_due_grace_ends_at) continue;
+
+    const graceEnds = new Date(row.past_due_grace_ends_at);
+
+    // Pass 1: T-3 final warning
+    if (graceEnds > now && graceEnds <= t3 && !row.past_due_final_warning_sent_at) {
+      try {
+        await sendFinalGraceWarning(supabase, row.id);
+        await supabase
+          .from('profiles')
+          .update({ past_due_final_warning_sent_at: now.toISOString() })
+          .eq('id', row.id);
+        finalsSent.push(row.id);
+      } catch (e: any) {
+        errors.push({ userId: row.id, reason: `final warning: ${e?.message ?? 'unknown'}` });
+      }
+      continue;
+    }
+
+    // Pass 2: actual demotion (grace expired)
+    if (graceEnds <= now) {
+      const fromTier = (row.subscription_tier ?? 'free') as PlanTier;
+      if (fromTier === 'free') {
+        // Tier already free — nothing to demote. Just clear the grace
+        // columns so the cron stops returning this row.
+        await supabase
+          .from('profiles')
+          .update({
+            past_due_grace_ends_at: null,
+            past_due_warning_sent_at: null,
+            past_due_final_warning_sent_at: null,
+            updated_at: now.toISOString(),
+          })
+          .eq('id', row.id);
+        continue;
+      }
+
+      try {
+        const { error: demoteErr } = await supabase
+          .from('profiles')
+          .update({
+            subscription_tier: 'free',
+            // Stripe webhook will eventually set 'canceled' — leave the
+            // status alone so we don't overwrite a more accurate state.
+            past_due_grace_ends_at: null,
+            past_due_warning_sent_at: null,
+            past_due_final_warning_sent_at: null,
+            updated_at: now.toISOString(),
+          })
+          .eq('id', row.id)
+          .neq('founding_member', true);
+        if (demoteErr) {
+          errors.push({ userId: row.id, reason: `demote: ${demoteErr.message}` });
+          continue;
+        }
+
+        // Archive bank/email overage. openDowngradeEvent uses archived_at
+        // — data is hidden from sync but never deleted, so reactivation
+        // restores everything.
+        await openDowngradeEvent(supabase as any, row.id, fromTier, 'free' as PlanTier);
+        await sendDemotionConfirmation(supabase, row.id, fromTier);
+        demoted.push(row.id);
+      } catch (e: any) {
+        errors.push({ userId: row.id, reason: `demotion flow: ${e?.message ?? 'unknown'}` });
+      }
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    scanned: rows?.length ?? 0,
+    finalsSent: finalsSent.length,
+    demoted: demoted.length,
+    errors,
+  });
+}

--- a/src/app/api/plan-status/route.ts
+++ b/src/app/api/plan-status/route.ts
@@ -63,6 +63,15 @@ export async function GET() {
     .limit(1)
     .maybeSingle();
 
+  // Payment grace window (separate from the plan_downgrade_events
+  // overage window above). This one fires when invoice.payment_failed
+  // sets a 7-day deadline before the user's tier auto-demotes to free.
+  const { data: paymentProfile } = await supabase
+    .from('profiles')
+    .select('subscription_tier, subscription_status, past_due_grace_ends_at')
+    .eq('id', user.id)
+    .maybeSingle();
+
   const status = {
     tier,
     limits: {
@@ -97,6 +106,12 @@ export async function GET() {
           daysRemaining: Math.max(0, Math.ceil((new Date(grace.grace_ends_at).getTime() - Date.now()) / 86400_000)),
         }
       : null,
+    // Read straight from profiles so the banner doesn't need to wait
+    // for the plan_downgrade_events row that's only inserted at
+    // demotion time.
+    past_due_grace_ends_at: paymentProfile?.past_due_grace_ends_at ?? null,
+    subscription_tier: paymentProfile?.subscription_tier ?? null,
+    subscription_status: paymentProfile?.subscription_status ?? null,
   };
 
   return NextResponse.json(status);

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -284,6 +284,11 @@ export async function POST(request: NextRequest) {
             subscription_tier: 'free',
             subscription_status: 'canceled',
             stripe_subscription_id: null,
+            // Wipe any in-flight grace state — the subscription is gone
+            // for good now, the cron has nothing to act on.
+            past_due_grace_ends_at: null,
+            past_due_warning_sent_at: null,
+            past_due_final_warning_sent_at: null,
             updated_at: new Date().toISOString(),
           })
           .eq('stripe_customer_id', customerId)
@@ -308,10 +313,54 @@ export async function POST(request: NextRequest) {
         const customerId = invoice.customer as string;
         console.log(`Webhook invoice.payment_failed: customer=${customerId}`);
 
-        await supabase
+        // Stripe fires payment_failed on every retry attempt. We only want
+        // to start the grace timer on the first failure — subsequent fires
+        // shouldn't reset the deadline or spam warnings.
+        const { data: existing } = await supabase
           .from('profiles')
-          .update({ subscription_status: 'past_due', updated_at: new Date().toISOString() })
+          .select('id, past_due_grace_ends_at, past_due_warning_sent_at')
+          .eq('stripe_customer_id', customerId)
+          .maybeSingle();
+
+        if (!existing) {
+          console.warn('Webhook payment_failed: profile not found for customer', customerId);
+          break;
+        }
+
+        const update: Record<string, unknown> = {
+          subscription_status: 'past_due',
+          updated_at: new Date().toISOString(),
+        };
+        let isFirstFailure = false;
+        if (!existing.past_due_grace_ends_at) {
+          // 7-day grace per CLAUDE.md plan. Smart Retries (Stripe Dashboard)
+          // will keep retrying the card during this window so most accounts
+          // recover before grace expiry.
+          const graceEnds = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+          update.past_due_grace_ends_at = graceEnds.toISOString();
+          update.past_due_warning_sent_at = new Date().toISOString();
+          isFirstFailure = true;
+        }
+
+        const { error: updateErr } = await supabase
+          .from('profiles')
+          .update(update)
           .eq('stripe_customer_id', customerId);
+        if (updateErr) {
+          console.error('Webhook payment_failed: profile update failed:', updateErr.message);
+          break;
+        }
+
+        if (isFirstFailure) {
+          // Fire-and-forget warning notification. The cron handles T-3
+          // final warning + the actual demotion at T+0.
+          try {
+            const { sendPaymentFailedWarning } = await import('@/lib/notifications/payment-grace');
+            await sendPaymentFailedWarning(supabase, existing.id);
+          } catch (e) {
+            console.error('Webhook payment_failed: warning send failed:', e);
+          }
+        }
         break;
       }
 
@@ -321,9 +370,20 @@ export async function POST(request: NextRequest) {
         console.log(`Webhook invoice.payment_succeeded: customer=${customerId} reason=${invoice.billing_reason}`);
 
         if (invoice.billing_reason && invoice.billing_reason.startsWith('subscription')) {
+          // Recovery path — clear the grace columns so the cron skips
+          // this user, and restore status. Even if grace had already
+          // expired and the cron had demoted, this resets cleanly: the
+          // existing customer.subscription.updated webhook will have
+          // already promoted them back.
           await supabase
             .from('profiles')
-            .update({ subscription_status: 'active', updated_at: new Date().toISOString() })
+            .update({
+              subscription_status: 'active',
+              past_due_grace_ends_at: null,
+              past_due_warning_sent_at: null,
+              past_due_final_warning_sent_at: null,
+              updated_at: new Date().toISOString(),
+            })
             .eq('stripe_customer_id', customerId);
         }
         break;

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import TrialBanner from '@/components/TrialBanner';
 import ConnectionHealthBanner from '@/components/ConnectionHealthBanner';
+import PaymentGraceBanner from '@/components/PaymentGraceBanner';
 import DashboardShell, { type UserSummary } from '@/components/dashboard/DashboardShell';
 import './shell-v2.css';
 import './dashboard.css';
@@ -194,6 +195,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
       {(isTrial || trialExpired) && (
         <TrialBanner daysLeft={trialDaysLeft} trialExpired={trialExpired} />
       )}
+      <PaymentGraceBanner />
       <ConnectionHealthBanner />
     </>
   );

--- a/src/components/PaymentGraceBanner.tsx
+++ b/src/components/PaymentGraceBanner.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+/**
+ * Top-of-dashboard banner shown when a user's last payment failed and
+ * the 7-day grace timer is running. Links to the billing portal so
+ * they can update the card before auto-demotion.
+ *
+ * The banner reads /api/plan-status which already exposes
+ * past_due_grace_ends_at — no extra endpoint needed.
+ *
+ * Dismissal is intentionally absent. Demotion to Free is happening
+ * unless they act, and a session-scoped X would let users hide the
+ * single most consequential UX event in the app.
+ */
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
+
+interface PlanStatus {
+  past_due_grace_ends_at: string | null;
+  subscription_tier: string | null;
+  subscription_status: string | null;
+}
+
+function formatDeadline(iso: string): { label: string; daysLeft: number } {
+  const target = new Date(iso).getTime();
+  const days = Math.max(0, Math.ceil((target - Date.now()) / 86_400_000));
+  const label = new Date(iso).toLocaleDateString('en-GB', {
+    weekday: 'short', day: 'numeric', month: 'short',
+  });
+  return { label, daysLeft: days };
+}
+
+export default function PaymentGraceBanner() {
+  const [status, setStatus] = useState<PlanStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/plan-status', { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (!cancelled && d) setStatus(d); })
+      .catch(() => { /* silent — banner just won't render */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!status?.past_due_grace_ends_at) return null;
+  const tier = status.subscription_tier ?? '';
+  if (tier === 'free') return null;
+
+  const { label, daysLeft } = formatDeadline(status.past_due_grace_ends_at);
+  const tierLabel = tier === 'pro' ? 'Pro' : tier === 'essential' ? 'Essential' : tier;
+  const urgent = daysLeft <= 3;
+
+  const headline = daysLeft === 0
+    ? `Your card hasn't gone through — ${tierLabel} access ends today`
+    : daysLeft === 1
+    ? `Card declined — ${tierLabel} access ends tomorrow`
+    : `Card declined — ${tierLabel} access ends in ${daysLeft} days (${label})`;
+
+  return (
+    <div className={urgent ? 'bg-red-50 border-b border-red-200' : 'bg-amber-50 border-b border-amber-200'}>
+      <div className="max-w-7xl mx-auto flex items-start gap-3 px-4 py-3">
+        <AlertTriangle className={urgent ? 'h-5 w-5 text-red-600 flex-shrink-0 mt-0.5' : 'h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5'} />
+        <div className="flex-1 min-w-0">
+          <p className={urgent ? 'text-sm font-semibold text-red-900' : 'text-sm font-semibold text-amber-900'}>
+            {headline}
+          </p>
+          <p className={urgent ? 'text-xs text-red-700 mt-0.5' : 'text-xs text-amber-700 mt-0.5'}>
+            We'll keep retrying your card automatically. If it still hasn't gone through by then, your account will switch to Free. Your data stays — extra connections are archived, not deleted.
+          </p>
+          <div className="mt-2">
+            <Link
+              href="/dashboard/profile?section=subscription"
+              className={urgent
+                ? 'inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-red-600 hover:bg-red-700 text-white transition-colors'
+                : 'inline-flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-amber-600 hover:bg-amber-700 text-white transition-colors'
+              }
+            >
+              Update card now
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/notifications/payment-grace.ts
+++ b/src/lib/notifications/payment-grace.ts
@@ -1,0 +1,206 @@
+/**
+ * Payment grace notifications.
+ *
+ * Critical billing messages — they bypass user channel prefs / quiet
+ * hours / rate limits because losing access without warning would be
+ * a worse UX than the buzz of an email + Telegram during a quiet
+ * window. The user opted-in to billing notifications when they
+ * created a paid subscription.
+ *
+ * Three send points:
+ *   - sendPaymentFailedWarning(): on the first invoice.payment_failed
+ *     webhook in the current grace window. Tells the user their card
+ *     was declined and they have 7 days to update.
+ *   - sendFinalGraceWarning(): T-3 days from grace_ends_at. The cron
+ *     fires this once per profile (timestamp guarded).
+ *   - sendDemotionConfirmation(): when the cron actually demotes a
+ *     user. Tells them their tier has been switched to Free and
+ *     points them at the path to upgrade again.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { resend, FROM_EMAIL } from '@/lib/resend';
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://paybacker.co.uk';
+const BILLING_PORTAL_URL = `${APP_URL}/dashboard/profile?section=subscription`;
+
+interface ProfileLite {
+  id: string;
+  email?: string | null;
+  first_name?: string | null;
+  subscription_tier?: string | null;
+  past_due_grace_ends_at?: string | null;
+}
+
+async function loadProfile(supabase: SupabaseClient, userId: string): Promise<ProfileLite | null> {
+  const { data } = await supabase
+    .from('profiles')
+    .select('id, email, first_name, subscription_tier, past_due_grace_ends_at')
+    .eq('id', userId)
+    .maybeSingle();
+  return data as ProfileLite | null;
+}
+
+async function loadTelegramChatId(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<number | null> {
+  const { data } = await supabase
+    .from('telegram_sessions')
+    .select('telegram_chat_id, is_active')
+    .eq('user_id', userId)
+    .eq('is_active', true)
+    .maybeSingle();
+  return (data?.telegram_chat_id as number | undefined) ?? null;
+}
+
+function fmtDeadline(iso: string | null | undefined): string {
+  if (!iso) return 'in 7 days';
+  return new Date(iso).toLocaleDateString('en-GB', {
+    weekday: 'long', day: 'numeric', month: 'long',
+  });
+}
+
+async function sendTelegram(chatId: number, text: string): Promise<void> {
+  const token = process.env.TELEGRAM_USER_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: 'Markdown',
+        disable_web_page_preview: true,
+      }),
+    });
+  } catch (e) {
+    console.error('payment-grace: telegram send failed', e);
+  }
+}
+
+export async function sendPaymentFailedWarning(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<void> {
+  const profile = await loadProfile(supabase, userId);
+  if (!profile?.email) return;
+  const tier = (profile.subscription_tier || 'paid').toString();
+  const tierLabel = tier === 'pro' ? 'Pro' : tier === 'essential' ? 'Essential' : tier;
+  const deadline = fmtDeadline(profile.past_due_grace_ends_at);
+  const greeting = profile.first_name ? `Hi ${profile.first_name},` : 'Hi,';
+
+  const subject = `Action needed: your Paybacker ${tierLabel} payment was declined`;
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width:560px; margin:auto; color:#0f172a;">
+      <p>${greeting}</p>
+      <p>We tried to charge your card for your Paybacker ${tierLabel} subscription and it was declined.</p>
+      <p>We'll keep retrying for the next few days, but if it still hasn't gone through by <strong>${deadline}</strong>, your account will switch to the Free tier. Your data won't be deleted — you'll just lose access to ${tierLabel} features (extra bank/email connections, ${tier === 'pro' ? 'unlimited letters, instant Telegram alerts' : 'unlimited letters, renewal reminders, full spending intelligence'}).</p>
+      <p style="margin:24px 0;">
+        <a href="${BILLING_PORTAL_URL}" style="background:#10b981; color:white; padding:12px 24px; border-radius:8px; text-decoration:none; font-weight:600; display:inline-block;">Update your card</a>
+      </p>
+      <p style="color:#64748b; font-size:13px;">Questions? Reply to this email and we'll help.</p>
+      <p style="color:#64748b; font-size:13px;">— The Paybacker team</p>
+    </div>
+  `;
+
+  try {
+    await resend.emails.send({ from: FROM_EMAIL, to: profile.email, subject, html });
+  } catch (e) {
+    console.error('payment-grace: email send failed', e);
+  }
+
+  const chatId = await loadTelegramChatId(supabase, userId);
+  if (chatId) {
+    await sendTelegram(
+      chatId,
+      `⚠️ *Your Paybacker ${tierLabel} payment was declined*\n\n` +
+      `We'll keep retrying. If it still hasn't gone through by *${deadline}*, your tier will switch to Free.\n\n` +
+      `[Update your card](${BILLING_PORTAL_URL})`,
+    );
+  }
+}
+
+export async function sendFinalGraceWarning(
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<void> {
+  const profile = await loadProfile(supabase, userId);
+  if (!profile?.email) return;
+  const tier = (profile.subscription_tier || 'paid').toString();
+  const tierLabel = tier === 'pro' ? 'Pro' : tier === 'essential' ? 'Essential' : tier;
+  const deadline = fmtDeadline(profile.past_due_grace_ends_at);
+  const greeting = profile.first_name ? `Hi ${profile.first_name},` : 'Hi,';
+
+  const subject = `Final reminder: 3 days until your Paybacker ${tierLabel} downgrade`;
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width:560px; margin:auto; color:#0f172a;">
+      <p>${greeting}</p>
+      <p>Your card still hasn't gone through. On <strong>${deadline}</strong> we'll switch your account to the Free tier unless we can charge it before then.</p>
+      <p>Your data stays — extra bank/email connections will be archived (not deleted), so if you reactivate later they'll come back.</p>
+      <p style="margin:24px 0;">
+        <a href="${BILLING_PORTAL_URL}" style="background:#10b981; color:white; padding:12px 24px; border-radius:8px; text-decoration:none; font-weight:600; display:inline-block;">Update your card now</a>
+      </p>
+      <p style="color:#64748b; font-size:13px;">— The Paybacker team</p>
+    </div>
+  `;
+
+  try {
+    await resend.emails.send({ from: FROM_EMAIL, to: profile.email, subject, html });
+  } catch (e) {
+    console.error('payment-grace: final email send failed', e);
+  }
+
+  const chatId = await loadTelegramChatId(supabase, userId);
+  if (chatId) {
+    await sendTelegram(
+      chatId,
+      `🔔 *3 days left to fix your Paybacker ${tierLabel} payment*\n\n` +
+      `Your card still hasn't gone through. On *${deadline}* your tier will switch to Free.\n\n` +
+      `Your data stays. Extra connections will be archived but not deleted.\n\n` +
+      `[Update your card](${BILLING_PORTAL_URL})`,
+    );
+  }
+}
+
+export async function sendDemotionConfirmation(
+  supabase: SupabaseClient,
+  userId: string,
+  fromTier: string,
+): Promise<void> {
+  const profile = await loadProfile(supabase, userId);
+  if (!profile?.email) return;
+  const fromLabel = fromTier === 'pro' ? 'Pro' : fromTier === 'essential' ? 'Essential' : fromTier;
+  const greeting = profile.first_name ? `Hi ${profile.first_name},` : 'Hi,';
+
+  const subject = `Your Paybacker account has switched to Free`;
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width:560px; margin:auto; color:#0f172a;">
+      <p>${greeting}</p>
+      <p>We weren't able to charge your card after several attempts, so your Paybacker ${fromLabel} subscription has ended and your account is now on the Free tier.</p>
+      <p><strong>Your data is safe.</strong> Bank and email connections beyond the free limits have been archived — they're hidden from sync but will reappear if you upgrade again. Subscriptions, disputes, and complaint letters all stay.</p>
+      <p style="margin:24px 0;">
+        <a href="${APP_URL}/pricing" style="background:#10b981; color:white; padding:12px 24px; border-radius:8px; text-decoration:none; font-weight:600; display:inline-block;">Reactivate ${fromLabel}</a>
+      </p>
+      <p style="color:#64748b; font-size:13px;">Questions or want help? Just reply.</p>
+      <p style="color:#64748b; font-size:13px;">— The Paybacker team</p>
+    </div>
+  `;
+
+  try {
+    await resend.emails.send({ from: FROM_EMAIL, to: profile.email, subject, html });
+  } catch (e) {
+    console.error('payment-grace: demotion email failed', e);
+  }
+
+  const chatId = await loadTelegramChatId(supabase, userId);
+  if (chatId) {
+    await sendTelegram(
+      chatId,
+      `Your Paybacker ${fromLabel} subscription has ended and your account is now on Free.\n\n` +
+      `Your data is safe — extra connections are archived but will reappear if you upgrade again.\n\n` +
+      `[Reactivate ${fromLabel}](${APP_URL}/pricing)`,
+    );
+  }
+}

--- a/supabase/migrations/20260427020000_payment_grace_columns.sql
+++ b/supabase/migrations/20260427020000_payment_grace_columns.sql
@@ -1,0 +1,41 @@
+-- 7-day payment-grace columns on profiles.
+--
+-- Flow:
+--   1. Stripe `invoice.payment_failed` webhook sets past_due_grace_ends_at
+--      to NOW() + 7d (only if not already set — Stripe fires multiple
+--      invoice.payment_failed events as it retries) and timestamps the
+--      first warning send.
+--   2. Daily cron `process-payment-grace`:
+--        - 3 days before grace_ends_at: send final warning, set
+--          past_due_final_warning_sent_at.
+--        - After grace_ends_at: demote tier to 'free', clear all three
+--          columns, then call openDowngradeEvent() to archive bank/email
+--          overage (data preserved via archived_at, never deleted).
+--   3. Stripe `invoice.payment_succeeded` clears all three columns and
+--      restores subscription_status='active'.
+--   4. `customer.subscription.deleted` continues to demote immediately
+--      (existing behaviour) and clears the grace columns as a side effect.
+--
+-- Per CLAUDE.md "Paid tiers are never auto-demoted. Demotion is webhook-
+-- driven" — the cron acts as a deferred webhook reaction once the user
+-- has had their 7 days to update their card. Auto-retry (Stripe Smart
+-- Retries) sits in front of this so most accounts recover before the
+-- grace expires; the demotion only fires on persistent non-payment.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS past_due_grace_ends_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS past_due_warning_sent_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS past_due_final_warning_sent_at TIMESTAMPTZ;
+
+-- Cron query is `WHERE past_due_grace_ends_at IS NOT NULL` so a partial
+-- index keeps the scan tight even at 100k+ profiles.
+CREATE INDEX IF NOT EXISTS profiles_past_due_grace_ends_at_idx
+  ON profiles (past_due_grace_ends_at)
+  WHERE past_due_grace_ends_at IS NOT NULL;
+
+COMMENT ON COLUMN profiles.past_due_grace_ends_at IS
+  '7-day deadline to update card before tier auto-demotes to free. Set by invoice.payment_failed webhook, cleared by invoice.payment_succeeded or by the demotion cron.';
+COMMENT ON COLUMN profiles.past_due_warning_sent_at IS
+  'Timestamp of the first "card declined" notification sent to the user. Prevents the webhook from firing duplicate warnings on each Stripe retry attempt.';
+COMMENT ON COLUMN profiles.past_due_final_warning_sent_at IS
+  'Timestamp of the T-3 final warning sent by process-payment-grace cron. Prevents the cron from re-sending on subsequent runs before grace expiry.';

--- a/vercel.json
+++ b/vercel.json
@@ -109,6 +109,10 @@
       "schedule": "0 9 * * *"
     },
     {
+      "path": "/api/cron/process-payment-grace",
+      "schedule": "30 9 * * *"
+    },
+    {
       "path": "/api/cron/compare-subscriptions",
       "schedule": "0 7 * * *"
     },


### PR DESCRIPTION
## Summary
When \`invoice.payment_failed\` fires we now start a 7-day grace timer instead of just flipping \`subscription_status\`. If the user updates their card before the deadline, \`payment_succeeded\` clears the grace and they keep their tier. If grace expires, a daily cron demotes them to Free and archives bank/email overage (data preserved via \`archived_at\`, never deleted).

Per the spec: _"demote to free if they aren't paying. Keep their data but don't make it usable or limit as per the tier."_

## Changes
- **Migration** adds \`past_due_grace_ends_at\` + 2 warning timestamps to \`profiles\` with a partial index for the cron's daily scan
- **\`invoice.payment_failed\` webhook** — starts 7d timer (idempotent: Stripe fires payment_failed on every retry, deadline only set on first), sends email + Telegram warning
- **\`invoice.payment_succeeded\` webhook** — clears all 3 grace columns + restores \`subscription_status='active'\`
- **\`customer.subscription.deleted\` webhook** — also clears grace columns (no orphan state if Stripe terminates before grace expiry)
- **New cron \`/api/cron/process-payment-grace\`** at 09:30 UTC daily: T-3 final warning, T+0 demote tier to free, archive overage via \`openDowngradeEvent()\`, send demotion confirmation
- **\`PaymentGraceBanner\`** on every dashboard page when grace is active. Countdown + "Update card" CTA. Red in last 3 days, amber otherwise. **Not dismissable** — demotion is too consequential to let users hide it
- **\`/api/plan-status\`** surfaces \`past_due_grace_ends_at\` + tier/status

## Manual deploy step
**Verify Stripe Smart Retries is on**: Stripe Dashboard → Settings → Billing → Subscriptions and emails → Manage failed payments. Default 4 retries over ~2 weeks. This sits in front of the 7d grace so most accounts recover before grace expires.

## Test plan
- [ ] Run migration in Supabase
- [ ] Stripe test mode: trigger \`payment_failed\` → \`past_due_grace_ends_at\` populated, warning email + Telegram arrive, dashboard banner appears
- [ ] Trigger \`payment_succeeded\` → grace cleared, banner gone, status active
- [ ] Manually run cron with \`past_due_grace_ends_at = NOW() - 1h\` → tier becomes \`free\`, bank_connections over the free cap have \`archived_at\` set (not deleted), demotion email arrives
- [ ] Demoted user: free-tier limits enforced (existing PLAN_LIMITS matrix), data still visible
- [ ] Founding members are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)