### PR TITLE
feat(b2b): checkout-lead capture + abandon alerts + public coverage page

### DIFF
--- a/src/app/api/v1/checkout/route.ts
+++ b/src/app/api/v1/checkout/route.ts
@@ -14,9 +14,99 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import { createClient } from '@supabase/supabase-js';
+import { resend } from '@/lib/resend';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+async function captureLead(args: {
+  email: string;
+  name: string;
+  company: string;
+  tier: string;
+  sessionId: string;
+}) {
+  const supabase = getAdmin();
+  const lower = args.email.trim().toLowerCase();
+
+  // Upsert by work_email so a returning lead bumps to the latest tier
+  // intent rather than silently failing the unique constraint.
+  const { data: existing } = await supabase
+    .from('b2b_waitlist')
+    .select('id, status')
+    .eq('work_email', lower)
+    .maybeSingle();
+
+  if (existing) {
+    await supabase.from('b2b_waitlist').update({
+      name: args.name || 'Unknown',
+      company: args.company || 'Unknown',
+      intended_tier: args.tier,
+      stripe_session_id: args.sessionId,
+      status: 'checkout_started',
+      reviewed_at: new Date().toISOString(),
+    }).eq('id', existing.id);
+  } else {
+    await supabase.from('b2b_waitlist').insert({
+      name: args.name || 'Unknown',
+      work_email: lower,
+      company: args.company || 'Unknown',
+      intended_tier: args.tier,
+      stripe_session_id: args.sessionId,
+      status: 'checkout_started',
+    });
+  }
+
+  // Founder email
+  if (process.env.RESEND_API_KEY) {
+    try {
+      await resend.emails.send({
+        from: process.env.B2B_FROM_EMAIL || 'Paybacker for Business <business@paybacker.co.uk>',
+        to: process.env.FOUNDER_EMAIL || 'business@paybacker.co.uk',
+        replyTo: lower,
+        subject: `🛒 Checkout started — ${args.company} (${args.tier})`,
+        html: `
+          <div style="font-family:-apple-system,'Segoe UI',sans-serif;max-width:560px;margin:auto;color:#0f172a;">
+            <h2 style="margin:0 0 6px;">B2B checkout started</h2>
+            <p style="margin:0 0 4px;"><strong>${escapeHtml(args.name)}</strong> @ <strong>${escapeHtml(args.company)}</strong></p>
+            <p style="margin:0 0 4px;"><a href="mailto:${escapeHtml(lower)}">${escapeHtml(lower)}</a></p>
+            <p style="margin:0 0 16px;">Tier intended: <strong>${escapeHtml(args.tier)}</strong></p>
+            <p style="background:#fefce8;border-left:3px solid #ca8a04;padding:10px 14px;color:#854d0e;border-radius:6px;font-size:14px;">Lead may convert or abandon. If you don't see a "B2B API sale" message within 30 minutes, this is a chase candidate.</p>
+            <p><a href="https://paybacker.co.uk/dashboard/admin/b2b" style="background:#0f172a;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;display:inline-block;">Open admin</a></p>
+          </div>`,
+      });
+    } catch {}
+  }
+
+  // Telegram
+  const tgToken = process.env.TELEGRAM_BOT_TOKEN;
+  const tgChat = process.env.TELEGRAM_FOUNDER_CHAT_ID;
+  if (tgToken && tgChat) {
+    try {
+      await fetch(`https://api.telegram.org/bot${tgToken}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chat_id: Number(tgChat),
+          text: `🛒 *B2B checkout started*\n\n*${args.name}* @ *${args.company}*\n${lower}\nTier: *${args.tier}*\n\n_Will fire a sale alert if they convert. If silent in 30 min, chase._`,
+          parse_mode: 'Markdown',
+        }),
+      });
+    } catch {}
+  }
+}
 
 const TIER_PRICE_ENV: Record<string, string> = {
   growth: 'STRIPE_PRICE_API_GROWTH_MONTHLY',
@@ -74,6 +164,15 @@ export async function POST(request: NextRequest) {
       },
       allow_promotion_codes: true,
     });
+
+    // Fire-and-forget lead capture so the redirect isn't blocked.
+    captureLead({
+      email,
+      name: name ?? '',
+      company: company ?? '',
+      tier,
+      sessionId: session.id,
+    }).catch((e) => console.error('[v1/checkout] captureLead failed', e?.message));
 
     return NextResponse.json({ url: session.url, id: session.id });
   } catch (e: any) {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -102,6 +102,19 @@ export async function POST(request: NextRequest) {
 
   try {
     switch (event.type) {
+      case 'checkout.session.expired': {
+        const session = event.data.object as Stripe.Checkout.Session;
+        if (session.metadata?.product === 'b2b_api') {
+          try {
+            const { handleB2bCheckoutExpired } = await import('@/lib/b2b/stripe-webhook');
+            await handleB2bCheckoutExpired(supabase as any, session);
+          } catch (e: any) {
+            console.error('[stripe webhook] b2b checkout.expired failed:', e?.message);
+          }
+        }
+        break;
+      }
+
       case 'checkout.session.completed': {
         const session = event.data.object as Stripe.Checkout.Session;
 

--- a/src/app/for-business/coverage/page.tsx
+++ b/src/app/for-business/coverage/page.tsx
@@ -1,0 +1,302 @@
+/**
+ * /for-business/coverage — public reference of every UK statute the
+ * /v1/disputes engine cites, grouped by sector + use case.
+ *
+ * Server-rendered from the legal_references table at request time so
+ * the published list always tracks what the engine actually grounds
+ * against. We render law name + section + a short summary; we do NOT
+ * expose source URLs (those are an engineering surface, not a sales
+ * surface) or how the engine reasons.
+ */
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { createClient } from '@supabase/supabase-js';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Coverage — Paybacker UK Consumer Rights API',
+  description:
+    'Every UK statute, regulation, and regulator code the Paybacker /v1/disputes API can cite — by sector and use case.',
+  alternates: { canonical: 'https://paybacker.co.uk/for-business/coverage' },
+};
+
+interface Ref {
+  law_name: string;
+  section: string | null;
+  summary: string | null;
+  category: string;
+}
+
+const FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
+const TEXT = '#0f172a';
+const MUTED = '#475569';
+const BORDER = '#e2e8f0';
+
+const SECTOR_LABELS: Record<string, { label: string; useCases: string[] }> = {
+  finance: {
+    label: 'Finance & credit',
+    useCases: [
+      'Section 75 chargebacks',
+      'Disputed transactions',
+      'Late fees & interest reversals',
+      'Debt-collection responses',
+      'Credit-file corrections',
+    ],
+  },
+  energy: {
+    label: 'Energy',
+    useCases: [
+      'Back-billing disputes',
+      'Price-cap breaches',
+      'Smart-meter failures',
+      'Switching block disputes',
+      'Final-bill inaccuracies',
+    ],
+  },
+  broadband: {
+    label: 'Broadband, mobile & TV',
+    useCases: [
+      'Speed below contract minimum',
+      'Mid-contract price rises',
+      'Penalty-free exit claims',
+      'Service credits',
+      'Cancellation disputes',
+    ],
+  },
+  travel: {
+    label: 'Air travel',
+    useCases: [
+      'Flight cancellation compensation (UK261)',
+      'Long delays',
+      'Denied boarding',
+      'Lost / damaged baggage',
+      'Package travel rights',
+    ],
+  },
+  rail: {
+    label: 'Rail',
+    useCases: [
+      'Delay Repay claims',
+      'Strike-related refunds',
+      'Cancelled-service refunds',
+      'Season-ticket disputes',
+    ],
+  },
+  insurance: {
+    label: 'Insurance',
+    useCases: [
+      'Wrongful claim declines',
+      'Underwriting errors',
+      'Renewal price-walking',
+      'Treating-customers-fairly breaches',
+    ],
+  },
+  council_tax: {
+    label: 'Council tax',
+    useCases: [
+      'Band challenges',
+      'Discount / exemption disputes',
+      'Liability disputes',
+    ],
+  },
+  parking: {
+    label: 'Parking',
+    useCases: [
+      'Private-land charge appeals',
+      'Council PCN appeals',
+      'Signage adequacy challenges',
+    ],
+  },
+  hmrc: {
+    label: 'HMRC',
+    useCases: [
+      'Tax-rebate claims',
+      'PAYE corrections',
+      'Penalty appeals',
+    ],
+  },
+  dvla: {
+    label: 'DVLA',
+    useCases: [
+      'Late-licensing penalty appeals',
+      'Wrong vehicle keeper records',
+    ],
+  },
+  nhs: {
+    label: 'NHS',
+    useCases: [
+      'Formal complaint escalation',
+      'Continuing-healthcare reviews',
+    ],
+  },
+  gym: {
+    label: 'Gym memberships',
+    useCases: [
+      'Cancellation disputes',
+      'Fee-after-cancellation claims',
+    ],
+  },
+  debt: {
+    label: 'Debt & enforcement',
+    useCases: [
+      'Statute-barred debt challenges',
+      'Bailiff conduct',
+    ],
+  },
+  general: {
+    label: 'Cross-sector consumer rights',
+    useCases: [
+      'Faulty / not-as-described goods (Consumer Rights Act 2015)',
+      'Distance-selling cancellation rights',
+      'Unfair contract terms',
+      'Misrepresentation',
+    ],
+  },
+};
+
+function getClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+  );
+}
+
+async function fetchCoverage(): Promise<Ref[]> {
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) return [];
+  try {
+    const supabase = getClient();
+    const { data } = await supabase
+      .from('legal_references')
+      .select('law_name, section, summary, category')
+      .order('law_name');
+    return (data ?? []) as Ref[];
+  } catch {
+    return [];
+  }
+}
+
+export default async function CoveragePage() {
+  const refs = await fetchCoverage();
+  const byCategory = new Map<string, Ref[]>();
+  for (const r of refs) {
+    const k = r.category || 'general';
+    if (!byCategory.has(k)) byCategory.set(k, []);
+    byCategory.get(k)!.push(r);
+  }
+
+  const orderedCats = Object.keys(SECTOR_LABELS).filter((k) => byCategory.has(k));
+
+  return (
+    <main style={{ background: '#fff', minHeight: '100vh', color: TEXT, fontFamily: FONT }}>
+      <div style={{ maxWidth: 880, margin: '0 auto', padding: '64px 24px', lineHeight: 1.65 }}>
+        <nav style={{ marginBottom: 40, fontSize: 14, color: '#64748b' }}>
+          <Link href="/for-business" style={{ color: '#64748b', textDecoration: 'none' }}>← Back to /for-business</Link>
+          {' · '}
+          <Link href="/for-business/docs" style={{ color: '#64748b', textDecoration: 'none' }}>Read the full API docs</Link>
+        </nav>
+
+        <h1 style={{ fontSize: 36, fontWeight: 600, letterSpacing: '-0.02em', margin: 0 }}>
+          What the API covers
+        </h1>
+        <p style={{ marginTop: 12, fontSize: 18, color: MUTED }}>
+          Every UK statute, regulation, and regulator code the engine can cite —
+          grouped by sector and the use cases they unlock.
+        </p>
+        <p style={{ marginTop: 8, fontSize: 14, color: MUTED }}>
+          {refs.length} grounded references · updated daily by an automated legal-monitoring cron.
+        </p>
+
+        <p style={{ marginTop: 32, fontSize: 14, color: MUTED }}>
+          A request is grounded against this index. The engine cannot fabricate
+          an act or section number — it can only cite from what is listed here.
+          Below is the public surface of that index.
+        </p>
+
+        {orderedCats.map((cat) => {
+          const meta = SECTOR_LABELS[cat];
+          const list = byCategory.get(cat) ?? [];
+          return (
+            <section key={cat} id={cat} style={{ marginTop: 56, scrollMarginTop: 80 }}>
+              <h2 style={{ fontSize: 26, fontWeight: 600, letterSpacing: '-0.01em', margin: 0 }}>
+                {meta.label} <span style={{ fontSize: 14, color: MUTED, fontWeight: 500 }}>· {list.length} references</span>
+              </h2>
+
+              <h3 style={{ marginTop: 16, fontSize: 14, color: MUTED, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+                Use cases this unlocks
+              </h3>
+              <ul style={{ marginTop: 6, paddingLeft: 20, color: '#334155' }}>
+                {meta.useCases.map((u) => <li key={u}>{u}</li>)}
+              </ul>
+
+              <h3 style={{ marginTop: 20, fontSize: 14, color: MUTED, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+                Statutes the API can cite for this sector
+              </h3>
+              <table style={{ marginTop: 8, width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+                <thead>
+                  <tr>
+                    <th style={{ textAlign: 'left', padding: '8px 12px 8px 0', borderBottom: `1px solid ${BORDER}`, color: MUTED, fontWeight: 600 }}>Law / Regulation</th>
+                    <th style={{ textAlign: 'left', padding: '8px 12px 8px 0', borderBottom: `1px solid ${BORDER}`, color: MUTED, fontWeight: 600 }}>Section / Article</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {list.map((r, i) => (
+                    <tr key={`${cat}-${i}`}>
+                      <td style={{ padding: '10px 12px 10px 0', borderBottom: '1px solid #f1f5f9', verticalAlign: 'top' }}>
+                        <div style={{ fontWeight: 600 }}>{r.law_name}</div>
+                        {r.summary && <div style={{ fontSize: 13, color: MUTED, marginTop: 2 }}>{truncate(r.summary, 180)}</div>}
+                      </td>
+                      <td style={{ padding: '10px 12px 10px 0', borderBottom: '1px solid #f1f5f9', verticalAlign: 'top', color: MUTED, whiteSpace: 'nowrap' }}>
+                        {r.section || '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          );
+        })}
+
+        <section style={{ marginTop: 72, padding: '24px 28px', background: '#f8fafc', borderRadius: 12 }}>
+          <h2 style={{ margin: 0, fontSize: 22, fontWeight: 600 }}>What you can build with this</h2>
+          <p style={{ marginTop: 8, color: '#334155' }}>
+            One endpoint, every sector above. Some example integration patterns:
+          </p>
+          <ul style={{ paddingLeft: 20, color: '#334155' }}>
+            <li><strong>CX agent assist.</strong> On every inbound complaint ticket, surface the cited statute + draft response inside the agent UI.</li>
+            <li><strong>Self-serve dispute portal.</strong> Customer describes the problem; you render the entitlement summary and let them download a draft letter.</li>
+            <li><strong>Refund triage.</strong> Score every refund request by which statute applies + estimated success — automate the easy ones, route the hard ones.</li>
+            <li><strong>Compliance copilot.</strong> Embed in your ops console so first-line agents always have the right citation a click away.</li>
+            <li><strong>Statute-grounded chatbot.</strong> Wrap your LLM in this API so it cannot cite a repealed act.</li>
+          </ul>
+          <p style={{ marginTop: 12 }}>
+            <Link href="/for-business" style={{ background: '#0f172a', color: '#fff', padding: '10px 18px', borderRadius: 8, textDecoration: 'none', fontWeight: 600, display: 'inline-block' }}>
+              Get a free 1,000-call key
+            </Link>
+            {' '}
+            <Link href="/for-business/docs" style={{ background: 'transparent', color: '#475569', padding: '10px 18px', borderRadius: 8, textDecoration: 'none', border: `1px solid ${BORDER}`, fontWeight: 600, display: 'inline-block' }}>
+              Read the docs
+            </Link>
+          </p>
+        </section>
+
+        <footer style={{ marginTop: 64, borderTop: `1px solid ${BORDER}`, paddingTop: 24, fontSize: 14, color: '#64748b' }}>
+          <p>
+            Paybacker LTD · Registered in the UK ·{' '}
+            <Link href="/for-business" style={{ color: '#64748b' }}>/for-business</Link>
+          </p>
+          <p style={{ marginTop: 8, fontSize: 12 }}>
+            This page lists statutes the engine grounds against — it is not legal advice.
+            The engine&rsquo;s reasoning, ranking heuristics, and retrieval pipeline are
+            proprietary and not described here.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -21,6 +21,54 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+export async function handleB2bCheckoutExpired(
+  supabase: SupabaseClient,
+  session: Stripe.Checkout.Session,
+): Promise<void> {
+  const email = session.customer_email || session.customer_details?.email || '';
+  if (!email) return;
+  const lower = email.toLowerCase();
+  // Only mark abandoned if still in checkout_started — don't clobber a converted row.
+  await supabase
+    .from('b2b_waitlist')
+    .update({ status: 'checkout_abandoned', reviewed_at: new Date().toISOString() })
+    .eq('work_email', lower)
+    .eq('status', 'checkout_started');
+
+  const tier = (session.metadata?.tier as string) || 'unknown';
+  const tgToken = process.env.TELEGRAM_BOT_TOKEN;
+  const tgChat = process.env.TELEGRAM_FOUNDER_CHAT_ID;
+  if (tgToken && tgChat) {
+    try {
+      await fetch(`https://api.telegram.org/bot${tgToken}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chat_id: Number(tgChat),
+          text: `🛒💀 *Checkout abandoned*\n\n${lower}\nTier: ${tier}\n\n_Chase candidate. Personal email + offer the Starter free pilot to keep them warm._`,
+          parse_mode: 'Markdown',
+        }),
+      });
+    } catch {}
+  }
+  if (process.env.RESEND_API_KEY) {
+    try {
+      await resend.emails.send({
+        from: process.env.B2B_FROM_EMAIL || 'Paybacker for Business <business@paybacker.co.uk>',
+        to: process.env.FOUNDER_EMAIL || 'business@paybacker.co.uk',
+        replyTo: lower,
+        subject: `🛒💀 B2B abandoned — ${lower} (${tier})`,
+        html: `<div style="font-family:-apple-system,sans-serif;max-width:560px;margin:auto;color:#0f172a;">
+          <h2 style="margin:0 0 6px;">B2B checkout abandoned</h2>
+          <p>${escapeHtml(lower)} started a <strong>${escapeHtml(tier)}</strong> checkout but did not complete.</p>
+          <p style="background:#fef2f2;border-left:3px solid #b91c1c;padding:10px 14px;color:#991b1b;border-radius:6px;">Personal email recommended. Offer the free Starter pilot as a softer entry point.</p>
+          <p><a href="https://paybacker.co.uk/dashboard/admin/b2b" style="background:#0f172a;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;display:inline-block;">Open admin</a></p>
+        </div>`,
+      });
+    } catch {}
+  }
+}
+
 export async function handleB2bCheckoutCompleted(
   supabase: SupabaseClient,
   stripe: Stripe,
@@ -41,6 +89,12 @@ export async function handleB2bCheckoutCompleted(
     console.error('[b2b stripe] no email on session, cannot mint key');
     return;
   }
+
+  // Mark waitlist row converted (if any).
+  await supabase
+    .from('b2b_waitlist')
+    .update({ status: 'converted', reviewed_at: new Date().toISOString() })
+    .eq('work_email', customerEmail.toLowerCase());
 
   // Mint key
   const minted = generateKey();


### PR DESCRIPTION
Captures every Subscribe click into b2b_waitlist with founder email + Telegram alert. Flips to 'converted' on Stripe success, 'checkout_abandoned' on expiry. Adds /for-business/coverage public reference page listing every UK statute the API cites, by sector. Stripe webhook now subscribes to checkout.session.expired (added live).