### PR TITLE
fix(ux): address HIGH-severity UX audit findings (A1/A5/A8/MH2/N1/L1/RP1/DB4)

### DIFF
--- a/src/app/auth/accept-terms/page.tsx
+++ b/src/app/auth/accept-terms/page.tsx
@@ -188,7 +188,7 @@ export default function AcceptTermsPage() {
   return (
     <div className="m-land-root">
       <MarkNav />
-      <main className="auth-shell">
+      <main id="main-content" tabIndex={-1} className="auth-shell">
         <div className="auth-wrap">
           <Link href="/" className="auth-brand">
             <span className="pay">Pay</span>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -240,7 +240,20 @@ export default function LoginPage() {
                     </>
                   )}
 
-                  {error && <div className="form-error">{error}</div>}
+                  {error && (
+                    <div className="form-error">
+                      <div>{error}</div>
+                      {lockoutUntil && Date.now() < lockoutUntil && (
+                        <div style={{ marginTop: 6, fontSize: 13 }}>
+                          Forgotten your password?{' '}
+                          <Link href="/auth/reset-password" style={{ textDecoration: 'underline', fontWeight: 600 }}>
+                            Reset it now
+                          </Link>{' '}
+                          or use a magic link instead.
+                        </div>
+                      )}
+                    </div>
+                  )}
 
                   <button type="submit" disabled={loading} className="auth-submit">
                     {loading ? 'Please wait…' : useMagicLink ? 'Send magic link' : 'Sign in'}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -129,7 +129,7 @@ export default function LoginPage() {
   return (
     <div className="m-land-root">
       <MarkNav />
-      <main className="auth-shell">
+      <main id="main-content" tabIndex={-1} className="auth-shell">
         <div className="auth-wrap">
           <Link href="/" className="auth-brand">
             <span className="pay">Pay</span>

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -45,7 +45,7 @@ export default function ResetPasswordPage() {
   return (
     <div className="m-land-root">
       <MarkNav />
-      <main className="auth-shell">
+      <main id="main-content" tabIndex={-1} className="auth-shell">
         <div className="auth-wrap" style={{ maxWidth: 440, textAlign: 'center' }}>
           <div
             style={{

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -21,14 +21,15 @@ export default function ResetPasswordPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    if (!email.includes('@')) {
-      setError('Enter the email you signed up with.');
+    const trimmed = email.trim();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setError('Enter a valid email address (e.g. you@example.com).');
       return;
     }
     setLoading(true);
     try {
       const origin = typeof window !== 'undefined' ? window.location.origin : 'https://paybacker.co.uk';
-      const { error: supaErr } = await supabase.auth.resetPasswordForEmail(email, {
+      const { error: supaErr } = await supabase.auth.resetPasswordForEmail(trimmed, {
         redirectTo: `${origin}/auth/update-password`,
       });
       if (supaErr) {

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -277,7 +277,7 @@ export default function SignupPage() {
   return (
     <div className="m-land-root">
       <MarkNav />
-      <main className="auth-shell">
+      <main id="main-content" tabIndex={-1} className="auth-shell">
         <div className="auth-wrap">
           <Link href="/" className="auth-brand">
             <span className="pay">Pay</span>

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertTriangle, RefreshCw, Home, MessageCircle } from 'lucide-react';
+
+/**
+ * Dashboard route-group error boundary. Catches runtime errors in any
+ * /dashboard/* page so a single crash doesn't take down the whole shell.
+ * Logs to PostHog (if available) and the console; users get an actionable
+ * recovery card rather than a Next.js error overlay.
+ *
+ * Addresses UX_AUDIT.md A1.
+ */
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log to PostHog if it's loaded; otherwise console.
+    const posthog = (window as unknown as { posthog?: { capture: (e: string, p: Record<string, unknown>) => void } }).posthog;
+    if (posthog?.capture) {
+      posthog.capture('dashboard_error', {
+        message: error.message,
+        digest: error.digest,
+        stack: error.stack?.split('\n').slice(0, 6).join('\n'),
+        path: typeof window !== 'undefined' ? window.location.pathname : undefined,
+      });
+    } else {
+      console.error('[dashboard/error]', error);
+    }
+  }, [error]);
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center p-4">
+      <div className="max-w-md w-full card shadow-lg p-8 text-center">
+        <div className="inline-flex items-center justify-center h-12 w-12 rounded-full bg-amber-100 mb-4">
+          <AlertTriangle className="h-6 w-6 text-amber-600" />
+        </div>
+        <h1 className="text-xl font-bold text-slate-900 mb-2">Something went wrong here.</h1>
+        <p className="text-sm text-slate-600 mb-6">
+          We hit an unexpected error loading this page. The rest of Paybacker is still
+          working &mdash; you can retry, head back to the dashboard, or message support
+          and we&apos;ll pick it up.
+        </p>
+        {error.digest && (
+          <p className="text-xs text-slate-400 mb-6 font-mono">Reference: {error.digest}</p>
+        )}
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            onClick={() => reset()}
+            className="inline-flex items-center justify-center gap-2 bg-mint-500 hover:bg-mint-600 active:bg-mint-700 text-white font-semibold text-sm px-4 h-10 rounded-lg transition-colors"
+          >
+            <RefreshCw className="h-4 w-4" /> Try again
+          </button>
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 active:bg-slate-300 text-slate-700 font-semibold text-sm px-4 h-10 rounded-lg transition-colors"
+          >
+            <Home className="h-4 w-4" /> Back to dashboard
+          </Link>
+        </div>
+        <a
+          href="mailto:support@paybacker.co.uk?subject=Dashboard error"
+          className="inline-flex items-center gap-1.5 mt-4 text-xs text-slate-500 hover:text-slate-700"
+        >
+          <MessageCircle className="h-3.5 w-3.5" /> Email support
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -571,8 +571,13 @@ export default function MoneyHubPage() {
  const captionTimer = !silent
    ? setInterval(() => setScanCaption((prev) => (prev + 1) % SCAN_CAPTIONS.length), 3000)
    : null;
+ // 90s hard timeout. Without this, if /api/gmail/scan hangs (Claude
+ // upstream stall, Gmail API rate limit) the rotating caption spins
+ // forever and the user has no way to recover. Addresses UX_AUDIT MH2.
+ const controller = new AbortController();
+ const timeoutId = setTimeout(() => controller.abort(), 90_000);
  try {
-   const res = await fetch('/api/gmail/scan', { method: 'POST' });
+   const res = await fetch('/api/gmail/scan', { method: 'POST', signal: controller.signal });
    if (!res.ok) throw new Error('Scan failed');
    const payload = await res.json();
    await refreshData();
@@ -599,11 +604,22 @@ export default function MoneyHubPage() {
      showToast(summary, 'success');
    }
  }
- catch {
-   if (!silent) showToast('Scan failed. Check your email connection in Profile.', 'error');
+ catch (err) {
+   if (!silent) {
+     const aborted = err instanceof Error && err.name === 'AbortError';
+     showToast(
+       aborted
+         ? 'Scan timed out after 90s. Try again or check your email connection in Profile.'
+         : 'Scan failed. Check your email connection in Profile.',
+       'error',
+     );
+   }
  }
- if (captionTimer) clearInterval(captionTimer);
- if (!silent) setScanning(false);
+ finally {
+   clearTimeout(timeoutId);
+   if (captionTimer) clearInterval(captionTimer);
+   if (!silent) setScanning(false);
+ }
  };
 
  // ─── Auto-scan ────────────────────────────────────────────────────────

--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -179,10 +179,24 @@ export default function NotificationsPage() {
                     {items.map((n, i) => {
                       const meta = TYPE_ICON[n.type || ''] || { icon: '🔔', tone: 'text' as const };
                       const unread = !n.read_at;
+                      const interactive = !!n.link_url;
                       return (
                         <div
                           key={n.id}
                           onClick={() => handleClick(n)}
+                          {...(interactive
+                            ? {
+                                role: 'button',
+                                tabIndex: 0,
+                                onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
+                                  if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault();
+                                    handleClick(n);
+                                  }
+                                },
+                                'aria-label': `${n.title || 'Notification'}${unread ? ' (unread)' : ''}`,
+                              }
+                            : {})}
                           style={{
                             padding: '16px 20px',
                             borderBottom: i < items.length - 1 ? '1px solid var(--divider)' : 'none',
@@ -190,7 +204,7 @@ export default function NotificationsPage() {
                             gap: 14,
                             alignItems: 'flex-start',
                             background: unread ? '#FEFDF7' : 'transparent',
-                            cursor: n.link_url ? 'pointer' : 'default',
+                            cursor: interactive ? 'pointer' : 'default',
                           }}
                         >
                           <div

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -65,6 +65,13 @@ export default function DashboardPage() {
   const supabase = createClient();
   const searchParams = useSearchParams();
 
+  useEffect(() => {
+    if (!toast) return;
+    const ms = toast.type === 'error' ? 8000 : 3000;
+    const id = setTimeout(() => setToast(null), ms);
+    return () => clearTimeout(id);
+  }, [toast]);
+
   const potentialSavings = calculateTotalSavings(comparisonDeals, priceAlerts);
 
   // Disconnect bank function
@@ -78,7 +85,6 @@ export default function DashboardPage() {
         body: JSON.stringify({ connectionId }),
       });
       if (res.ok) {
-        // Remove from local state optimistically
         setBankAccounts(bankAccounts.filter(b => b.id !== connectionId));
         setToast({ message: `${bankName || 'Bank'} disconnected`, type: 'success' });
       } else {
@@ -1625,6 +1631,9 @@ export default function DashboardPage() {
       {/* Toast */}
       {toast && (
         <div
+          role="status"
+          aria-live={toast.type === 'error' ? 'assertive' : 'polite'}
+          onClick={() => setToast(null)}
           style={{
             position: 'fixed',
             bottom: 24,
@@ -1637,6 +1646,7 @@ export default function DashboardPage() {
             fontWeight: 600,
             zIndex: 60,
             boxShadow: '0 10px 30px -10px rgba(0,0,0,0.25)',
+            cursor: 'pointer',
           }}
         >
           {toast.message}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { AlertTriangle, RefreshCw, Home } from 'lucide-react';
+
+/**
+ * Top-level (App Router root) error boundary. Catches runtime errors from
+ * public pages — homepage, auth, pricing, marketing routes — that the
+ * dashboard error boundary wouldn't see.
+ *
+ * Addresses UX_AUDIT.md A1.
+ */
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    const posthog = (window as unknown as { posthog?: { capture: (e: string, p: Record<string, unknown>) => void } }).posthog;
+    if (posthog?.capture) {
+      posthog.capture('root_error', {
+        message: error.message,
+        digest: error.digest,
+        path: typeof window !== 'undefined' ? window.location.pathname : undefined,
+      });
+    } else {
+      console.error('[root/error]', error);
+    }
+  }, [error]);
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px' }}>
+      <div style={{ maxWidth: 480, width: '100%', background: '#fff', border: '1px solid #E5E7EB', borderRadius: 16, padding: 32, textAlign: 'center', boxShadow: '0 10px 30px -10px rgba(11,18,32,0.14)' }}>
+        <div style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', height: 48, width: 48, borderRadius: '50%', background: '#FEF3C7', marginBottom: 16 }}>
+          <AlertTriangle style={{ height: 24, width: 24, color: '#D97706' }} />
+        </div>
+        <h1 style={{ fontSize: 20, fontWeight: 700, color: '#0B1220', margin: '0 0 8px' }}>Something went wrong.</h1>
+        <p style={{ fontSize: 14, color: '#475569', margin: '0 0 24px', lineHeight: 1.6 }}>
+          The page hit an unexpected error. Try again, or head back to the homepage.
+        </p>
+        {error.digest && (
+          <p style={{ fontSize: 12, color: '#94A3B8', margin: '0 0 24px', fontFamily: 'monospace' }}>
+            Reference: {error.digest}
+          </p>
+        )}
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <button
+            onClick={() => reset()}
+            style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 8, background: '#10B981', color: 'white', fontWeight: 600, fontSize: 14, padding: '0 16px', height: 40, borderRadius: 8, border: 'none', cursor: 'pointer' }}
+          >
+            <RefreshCw style={{ height: 16, width: 16 }} /> Try again
+          </button>
+          <Link
+            href="/"
+            style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 8, background: '#F1F5F9', color: '#334155', fontWeight: 600, fontSize: 14, padding: '0 16px', height: 40, borderRadius: 8, textDecoration: 'none' }}
+          >
+            <Home style={{ height: 16, width: 16 }} /> Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -128,8 +128,17 @@ export default function RootLayout({
             }),
           }}
         />
+        {/* Skip-to-main-content — keyboard / screen-reader users bypass nav */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-[10000] focus:bg-mint-500 focus:text-white focus:px-4 focus:py-2 focus:rounded-lg focus:font-semibold focus:shadow-lg"
+        >
+          Skip to main content
+        </a>
         <PostHogProvider>
-          {children}
+          <div id="main-content" tabIndex={-1} className="flex-1 flex flex-col">
+            {children}
+          </div>
           <ChatWidget />
         </PostHogProvider>
         <TrackingScripts />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -136,7 +136,10 @@ export default function RootLayout({
           Skip to main content
         </a>
         <PostHogProvider>
-          <div id="main-content" tabIndex={-1} className="flex-1 flex flex-col">
+          {/* Each route attaches `id="main-content" tabIndex={-1}` to its
+              real <main> (dashboard shell, auth pages, marketing pages) so
+              the skip link lands AFTER any in-page navigation. */}
+          <div id="app-shell" className="flex-1 flex flex-col">
             {children}
           </div>
           <ChatWidget />

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -15,7 +15,7 @@ export default function CookieConsentBanner() {
   const [visible, setVisible] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
   const [prefs, setPrefs] = useState({ analytics: false, marketing: false, functional: false });
-  const cardRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!hasConsentBeenGiven()) {
@@ -33,19 +33,22 @@ export default function CookieConsentBanner() {
       document.body.style.paddingBottom = '';
       return;
     }
-    const card = cardRef.current;
-    if (!card) return;
+    // Measure the outer fixed wrapper (not the inner card) so the reserved
+    // padding includes the wrapper's p-4 vertical padding — otherwise we
+    // under-reserve by ~32px and controls near the viewport bottom can still
+    // sit under the banner on small screens. Codex P2 finding on PR #333.
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
 
     const apply = () => {
-      const h = card.offsetHeight;
-      // Add a small gap (12px) so content never visually butts against the card.
-      document.body.style.paddingBottom = `${h + 12}px`;
+      const h = wrapper.offsetHeight;
+      document.body.style.paddingBottom = `${h}px`;
     };
     apply();
 
     // Re-measure if banner content changes (preferences view is taller)
     const ro = new ResizeObserver(apply);
-    ro.observe(card);
+    ro.observe(wrapper);
     return () => {
       ro.disconnect();
       document.body.style.paddingBottom = '';
@@ -86,8 +89,8 @@ export default function CookieConsentBanner() {
   if (!visible) return null;
 
   return (
-    <div className="fixed bottom-0 inset-x-0 z-[9999] p-4" role="region" aria-label="Cookie consent">
-      <div ref={cardRef} className="max-w-2xl mx-auto card shadow-2xl p-6">
+    <div ref={wrapperRef} className="fixed bottom-0 inset-x-0 z-[9999] p-4" role="region" aria-label="Cookie consent">
+      <div className="max-w-2xl mx-auto card shadow-2xl p-6">
         {!showPreferences ? (
           <>
             <p className="text-sm text-slate-700 mb-4">

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import {
   getConsent,
@@ -15,12 +15,42 @@ export default function CookieConsentBanner() {
   const [visible, setVisible] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
   const [prefs, setPrefs] = useState({ analytics: false, marketing: false, functional: false });
+  const cardRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!hasConsentBeenGiven()) {
       setVisible(true);
     }
   }, []);
+
+  // While the banner is visible, reserve bottom padding on the body equal
+  // to the banner's height so the banner can't sit over auth submit buttons,
+  // checkout CTAs, or any sticky bottom action. Without this, fixed-bottom
+  // overlay intercepts clicks at typical viewport heights (caught by e2e
+  // suite and surfaced as A8 in UX_AUDIT.md).
+  useEffect(() => {
+    if (!visible) {
+      document.body.style.paddingBottom = '';
+      return;
+    }
+    const card = cardRef.current;
+    if (!card) return;
+
+    const apply = () => {
+      const h = card.offsetHeight;
+      // Add a small gap (12px) so content never visually butts against the card.
+      document.body.style.paddingBottom = `${h + 12}px`;
+    };
+    apply();
+
+    // Re-measure if banner content changes (preferences view is taller)
+    const ro = new ResizeObserver(apply);
+    ro.observe(card);
+    return () => {
+      ro.disconnect();
+      document.body.style.paddingBottom = '';
+    };
+  }, [visible, showPreferences]);
 
   // Listen for "open cookie settings" events from footer link
   useEffect(() => {
@@ -56,8 +86,8 @@ export default function CookieConsentBanner() {
   if (!visible) return null;
 
   return (
-    <div className="fixed bottom-0 inset-x-0 z-[9999] p-4">
-      <div className="max-w-2xl mx-auto card shadow-2xl p-6">
+    <div className="fixed bottom-0 inset-x-0 z-[9999] p-4" role="region" aria-label="Cookie consent">
+      <div ref={cardRef} className="max-w-2xl mx-auto card shadow-2xl p-6">
         {!showPreferences ? (
           <>
             <p className="text-sm text-slate-700 mb-4">

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -249,10 +249,10 @@ export default function DashboardShell({
         {sidebar}
         <div className="main">
           <Topbar crumb={crumb} />
-          <div className="main-inner">
+          <main id="main-content" tabIndex={-1} className="main-inner">
             {topBanner}
             {children}
-          </div>
+          </main>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Sweeps the HIGH-severity findings from `_handoff/UX_AUDIT.md` (the Playwright + code audit landed in #303). Eight surface-level fixes; no schema or API changes.

| Finding | What changed |
|---|---|
| **A1** Global error boundaries | New `src/app/error.tsx` (root) and `src/app/dashboard/error.tsx`. PostHog logging where available; friendly card with `error.digest` reference + Try-again / Home actions. |
| **A5** Skip-to-main-content link | Skip link in root layout; children wrapped in focusable `<div id="main-content" tabIndex={-1}>`. |
| **A8** Cookie banner click intercept | `CookieConsentBanner` reserves `body { padding-bottom }` equal to its measured height (ResizeObserver), so the fixed-bottom banner no longer covers the auth submit button. Added `role="region"` + `aria-label`. |
| **MH2** Money Hub scan timeout | `AbortController` with **90s hard timeout** on `/api/gmail/scan`. Caption interval + timer cleared in `finally`. AbortError gets a distinct toast. |
| **N1** Notifications keyboard a11y | Rows with `link_url` now get `role=button`, `tabIndex=0`, Enter/Space `onKeyDown`, and an `aria-label` noting unread state. |
| **L1** Login lockout recovery | When locked out after 5 failed attempts, error block now surfaces a "Reset it now" link + magic-link suggestion. |
| **RP1** Reset-password validation | `email.includes('@')` → proper regex + `.trim()`. |
| **DB4** Dashboard toast UX | Auto-dismiss after **3s** (success/info) / **8s** (error). Click-to-dismiss. `role="status"` + `aria-live` tuned to severity. |

Branch is `fix/ux-audit-highs-v2` because `fix/ux-audit-highs` is in use locally by a concurrent session — same intent, fresh branch off `master` to keep the diff clean.

## Test plan

- [ ] Throw a runtime error in a dashboard page — error.tsx renders, PostHog event fires, Try-again recovers
- [ ] Throw in a public route — root error.tsx renders
- [ ] Tab from page top — skip-to-main-content link appears, focus lands in #main-content
- [ ] /auth/login — submit fully clickable, banner reserves space below content
- [ ] Money Hub scan: simulate hung /api/gmail/scan — toast shows "Scan timed out after 90s" at 90s
- [ ] Notifications: Tab to a linked row, press Enter/Space — navigates; SR announces unread state
- [ ] 5 failed logins → lockout copy contains "Reset it now" link
- [ ] /auth/reset-password: "notanemail" blocked; "you@example.com" accepted
- [ ] Dashboard: success toast auto-dismisses ~3s, error toast ~8s; click dismisses early

🤖 Generated with [Claude Code](https://claude.com/claude-code)