### PR TITLE
fix(deals): un-exclude switchable categories (water, loans, mortgages, CC, car finance)

### DIFF
--- a/src/lib/savings-utils.ts
+++ b/src/lib/savings-utils.ts
@@ -1,6 +1,24 @@
+// Categories the deal-matcher should never try to find a switch for.
+//
+// Trimmed 27 Apr 2026: previously this also blocked mortgages, loans,
+// credit cards, car finance, and (briefly) water — but all of these
+// ARE switchable in the UK and the affiliate catalogue at
+// /dashboard/deals already carries deals for each (Habito + L&C for
+// mortgages, Freedom Finance + AA Loans for loans, MSE + CtM for
+// credit-card balance transfers, Carwow + Zuto for car finance,
+// CCW + WaterSure links for water). Excluding them meant the deal
+// widget refused to surface real refinance / balance-transfer / meter
+// savings to users.
+//
+// What stays excluded:
+//   - council_tax / tax — one council per address, can't switch (the
+//     band-challenge flow is its own dispute, not a deal-match)
+//   - fee / parking — one-off transactions, not recurring bills
+//
+// The 80% saving cap downstream still protects against weird
+// matches (a £15k/yr "saving" on a £18k mortgage gets dropped).
 export const EXCLUDED_SAVINGS_CATEGORIES = new Set([
-  'mortgage', 'mortgages', 'loan', 'loans', 'council_tax', 'tax',
-  'credit_card', 'credit cards', 'credit-cards', 'car_finance', 'car finance', 'car-finance',
+  'council_tax', 'tax',
   'fee', 'parking',
 ]);
 


### PR DESCRIPTION
## What you flagged
> _You can change your water bill and loan supplier so why are they excluded?_

\`EXCLUDED_SAVINGS_CATEGORIES\` in \`src/lib/savings-utils.ts\` has historically blocked the deal-matcher from surfacing switch deals for **mortgages, loans, credit cards, car finance** — all of which are switchable in the UK. Concurrent-session PR #322 then added **water** to the same exclusion. None of these belong there:

| Category | Switchable? | Affiliate deals already in /dashboard/deals |
|---|---|---|
| Mortgages | ✅ remortgage | Habito, L&C, Trussle, Maze |
| Loans | ✅ refinance / consolidate | Freedom Finance, AA Loans, Loan.co.uk |
| Credit cards | ✅ balance transfer | MSE, Compare the Market, TotallyMoney |
| Car finance | ✅ refinance | Carwow, Zuto |
| Water | ✅ meter request, WaterSure, business switching since 2017 | CCW, WaterSure, MSE water tips |

## Change

Trimmed `EXCLUDED_SAVINGS_CATEGORIES` to only the genuinely non-switchable categories:
- \`council_tax\` / \`tax\` — one council per address (band challenge is a separate dispute flow)
- \`fee\` / \`parking\` — one-off transactions, not recurring bills

The 80% downstream saving cap (\`currentPrice * 12 * 0.8\`) is still in place to drop weird matches like a £15k/yr "saving" on an £18k mortgage.

## Supersedes PR #322
PR #322 added \`water\` + \`water_company\` to the exclusion list with rationale "Can't switch UK water suppliers" — that's incomplete. This PR removes them. **Do not merge PR #322.** Either close it or merge this one first and resolve the conflict by taking this side.

## Test plan
- [ ] Connect a bank with mortgage / loan / credit-card / water transactions
- [ ] /dashboard/deals "Cheaper alternatives" surfaces matches for these categories
- [ ] Money Hub Switch & Save card no longer hides loans/mortgages/water
- [ ] Council tax + parking still excluded (verify by adding a council-tax direct debit; no deal should match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)