### PR TITLE
fix(price-alerts): dismissed alerts stop alerting

### DIFF
--- a/src/app/api/cron/price-increases/route.ts
+++ b/src/app/api/cron/price-increases/route.ts
@@ -55,15 +55,29 @@ export async function GET(request: NextRequest) {
       const increases = await detectPriceIncreases(userId);
       if (increases.length === 0) continue;
 
-      // Get existing active alerts for this user to prevent duplicates
+      // Get existing alerts (active OR dismissed) to prevent duplicates.
+      //
+      // Previously we only checked `status='active'`, so when a user
+      // dismissed a price alert in the dashboard it flipped to 'dismissed'
+      // and the next day's cron re-inserted an identical 'active' row —
+      // user got re-alerted via Telegram for an alert they'd already
+      // explicitly told us they didn't want. Founder confirmed: dismiss
+      // means "don't bother me about this again unless it changes
+      // further".
+      //
+      // Dedup key is (merchant_normalized, new_amount). If the price goes
+      // up again after dismissal, the new_amount changes, dedup misses,
+      // and the user gets a fresh alert — which is correct behaviour.
       const { data: existingAlerts } = await supabase
         .from('price_increase_alerts')
-        .select('merchant_normalized')
+        .select('merchant_normalized, new_amount, status')
         .eq('user_id', userId)
-        .eq('status', 'active');
+        .in('status', ['active', 'dismissed', 'actioned']);
 
-      const existingMerchants = new Set(
-        (existingAlerts || []).map(a => a.merchant_normalized)
+      const existingKeys = new Set(
+        (existingAlerts || []).map((a) =>
+          `${a.merchant_normalized}::${Number(a.new_amount).toFixed(2)}`,
+        ),
       );
 
       // Get user profile for email and tier
@@ -80,8 +94,11 @@ export async function GET(request: NextRequest) {
       const newIncreases: typeof increases = [];
 
       for (const increase of increases) {
-        // Skip if already alerted for this merchant
-        if (existingMerchants.has(increase.merchantNormalized)) continue;
+        // Skip if already alerted at this exact price — covers both
+        // "still active waiting for user action" and "user already
+        // dismissed/actioned this exact figure".
+        const key = `${increase.merchantNormalized}::${Number(increase.newAmount).toFixed(2)}`;
+        if (existingKeys.has(key)) continue;
 
         // Insert alert
         const { error: insertError } = await supabase


### PR DESCRIPTION
## What you flagged
> _this price increase is still coming through to telegram even though it was dismissed in the Paybacker website_

Reproduced from your Telegram screenshot — Winchester Council Tax (£233 → £1083.52) and HMRC NDDS (£801.73 → £1000) keep alerting every morning at 09:00 UTC despite being dismissed in the dashboard.

## Root cause
\`/api/cron/price-increases\` dedup query (line 63) filtered \`status = 'active'\` only:

\`\`\`ts
const { data: existingAlerts } = await supabase
  .from('price_increase_alerts')
  .select('merchant_normalized')
  .eq('user_id', userId)
  .eq('status', 'active');  // ← bug
\`\`\`

When you dismiss in the dashboard, the row flips to \`status='dismissed'\`. Tomorrow's cron asks "any *active* alerts for this merchant?" — answer: no, the dismissed one doesn't count. So it inserts a fresh active row at 08:00:13 UTC, the every-6h \`telegram-alerts\` cron picks it up, you get re-alerted at 09:00.

DB confirms the loop: **6 dismissed Winchester rows + 4 dismissed HMRC rows already**, all with identical amounts, dating back to 21 Apr. Each one is a re-insert after dismiss.

## Change
- Dedup key changed from \`merchant_normalized\` alone to \`(merchant_normalized, new_amount.toFixed(2))\` so the same merchant at a different price is still treated as a new alert.
- Existing-keys check now includes \`active\` + \`dismissed\` + \`actioned\` statuses. Once you dismiss at a given price, stays quiet at that price.
- If the price goes up further (e.g. Winchester £1083.52 → £1200), \`new_amount\` differs, dedup misses, you get a fresh alert — which is correct.

## Test plan
- [ ] Merge → tomorrow 08:00 UTC the cron runs, you should NOT receive a re-alert for Winchester or HMRC at the same amounts
- [ ] Insert a synthetic price_increase_alerts row with status='dismissed', re-run the cron with the same merchant/amount, confirm no new row inserted
- [ ] Change \`new_amount\` slightly (e.g. £1100), re-run cron, confirm fresh alert fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)