### PR TITLE
fix(b2b): codex P1s — webhook idempotency, fail-loud insert, coverage filter

### DIFF
--- a/src/app/for-business/coverage/page.tsx
+++ b/src/app/for-business/coverage/page.tsx
@@ -167,9 +167,13 @@ async function fetchCoverage(): Promise<Ref[]> {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL) return [];
   try {
     const supabase = getClient();
+    // Only show statutes the engine actually grounds against today —
+    // those marked current/updated by the verification cron. Filtering
+    // here keeps the published count honest as the index drifts.
     const { data } = await supabase
       .from('legal_references')
       .select('law_name, section, summary, category')
+      .in('verification_status', ['current', 'updated'])
       .order('law_name');
     return (data ?? []) as Ref[];
   } catch {

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -86,8 +86,23 @@ export async function handleB2bCheckoutCompleted(
   const customerId = session.customer as string | null;
 
   if (!customerEmail) {
-    console.error('[b2b stripe] no email on session, cannot mint key');
-    return;
+    throw new Error('[b2b stripe] no email on checkout session — cannot mint key');
+  }
+
+  // Idempotency: Stripe can replay checkout.session.completed. If a
+  // non-revoked key already exists for this subscription, no-op so we
+  // don't mint duplicates and email conflicting credentials.
+  if (subscriptionId) {
+    const { data: dupe } = await supabase
+      .from('b2b_api_keys')
+      .select('id')
+      .eq('stripe_subscription_id', subscriptionId)
+      .is('revoked_at', null)
+      .maybeSingle();
+    if (dupe) {
+      console.log(`[b2b stripe] idempotent skip — key already exists for sub ${subscriptionId}`);
+      return;
+    }
   }
 
   // Mark waitlist row converted (if any).
@@ -110,8 +125,10 @@ export async function handleB2bCheckoutCompleted(
     notes: `Stripe checkout · contact: ${contactName} · session: ${session.id}`,
   });
   if (error) {
-    console.error('[b2b stripe] insert key failed:', error.message);
-    return;
+    // Throw so the webhook returns 500 and Stripe retries delivery —
+    // a transient Supabase failure must not leave a paid customer
+    // without a provisioned key.
+    throw new Error(`[b2b stripe] key insert failed: ${error.message}`);
   }
 
   // Email plaintext to customer ONCE — sent from business@ so replies

--- a/supabase/migrations/20260428040000_b2b_waitlist_checkout_status.sql
+++ b/supabase/migrations/20260428040000_b2b_waitlist_checkout_status.sql
@@ -1,0 +1,21 @@
+-- Extend b2b_waitlist to track checkout intent + abandonment so the
+-- /for-business buy flow can capture leads BEFORE Stripe redirects
+-- and the webhook can mark conversion / abandonment retrospectively.
+--
+-- (This migration was applied to remote on 2026-04-28 ahead of the
+-- code that depends on it — committing the SQL afterwards keeps the
+-- repo migration history canonical for fresh environments.)
+
+ALTER TABLE b2b_waitlist DROP CONSTRAINT IF EXISTS b2b_waitlist_status_check;
+ALTER TABLE b2b_waitlist ADD CONSTRAINT b2b_waitlist_status_check
+  CHECK (status IN ('new', 'qualified', 'contacted', 'rejected', 'converted', 'checkout_started', 'checkout_abandoned'));
+
+ALTER TABLE b2b_waitlist
+  ADD COLUMN IF NOT EXISTS intended_tier TEXT,
+  ADD COLUMN IF NOT EXISTS stripe_session_id TEXT;
+
+-- Checkout-driven leads don't fill the use-case / volume fields, so
+-- relax those NOT NULL constraints to accommodate both lead sources.
+ALTER TABLE b2b_waitlist ALTER COLUMN expected_volume DROP NOT NULL;
+ALTER TABLE b2b_waitlist ALTER COLUMN use_case DROP NOT NULL;
+ALTER TABLE b2b_waitlist DROP CONSTRAINT IF EXISTS b2b_waitlist_use_case_check;


### PR DESCRIPTION
Three Codex findings on PR #346/#348: webhook now idempotent on duplicate Stripe deliveries, key-insert errors propagate so Stripe retries, coverage page filters to verification_status the engine actually uses. Also commits the migration applied via MCP to keep repo history canonical.