### PR TITLE
feat(b2b): drop waitlist + send from business@paybacker.co.uk

### DIFF
--- a/src/app/api/v1/free-pilot/route.ts
+++ b/src/app/api/v1/free-pilot/route.ts
@@ -11,7 +11,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { generateKey } from '@/lib/b2b/auth';
-import { resend, FROM_EMAIL } from '@/lib/resend';
+import { resend } from '@/lib/resend';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -83,8 +83,9 @@ export async function POST(request: NextRequest) {
   if (process.env.RESEND_API_KEY) {
     try {
       await resend.emails.send({
-        from: FROM_EMAIL,
+        from: process.env.B2B_FROM_EMAIL || 'Paybacker for Business <business@paybacker.co.uk>',
         to: lower,
+        replyTo: 'business@paybacker.co.uk',
         subject: 'Your Paybacker API key (Starter — 1,000 calls/month)',
         html: `
           <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:560px;margin:auto;color:#0f172a;">

--- a/src/app/for-business/page.tsx
+++ b/src/app/for-business/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
-import WaitlistForm from './WaitlistForm';
 import BuyButtons from './BuyButtons';
 import './styles.css';
 
@@ -295,16 +294,16 @@ export default function ForBusinessPage() {
         </div>
       </section>
 
-      {/* ── Waitlist (talk to us) ─────────────────────────── */}
-      <section className="m-business-section m-business-section--alt" id="waitlist">
+      {/* ── Bespoke (email-only — no waitlist) ────────────── */}
+      <section className="m-business-section m-business-section--alt" id="bespoke">
         <div className="m-business-wrap m-business-wrap--narrow">
           <span className="m-business-eyebrow">Need something custom?</span>
-          <h2>Talk to us.</h2>
+          <h2>Talk to us directly.</h2>
           <p className="m-business-sub">
-            For bespoke deployments, on-prem, or volume above Enterprise — drop us a note and
-            Paul will reply within 24 hours.
+            For bespoke deployments, on-prem hosting, or volume above Enterprise — email{' '}
+            <a href="mailto:business@paybacker.co.uk" className="m-business-link">business@paybacker.co.uk</a>{' '}
+            and we will reply within 24 hours.
           </p>
-          <WaitlistForm />
         </div>
       </section>
 

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -9,7 +9,7 @@
 import type Stripe from 'stripe';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { generateKey } from './auth';
-import { resend, FROM_EMAIL } from '@/lib/resend';
+import { resend } from '@/lib/resend';
 
 const TIER_LIMITS: Record<string, number> = {
   starter: 1000,
@@ -60,12 +60,14 @@ export async function handleB2bCheckoutCompleted(
     return;
   }
 
-  // Email plaintext to customer ONCE
+  // Email plaintext to customer ONCE — sent from business@ so replies
+  // route to the B2B inbox the founder watches separately.
   if (process.env.RESEND_API_KEY) {
     try {
       await resend.emails.send({
-        from: FROM_EMAIL,
+        from: process.env.B2B_FROM_EMAIL || 'Paybacker for Business <business@paybacker.co.uk>',
         to: customerEmail,
+        replyTo: 'business@paybacker.co.uk',
         subject: `Your Paybacker API key (${tier} — ${monthlyLimit.toLocaleString()} calls/month)`,
         html: `
           <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:560px;margin:auto;color:#0f172a;">


### PR DESCRIPTION
Removes the waitlist section from /for-business now that purchase is live. Sets B2B transactional emails to come from business@paybacker.co.uk (configurable via B2B_FROM_EMAIL env var).