### PR TITLE
feat(b2b): admin dashboard + /v1/disputes API stub

### DIFF
--- a/src/app/api/admin/b2b-keys/route.ts
+++ b/src/app/api/admin/b2b-keys/route.ts
@@ -1,0 +1,149 @@
+/**
+ * GET  /api/admin/b2b-keys — list issued keys (no plaintext, ever)
+ * POST /api/admin/b2b-keys — mint a new key, plaintext returned ONCE
+ * PATCH /api/admin/b2b-keys — revoke a key
+ *
+ * Founder-only via NEXT_PUBLIC_ADMIN_EMAILS. The plaintext from a
+ * mint is shown once and then exists nowhere — no logs, no DB. If
+ * the customer loses it they get a new one and we revoke the old.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@supabase/supabase-js';
+import { generateKey } from '@/lib/b2b/auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const TIER_LIMITS: Record<string, number> = {
+  starter: 1000,
+  growth: 10_000,
+  enterprise: 100_000,
+};
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+async function requireAdmin(): Promise<{ ok: true } | { ok: false; res: NextResponse }> {
+  const supabase = await createServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email) {
+    return { ok: false, res: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const adminEmails = (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  if (!adminEmails.includes(user.email.toLowerCase())) {
+    return { ok: false, res: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+  return { ok: true };
+}
+
+export async function GET() {
+  const auth = await requireAdmin();
+  if (!auth.ok) return auth.res;
+
+  const supabase = getAdmin();
+  const { data: keys, error } = await supabase
+    .from('b2b_api_keys')
+    .select('id, name, key_prefix, tier, monthly_limit, owner_email, waitlist_id, last_used_at, revoked_at, notes, created_at')
+    .order('created_at', { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Pull this-month usage counts for every key in one round trip.
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+  const { data: usage } = await supabase
+    .from('b2b_api_usage')
+    .select('key_id')
+    .gte('created_at', monthStart.toISOString());
+  const usageByKey = new Map<string, number>();
+  for (const row of usage ?? []) {
+    const k = (row as any).key_id as string;
+    usageByKey.set(k, (usageByKey.get(k) ?? 0) + 1);
+  }
+  const enriched = (keys ?? []).map((k) => ({
+    ...k,
+    monthly_used: usageByKey.get(k.id) ?? 0,
+  }));
+
+  return NextResponse.json({ keys: enriched });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAdmin();
+  if (!auth.ok) return auth.res;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { name, tier, owner_email, waitlist_id, notes } = body ?? {};
+  if (!name || typeof name !== 'string' || name.trim().length < 2) {
+    return NextResponse.json({ error: '`name` is required' }, { status: 400 });
+  }
+  const t = tier ?? 'starter';
+  if (!TIER_LIMITS[t]) {
+    return NextResponse.json({ error: `\`tier\` must be one of ${Object.keys(TIER_LIMITS).join(', ')}` }, { status: 400 });
+  }
+
+  const minted = generateKey();
+  const supabase = getAdmin();
+  const { data, error } = await supabase
+    .from('b2b_api_keys')
+    .insert({
+      name: name.trim(),
+      key_hash: minted.hash,
+      key_prefix: minted.prefix,
+      tier: t,
+      monthly_limit: TIER_LIMITS[t],
+      owner_email: owner_email ?? null,
+      waitlist_id: waitlist_id ?? null,
+      notes: notes ?? null,
+    })
+    .select('id, name, key_prefix, tier, monthly_limit, created_at')
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({
+    ok: true,
+    key: data,
+    plaintext: minted.plaintext, // ⚠ shown ONCE — never persisted
+    warning: 'Save this token now. You will not be able to retrieve it again.',
+  });
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireAdmin();
+  if (!auth.ok) return auth.res;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { id, action } = body ?? {};
+  if (!id || action !== 'revoke') {
+    return NextResponse.json({ error: '`id` and `action: "revoke"` required' }, { status: 400 });
+  }
+
+  const supabase = getAdmin();
+  const { error } = await supabase
+    .from('b2b_api_keys')
+    .update({ revoked_at: new Date().toISOString() })
+    .eq('id', id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/b2b-waitlist/route.ts
+++ b/src/app/api/admin/b2b-waitlist/route.ts
@@ -1,0 +1,88 @@
+/**
+ * GET  /api/admin/b2b-waitlist — list signups (founder-only)
+ * PATCH /api/admin/b2b-waitlist — flip a signup's status / add notes
+ *
+ * Auth: requires the caller's email to be in NEXT_PUBLIC_ADMIN_EMAILS
+ * (same gate the rest of /dashboard/admin uses). This is a private
+ * surface — never exposed to non-admin users.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+async function requireAdmin(): Promise<{ ok: true; email: string } | { ok: false; res: NextResponse }> {
+  const supabase = await createServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email) {
+    return { ok: false, res: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const adminEmails = (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  if (!adminEmails.includes(user.email.toLowerCase())) {
+    return { ok: false, res: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+  return { ok: true, email: user.email };
+}
+
+export async function GET() {
+  const auth = await requireAdmin();
+  if (!auth.ok) return auth.res;
+
+  const supabase = getAdmin();
+  const { data, error } = await supabase
+    .from('b2b_waitlist')
+    .select('id, name, work_email, company, role, expected_volume, use_case, status, notes, utm_source, utm_medium, utm_campaign, referrer, created_at, reviewed_at')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ signups: data ?? [] });
+}
+
+export async function PATCH(request: NextRequest) {
+  const auth = await requireAdmin();
+  if (!auth.ok) return auth.res;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { id, status, notes } = body ?? {};
+  if (!id || typeof id !== 'string') {
+    return NextResponse.json({ error: '`id` is required' }, { status: 400 });
+  }
+  const validStatuses = ['new', 'qualified', 'contacted', 'rejected', 'converted'];
+  if (status && !validStatuses.includes(status)) {
+    return NextResponse.json({ error: `\`status\` must be one of ${validStatuses.join(', ')}` }, { status: 400 });
+  }
+
+  const update: Record<string, unknown> = { reviewed_at: new Date().toISOString() };
+  if (status) update.status = status;
+  if (typeof notes === 'string') update.notes = notes;
+
+  const supabase = getAdmin();
+  const { error } = await supabase
+    .from('b2b_waitlist')
+    .update(update)
+    .eq('id', id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/disputes/route.ts
+++ b/src/app/api/v1/disputes/route.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /api/v1/disputes — B2B UK Consumer Rights API
+ *
+ * Public-facing v1 surface. Bearer-token auth, monthly rate limit
+ * per key, structured response with primary UK statute citation,
+ * entitlement analysis, draft letter excerpt and escalation path.
+ *
+ * Lives at /api/v1/disputes rather than /v1/disputes because Next
+ * App Router puts API handlers under /api by convention. Customers
+ * call `paybacker.co.uk/api/v1/disputes`. The /api → /for-business
+ * redirect added in #341 is exact-match only so this path resolves
+ * normally.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticate, logUsage } from '@/lib/b2b/auth';
+import { validateRequest, resolveDispute } from '@/lib/b2b/disputes';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+function rateLimitHeaders(monthlyUsed: number, monthlyLimit: number) {
+  const remaining = Math.max(0, monthlyLimit - monthlyUsed - 1); // -1 for this call
+  return {
+    'X-RateLimit-Limit': String(monthlyLimit),
+    'X-RateLimit-Remaining': String(remaining),
+  };
+}
+
+export async function POST(request: NextRequest) {
+  const t0 = Date.now();
+  const auth = await authenticate(request.headers.get('authorization'));
+  if (!auth.ok || !auth.key) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status ?? 401 });
+  }
+  const { key } = auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    await logUsage(key.id, '/v1/disputes', 400, Date.now() - t0, { error_code: 'INVALID_JSON' });
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const validated = validateRequest(body);
+  if ('code' in validated && validated.code === 'VALIDATION') {
+    await logUsage(key.id, '/v1/disputes', 400, Date.now() - t0, { error_code: 'VALIDATION' });
+    return NextResponse.json({ error: validated.message }, { status: 400 });
+  }
+
+  const result = await resolveDispute(validated as any);
+  if ('code' in result) {
+    const status = result.code === 'NO_STATUTE_MATCH' ? 422 : 500;
+    await logUsage(key.id, '/v1/disputes', status, Date.now() - t0, {
+      error_code: result.code,
+    });
+    return NextResponse.json({ error: result.message, code: result.code }, { status });
+  }
+
+  await logUsage(key.id, '/v1/disputes', 200, Date.now() - t0, {
+    scenario_kind: result.legal_references[0] ?? null,
+  });
+  return NextResponse.json(result, {
+    status: 200,
+    headers: rateLimitHeaders(key.monthlyUsed, key.monthlyLimit),
+  });
+}
+
+export async function GET() {
+  return NextResponse.json({
+    name: 'Paybacker UK Consumer Rights API',
+    version: 'v1',
+    docs: 'https://paybacker.co.uk/for-business',
+    auth: 'Bearer token in Authorization header (request a key at /for-business)',
+    endpoints: {
+      'POST /api/v1/disputes': 'Resolve a UK consumer dispute scenario into statute + entitlement + draft + escalation',
+    },
+  });
+}

--- a/src/app/dashboard/admin/b2b/page.tsx
+++ b/src/app/dashboard/admin/b2b/page.tsx
@@ -1,0 +1,359 @@
+'use client';
+
+/**
+ * /dashboard/admin/b2b — founder-only B2B operations console.
+ *
+ * Two sections:
+ *   1. Waitlist signups — triage, status flips, notes
+ *   2. API keys — mint, revoke, see this-month usage
+ *
+ * Auth is enforced server-side by the underlying /api/admin/b2b-*
+ * endpoints. This page just renders for any authed user — non-admin
+ * fetches will get 403 and the lists stay empty, which is fine.
+ *
+ * Lives under /dashboard/admin/b2b so the existing dashboard shell
+ * (sidebar, NotificationBell, banner stack) wraps it for free.
+ */
+
+import { useEffect, useState } from 'react';
+
+interface Signup {
+  id: string;
+  name: string;
+  work_email: string;
+  company: string;
+  role: string | null;
+  expected_volume: string;
+  use_case: string;
+  status: 'new' | 'qualified' | 'contacted' | 'rejected' | 'converted';
+  notes: string | null;
+  utm_source: string | null;
+  created_at: string;
+  reviewed_at: string | null;
+}
+
+interface ApiKey {
+  id: string;
+  name: string;
+  key_prefix: string;
+  tier: 'starter' | 'growth' | 'enterprise';
+  monthly_limit: number;
+  monthly_used: number;
+  owner_email: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  notes: string | null;
+  created_at: string;
+}
+
+const STATUSES: Signup['status'][] = ['new', 'qualified', 'contacted', 'rejected', 'converted'];
+
+export default function AdminB2BPage() {
+  const [signups, setSignups] = useState<Signup[]>([]);
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [mintedToken, setMintedToken] = useState<{ name: string; plaintext: string } | null>(null);
+
+  // Mint form
+  const [mintName, setMintName] = useState('');
+  const [mintTier, setMintTier] = useState<ApiKey['tier']>('starter');
+  const [mintEmail, setMintEmail] = useState('');
+  const [minting, setMinting] = useState(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const [w, k] = await Promise.all([
+        fetch('/api/admin/b2b-waitlist').then((r) => r.json()),
+        fetch('/api/admin/b2b-keys').then((r) => r.json()),
+      ]);
+      if (w.error || k.error) throw new Error(w.error || k.error);
+      setSignups(w.signups ?? []);
+      setKeys(k.keys ?? []);
+      setError(null);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const updateStatus = async (id: string, status: Signup['status']) => {
+    await fetch('/api/admin/b2b-waitlist', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, status }),
+    });
+    await refresh();
+  };
+
+  const mintKey = async () => {
+    if (!mintName.trim()) return;
+    setMinting(true);
+    try {
+      const res = await fetch('/api/admin/b2b-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: mintName.trim(),
+          tier: mintTier,
+          owner_email: mintEmail || null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Mint failed');
+      setMintedToken({ name: data.key.name, plaintext: data.plaintext });
+      setMintName('');
+      setMintEmail('');
+      await refresh();
+    } catch (e: any) {
+      setError(e?.message ?? 'Mint failed');
+    } finally {
+      setMinting(false);
+    }
+  };
+
+  const revokeKey = async (id: string) => {
+    if (!confirm('Revoke this key? Calls using it will start failing immediately.')) return;
+    await fetch('/api/admin/b2b-keys', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, action: 'revoke' }),
+    });
+    await refresh();
+  };
+
+  const stats = {
+    total: signups.length,
+    qualified: signups.filter((s) => ['qualified', 'contacted', 'converted'].includes(s.status)).length,
+    new: signups.filter((s) => s.status === 'new').length,
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto p-6 space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-slate-900">B2B Operations</h1>
+        <p className="text-sm text-slate-500 mt-1">
+          UK Consumer Rights API — waitlist triage and key management.
+        </p>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-red-800 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-4">
+        <Stat label="Signups" value={stats.total} />
+        <Stat label="Qualified" value={stats.qualified} accent="green" />
+        <Stat label="New (need triage)" value={stats.new} accent={stats.new > 0 ? 'amber' : undefined} />
+      </div>
+
+      {/* Decision tracker */}
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-900">
+        <strong>Decision rule:</strong> 10+ qualified signups in 30 days post-launch → green-light B2B build. &lt;10 → archive page.
+        {' '}
+        Currently <strong>{stats.qualified}/10 qualified</strong>.
+      </div>
+
+      {/* Waitlist */}
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900 mb-3">Waitlist signups</h2>
+        {loading ? (
+          <p className="text-slate-500 text-sm">Loading…</p>
+        ) : signups.length === 0 ? (
+          <p className="text-slate-500 text-sm">No signups yet. Once /for-business is live, submissions land here.</p>
+        ) : (
+          <div className="space-y-3">
+            {signups.map((s) => (
+              <div key={s.id} className="bg-white border border-slate-200 rounded-lg p-4">
+                <div className="flex justify-between gap-4 flex-wrap">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-semibold text-slate-900">{s.name}</span>
+                      <span className="text-slate-500">@</span>
+                      <span className="font-medium text-slate-900">{s.company}</span>
+                      {s.role && <span className="text-xs text-slate-500">({s.role})</span>}
+                    </div>
+                    <p className="text-xs text-slate-500 mt-0.5">
+                      <a href={`mailto:${s.work_email}`} className="text-emerald-600 hover:underline">
+                        {s.work_email}
+                      </a>
+                      {' · '}
+                      Volume: <span className="font-medium text-slate-700">{s.expected_volume}</span>
+                      {' · '}
+                      {new Date(s.created_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}
+                      {s.utm_source && ` · src:${s.utm_source}`}
+                    </p>
+                    <p className="text-sm text-slate-700 mt-2 leading-relaxed">{s.use_case}</p>
+                  </div>
+                  <div className="flex flex-col gap-2 items-end shrink-0">
+                    <select
+                      value={s.status}
+                      onChange={(e) => updateStatus(s.id, e.target.value as Signup['status'])}
+                      className="text-xs border border-slate-300 rounded px-2 py-1 bg-white"
+                    >
+                      {STATUSES.map((st) => (
+                        <option key={st} value={st}>
+                          {st}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Keys */}
+      <section>
+        <h2 className="text-lg font-semibold text-slate-900 mb-3">API keys</h2>
+
+        {/* Just-minted plaintext display — show once */}
+        {mintedToken && (
+          <div className="bg-emerald-50 border border-emerald-300 rounded-lg p-4 mb-4">
+            <p className="text-sm font-semibold text-emerald-900">Key minted: {mintedToken.name}</p>
+            <p className="text-xs text-emerald-700 mt-1">
+              Save this now. We do not store the plaintext and cannot show it again.
+            </p>
+            <code className="block bg-white border border-emerald-200 rounded mt-2 p-3 text-sm font-mono break-all text-slate-900">
+              {mintedToken.plaintext}
+            </code>
+            <button
+              onClick={() => setMintedToken(null)}
+              className="text-xs text-emerald-700 hover:text-emerald-900 mt-2"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+
+        {/* Mint form */}
+        <div className="bg-white border border-slate-200 rounded-lg p-4 mb-4">
+          <h3 className="text-sm font-semibold text-slate-900 mb-3">Mint a new key</h3>
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+            <input
+              type="text"
+              placeholder="Name (e.g. Acme Production)"
+              value={mintName}
+              onChange={(e) => setMintName(e.target.value)}
+              className="border border-slate-300 rounded px-3 py-2 text-sm"
+            />
+            <input
+              type="email"
+              placeholder="Owner email (optional)"
+              value={mintEmail}
+              onChange={(e) => setMintEmail(e.target.value)}
+              className="border border-slate-300 rounded px-3 py-2 text-sm"
+            />
+            <select
+              value={mintTier}
+              onChange={(e) => setMintTier(e.target.value as ApiKey['tier'])}
+              className="border border-slate-300 rounded px-3 py-2 text-sm bg-white"
+            >
+              <option value="starter">Starter — 1,000 / mo</option>
+              <option value="growth">Growth — 10,000 / mo</option>
+              <option value="enterprise">Enterprise — 100,000 / mo</option>
+            </select>
+            <button
+              onClick={mintKey}
+              disabled={minting || !mintName.trim()}
+              className="bg-slate-900 text-white text-sm font-semibold rounded px-4 py-2 disabled:opacity-50"
+            >
+              {minting ? 'Minting…' : 'Mint key'}
+            </button>
+          </div>
+        </div>
+
+        {/* Existing keys */}
+        {keys.length === 0 ? (
+          <p className="text-slate-500 text-sm">No keys minted yet.</p>
+        ) : (
+          <div className="bg-white border border-slate-200 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 text-xs uppercase text-slate-500">
+                <tr>
+                  <th className="text-left px-4 py-2">Name</th>
+                  <th className="text-left px-4 py-2">Prefix</th>
+                  <th className="text-left px-4 py-2">Tier</th>
+                  <th className="text-left px-4 py-2">Usage</th>
+                  <th className="text-left px-4 py-2">Last used</th>
+                  <th className="text-right px-4 py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {keys.map((k) => {
+                  const pct = (k.monthly_used / k.monthly_limit) * 100;
+                  return (
+                    <tr key={k.id} className="border-t border-slate-100">
+                      <td className="px-4 py-3">
+                        <div className="font-medium text-slate-900">{k.name}</div>
+                        {k.owner_email && (
+                          <div className="text-xs text-slate-500">{k.owner_email}</div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 font-mono text-xs text-slate-700">pbk_{k.key_prefix}_…</td>
+                      <td className="px-4 py-3 capitalize">{k.tier}</td>
+                      <td className="px-4 py-3">
+                        <div className="text-xs text-slate-700">
+                          {k.monthly_used.toLocaleString()} / {k.monthly_limit.toLocaleString()}
+                        </div>
+                        <div className="h-1.5 bg-slate-100 rounded-full mt-1 overflow-hidden">
+                          <div
+                            className={`h-full ${pct >= 90 ? 'bg-red-500' : pct >= 60 ? 'bg-amber-500' : 'bg-emerald-500'}`}
+                            style={{ width: `${Math.min(100, pct)}%` }}
+                          />
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-slate-500">
+                        {k.last_used_at
+                          ? new Date(k.last_used_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+                          : 'Never'}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {k.revoked_at ? (
+                          <span className="text-xs text-slate-400">Revoked</span>
+                        ) : (
+                          <button
+                            onClick={() => revokeKey(k.id)}
+                            className="text-xs text-red-600 hover:text-red-800"
+                          >
+                            Revoke
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Stat({ label, value, accent }: { label: string; value: number; accent?: 'green' | 'amber' }) {
+  const tone =
+    accent === 'green'
+      ? 'text-emerald-700 bg-emerald-50 border-emerald-200'
+      : accent === 'amber'
+      ? 'text-amber-700 bg-amber-50 border-amber-200'
+      : 'text-slate-900 bg-white border-slate-200';
+  return (
+    <div className={`border rounded-lg p-4 ${tone}`}>
+      <div className="text-xs uppercase tracking-wider opacity-70">{label}</div>
+      <div className="text-3xl font-bold mt-1">{value}</div>
+    </div>
+  );
+}

--- a/src/lib/b2b/auth.ts
+++ b/src/lib/b2b/auth.ts
@@ -1,0 +1,157 @@
+/**
+ * Bearer-token auth for the /v1/* B2B API surface.
+ *
+ * Key format: `pbk_<8-prefix>_<32-hex-secret>`. The prefix is stored
+ * plain so the admin UI can identify which key a customer is using;
+ * the full token is hashed and only the hash sits in b2b_api_keys.
+ *
+ * Hash uses Node's built-in SHA-256 — adequate for what's effectively
+ * a 32-byte random secret. We don't need bcrypt's slow work factor
+ * here because the input is already high-entropy.
+ *
+ * Rate limit: per-key per-calendar-month, counted live from
+ * b2b_api_usage. Cheap on the hot path because the index is keyed
+ * (key_id, created_at DESC).
+ */
+
+import crypto from 'node:crypto';
+import { createClient } from '@supabase/supabase-js';
+
+export interface AuthedKey {
+  id: string;
+  name: string;
+  tier: 'starter' | 'growth' | 'enterprise';
+  monthlyLimit: number;
+  monthlyUsed: number;
+  ownerEmail: string | null;
+  waitlistId: string | null;
+}
+
+export interface AuthResult {
+  ok: boolean;
+  key?: AuthedKey;
+  error?: string;
+  status?: number;
+}
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export function hashKey(plaintext: string): string {
+  return crypto.createHash('sha256').update(plaintext, 'utf8').digest('hex');
+}
+
+/**
+ * Mint a new key. Returns both the plaintext (shown once) and the
+ * stored prefix. Caller is responsible for inserting into b2b_api_keys
+ * with the returned hash.
+ */
+export function generateKey(): { plaintext: string; prefix: string; hash: string } {
+  const prefix = crypto.randomBytes(4).toString('hex'); // 8 hex chars
+  const secret = crypto.randomBytes(16).toString('hex'); // 32 hex chars
+  const plaintext = `pbk_${prefix}_${secret}`;
+  return { plaintext, prefix, hash: hashKey(plaintext) };
+}
+
+/**
+ * Validate an Authorization header. Returns the authed key on success
+ * or { ok: false, error, status } on failure. Status mirrors what the
+ * caller should send back to the client.
+ */
+export async function authenticate(authHeader: string | null): Promise<AuthResult> {
+  if (!authHeader) {
+    return { ok: false, error: 'Missing Authorization header. Expected `Authorization: Bearer pbk_...`.', status: 401 };
+  }
+  const m = authHeader.match(/^Bearer\s+(pbk_[a-f0-9]{8}_[a-f0-9]{32})$/);
+  if (!m) {
+    return { ok: false, error: 'Authorization header format invalid.', status: 401 };
+  }
+  const plaintext = m[1];
+  const prefix = plaintext.slice(4, 12);
+  const hash = hashKey(plaintext);
+
+  const supabase = getAdmin();
+  const { data: keyRow, error } = await supabase
+    .from('b2b_api_keys')
+    .select('id, name, tier, monthly_limit, owner_email, waitlist_id, key_hash, revoked_at')
+    .eq('key_prefix', prefix)
+    .maybeSingle();
+
+  if (error || !keyRow) {
+    return { ok: false, error: 'Invalid API key.', status: 401 };
+  }
+  if (keyRow.revoked_at) {
+    return { ok: false, error: 'API key has been revoked.', status: 401 };
+  }
+  // Constant-time compare protects against any theoretical prefix-
+  // probing timing side channel (the prefix lookup itself is in DB).
+  const stored = Buffer.from(keyRow.key_hash, 'hex');
+  const presented = Buffer.from(hash, 'hex');
+  if (stored.length !== presented.length || !crypto.timingSafeEqual(stored, presented)) {
+    return { ok: false, error: 'Invalid API key.', status: 401 };
+  }
+
+  // Live count of usage this calendar month.
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+  const { count } = await supabase
+    .from('b2b_api_usage')
+    .select('id', { count: 'exact', head: true })
+    .eq('key_id', keyRow.id)
+    .gte('created_at', monthStart.toISOString());
+  const monthlyUsed = count ?? 0;
+
+  if (monthlyUsed >= keyRow.monthly_limit) {
+    return {
+      ok: false,
+      error: `Monthly call limit reached (${keyRow.monthly_limit} on tier "${keyRow.tier}"). Upgrade or wait until the 1st.`,
+      status: 429,
+    };
+  }
+
+  // Bump last_used_at fire-and-forget — it's ok if this races.
+  void supabase
+    .from('b2b_api_keys')
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('id', keyRow.id);
+
+  return {
+    ok: true,
+    key: {
+      id: keyRow.id,
+      name: keyRow.name,
+      tier: keyRow.tier as AuthedKey['tier'],
+      monthlyLimit: keyRow.monthly_limit,
+      monthlyUsed,
+      ownerEmail: keyRow.owner_email,
+      waitlistId: keyRow.waitlist_id,
+    },
+  };
+}
+
+export async function logUsage(
+  keyId: string,
+  endpoint: string,
+  statusCode: number,
+  latencyMs: number,
+  extra: { scenario_kind?: string | null; error_code?: string | null } = {},
+): Promise<void> {
+  try {
+    const supabase = getAdmin();
+    await supabase.from('b2b_api_usage').insert({
+      key_id: keyId,
+      endpoint,
+      status_code: statusCode,
+      latency_ms: latencyMs,
+      scenario_kind: extra.scenario_kind ?? null,
+      error_code: extra.error_code ?? null,
+    });
+  } catch (e: any) {
+    console.error('[b2b/auth] logUsage failed', e?.message);
+  }
+}

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -1,0 +1,207 @@
+/**
+ * /v1/disputes contract.
+ *
+ * Wraps the same Claude-driven engine that powers the consumer
+ * Paybacker complaint flow (lib/agents/complaints-agent.ts) and
+ * shapes the response into a stable B2B contract — statute citation,
+ * structured entitlement, draft letter excerpt, escalation path.
+ *
+ * The shape is deliberately stable across statute domains: a UK261
+ * flight-cancellation scenario and a Section 75 chargeback both
+ * return the same fields. Callers parse one schema, not many.
+ *
+ * Anti-hallucination: the consumer engine pulls verified statute
+ * references from the legal_references table before prompting
+ * Claude. We reuse that path here so a B2B caller never gets a
+ * fabricated act or section number.
+ */
+
+import { generateComplaintLetter } from '@/lib/agents/complaints-agent';
+import { createClient } from '@supabase/supabase-js';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export interface DisputeRequest {
+  scenario: string;
+  context?: Record<string, unknown>;
+  jurisdiction?: 'UK';
+  desired_outcome?: string;
+  amount?: number;
+  consumer_name?: string;
+}
+
+export interface DisputeResponse {
+  statute: string;
+  entitlement: {
+    summary: string;
+    rationale: string;
+    additional_rights?: string[];
+    estimated_success: 'low' | 'medium' | 'high';
+  };
+  draft_letter_excerpt: string;
+  escalation_path: Array<{ step: number; to: string; wait_days?: number; url?: string }>;
+  legal_references: string[];
+  confidence: number;
+}
+
+export interface DisputeError {
+  code: 'VALIDATION' | 'NO_STATUTE_MATCH' | 'ENGINE_ERROR';
+  message: string;
+}
+
+export function validateRequest(body: unknown): DisputeRequest | DisputeError {
+  if (!body || typeof body !== 'object') {
+    return { code: 'VALIDATION', message: 'Body must be a JSON object.' };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.scenario !== 'string' || b.scenario.trim().length < 10) {
+    return { code: 'VALIDATION', message: '`scenario` is required and must be at least 10 characters.' };
+  }
+  if (b.context && typeof b.context !== 'object') {
+    return { code: 'VALIDATION', message: '`context` must be an object when provided.' };
+  }
+  if (b.jurisdiction && b.jurisdiction !== 'UK') {
+    return { code: 'VALIDATION', message: 'Only `jurisdiction: "UK"` is supported in v1.' };
+  }
+  return {
+    scenario: b.scenario.trim(),
+    context: (b.context as Record<string, unknown>) ?? {},
+    jurisdiction: 'UK',
+    desired_outcome: typeof b.desired_outcome === 'string' ? b.desired_outcome : undefined,
+    amount: typeof b.amount === 'number' ? b.amount : undefined,
+    consumer_name: typeof b.consumer_name === 'string' ? b.consumer_name : undefined,
+  };
+}
+
+/**
+ * Pull verified UK statute references that match the scenario keywords.
+ * The complaint engine consumes this to keep its citations grounded.
+ */
+async function fetchVerifiedRefs(scenario: string): Promise<any[]> {
+  const supabase = getAdmin();
+  // Coarse keyword match — the engine will narrow further. We want
+  // enough candidate statutes that Claude has the right one available
+  // without flooding the prompt.
+  const tokens = scenario.toLowerCase().split(/\s+/).filter((t) => t.length >= 4).slice(0, 8);
+  if (tokens.length === 0) return [];
+
+  const { data } = await supabase
+    .from('legal_references')
+    .select('law_name, section, summary, full_text, url, category')
+    .limit(20);
+  if (!data) return [];
+
+  // Score by token overlap — simple but works for v1.
+  return data
+    .map((ref) => {
+      const haystack = `${ref.law_name} ${ref.section ?? ''} ${ref.summary ?? ''} ${ref.category ?? ''}`.toLowerCase();
+      const score = tokens.reduce((s, tok) => s + (haystack.includes(tok) ? 1 : 0), 0);
+      return { ref, score };
+    })
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 8)
+    .map((x) => x.ref);
+}
+
+function inferStatute(legalReferences: string[]): string {
+  if (legalReferences.length === 0) return 'No primary UK statute identified for this scenario.';
+  return legalReferences[0];
+}
+
+function deriveEscalationPath(scenario: string): DisputeResponse['escalation_path'] {
+  const s = scenario.toLowerCase();
+  // Sector-specific escalation routes the consumer engine already
+  // knows. Replicating the lookup table here keeps the B2B contract
+  // self-contained; a future PR can hoist it to a shared helper.
+  if (/flight|airline|cancell?ed|delay/.test(s)) {
+    return [
+      { step: 1, to: 'carrier_claims_team', wait_days: 14 },
+      { step: 2, to: 'CAA — Consumer Protection Group', url: 'https://www.caa.co.uk/passengers' },
+      { step: 3, to: 'Alternative Dispute Resolution scheme', wait_days: 56 },
+    ];
+  }
+  if (/broadband|mobile|isp|ofcom/.test(s)) {
+    return [
+      { step: 1, to: 'provider_complaints_team', wait_days: 28 },
+      { step: 2, to: 'CISAS or Ombudsman Services Communications', url: 'https://www.ofcom.org.uk/complaints' },
+    ];
+  }
+  if (/energy|gas|electric|ofgem/.test(s)) {
+    return [
+      { step: 1, to: 'energy_supplier_complaints', wait_days: 56 },
+      { step: 2, to: 'Energy Ombudsman', url: 'https://www.energyombudsman.org' },
+    ];
+  }
+  if (/section\s*75|credit\s*card|chargeback/.test(s)) {
+    return [
+      { step: 1, to: 'card_issuer_disputes', wait_days: 14 },
+      { step: 2, to: 'Financial Ombudsman Service', url: 'https://www.financial-ombudsman.org.uk', wait_days: 56 },
+    ];
+  }
+  if (/insurance|claim|warranty/.test(s)) {
+    return [
+      { step: 1, to: 'insurer_complaints_team', wait_days: 28 },
+      { step: 2, to: 'Financial Ombudsman Service', url: 'https://www.financial-ombudsman.org.uk' },
+    ];
+  }
+  return [
+    { step: 1, to: 'merchant_complaints_team', wait_days: 14 },
+    { step: 2, to: 'Citizens Advice', url: 'https://www.citizensadvice.org.uk' },
+    { step: 3, to: 'Trading Standards', wait_days: 28 },
+  ];
+}
+
+/**
+ * Run the engine against a B2B request. Returns a fully-shaped
+ * DisputeResponse on success, or a DisputeError that the caller
+ * maps to an HTTP status code.
+ */
+export async function resolveDispute(req: DisputeRequest): Promise<DisputeResponse | DisputeError> {
+  const verifiedRefs = await fetchVerifiedRefs(req.scenario);
+
+  let result: any;
+  try {
+    result = await generateComplaintLetter({
+      companyName: (req.context?.merchant as string) || 'the merchant',
+      issueDescription: req.scenario,
+      desiredOutcome: req.desired_outcome ?? '',
+      amount: req.amount != null ? String(req.amount) : undefined,
+      letterType: 'complaint',
+      verifiedLegalRefs: verifiedRefs as any,
+    });
+  } catch (e: any) {
+    return {
+      code: 'ENGINE_ERROR',
+      message: `Engine failed to produce a draft: ${e?.message ?? 'unknown error'}`,
+    };
+  }
+
+  const legalRefs: string[] = Array.isArray(result?.legalReferences) ? result.legalReferences : [];
+  const letter: string = typeof result?.letter === 'string' ? result.letter : '';
+  const successLabel: 'low' | 'medium' | 'high' =
+    result?.estimatedSuccess === 'high' || result?.estimatedSuccess === 'low'
+      ? result.estimatedSuccess
+      : 'medium';
+
+  return {
+    statute: inferStatute(legalRefs),
+    entitlement: {
+      summary: result?.nextSteps ?? 'See draft letter for the entitlement narrative.',
+      rationale: verifiedRefs[0]?.summary ?? 'Reasoning grounded in the cited UK statute.',
+      additional_rights: verifiedRefs.slice(0, 3).map((r: any) => r.law_name),
+      estimated_success: successLabel,
+    },
+    draft_letter_excerpt: letter.slice(0, 1200),
+    escalation_path: Array.isArray(result?.escalationPath) && result.escalationPath.length > 0
+      ? result.escalationPath.map((step: string, i: number) => ({ step: i + 1, to: step }))
+      : deriveEscalationPath(req.scenario),
+    legal_references: legalRefs,
+    confidence: typeof result?.confidence === 'number' ? result.confidence : 0.8,
+  };
+}

--- a/supabase/migrations/20260428020000_b2b_api_keys.sql
+++ b/supabase/migrations/20260428020000_b2b_api_keys.sql
@@ -1,0 +1,67 @@
+-- B2B API key store + usage audit for the /v1/disputes surface.
+--
+-- Authentication model: bearer token in `Authorization: Bearer pbk_xxx`.
+-- The plaintext key is shown ONCE at mint time. We persist only the
+-- bcrypt-style hash + an 8-char prefix so the admin UI can identify
+-- which key a user is talking about without ever seeing the secret.
+--
+-- Rate limiting: monthly_limit per key, with the count derived from
+-- b2b_api_usage rows in the calendar month. Cheap (one COUNT query
+-- per request) and works without a Redis dependency.
+--
+-- Tier metadata follows the indicative pricing on /for-business
+-- (Starter / Growth / Enterprise) so we can surface upgrade prompts
+-- when a key is approaching its monthly cap.
+
+CREATE TABLE IF NOT EXISTS b2b_api_keys (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  -- Display name the customer chose ("Acme Production", "Staging").
+  name TEXT NOT NULL,
+  -- Owner — links to the b2b_waitlist row when minted via admin
+  -- (so we know who the key was issued to and why). Nullable so we
+  -- can mint internal/test keys without a waitlist entry.
+  waitlist_id UUID REFERENCES b2b_waitlist(id) ON DELETE SET NULL,
+  owner_email TEXT,
+  -- Secret material
+  key_hash TEXT NOT NULL,
+  key_prefix TEXT NOT NULL,
+  -- Plan
+  tier TEXT NOT NULL DEFAULT 'starter' CHECK (tier IN ('starter', 'growth', 'enterprise')),
+  monthly_limit INTEGER NOT NULL DEFAULT 1000,
+  -- Lifecycle
+  last_used_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS b2b_api_keys_prefix_idx
+  ON b2b_api_keys (key_prefix)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS b2b_api_keys_waitlist_idx
+  ON b2b_api_keys (waitlist_id);
+
+COMMENT ON TABLE b2b_api_keys IS
+  'Hashed bearer-token store for the /v1/disputes B2B API. Plaintext shown once at mint. Limit enforcement is per-key per-calendar-month via COUNT on b2b_api_usage.';
+
+-- Per-call audit. Big table over time so we keep it lean — no full
+-- request/response bodies, just enough to drive billing + rate limit
+-- + usage analytics.
+CREATE TABLE IF NOT EXISTS b2b_api_usage (
+  id BIGSERIAL PRIMARY KEY,
+  key_id UUID NOT NULL REFERENCES b2b_api_keys(id) ON DELETE CASCADE,
+  endpoint TEXT NOT NULL,
+  status_code INTEGER NOT NULL,
+  latency_ms INTEGER,
+  -- Optional debug aids — never store the full payload
+  scenario_kind TEXT,
+  error_code TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS b2b_api_usage_key_month_idx
+  ON b2b_api_usage (key_id, created_at DESC);
+
+COMMENT ON TABLE b2b_api_usage IS
+  'Per-call audit for the /v1/disputes API. Used for monthly rate-limit counting + billing reconciliation. Body content intentionally not stored.';


### PR DESCRIPTION
## Summary
- New `b2b_api_keys` + `b2b_api_usage` tables; bearer auth (`pbk_<prefix>_<secret>`) with SHA-256 + timingSafeEqual + per-key monthly rate limit.
- `POST /api/v1/disputes` — public endpoint wrapping the existing complaint engine, returns stable {statute, entitlement, draft_letter_excerpt, escalation_path, legal_references, confidence}.
- Founder-only `/dashboard/admin/b2b` — waitlist triage + mint/revoke keys + 10-qualified-signups decision tracker.

## Test plan
- [ ] Apply migration `20260428020000_b2b_api_keys.sql` to Supabase
- [ ] Visit `/dashboard/admin/b2b`, mint a starter key, copy plaintext
- [ ] `curl -X POST https://paybacker.co.uk/api/v1/disputes -H "Authorization: Bearer pbk_..." -H "Content-Type: application/json" -d '{"scenario":"Ryanair cancelled my flight LGW-DUB 6 hours before departure, refusing compensation"}'`
- [ ] Verify `X-RateLimit-Remaining` decrements and usage row appears
- [ ] Confirm revoked key returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)