### PR TITLE
feat(blog): surface on homepage + match images to subject

### DIFF
--- a/src/app/api/blog-feed/route.ts
+++ b/src/app/api/blog-feed/route.ts
@@ -1,0 +1,61 @@
+/**
+ * GET /api/blog-feed?limit=3
+ *
+ * Lightweight read endpoint for the homepage Journal section.
+ * Returns the most recent published blog_posts with category-mapped
+ * gradient + emoji so the homepage doesn't need access to the
+ * service-role client (it's a 'use client' component).
+ *
+ * Falls back gracefully — if Supabase is unavailable the homepage
+ * shows three hand-coded SEO posts instead of empty-stating.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { blogIconFor } from '@/lib/blog-icons';
+
+export const runtime = 'nodejs';
+export const revalidate = 600; // 10 min — blog posts don't change often
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const limit = Math.min(20, Math.max(1, Number(url.searchParams.get('limit') || '3')));
+
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return NextResponse.json({ posts: [] });
+  }
+
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY,
+    );
+    const { data } = await supabase
+      .from('blog_posts')
+      .select('slug, title, excerpt, published_at, category')
+      .eq('status', 'published')
+      .order('published_at', { ascending: false })
+      .limit(limit);
+
+    const posts = (data ?? []).map((p) => {
+      const icon = blogIconFor(p.category as string | null);
+      const cat = (p.category as string | null) ?? 'Essay';
+      return {
+        title: p.title,
+        excerpt: (p.excerpt as string | null) ?? '',
+        href: `/blog/${p.slug}`,
+        date: new Date(p.published_at).toLocaleDateString('en-GB', {
+          day: 'numeric', month: 'long', year: 'numeric',
+        }),
+        cat: cat.charAt(0).toUpperCase() + cat.slice(1).replace(/_/g, ' '),
+        emoji: icon.emoji,
+        bg: icon.bg,
+      };
+    });
+
+    return NextResponse.json({ posts });
+  } catch (e: any) {
+    console.error('blog-feed error:', e?.message ?? e);
+    return NextResponse.json({ posts: [] });
+  }
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import type { CSSProperties } from 'react';
 import { createClient } from '@supabase/supabase-js';
 import { MarkNav, MarkFoot } from './_shared';
+import { blogIconFor } from '@/lib/blog-icons';
 import './styles.css';
 
 /**
@@ -48,14 +49,6 @@ type Post = {
   emoji: string;
 };
 
-const GRADIENTS = [
-  { bg: 'linear-gradient(135deg, #34D399, #059669)', emoji: '✉' },
-  { bg: 'linear-gradient(135deg, #F59E0B, #D97706)', emoji: '📡' },
-  { bg: 'linear-gradient(135deg, #3B82F6, #2563EB)', emoji: '✈' },
-  { bg: 'linear-gradient(135deg, #8B5CF6, #6D28D9)', emoji: '⚖' },
-  { bg: 'linear-gradient(135deg, #F43F5E, #DC2626)', emoji: '💷' },
-];
-
 // Hand-coded SEO posts that already exist as live pages under /blog/*.
 const STATIC_POSTS: ReadonlyArray<Omit<Post, 'gradient' | 'emoji'>> = [
   {
@@ -100,8 +93,8 @@ async function fetchDynamicPosts(): Promise<Post[]> {
       .order('published_at', { ascending: false })
       .limit(20);
     if (!data) return [];
-    return data.map((p, i): Post => {
-      const g = GRADIENTS[i % GRADIENTS.length];
+    return data.map((p): Post => {
+      const icon = blogIconFor(p.category as string | null);
       return {
         title: p.title,
         excerpt: p.excerpt ?? '',
@@ -112,8 +105,8 @@ async function fetchDynamicPosts(): Promise<Post[]> {
           year: 'numeric',
         }),
         cat: (p.category as string | null) ?? 'Essay',
-        gradient: g.bg,
-        emoji: g.emoji,
+        gradient: icon.bg,
+        emoji: icon.emoji,
       };
     });
   } catch {
@@ -123,9 +116,23 @@ async function fetchDynamicPosts(): Promise<Post[]> {
 
 export default async function BlogIndexPage() {
   const dynamicPosts = await fetchDynamicPosts();
-  const staticWithArt: Post[] = STATIC_POSTS.map((p, i) => {
-    const g = GRADIENTS[(dynamicPosts.length + i) % GRADIENTS.length];
-    return { ...p, gradient: g.bg, emoji: g.emoji };
+  // The three static SEO posts all carry cat='Guides' which isn't
+  // category-specific. Look at the title to pick a topical icon —
+  // flight → ✈, energy → ⚡, broadband → 📡 — so the visual matches
+  // the subject like the dynamic posts do.
+  const staticWithArt: Post[] = STATIC_POSTS.map((p) => {
+    const t = p.title.toLowerCase();
+    const inferred =
+      t.includes('flight') || t.includes('airline') ? 'travel' :
+      t.includes('energy') || t.includes('gas') || t.includes('electric') ? 'energy' :
+      t.includes('broadband') || t.includes('wifi') || t.includes('internet') ? 'broadband' :
+      t.includes('mobile') ? 'mobile' :
+      t.includes('insurance') ? 'insurance' :
+      t.includes('council tax') ? 'council_tax' :
+      t.includes('water') ? 'water' :
+      'consumer';
+    const icon = blogIconFor(inferred);
+    return { ...p, gradient: icon.bg, emoji: icon.emoji };
   });
   const allPosts: Post[] = [...dynamicPosts, ...staticWithArt];
   const [featured, ...rest] = allPosts;

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -224,7 +224,7 @@ function Nav() {
     ['Product', '#features'],
     ['Deals', '#deals'],
     ['Pricing', '#pricing'],
-    ['Stories', '#testimonials'],
+    ['Journal', '/blog'],
   ];
 
   return (
@@ -782,6 +782,127 @@ function StickyCTA() {
     <div className={`sticky-cta mobile-hidden${visible ? ' shown' : ''}`} aria-hidden={!visible}>
       <span>Find your overcharges in 30s — no card, no catch.</span>
       <Link href="/auth/signup">Start free →</Link>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Journal — three most-recent published blog posts, surfaced on the
+// homepage so /blog isn't an orphaned section. Pulls live from
+// blog_posts via /api/blog-feed (lightweight server route).
+// Falls back to the three hand-coded SEO posts if the API errors so
+// the section never empty-states the user.
+// ---------------------------------------------------------------------------
+type JournalPost = {
+  title: string;
+  excerpt: string;
+  href: string;
+  date: string;
+  cat: string;
+  emoji: string;
+  bg: string;
+};
+
+const JOURNAL_FALLBACK: JournalPost[] = [
+  {
+    title: 'How to Claim Flight Delay Compensation UK — Up to £520',
+    excerpt: 'Complete guide to claiming under UK261 regulations. Up to £520 per person, claim back 6 years.',
+    href: '/blog/how-to-claim-flight-delay-compensation-uk',
+    date: '25 March 2026',
+    cat: 'Travel',
+    emoji: '✈',
+    bg: 'linear-gradient(135deg, #0EA5E9, #0369A1)',
+  },
+  {
+    title: 'Are You Overpaying on Energy in 2026?',
+    excerpt: 'The energy price cap hits £1,641 from April 2026. Find out if you’re on a standard variable tariff.',
+    href: '/blog/are-you-overpaying-on-energy',
+    date: '23 March 2026',
+    cat: 'Energy',
+    emoji: '⚡',
+    bg: 'linear-gradient(135deg, #F59E0B, #D97706)',
+  },
+  {
+    title: 'Your Broadband Contract Has Ended — You’re Probably Being Overcharged',
+    excerpt: 'Millions of UK households are out of contract on broadband and overpaying. Save up to £300 a year.',
+    href: '/blog/broadband-contract-ended',
+    date: '23 March 2026',
+    cat: 'Broadband',
+    emoji: '📡',
+    bg: 'linear-gradient(135deg, #3B82F6, #1D4ED8)',
+  },
+];
+
+function Journal() {
+  const [posts, setPosts] = useState<JournalPost[]>(JOURNAL_FALLBACK);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/blog-feed?limit=3')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (cancelled || !d?.posts || !Array.isArray(d.posts) || d.posts.length === 0) return;
+        setPosts(d.posts as JournalPost[]);
+      })
+      .catch(() => { /* keep fallback */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 24 }}>
+      {posts.map((p) => (
+        <Link key={p.href} href={p.href} style={{ textDecoration: 'none', color: 'inherit', display: 'block' }}>
+          <article
+            style={{
+              background: '#fff',
+              border: '1px solid #E2E8F0',
+              borderRadius: 16,
+              overflow: 'hidden',
+              transition: 'transform 0.2s, box-shadow 0.2s',
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.transform = 'translateY(-4px)';
+              e.currentTarget.style.boxShadow = '0 12px 32px rgba(0,0,0,0.08)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.transform = 'translateY(0)';
+              e.currentTarget.style.boxShadow = 'none';
+            }}
+          >
+            <div
+              style={{
+                height: 140,
+                background: p.bg,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 56,
+                color: '#fff',
+              }}
+              aria-hidden
+            >
+              {p.emoji}
+            </div>
+            <div style={{ padding: '20px 22px', display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
+              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--mint-deep)' }}>
+                {p.cat}
+              </div>
+              <h3 style={{ fontSize: 18, fontWeight: 700, lineHeight: 1.3, margin: 0, color: 'var(--text-1, #0f172a)' }}>
+                {p.title}
+              </h3>
+              <p style={{ fontSize: 14, color: 'var(--text-2, #475569)', lineHeight: 1.5, margin: 0 }}>
+                {p.excerpt}
+              </p>
+              <div style={{ marginTop: 'auto', fontSize: 12, color: 'var(--text-3, #94a3b8)' }}>
+                {p.date}
+              </div>
+            </div>
+          </article>
+        </Link>
+      ))}
     </div>
   );
 }
