### PR TITLE
fix(spending): apply same exclusions across summaries + RPCs

### DIFF
--- a/src/app/api/cron/telegram-evening-summary/route.ts
+++ b/src/app/api/cron/telegram-evening-summary/route.ts
@@ -308,7 +308,15 @@ export async function GET(request: NextRequest) {
         .order('amount', { ascending: true }) // most negative first = biggest spend
         .limit(8);
 
-      const EXCLUDE_CATS = new Set(['transfers', 'income']);
+      // Mirror lib/spending.ts exclusions so notable transactions
+      // don't surface CC bill payments / pension top-ups / Loqbox
+      // moves as "spending" the user should care about.
+      const EXCLUDE_CATS = new Set([
+        'transfer', 'transfers', 'internal_transfer', 'self_transfer',
+        'credit_card_payment', 'credit_card',
+        'investment', 'investments', 'savings', 'pension',
+        'income', 'fee_refund',
+      ]);
       const notableTx = (recentTxData ?? []).filter(
         tx => !EXCLUDE_CATS.has(tx.user_category ?? '') && Math.abs(Number(tx.amount)) >= 10,
       ).slice(0, 5);

--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -205,7 +205,16 @@ export async function GET(request: NextRequest) {
       sections.push('*Good morning! Here\'s your daily money briefing:*');
 
       // ------ 1. Yesterday's spending ------
-      const EXCLUDE_CATS = new Set(['transfers', 'income']);
+      // Mirror lib/spending.ts exclusions so the morning summary matches
+      // Money Hub + the weekly digest. Previous list was just
+      // ('transfers','income') which double-counted credit-card bill
+      // repayments + investments + pension contributions.
+      const EXCLUDE_CATS = new Set([
+        'transfer', 'transfers', 'internal_transfer', 'self_transfer',
+        'credit_card_payment', 'credit_card',
+        'investment', 'investments', 'savings', 'pension',
+        'income', 'fee_refund',
+      ]);
       const { data: yesterdayTxRaw } = await supabase
         .from('bank_transactions')
         .select('user_category, amount')

--- a/supabase/migrations/20260427030000_spending_total_full_exclusions.sql
+++ b/supabase/migrations/20260427030000_spending_total_full_exclusions.sql
@@ -1,0 +1,68 @@
+-- Extend the get_monthly_spending RPCs so the exclusion set matches
+-- src/lib/spending.ts (introduced 27 Apr 2026 to fix the £20,733
+-- digest misinformation).
+--
+-- Previous version excluded only:
+--   user_category IN ('transfers', 'income')
+--   category = 'TRANSFER'
+--   income_type IN ('transfer', 'credit_loan')
+--
+-- That left credit-card bill repayments, investments, savings
+-- top-ups, and pension contributions counted as "spending" — which
+-- inflates the monthly spend headline shown in:
+--   - Money Hub Spending KPI (via /api/spending)
+--   - Telegram morning + evening summaries
+--   - Monthly recap
+-- All were over-reporting before this migration.
+--
+-- Loans / mortgages / water are intentionally NOT excluded — they're
+-- switchable bills the user wants to see surfaced. See lib/spending.ts
+-- for the full rationale.
+
+CREATE OR REPLACE FUNCTION public.get_monthly_spending_total(p_user_id uuid, p_year integer, p_month integer)
+ RETURNS numeric
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT COALESCE(SUM(ABS(amount)), 0)
+  FROM bank_transactions
+  WHERE user_id = p_user_id
+    AND timestamp >= MAKE_DATE(p_year, p_month, 1)::TIMESTAMPTZ
+    AND timestamp < (MAKE_DATE(p_year, p_month, 1) + INTERVAL '1 month')::TIMESTAMPTZ
+    AND amount < 0
+    AND LOWER(COALESCE(user_category, '')) NOT IN (
+      'transfer', 'transfers', 'internal_transfer', 'self_transfer',
+      'credit_card_payment', 'credit_card',
+      'investment', 'investments', 'savings', 'pension',
+      'income', 'fee_refund'
+    )
+    AND UPPER(COALESCE(category, '')) NOT IN ('TRANSFER', 'CREDIT_CARD_PAYMENT')
+    AND COALESCE(income_type, '') NOT IN ('transfer', 'credit_loan')
+$function$;
+
+-- The category-breakdown RPC (used by the evening-summary "this
+-- month by category" panel) needs the same exclusion list.
+CREATE OR REPLACE FUNCTION public.get_monthly_spending(p_user_id uuid, p_year integer, p_month integer)
+ RETURNS TABLE(category text, category_total numeric, transaction_count bigint)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT
+    LOWER(TRIM(COALESCE(user_category, category, 'other'))) AS category,
+    SUM(ABS(amount)) AS category_total,
+    COUNT(*) AS transaction_count
+  FROM bank_transactions
+  WHERE user_id = p_user_id
+    AND timestamp >= MAKE_DATE(p_year, p_month, 1)::TIMESTAMPTZ
+    AND timestamp < (MAKE_DATE(p_year, p_month, 1) + INTERVAL '1 month')::TIMESTAMPTZ
+    AND amount < 0
+    AND LOWER(COALESCE(user_category, '')) NOT IN (
+      'transfer', 'transfers', 'internal_transfer', 'self_transfer',
+      'credit_card_payment', 'credit_card',
+      'investment', 'investments', 'savings', 'pension',
+      'income', 'fee_refund'
+    )
+    AND UPPER(COALESCE(category, '')) NOT IN ('TRANSFER', 'CREDIT_CARD_PAYMENT')
+    AND COALESCE(income_type, '') NOT IN ('transfer', 'credit_loan')
+  GROUP BY LOWER(TRIM(COALESCE(user_category, category, 'other')))
+$function$;


### PR DESCRIPTION
## What
Extends the spending exclusion set introduced in #326 (lib/spending.ts) to every other surface that summarises user spending. Money Hub already excluded transfers correctly; morning + evening Telegram summaries and the underlying \`get_monthly_spending_total\` / \`get_monthly_spending\` RPCs did not.

## What was wrong
- **Morning summary** (07:30 UTC): \`EXCLUDE_CATS = new Set(['transfers', 'income'])\`. Yesterday's CC bill payment + Loqbox top-up + pension contribution all counted as spend.
- **Evening summary** (20:00 UTC): same hard-coded EXCLUDE_CATS for the "Recent Transactions" panel; the month-to-date headline uses \`get_monthly_spending_total\` which itself only excluded transfers.
- Result: month-to-date spend shown to the user was inflated by however much they put into Loqbox / paid off on their CC / dropped into pension.

## Change
- **Migration `20260427030000_spending_total_full_exclusions.sql`** rewrites both RPCs with the full exclusion list:
  - \`user_category\` ∈ {transfer, transfers, internal_transfer, self_transfer, credit_card_payment, credit_card, investment, investments, savings, pension, income, fee_refund}
  - \`category\` (uppercase, Open Banking) ∈ {TRANSFER, CREDIT_CARD_PAYMENT}
  - \`income_type\` ∈ {transfer, credit_loan}
- Loans / mortgages / water / council_tax stay counted — switchable bills the user wants visible (per founder spec from earlier today).
- Morning + evening summary \`EXCLUDE_CATS\` updated to the same list inline.

## Test plan
- [ ] Run migration in Supabase
- [ ] Manually invoke \`get_monthly_spending_total('64a7d7bf-...', 2026, 4)\` for the founder and compare to the same query without the new exclusions — expect the new total to be lower (CC payments + investments now excluded).
- [ ] Trigger telegram-morning-summary cron tomorrow and verify yesterday-spending headline drops the CC bill and Loqbox top-up.
- [ ] Money Hub overview still renders correctly (it doesn't use these RPCs but verify nothing regressed in /api/spending which does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)