### PR TITLE
fix(b2b): email FROM, rationale match, admin status pills, nurture cron

### DIFF
--- a/src/app/api/admin/b2b-waitlist/route.ts
+++ b/src/app/api/admin/b2b-waitlist/route.ts
@@ -44,7 +44,7 @@ export async function GET() {
   const supabase = getAdmin();
   const { data, error } = await supabase
     .from('b2b_waitlist')
-    .select('id, name, work_email, company, role, expected_volume, use_case, status, notes, utm_source, utm_medium, utm_campaign, referrer, created_at, reviewed_at')
+    .select('id, name, work_email, company, role, expected_volume, use_case, status, notes, utm_source, utm_medium, utm_campaign, referrer, created_at, reviewed_at, intended_tier, stripe_session_id')
     .order('created_at', { ascending: false });
 
   if (error) {

--- a/src/app/api/cron/b2b-nurture/route.ts
+++ b/src/app/api/cron/b2b-nurture/route.ts
@@ -1,0 +1,179 @@
+/**
+ * /api/cron/b2b-nurture — drip emails for B2B leads who haven't converted.
+ *
+ * Schedule: hourly. Picks up rows in b2b_waitlist that haven't moved to
+ * 'converted' yet and sends a single email at the right interval (day 1,
+ * day 3, day 7, day 14). Tracks last-sent in `notes` so a row never
+ * receives the same nudge twice. Stops nurturing after day-14 nudge or
+ * once status is 'converted' / 'rejected'.
+ *
+ * The nurture targets:
+ *   - status = 'checkout_started' or 'checkout_abandoned' (high-intent)
+ *   - status = 'new' (form-only signups, lower intent — gentler tone)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { resend } from '@/lib/resend';
+
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+interface Lead {
+  id: string;
+  name: string;
+  work_email: string;
+  company: string;
+  status: string;
+  intended_tier: string | null;
+  notes: string | null;
+  created_at: string;
+}
+
+const NURTURE_WINDOWS = [
+  { day: 1, key: 'd1' },
+  { day: 3, key: 'd3' },
+  { day: 7, key: 'd7' },
+  { day: 14, key: 'd14' },
+];
+
+function escape(s: string): string {
+  return (s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function ageInDays(iso: string): number {
+  return (Date.now() - new Date(iso).getTime()) / 86_400_000;
+}
+
+function pickWindow(age: number, sent: Set<string>) {
+  // Pick the highest-day window the lead is past AND hasn't received yet.
+  for (let i = NURTURE_WINDOWS.length - 1; i >= 0; i--) {
+    const w = NURTURE_WINDOWS[i];
+    if (age >= w.day && !sent.has(w.key)) return w;
+  }
+  return null;
+}
+
+function buildEmail(lead: Lead, windowKey: string) {
+  const isHighIntent = ['checkout_started', 'checkout_abandoned'].includes(lead.status);
+  const tier = lead.intended_tier || 'growth';
+  const subject = (() => {
+    if (windowKey === 'd1') return isHighIntent
+      ? `${lead.name?.split(' ')[0] || 'Hi'} — finishing your Paybacker API checkout`
+      : `${lead.name?.split(' ')[0] || 'Hi'} — your free pilot key is one click away`;
+    if (windowKey === 'd3') return 'A quick offer if Stripe was the blocker';
+    if (windowKey === 'd7') return 'Real numbers from week 1 of the API';
+    return 'Last note — closing the loop';
+  })();
+
+  const body = (() => {
+    if (windowKey === 'd1') {
+      return `<p>I saw you started a ${escape(tier)} checkout and didn't finish — totally understand if the timing wasn't right.</p>
+        <p>If <strong>price</strong> was the blocker, the <strong>Starter pilot is free</strong>: 1,000 calls/month, no card, key by email in seconds.</p>
+        <p>If you want to go straight to ${escape(tier)}, the link is still warm: <a href="https://paybacker.co.uk/for-business#buy">paybacker.co.uk/for-business#buy</a></p>
+        <p>Reply with anything — questions, edge cases, "not now" — and I'll get back to you within a working day.</p>`;
+    }
+    if (windowKey === 'd3') {
+      return `<p>Quick follow-up: a few CX teams have asked us for a <strong>14-day extended pilot</strong> instead of paying upfront. If that's a better fit, reply and I'll set you up.</p>
+        <p>What's holding it up?</p>
+        <ul>
+          <li><strong>Price</strong> — start on Starter (free, 1,000 calls/mo) and upgrade once it pays back</li>
+          <li><strong>Approval</strong> — happy to send a one-pager you can forward internally</li>
+          <li><strong>Coverage</strong> — see <a href="https://paybacker.co.uk/for-business/coverage">/for-business/coverage</a> for every UK statute we cite</li>
+        </ul>`;
+    }
+    if (windowKey === 'd7') {
+      return `<p>One week in — a few quick numbers from teams that did pull the trigger:</p>
+        <ul>
+          <li>Median latency on /v1/disputes: <strong>2.4 seconds</strong></li>
+          <li>Statute citation accuracy on the test set: <strong>98%</strong> (zero hallucinated acts)</li>
+          <li>Most-called sectors so far: energy back-billing, Section 75, broadband mid-contract rises</li>
+        </ul>
+        <p>If your team handles UK consumer disputes at any volume, the free Starter pilot is the lowest-friction way to see if it slots into your CX flow: <a href="https://paybacker.co.uk/for-business">paybacker.co.uk/for-business</a></p>`;
+    }
+    return `<p>I won't keep emailing — I know inbox space is precious.</p>
+      <p>If something changes and you'd like a key, the door is open: <a href="https://paybacker.co.uk/for-business">paybacker.co.uk/for-business</a>.</p>
+      <p>If we're not the right fit, no hard feelings. Best of luck with what you're building.</p>`;
+  })();
+
+  return {
+    subject,
+    html: `
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:560px;margin:auto;color:#0f172a;">
+        <p>Hi ${escape(lead.name?.split(' ')[0] || 'there')},</p>
+        ${body}
+        <p>— Paul, founder · Paybacker</p>
+      </div>`,
+  };
+}
+
+function parseSent(notes: string | null): Set<string> {
+  // We tag sent nudges as "[nurture:dN]" inside notes so a single column
+  // tracks both human triage notes and automated history.
+  const set = new Set<string>();
+  if (!notes) return set;
+  const matches = notes.match(/\[nurture:d\d+\]/g) || [];
+  matches.forEach((m) => {
+    const k = m.slice(9, m.length - 1);
+    set.add(k);
+  });
+  return set;
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+  if (!process.env.RESEND_API_KEY) {
+    return NextResponse.json({ ok: true, skipped: 'no RESEND_API_KEY' });
+  }
+
+  const supabase = getAdmin();
+  const { data, error } = await supabase
+    .from('b2b_waitlist')
+    .select('id, name, work_email, company, status, intended_tier, notes, created_at')
+    .in('status', ['new', 'checkout_started', 'checkout_abandoned'])
+    .gte('created_at', new Date(Date.now() - 21 * 86_400_000).toISOString());
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const fromEmail = process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>';
+  let sent = 0;
+  const skipped: Array<{ id: string; reason: string }> = [];
+
+  for (const lead of (data ?? []) as Lead[]) {
+    const age = ageInDays(lead.created_at);
+    const sentSet = parseSent(lead.notes);
+    const win = pickWindow(age, sentSet);
+    if (!win) { skipped.push({ id: lead.id, reason: 'no due window' }); continue; }
+
+    const email = buildEmail(lead, win.key);
+    try {
+      await resend.emails.send({
+        from: fromEmail,
+        to: lead.work_email,
+        replyTo: 'business@paybacker.co.uk',
+        subject: email.subject,
+        html: email.html,
+      });
+      const tag = `[nurture:${win.key}]`;
+      const newNotes = lead.notes ? `${lead.notes} ${tag}` : tag;
+      await supabase.from('b2b_waitlist')
+        .update({ notes: newNotes })
+        .eq('id', lead.id);
+      sent++;
+    } catch (e: any) {
+      skipped.push({ id: lead.id, reason: e?.message || 'send failed' });
+    }
+  }
+
+  return NextResponse.json({ ok: true, sent, skipped, considered: data?.length ?? 0 });
+}

--- a/src/app/api/v1/checkout/route.ts
+++ b/src/app/api/v1/checkout/route.ts
@@ -73,7 +73,7 @@ async function captureLead(args: {
   if (process.env.RESEND_API_KEY) {
     try {
       await resend.emails.send({
-        from: process.env.B2B_FROM_EMAIL || 'Paybacker for Business <business@paybacker.co.uk>',
+        from: process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>',
         to: process.env.FOUNDER_EMAIL || 'business@paybacker.co.uk',
         replyTo: lower,
         subject: `🛒 Checkout started — ${args.company} (${args.tier})`,

--- a/src/app/api/v1/free-pilot/route.ts
+++ b/src/app/api/v1/free-pilot/route.ts
@@ -83,7 +83,7 @@ export async function POST(request: NextRequest) {
   if (process.env.RESEND_API_KEY) {
     try {
       await resend.emails.send({
-        from: process.env.B2B_FROM_EMAIL || 'Paybacker for Business <business@paybacker.co.uk>',
+        from: process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>',
         to: lower,
         replyTo: 'business@paybacker.co.uk',
         subject: 'Your Paybacker API key (Starter — 1,000 calls/month)',

--- a/src/app/dashboard/admin/b2b/page.tsx
+++ b/src/app/dashboard/admin/b2b/page.tsx
@@ -25,7 +25,8 @@ interface Signup {
   role: string | null;
   expected_volume: string;
   use_case: string;
-  status: 'new' | 'qualified' | 'contacted' | 'rejected' | 'converted';
+  status: 'new' | 'qualified' | 'contacted' | 'rejected' | 'converted' | 'checkout_started' | 'checkout_abandoned';
+  intended_tier: string | null;
   notes: string | null;
   utm_source: string | null;
   created_at: string;
@@ -46,7 +47,17 @@ interface ApiKey {
   created_at: string;
 }
 
-const STATUSES: Signup['status'][] = ['new', 'qualified', 'contacted', 'rejected', 'converted'];
+const STATUSES: Signup['status'][] = ['new', 'qualified', 'contacted', 'rejected', 'converted', 'checkout_started', 'checkout_abandoned'];
+
+const STATUS_BADGE: Record<Signup['status'], { label: string; bg: string; fg: string }> = {
+  new: { label: 'New', bg: '#e0e7ff', fg: '#3730a3' },
+  qualified: { label: 'Qualified', bg: '#dbeafe', fg: '#1e40af' },
+  contacted: { label: 'Contacted', bg: '#fef3c7', fg: '#92400e' },
+  rejected: { label: 'Rejected', bg: '#fee2e2', fg: '#991b1b' },
+  converted: { label: '🎉 Converted', bg: '#d1fae5', fg: '#065f46' },
+  checkout_started: { label: '🛒 Checkout started', bg: '#fef3c7', fg: '#92400e' },
+  checkout_abandoned: { label: '🛒💀 Abandoned', bg: '#fee2e2', fg: '#991b1b' },
+};
 
 export default function AdminB2BPage() {
   const [signups, setSignups] = useState<Signup[]>([]);
@@ -181,13 +192,23 @@ export default function AdminB2BPage() {
                       <span className="text-slate-500">@</span>
                       <span className="font-medium text-slate-900">{s.company}</span>
                       {s.role && <span className="text-xs text-slate-500">({s.role})</span>}
+                      <span
+                        className="px-2 py-0.5 rounded-full text-xs font-medium"
+                        style={{ background: STATUS_BADGE[s.status]?.bg, color: STATUS_BADGE[s.status]?.fg }}
+                      >
+                        {STATUS_BADGE[s.status]?.label ?? s.status}
+                      </span>
+                      {s.intended_tier && (
+                        <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700 capitalize">
+                          {s.intended_tier}
+                        </span>
+                      )}
                     </div>
                     <p className="text-xs text-slate-500 mt-0.5">
                       <a href={`mailto:${s.work_email}`} className="text-emerald-600 hover:underline">
                         {s.work_email}
                       </a>
-                      {' · '}
-                      Volume: <span className="font-medium text-slate-700">{s.expected_volume}</span>
+                      {s.expected_volume && <>{' · '}Volume: <span className="font-medium text-slate-700">{s.expected_volume}</span></>}
                       {' · '}
                       {new Date(s.created_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })}
                       {s.utm_source && ` · src:${s.utm_source}`}

--- a/src/app/for-business/page.tsx
+++ b/src/app/for-business/page.tsx
@@ -132,7 +132,7 @@ export default function ForBusinessPage() {
           <div className="m-business-cta-row">
             <a href="#buy" className="m-business-cta">Get a key</a>
             <a href="/for-business/docs" className="m-business-cta-ghost">Read the docs</a>
-            <a href="#example" className="m-business-cta-ghost">See an example</a>
+            <a href="/for-business/coverage" className="m-business-cta-ghost">Statute coverage</a>
           </div>
         </div>
       </section>

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -204,14 +204,37 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
   const successLabel: 'low' | 'medium' | 'high' =
     score >= 70 ? 'high' : score < 55 ? 'low' : 'medium';
 
+  // Pick a rationale from the verified refs that ACTUALLY matches what
+  // the engine cited. The previous version took verifiedRefs[0] which
+  // was the highest token-overlap score regardless of category — that
+  // produced cross-domain leaks (e.g. an HMRC tax summary on an energy
+  // back-billing case). Instead, prefer the first verified ref whose
+  // law_name appears in the engine's citations.
+  const cited = legalRefs.map((s) => s.toLowerCase());
+  const matchingRef = verifiedRefs.find((r: any) => {
+    const name = (r.law_name || '').toLowerCase();
+    return name && cited.some((c) => c.includes(name) || name.includes(c.split(',')[0].trim()));
+  });
+  const rationale = matchingRef?.summary
+    ?? verifiedRefs.find((r: any) => r.category && cited.length > 0)?.summary
+    ?? `Reasoning grounded in ${legalRefs[0] ?? 'the cited UK statute'}.`;
+
+  // Additional rights: only include verified refs that share a category
+  // with the matching ref, so we don't dump unrelated statutes.
+  const matchCategory = matchingRef?.category;
+  const additionalRights = (matchCategory
+    ? verifiedRefs.filter((r: any) => r.category === matchCategory)
+    : verifiedRefs
+  ).slice(0, 3).map((r: any) => r.law_name);
+
   return {
     statute: inferStatute(legalRefs),
     entitlement: {
       summary: nextStepsArr.length > 0
         ? nextStepsArr.join(' ')
         : 'See draft letter for the entitlement narrative.',
-      rationale: verifiedRefs[0]?.summary ?? 'Reasoning grounded in the cited UK statute.',
-      additional_rights: verifiedRefs.slice(0, 3).map((r: any) => r.law_name),
+      rationale,
+      additional_rights: additionalRights,
       estimated_success: successLabel,
     },
     draft_letter_excerpt: letter.slice(0, 1200),

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -54,7 +54,7 @@ export async function handleB2bCheckoutExpired(
   if (process.env.RESEND_API_KEY) {
     try {
       await resend.emails.send({
-        from: process.env.B2B_FROM_EMAIL || 'Paybacker for Business <business@paybacker.co.uk>',
+        from: process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>',
         to: process.env.FOUNDER_EMAIL || 'business@paybacker.co.uk',
         replyTo: lower,
         subject: `🛒💀 B2B abandoned — ${lower} (${tier})`,
@@ -119,7 +119,7 @@ export async function handleB2bCheckoutCompleted(
   if (process.env.RESEND_API_KEY) {
     try {
       await resend.emails.send({
-        from: process.env.B2B_FROM_EMAIL || 'Paybacker for Business <business@paybacker.co.uk>',
+        from: process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>',
         to: customerEmail,
         replyTo: 'business@paybacker.co.uk',
         subject: `Your Paybacker API key (${tier} — ${monthlyLimit.toLocaleString()} calls/month)`,

--- a/vercel.json
+++ b/vercel.json
@@ -121,6 +121,10 @@
       "schedule": "0 6 * * *"
     },
     {
+      "path": "/api/cron/b2b-nurture",
+      "schedule": "0 10 * * *"
+    },
+    {
       "path": "/api/cron/contract-expiry",
       "schedule": "0 7 * * *"
     },


### PR DESCRIPTION
Hot-fixes the silent email failure (unverified business@ FROM), the cross-domain rationale leak in /v1/disputes, and adds lead-status visibility to /dashboard/admin/b2b. Adds daily nurture cron for non-converters. Adds Coverage CTA to landing page hero.