@@ -1517,6 +1638,29 @@ export default function HomepageV3PreviewPage() {
           </h2>
         </Reveal>
         <Testimonials />
+      </section>
+
+      {/* ========== Journal — latest blog posts ========== */}
+      <section className="journal-section section-light" id="journal" style={{ padding: '120px 0' }}>
+        <div className="wrap" style={{ maxWidth: 1200, margin: '0 auto', padding: '0 24px' }}>
+          <Reveal>
+            <span className="eyebrow">From the Paybacker Journal</span>
+            <h2 style={{ fontSize: 'clamp(28px, 4vw, 44px)', fontWeight: 800, letterSpacing: '-0.02em', margin: '8px 0 12px' }}>
+              UK consumer rights,
+              <br />
+              decoded for everyday bills.
+            </h2>
+            <p style={{ fontSize: 16, color: 'var(--text-2, #475569)', maxWidth: 640, margin: '0 0 40px' }}>
+              Money-saving guides and statutory explainers from the Paybacker team. One UK overcharge, dissected.
+            </p>
+          </Reveal>
+          <Journal />
+          <div style={{ marginTop: 40, textAlign: 'center' }}>
+            <Link href="/blog" className="cta-ghost" style={{ display: 'inline-block', padding: '12px 28px', borderRadius: 999, border: '1px solid #CBD5E1', color: 'var(--text-1, #0f172a)', textDecoration: 'none', fontWeight: 600 }}>
+              Read all articles →
+            </Link>
+          </div>
+        </div>
       </section>
 
       {/* ========== Developer · MCP ========== */}

--- a/src/lib/blog-icons.ts
+++ b/src/lib/blog-icons.ts
@@ -1,0 +1,54 @@
+/**
+ * Subject-matched gradient + emoji for blog post cards.
+ *
+ * Replaces the old `i % 5` round-robin pool that picked random
+ * visuals — a flight-delay article could end up with a council-tax
+ * gavel ⚖, an energy article with a plane ✈. Now each category
+ * has its own colourway so the visual matches the post.
+ *
+ * Categories follow the `blog_posts.category` set used by the
+ * publish-blog cron (see TOPIC_POOL in
+ * src/app/api/cron/publish-blog/route.ts). New categories can be
+ * added here without breaking older posts — anything unknown falls
+ * through to DEFAULT.
+ */
+
+export interface BlogIcon {
+  bg: string;
+  emoji: string;
+}
+
+const CATEGORY_MAP: Record<string, BlogIcon> = {
+  energy:        { bg: 'linear-gradient(135deg, #F59E0B, #D97706)', emoji: '⚡' },
+  broadband:     { bg: 'linear-gradient(135deg, #3B82F6, #1D4ED8)', emoji: '📡' },
+  mobile:        { bg: 'linear-gradient(135deg, #06B6D4, #0891B2)', emoji: '📱' },
+  insurance:     { bg: 'linear-gradient(135deg, #8B5CF6, #6D28D9)', emoji: '🛡' },
+  travel:        { bg: 'linear-gradient(135deg, #0EA5E9, #0369A1)', emoji: '✈' },
+  transport:     { bg: 'linear-gradient(135deg, #14B8A6, #0F766E)', emoji: '🚆' },
+  housing:       { bg: 'linear-gradient(135deg, #84CC16, #4D7C0F)', emoji: '🏠' },
+  council_tax:   { bg: 'linear-gradient(135deg, #6366F1, #4338CA)', emoji: '🏛' },
+  tax:           { bg: 'linear-gradient(135deg, #6366F1, #4338CA)', emoji: '🏛' },
+  water:         { bg: 'linear-gradient(135deg, #0EA5E9, #075985)', emoji: '💧' },
+  parking:       { bg: 'linear-gradient(135deg, #F97316, #C2410C)', emoji: '🅿' },
+  fitness:       { bg: 'linear-gradient(135deg, #EC4899, #BE185D)', emoji: '🏋' },
+  debt:          { bg: 'linear-gradient(135deg, #F43F5E, #BE123C)', emoji: '💷' },
+  credit:        { bg: 'linear-gradient(135deg, #F43F5E, #BE123C)', emoji: '💳' },
+  banking:       { bg: 'linear-gradient(135deg, #10B981, #047857)', emoji: '🏦' },
+  consumer:      { bg: 'linear-gradient(135deg, #34D399, #059669)', emoji: '✉' },
+  data:          { bg: 'linear-gradient(135deg, #64748B, #334155)', emoji: '🔒' },
+  employment:    { bg: 'linear-gradient(135deg, #A855F7, #6B21A8)', emoji: '⚖' },
+  ppi:           { bg: 'linear-gradient(135deg, #F43F5E, #BE123C)', emoji: '💷' },
+  nhs:           { bg: 'linear-gradient(135deg, #2563EB, #1E3A8A)', emoji: '🏥' },
+  tv:            { bg: 'linear-gradient(135deg, #DC2626, #991B1B)', emoji: '📺' },
+};
+
+const DEFAULT: BlogIcon = {
+  bg: 'linear-gradient(135deg, #34D399, #059669)',
+  emoji: '✉',
+};
+
+export function blogIconFor(category: string | null | undefined): BlogIcon {
+  if (!category) return DEFAULT;
+  const key = category.toLowerCase().replace(/[\s-]/g, '_');
+  return CATEGORY_MAP[key] ?? DEFAULT;
+}


### PR DESCRIPTION
## What you flagged
> _the blog is missing from the homepage — have the blog images been updated to match the subject of the blog?_

Both confirmed. Blog at \`/blog\` exists with 3 hand-coded SEO posts + dynamic posts from \`blog_posts\`, but the homepage at \`/preview/homepage/page.tsx\` (which is now \`/\`) had zero references to it. And every blog card used a 5-element round-robin emoji/gradient pool — \`i % 5\` — so a flight-delay article could end up with a gym ⚖ icon and an energy article with a plane ✈.

## Changes

**`src/lib/blog-icons.ts`** — single source of truth that maps each \`blog_posts.category\` to a coherent gradient + emoji pair. 21 categories covered (energy ⚡, broadband 📡, travel ✈, council_tax 🏛, debt 💷, banking 🏦, water 💧, fitness 🏋, etc.) with a default consumer-rights ✉ fallback for anything unknown.

**`/api/blog-feed`** — lightweight read endpoint (10 min revalidate) that returns the most-recent published posts with the icon mapping pre-resolved. Means the homepage doesn't need access to the service-role Supabase client (it's a \`'use client'\` component).

**Homepage `Journal` section** — new "From the Paybacker Journal" block between Testimonials and MCP, fetches three posts on mount with a fallback to the three hand-coded SEO posts so it's never empty. "Read all articles →" CTA links to \`/blog\`.

**Homepage nav** — swaps \`#testimonials\` for \`/blog\` as "Journal" (testimonials stay linked from inside the page via the section header).

**`/blog`** — switched from the round-robin pool to the category-based mapping for both dynamic posts (using the row's \`category\`) and the three static SEO posts (inferred from title — flight/energy/broadband). Cards now visually match what they're about.

## Per-post hero images
Per CLAUDE.md rule #1, generating per-post hero images has to go through fal.ai. That's a separate follow-up — the category icons are a meaningful step up on their own and ship today.

## Test plan
- [ ] Visit \`/\` → "From the Paybacker Journal" section renders between Testimonials and MCP with 3 cards; cards link to \`/blog/<slug>\` and "Read all articles" → \`/blog\`
- [ ] Cards show category-appropriate emoji (e.g. ✈ for travel, ⚡ for energy)
- [ ] Header nav has "Journal" linking to /blog
- [ ] Visit \`/blog\` — featured + grid cards use the new category mapping; old i%5 randomness gone
- [ ] Hit \`/api/blog-feed?limit=3\` directly → \`{ posts: [...] }\` with cat / emoji / bg fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)