### PR TITLE
feat(b2b): customer portal + B2B-facing response + docs/coverage rewrite

### DIFF
--- a/src/app/api/v1/portal-keys/route.ts
+++ b/src/app/api/v1/portal-keys/route.ts
@@ -1,0 +1,149 @@
+/**
+ * Portal-token-gated key management for B2B customers.
+ *
+ * GET  /api/v1/portal-keys?token=...&email=... — list keys
+ * POST /api/v1/portal-keys                       — { action: 'revoke' | 'reissue', id, token, email }
+ *
+ * Token is single-use BUT we don't burn it on every read — that would
+ * make the dashboard unusable. We burn the token only on a mutating
+ * action (revoke / reissue). For reads we just verify it exists, isn't
+ * expired, and matches the email. Tokens expire in 30 minutes either
+ * way.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'node:crypto';
+import { generateKey } from '@/lib/b2b/auth';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+async function verifyToken(supabase: any, token: string, email: string, burn: boolean): Promise<boolean> {
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const { data } = await supabase
+    .from('b2b_portal_tokens')
+    .select('id, expires_at, used_at')
+    .eq('token_hash', tokenHash)
+    .eq('email', email)
+    .maybeSingle();
+  if (!data) return false;
+  if (data.used_at) return false;
+  if (new Date(data.expires_at) < new Date()) return false;
+  if (burn) {
+    await supabase
+      .from('b2b_portal_tokens')
+      .update({ used_at: new Date().toISOString() })
+      .eq('id', data.id);
+  }
+  return true;
+}
+
+async function loadKeys(supabase: any, email: string) {
+  const { data: keys } = await supabase
+    .from('b2b_api_keys')
+    .select('id, name, key_prefix, tier, monthly_limit, last_used_at, revoked_at, created_at')
+    .eq('owner_email', email)
+    .is('revoked_at', null)
+    .order('created_at', { ascending: false });
+
+  // Compute monthly_used for each
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+  const ids = (keys ?? []).map((k: any) => k.id);
+  const usageByKey = new Map<string, number>();
+  if (ids.length > 0) {
+    const { data: usage } = await supabase
+      .from('b2b_api_usage')
+      .select('key_id')
+      .in('key_id', ids)
+      .gte('created_at', monthStart.toISOString());
+    for (const row of usage ?? []) {
+      const k = (row as any).key_id as string;
+      usageByKey.set(k, (usageByKey.get(k) ?? 0) + 1);
+    }
+  }
+  return (keys ?? []).map((k: any) => ({ ...k, monthly_used: usageByKey.get(k.id) ?? 0 }));
+}
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get('token') ?? '';
+  const email = (url.searchParams.get('email') ?? '').toLowerCase();
+  if (!token || !email) return NextResponse.json({ error: 'Missing token or email' }, { status: 400 });
+
+  const supabase = getAdmin();
+  const ok = await verifyToken(supabase, token, email, false);
+  if (!ok) return NextResponse.json({ error: 'Invalid or expired link. Request a new one.' }, { status: 401 });
+
+  const keys = await loadKeys(supabase, email);
+  return NextResponse.json({ keys });
+}
+
+export async function POST(request: NextRequest) {
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const token = String(body?.token || '');
+  const email = String(body?.email || '').toLowerCase();
+  const action = body?.action;
+  const id = body?.id;
+  if (!token || !email || !action || !id) {
+    return NextResponse.json({ error: 'token, email, action, id required' }, { status: 400 });
+  }
+
+  const supabase = getAdmin();
+  const ok = await verifyToken(supabase, token, email, true);
+  if (!ok) return NextResponse.json({ error: 'Invalid or expired link. Request a new one.' }, { status: 401 });
+
+  // Make sure the key actually belongs to this email.
+  const { data: row } = await supabase
+    .from('b2b_api_keys')
+    .select('id, tier, monthly_limit, name, owner_email')
+    .eq('id', id)
+    .eq('owner_email', email)
+    .maybeSingle();
+  if (!row) return NextResponse.json({ error: 'Key not found' }, { status: 404 });
+
+  if (action === 'revoke') {
+    await supabase
+      .from('b2b_api_keys')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', id);
+    return NextResponse.json({ ok: true });
+  }
+
+  if (action === 'reissue') {
+    // Revoke old + insert new with same tier/limit/name + emit plaintext.
+    await supabase
+      .from('b2b_api_keys')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', id);
+
+    const minted = generateKey();
+    const { error } = await supabase.from('b2b_api_keys').insert({
+      name: `${row.name} (re-issued)`,
+      key_hash: minted.hash,
+      key_prefix: minted.prefix,
+      tier: row.tier,
+      monthly_limit: row.monthly_limit,
+      owner_email: email,
+      notes: `Self-serve re-issue at ${new Date().toISOString()}`,
+    });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ ok: true, plaintext: minted.plaintext });
+  }
+
+  return NextResponse.json({ error: 'unknown action' }, { status: 400 });
+}

--- a/src/app/api/v1/portal-login/route.ts
+++ b/src/app/api/v1/portal-login/route.ts
@@ -1,0 +1,89 @@
+/**
+ * POST /api/v1/portal-login — send a one-time portal-access token to
+ * a B2B customer's work email.
+ *
+ * Body: { email: string }
+ *
+ * We don't use Supabase Auth for B2B customers because they aren't
+ * Paybacker users — they're API customers. Instead we mint a short-
+ * lived signed token tied to the email + a key the email owns, and
+ * email it as a one-click link. Token lives in `b2b_portal_tokens`
+ * with single-use semantics.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'node:crypto';
+import { resend } from '@/lib/resend';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export async function POST(request: NextRequest) {
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const email = String(body?.email || '').trim().toLowerCase();
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return NextResponse.json({ error: 'A valid email is required' }, { status: 400 });
+  }
+
+  const supabase = getAdmin();
+
+  // We always return ok=true even if no key exists for this email, so
+  // the response can't be used as an enumeration oracle.
+  const { data: hasKey } = await supabase
+    .from('b2b_api_keys')
+    .select('id')
+    .eq('owner_email', email)
+    .is('revoked_at', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (hasKey) {
+    const token = crypto.randomBytes(32).toString('base64url');
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const expiresAt = new Date(Date.now() + 30 * 60 * 1000).toISOString(); // 30 min
+
+    await supabase.from('b2b_portal_tokens').insert({
+      email,
+      token_hash: tokenHash,
+      expires_at: expiresAt,
+    });
+
+    if (process.env.RESEND_API_KEY) {
+      const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://paybacker.co.uk';
+      const link = `${baseUrl}/dashboard/api-keys?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`;
+      try {
+        await resend.emails.send({
+          from: process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>',
+          to: email,
+          replyTo: 'business@paybacker.co.uk',
+          subject: 'Your Paybacker API portal link',
+          html: `
+            <div style="font-family:-apple-system,'Segoe UI',sans-serif;max-width:560px;margin:auto;color:#0f172a;">
+              <p>Click below to access your Paybacker API portal. The link expires in 30 minutes and can only be used once.</p>
+              <p style="margin:24px 0;"><a href="${link}" style="background:#0f172a;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:600;">Open portal</a></p>
+              <p style="color:#64748b;font-size:13px;">If you didn't request this, ignore this email — no action required.</p>
+              <p style="color:#64748b;font-size:13px;">Direct link: <a href="${link}">${link}</a></p>
+            </div>`,
+        });
+      } catch (e: any) {
+        console.error('[portal-login] email failed:', e?.message);
+      }
+    }
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/dashboard/api-keys/page.tsx
+++ b/src/app/dashboard/api-keys/page.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+/**
+ * /dashboard/api-keys — B2B customer self-serve portal.
+ *
+ * Token-gated (not Supabase auth) — link is delivered by email via
+ * /api/v1/portal-login. Customer can:
+ *   - See their key prefix, tier, monthly usage, last-used timestamp
+ *   - Re-issue (revoke + mint replacement, plaintext shown ONCE)
+ *   - Revoke a key
+ *
+ * The plaintext key is never re-displayed for an existing key — that
+ * is the whole point of hashing. To recover from a lost key, customers
+ * use Re-issue: it revokes the old key and shows the new plaintext
+ * once on this page.
+ */
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+
+interface Key {
+  id: string;
+  name: string;
+  key_prefix: string;
+  tier: string;
+  monthly_limit: number;
+  monthly_used: number;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+export const dynamic = 'force-dynamic';
+
+export default function ApiKeysPortalPage() {
+  const params = useSearchParams();
+  const token = params.get('token');
+  const email = params.get('email');
+
+  const [requestEmail, setRequestEmail] = useState('');
+  const [requestSent, setRequestSent] = useState(false);
+  const [requesting, setRequesting] = useState(false);
+  const [keys, setKeys] = useState<Key[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reissued, setReissued] = useState<{ id: string; plaintext: string } | null>(null);
+
+  async function load() {
+    if (!token || !email) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch(`/api/v1/portal-keys?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`);
+      const j = await r.json();
+      if (!r.ok) throw new Error(j.error || 'Could not load keys');
+      setKeys(j.keys ?? []);
+    } catch (e: any) {
+      setError(e?.message || 'Failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(); }, [token, email]);
+
+  async function requestLink(e: React.FormEvent) {
+    e.preventDefault();
+    setRequesting(true);
+    try {
+      await fetch('/api/v1/portal-login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: requestEmail }),
+      });
+      setRequestSent(true);
+    } finally {
+      setRequesting(false);
+    }
+  }
+
+  async function reissue(id: string) {
+    if (!confirm('Re-issue replaces this key. The old key will stop working immediately. Continue?')) return;
+    const r = await fetch('/api/v1/portal-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, email, action: 'reissue', id }),
+    });
+    const j = await r.json();
+    if (!r.ok) { alert(j.error || 'Failed'); return; }
+    setReissued({ id, plaintext: j.plaintext });
+    await load();
+  }
+
+  async function revoke(id: string) {
+    if (!confirm('Revoke this key? Calls will fail immediately.')) return;
+    const r = await fetch('/api/v1/portal-keys', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, email, action: 'revoke', id }),
+    });
+    if (r.ok) await load();
+  }
+
+  // No token → render request-link form
+  if (!token || !email) {
+    return (
+      <main style={pageWrap}>
+        <div style={card}>
+          <h1 style={{ margin: 0, fontSize: 28, letterSpacing: '-0.01em' }}>API portal sign-in</h1>
+          <p style={{ color: '#475569' }}>
+            Enter the work email your Paybacker API key is registered to. We&rsquo;ll send a one-time link.
+          </p>
+          {requestSent ? (
+            <div style={{ background: '#ecfdf5', border: '1px solid #6ee7b7', padding: 12, borderRadius: 8, color: '#065f46' }}>
+              If a key exists for that email, a link has been sent. It expires in 30 minutes.
+            </div>
+          ) : (
+            <form onSubmit={requestLink} style={{ display: 'grid', gap: 10 }}>
+              <input
+                type="email"
+                required
+                value={requestEmail}
+                onChange={(e) => setRequestEmail(e.target.value)}
+                placeholder="you@company.com"
+                style={input}
+              />
+              <button type="submit" disabled={requesting} style={btn}>{requesting ? 'Sending…' : 'Send sign-in link'}</button>
+            </form>
+          )}
+          <p style={{ color: '#64748b', fontSize: 13, marginTop: 24 }}>
+            Don&rsquo;t have a key yet? <Link href="/for-business" style={{ color: '#0f172a' }}>Get one →</Link>
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main style={pageWrap}>
+      <div style={{ ...card, maxWidth: 720 }}>
+        <h1 style={{ margin: 0, fontSize: 28, letterSpacing: '-0.01em' }}>Your API keys</h1>
+        <p style={{ color: '#475569' }}>Signed in as <strong>{email}</strong></p>
+
+        {reissued && (
+          <div style={{ background: '#fefce8', border: '1px solid #fde68a', padding: 16, borderRadius: 8, marginTop: 16 }}>
+            <strong style={{ color: '#854d0e' }}>New key — copy now, it is shown ONCE:</strong>
+            <pre style={{ marginTop: 8, background: '#0f172a', color: '#e2e8f0', padding: 12, borderRadius: 6, overflow: 'auto', fontSize: 13 }}>{reissued.plaintext}</pre>
+          </div>
+        )}
+
+        {loading && <p>Loading…</p>}
+        {error && <p style={{ color: '#b91c1c' }}>{error}</p>}
+
+        {keys?.length === 0 && (
+          <p style={{ color: '#64748b' }}>No active keys for this email. <Link href="/for-business">Get one →</Link></p>
+        )}
+
+        <div style={{ display: 'grid', gap: 12, marginTop: 16 }}>
+          {keys?.map((k) => {
+            const pct = k.monthly_limit > 0 ? Math.min(100, Math.round((k.monthly_used / k.monthly_limit) * 100)) : 0;
+            return (
+              <div key={k.id} style={{ border: '1px solid #e2e8f0', borderRadius: 10, padding: 16 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16, flexWrap: 'wrap' }}>
+                  <div>
+                    <div style={{ fontWeight: 600 }}>{k.name}</div>
+                    <div style={{ color: '#64748b', fontSize: 13, marginTop: 2 }}>
+                      Prefix <code style={codeInline}>{k.key_prefix}</code> · Tier <strong style={{ color: '#0f172a' }}>{k.tier}</strong>
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <button onClick={() => reissue(k.id)} style={{ ...btn, background: '#0f172a' }}>Re-issue</button>
+                    <button onClick={() => revoke(k.id)} style={{ ...btn, background: '#b91c1c' }}>Revoke</button>
+                  </div>
+                </div>
+                <div style={{ marginTop: 12, fontSize: 13, color: '#64748b' }}>
+                  Usage this month: <strong style={{ color: '#0f172a' }}>{k.monthly_used.toLocaleString()}</strong> / {k.monthly_limit.toLocaleString()} ({pct}%)
+                </div>
+                <div style={{ height: 6, background: '#f1f5f9', borderRadius: 3, marginTop: 6, overflow: 'hidden' }}>
+                  <div style={{ width: `${pct}%`, height: '100%', background: pct >= 90 ? '#dc2626' : pct >= 60 ? '#d97706' : '#059669' }} />
+                </div>
+                {k.last_used_at && (
+                  <div style={{ fontSize: 12, color: '#94a3b8', marginTop: 8 }}>
+                    Last used {new Date(k.last_used_at).toLocaleString('en-GB')}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <p style={{ color: '#64748b', fontSize: 13, marginTop: 24 }}>
+          <Link href="/for-business/docs" style={{ color: '#0f172a' }}>API docs</Link> ·
+          {' '}<Link href="/for-business/coverage" style={{ color: '#0f172a' }}>Statute coverage</Link> ·
+          {' '}<a href="mailto:business@paybacker.co.uk" style={{ color: '#0f172a' }}>business@paybacker.co.uk</a>
+        </p>
+      </div>
+    </main>
+  );
+}
+
+const pageWrap: React.CSSProperties = {
+  minHeight: '100vh', background: '#f8fafc', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24,
+  fontFamily: '-apple-system, "Segoe UI", system-ui, sans-serif', color: '#0f172a',
+};
+const card: React.CSSProperties = {
+  background: '#fff', border: '1px solid #e2e8f0', borderRadius: 14, padding: 32, maxWidth: 480, width: '100%', display: 'grid', gap: 12,
+};
+const input: React.CSSProperties = {
+  border: '1px solid #cbd5e1', borderRadius: 8, padding: '12px 14px', font: 'inherit', fontSize: 15,
+};
+const btn: React.CSSProperties = {
+  background: '#0f172a', color: '#fff', border: 0, padding: '10px 16px', borderRadius: 8, fontWeight: 600, cursor: 'pointer', fontSize: 14,
+};
+const codeInline: React.CSSProperties = {
+  background: '#f1f5f9', padding: '1px 6px', borderRadius: 4, fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 13,
+};

--- a/src/app/for-business/coverage/page.tsx
+++ b/src/app/for-business/coverage/page.tsx
@@ -38,120 +38,120 @@ const SECTOR_LABELS: Record<string, { label: string; useCases: string[] }> = {
   finance: {
     label: 'Finance & credit',
     useCases: [
-      'Section 75 chargebacks',
-      'Disputed transactions',
-      'Late fees & interest reversals',
-      'Debt-collection responses',
-      'Credit-file corrections',
+      'Auto-triage Section 75 chargeback claims at the agent UI level',
+      'Score disputed-transaction tickets by entitlement before assigning',
+      'Generate FCA-CONC compliant late-fee reversal responses',
+      'Debt-collection inbound triage (statute-barred detection)',
+      'Credit-file correction workflows grounded in CCA 1974',
     ],
   },
   energy: {
     label: 'Energy',
     useCases: [
-      'Back-billing disputes',
-      'Price-cap breaches',
-      'Smart-meter failures',
-      'Switching block disputes',
-      'Final-bill inaccuracies',
+      'Back-billing eligibility scoring inside CX agent UI',
+      'Ofgem price-cap breach detection in billing-anomaly pipelines',
+      'Smart-meter failure complaint drafts ready for agent review',
+      'Switching-block dispute resolution at first contact',
+      'Auto-flag final-bill inaccuracies for a customer service review queue',
     ],
   },
   broadband: {
     label: 'Broadband, mobile & TV',
     useCases: [
-      'Speed below contract minimum',
-      'Mid-contract price rises',
-      'Penalty-free exit claims',
-      'Service credits',
-      'Cancellation disputes',
+      'Real-time speed-vs-contract checks against Ofcom minimum-speed code',
+      'Mid-contract CPI price rise dispute detection',
+      'Penalty-free-exit eligibility scoring on cancellation flows',
+      'Auto-generate service-credit calculations grounded in GC C1',
+      'Cancellation-dispute response copy for retention agents',
     ],
   },
   travel: {
     label: 'Air travel',
     useCases: [
-      'Flight cancellation compensation (UK261)',
-      'Long delays',
-      'Denied boarding',
-      'Lost / damaged baggage',
-      'Package travel rights',
+      'UK261 cancellation/delay compensation eligibility at the agent UI',
+      'Long-delay scoring with extraordinary-circumstances test',
+      'Denied-boarding entitlement narrative for claims assessors',
+      'Lost-baggage Montreal-Convention liability calculation',
+      'Package-travel-regs route handling in OTA self-serve',
     ],
   },
   rail: {
     label: 'Rail',
     useCases: [
-      'Delay Repay claims',
-      'Strike-related refunds',
-      'Cancelled-service refunds',
-      'Season-ticket disputes',
+      'Delay Repay eligibility automation in passenger apps',
+      'Strike-related refund triage with NRCoT grounding',
+      'Cancelled-service refund response copy for first-line agents',
+      'Season-ticket dispute resolution against TOC conditions of carriage',
     ],
   },
   insurance: {
     label: 'Insurance',
     useCases: [
-      'Wrongful claim declines',
-      'Underwriting errors',
-      'Renewal price-walking',
-      'Treating-customers-fairly breaches',
+      'Wrongful claim-decline detection in FOS-bound complaint pipelines',
+      'Underwriting-error response generation at point of complaint',
+      'Renewal price-walking compliance checks against FCA general insurance pricing rules',
+      'Treating-Customers-Fairly breach scoring for compliance dashboards',
     ],
   },
   council_tax: {
     label: 'Council tax',
     useCases: [
-      'Band challenges',
-      'Discount / exemption disputes',
-      'Liability disputes',
+      'Band-challenge eligibility scoring inside council CX tools',
+      'Discount/exemption dispute response generation',
+      'Liability dispute resolution drafts for revenue teams',
     ],
   },
   parking: {
     label: 'Parking',
     useCases: [
-      'Private-land charge appeals',
-      'Council PCN appeals',
-      'Signage adequacy challenges',
+      'POPLA-grade appeal generation at point of charge',
+      'Council PCN appeal triage by ground of appeal',
+      'Signage-adequacy compliance checks against BPA Code of Practice',
     ],
   },
   hmrc: {
     label: 'HMRC',
     useCases: [
-      'Tax-rebate claims',
-      'PAYE corrections',
-      'Penalty appeals',
+      'Tax-rebate claim eligibility for HR/payroll platforms',
+      'PAYE-correction response copy for employer support teams',
+      'Penalty-appeal grounds detection',
     ],
   },
   dvla: {
     label: 'DVLA',
     useCases: [
-      'Late-licensing penalty appeals',
-      'Wrong vehicle keeper records',
+      'Late-licensing penalty appeal generation',
+      'Vehicle keeper record correction workflows',
     ],
   },
   nhs: {
     label: 'NHS',
     useCases: [
-      'Formal complaint escalation',
-      'Continuing-healthcare reviews',
+      'Formal-complaint escalation drafts grounded in NHS complaint procedure',
+      'Continuing-healthcare review eligibility scoring',
     ],
   },
   gym: {
     label: 'Gym memberships',
     useCases: [
-      'Cancellation disputes',
-      'Fee-after-cancellation claims',
+      'Cancellation-dispute resolution under the unfair contract terms regime',
+      'Post-cancellation-fee dispute drafts for member support teams',
     ],
   },
   debt: {
     label: 'Debt & enforcement',
     useCases: [
-      'Statute-barred debt challenges',
-      'Bailiff conduct',
+      'Statute-barred detection in Limitation Act 1980 grounded responses',
+      'Bailiff conduct complaint generation for debt-advice platforms',
     ],
   },
   general: {
     label: 'Cross-sector consumer rights',
     useCases: [
-      'Faulty / not-as-described goods (Consumer Rights Act 2015)',
-      'Distance-selling cancellation rights',
-      'Unfair contract terms',
-      'Misrepresentation',
+      'Faulty / not-as-described handling for D2C retail CX (CRA 2015)',
+      'Distance-selling cancellation flows (Consumer Contracts Regulations 2013)',
+      'Unfair contract terms detection in product compliance reviews',
+      'Misrepresentation response automation at marketplace scale',
     ],
   },
 };
@@ -202,20 +202,21 @@ export default async function CoveragePage() {
         </nav>
 
         <h1 style={{ fontSize: 36, fontWeight: 600, letterSpacing: '-0.02em', margin: 0 }}>
-          What the API covers
+          Statute coverage for your CX, claims, and product teams
         </h1>
         <p style={{ marginTop: 12, fontSize: 18, color: MUTED }}>
-          Every UK statute, regulation, and regulator code the engine can cite —
-          grouped by sector and the use cases they unlock.
+          Every UK statute, regulation, and regulator code your team can ground
+          a customer-facing response in — grouped by sector with the workflows each unlocks.
         </p>
         <p style={{ marginTop: 8, fontSize: 14, color: MUTED }}>
-          {refs.length} grounded references · updated daily by an automated legal-monitoring cron.
+          {refs.length} grounded references · refreshed daily by an automated legal-monitoring cron.
+          Your team gets the same index any UK consumer-law lawyer would consult, exposed as a single API call.
         </p>
 
         <p style={{ marginTop: 32, fontSize: 14, color: MUTED }}>
-          A request is grounded against this index. The engine cannot fabricate
-          an act or section number — it can only cite from what is listed here.
-          Below is the public surface of that index.
+          Anti-hallucination is structural: a /v1/disputes call can only return citations from this index.
+          Your CX agents, product copilots, and self-serve dispute portals never receive a fabricated act
+          or section number, regardless of which model sits behind the call.
         </p>
 
         {orderedCats.map((cat) => {
@@ -228,14 +229,14 @@ export default async function CoveragePage() {
               </h2>
 
               <h3 style={{ marginTop: 16, fontSize: 14, color: MUTED, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-                Use cases this unlocks
+                What your team can build
               </h3>
               <ul style={{ marginTop: 6, paddingLeft: 20, color: '#334155' }}>
                 {meta.useCases.map((u) => <li key={u}>{u}</li>)}
               </ul>
 
               <h3 style={{ marginTop: 20, fontSize: 14, color: MUTED, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-                Statutes the API can cite for this sector
+                Statutes the API will ground responses in
               </h3>
               <table style={{ marginTop: 8, width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
                 <thead>

--- a/src/app/for-business/coverage/page.tsx
+++ b/src/app/for-business/coverage/page.tsx
@@ -167,9 +167,13 @@ async function fetchCoverage(): Promise<Ref[]> {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL) return [];
   try {
     const supabase = getClient();
+    // Only show statutes the engine actually grounds against today —
+    // those marked current/updated by the verification cron. Filtering
+    // here keeps the published count honest as the index drifts.
     const { data } = await supabase
       .from('legal_references')
       .select('law_name, section, summary, category')
+      .in('verification_status', ['current', 'updated'])
       .order('law_name');
     return (data ?? []) as Ref[];
   } catch {

--- a/src/app/for-business/docs/page.tsx
+++ b/src/app/for-business/docs/page.tsx
@@ -28,9 +28,11 @@ export default function DocsPage() {
           <Link href="/for-business" style={{ color: '#64748b', textDecoration: 'none' }}>← Back to /for-business</Link>
         </nav>
 
-        <h1 style={{ fontSize: 36, fontWeight: 600, letterSpacing: '-0.02em', margin: 0 }}>UK Consumer Rights API — manual</h1>
+        <h1 style={{ fontSize: 36, fontWeight: 600, letterSpacing: '-0.02em', margin: 0 }}>API manual for engineering teams</h1>
         <p style={{ marginTop: 12, fontSize: 18, color: MUTED }}>
-          One endpoint. Verified UK statute citations, structured entitlement, draft letter, escalation path. Built on the same engine that powers <a style={{ color: TEXT }} href="https://paybacker.co.uk">paybacker.co.uk</a>.
+          Drop UK consumer-law reasoning into your CX flow, claims pipeline, or product copilot in one POST.
+          Verified statute citation, sector classification, entitlement scoring, customer-facing copy your agents can paste,
+          and a draft letter as a starting point.
         </p>
 
         <ul style={{ marginTop: 40, padding: 0, listStyle: 'none', display: 'grid', gap: 4, fontSize: 14, color: MUTED }}>
@@ -48,7 +50,16 @@ export default function DocsPage() {
         </ul>
 
         <Section id="getting-a-key" title="1. Getting a key">
-          <p>Request a key by filling the form at <Link href="/for-business" style={{ color: TEXT }}>paybacker.co.uk/for-business</Link>. Approved keys are issued within one working day. Each key starts with <Inline>pbk_</Inline> and is shown to you <strong>once</strong>. Store it as a secret. If lost, contact us to revoke and re-issue.</p>
+          <p>
+            Get a key in seconds at <Link href="/for-business" style={{ color: TEXT }}>paybacker.co.uk/for-business</Link>.
+            Free tier (1,000 calls/month) is self-serve. Growth (£499/month, 10k calls) and Enterprise (£1,999/month, 100k calls) go via Stripe Checkout — your key is emailed within seconds of payment success.
+          </p>
+          <p>
+            Each key starts with <Inline>pbk_</Inline> and is shown <strong>once</strong> at provisioning time. Treat it like any other API credential — push it to your secret manager (1Password, AWS Secrets Manager, Vault, Doppler) immediately and never check it into git.
+          </p>
+          <p>
+            Lost a key? Sign in to your <Link href="/dashboard/api-keys" style={{ color: TEXT }}>customer portal</Link> with your work email and click <strong>Re-issue</strong> — this revokes the old key and shows the new plaintext once.
+          </p>
         </Section>
 
         <Section id="authentication" title="2. Authentication">
@@ -77,13 +88,21 @@ export default function DocsPage() {
 
         <Section id="response" title="5. Response schema">
           <Code>{`{
-  "statute": string,
+  "statute": string,                    // primary cited authority
+  "dispute_type": "energy" | "broadband" | "finance" | "travel" | "rail"
+                | "insurance" | "council_tax" | "parking" | "hmrc"
+                | "dvla" | "nhs" | "gym" | "debt" | "general",
+  "regulator": string | null,           // e.g. "Ofgem", "FCA / FOS"
   "entitlement": {
     "summary": string,
     "rationale": string,
     "additional_rights": string[],
     "estimated_success": "low" | "medium" | "high"
   },
+  "customer_facing_response": string,   // paste-ready paragraph for your agent
+  "agent_talking_points": string[],     // bullets your agent should hit
+  "claim_value_estimate": { "min": number, "max": number, "currency": "GBP" } | null,
+  "time_sensitivity": "high" | "medium" | "low",
   "draft_letter_excerpt": string,
   "escalation_path": [
     { "step": number, "to": string, "wait_days"?: number, "url"?: string }
@@ -91,7 +110,12 @@ export default function DocsPage() {
   "legal_references": string[],
   "confidence": number
 }`}</Code>
-          <p>Shape is stable across statute domains — a UK261 case and a Section 75 case populate the same fields. Parse one schema, not many.</p>
+          <p>
+            Shape is stable across statute domains — a UK261 cancellation and a Section 75 chargeback populate the same fields. Parse one schema, route on <Inline>dispute_type</Inline>, score on <Inline>entitlement.estimated_success</Inline>, render <Inline>customer_facing_response</Inline> verbatim in your agent UI, expose <Inline>claim_value_estimate</Inline> in self-serve flows.
+          </p>
+          <p style={{ background: '#f8fafc', borderLeft: '3px solid #0f172a', padding: '12px 16px', borderRadius: 6 }}>
+            <strong>Most B2B integrations don&rsquo;t use <Inline>draft_letter_excerpt</Inline>.</strong> It&rsquo;s a starting point your team can edit into your tone of voice — useful for self-serve dispute portals and for first-line agents who want a base to work from. CX-assist and triage workflows typically only consume the structured fields.
+          </p>
         </Section>
 
         <Section id="examples" title="6. Worked examples">
@@ -159,12 +183,26 @@ X-RateLimit-Remaining: <calls left this calendar month>`}</Code>
         </Section>
 
         <Section id="integration" title="9. Integration patterns">
-          <H3>CX agent assist</H3>
-          <p>Trigger on every inbound complaint ticket. Surface the cited statute and draft letter inside the agent UI; the agent edits and sends rather than drafting from scratch. Typical handle-time reduction: <strong>40–60%</strong>.</p>
-          <H3>Self-serve dispute resolution</H3>
-          <p>Embed in your customer portal. User describes the problem, your front-end POSTs to /v1/disputes, you render the entitlement summary and let them download the draft letter.</p>
-          <H3>Webhook / async pipeline</H3>
-          <p>For batch jobs (e.g. nightly review of all open disputes), the API tolerates concurrent requests up to your tier’s cap. Latency is dominated by the LLM call — parallelise aggressively.</p>
+          <H3>CX agent assist (most common pattern)</H3>
+          <p>
+            Trigger on every inbound complaint ticket. Render <Inline>statute</Inline> + <Inline>entitlement.summary</Inline> + <Inline>agent_talking_points</Inline> in a sidebar of your agent UI. Surface <Inline>customer_facing_response</Inline> as a paste-ready reply. Route by <Inline>dispute_type</Inline>; escalate when <Inline>time_sensitivity</Inline> is <Inline>high</Inline>. Handle-time reduction observed in early deployments: <strong>40–60%</strong>.
+          </p>
+          <H3>Self-serve dispute portal</H3>
+          <p>
+            Embed in your authenticated customer area. User describes the issue, your front-end POSTs to /v1/disputes, you render <Inline>entitlement.summary</Inline> + <Inline>claim_value_estimate</Inline> + <Inline>escalation_path</Inline>. Offer the <Inline>draft_letter_excerpt</Inline> as a download.
+          </p>
+          <H3>Refund / claims triage queue</H3>
+          <p>
+            Score every inbound ticket on <Inline>entitlement.estimated_success</Inline>. Auto-approve <Inline>high</Inline>, fast-track <Inline>medium</Inline>, escalate <Inline>low</Inline> for human judgement. Cuts ops backlog without touching customer-facing copy.
+          </p>
+          <H3>Statute-grounded chatbot</H3>
+          <p>
+            Wrap your LLM in this API. Inject <Inline>legal_references</Inline> + <Inline>entitlement.rationale</Inline> as grounding context for every consumer-rights question. Eliminates hallucinated UK statute citations regardless of base model.
+          </p>
+          <H3>Compliance / second-line review</H3>
+          <p>
+            Run nightly batches against open disputes; surface anomalies where your team&rsquo;s outgoing response diverges from the engine&rsquo;s recommended <Inline>customer_facing_response</Inline>. Latency is LLM-bound — parallelise aggressively up to your tier&rsquo;s cap.
+          </p>
         </Section>
 
         <Section id="legal" title="10. Legal & data handling">

--- a/src/app/for-business/page.tsx
+++ b/src/app/for-business/page.tsx
@@ -340,8 +340,10 @@ function Header() {
           <span className="m-business-brand-product">Business</span>
         </Link>
         <nav>
-          <a href="#example">Example</a>
-          <a href="#waitlist" className="m-business-nav-cta">Join waitlist</a>
+          <a href="/for-business/docs">Docs</a>
+          <a href="/for-business/coverage">Coverage</a>
+          <a href="/dashboard/api-keys">Sign in</a>
+          <a href="#buy" className="m-business-nav-cta">Get a key</a>
         </nav>
       </div>
     </header>

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -35,14 +35,32 @@ export interface DisputeRequest {
   consumer_name?: string;
 }
 
+export type DisputeType =
+  | 'energy' | 'broadband' | 'finance' | 'travel' | 'rail' | 'insurance'
+  | 'council_tax' | 'parking' | 'hmrc' | 'dvla' | 'nhs' | 'gym' | 'debt' | 'general';
+
 export interface DisputeResponse {
+  /** Primary UK statute / regulation grounding the response. */
   statute: string;
+  /** Coarse sector tag the caller can route on. */
+  dispute_type: DisputeType;
+  /** Primary regulator with jurisdiction, when applicable. */
+  regulator: string | null;
   entitlement: {
     summary: string;
     rationale: string;
     additional_rights?: string[];
     estimated_success: 'low' | 'medium' | 'high';
   };
+  /** Short paragraph a CX agent can paste into a customer reply. */
+  customer_facing_response: string;
+  /** Bullet points the CX agent should hit. */
+  agent_talking_points: string[];
+  /** Estimated claim value range in GBP, where the statute quantifies it. */
+  claim_value_estimate: { min: number; max: number; currency: 'GBP' } | null;
+  /** Time pressure: 'high' means a statutory deadline is close. */
+  time_sensitivity: 'high' | 'medium' | 'low';
+  /** Draft letter — most B2B callers edit, do not send verbatim. */
   draft_letter_excerpt: string;
   escalation_path: Array<{ step: number; to: string; wait_days?: number; url?: string }>;
   legal_references: string[];
@@ -227,8 +245,27 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
     : verifiedRefs
   ).slice(0, 3).map((r: any) => r.law_name);
 
+  const disputeType = classifyDisputeType(req.scenario, matchCategory);
+  const regulator = pickRegulator(disputeType);
+  const claimValue = estimateClaimValue(disputeType, req.scenario, req.amount);
+  const timeSensitivity = scoreTimeSensitivity(disputeType, req.scenario);
+
+  // Customer-facing response: a short paragraph the agent can lift
+  // verbatim into a reply. Pulled from the draft letter's opening, not
+  // its sign-off, so it stays neutral and product-of-the-business voice.
+  const customerFacingResponse = extractCustomerResponse(letter, rationale, legalRefs[0]);
+
+  // Agent talking points: bulleted form of nextSteps, capped, prefixed
+  // with the cited statute so the agent leads with authority.
+  const agentTalkingPoints: string[] = [];
+  if (legalRefs[0]) agentTalkingPoints.push(`Cited authority: ${legalRefs[0]}`);
+  agentTalkingPoints.push(...nextStepsArr.slice(0, 4));
+  if (timeSensitivity === 'high') agentTalkingPoints.push('Statutory deadline applies — flag urgency.');
+
   return {
     statute: inferStatute(legalRefs),
+    dispute_type: disputeType,
+    regulator,
     entitlement: {
       summary: nextStepsArr.length > 0
         ? nextStepsArr.join(' ')
@@ -237,6 +274,10 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
       additional_rights: additionalRights,
       estimated_success: successLabel,
     },
+    customer_facing_response: customerFacingResponse,
+    agent_talking_points: agentTalkingPoints,
+    claim_value_estimate: claimValue,
+    time_sensitivity: timeSensitivity,
     draft_letter_excerpt: letter.slice(0, 1200),
     escalation_path: Array.isArray(result?.escalationPath) && result.escalationPath.length > 0
       ? result.escalationPath.map((step: string, i: number) => ({ step: i + 1, to: step }))
@@ -244,4 +285,81 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
     legal_references: legalRefs,
     confidence: typeof result?.confidence === 'number' ? result.confidence : 0.8,
   };
+}
+
+function classifyDisputeType(scenario: string, refCategory?: string): DisputeType {
+  if (refCategory && ['energy','broadband','finance','travel','rail','insurance','council_tax','parking','hmrc','dvla','nhs','gym','debt','general'].includes(refCategory)) {
+    return refCategory as DisputeType;
+  }
+  const s = scenario.toLowerCase();
+  if (/flight|airline|cancell?ed|delay|baggage|boarding/.test(s)) return 'travel';
+  if (/train|rail|delay\s*repay|tfl/.test(s)) return 'rail';
+  if (/broadband|mobile|isp|ofcom|sky|virgin|bt\b/.test(s)) return 'broadband';
+  if (/energy|gas|electric|ofgem|british\s*gas|octopus|edf|ovo|eon|sse/.test(s)) return 'energy';
+  if (/section\s*75|credit\s*card|chargeback|payment\s*dispute|bank/.test(s)) return 'finance';
+  if (/insurance|claim\s*declined|underwriter|loss\s*adjuster/.test(s)) return 'insurance';
+  if (/council\s*tax|band\b/.test(s)) return 'council_tax';
+  if (/parking|pcn|penalty\s*charge/.test(s)) return 'parking';
+  if (/hmrc|tax\s*rebate|paye/.test(s)) return 'hmrc';
+  if (/dvla|driving\s*licence/.test(s)) return 'dvla';
+  if (/nhs|hospital/.test(s)) return 'nhs';
+  if (/gym|membership/.test(s)) return 'gym';
+  if (/debt|bailiff|enforcement|statute\s*barred/.test(s)) return 'debt';
+  return 'general';
+}
+
+function pickRegulator(t: DisputeType): string | null {
+  return ({
+    energy: 'Ofgem',
+    broadband: 'Ofcom',
+    finance: 'FCA / Financial Ombudsman Service',
+    travel: 'Civil Aviation Authority (CAA)',
+    rail: 'Office of Rail and Road (ORR)',
+    insurance: 'FCA / Financial Ombudsman Service',
+    council_tax: 'Valuation Office Agency / Valuation Tribunal',
+    parking: 'POPLA / Independent Appeals Service / local council',
+    hmrc: 'HMRC',
+    dvla: 'DVLA',
+    nhs: 'Parliamentary and Health Service Ombudsman',
+    gym: 'Trading Standards / Citizens Advice',
+    debt: 'FCA / Financial Ombudsman Service',
+    general: 'Trading Standards / Citizens Advice',
+  } as Record<DisputeType, string>)[t] ?? null;
+}
+
+function estimateClaimValue(
+  type: DisputeType,
+  scenario: string,
+  amount?: number,
+): { min: number; max: number; currency: 'GBP' } | null {
+  if (typeof amount === 'number' && amount > 0) {
+    return { min: Math.round(amount * 0.6), max: Math.round(amount), currency: 'GBP' };
+  }
+  // UK261 short-haul / long-haul bands.
+  if (type === 'travel') {
+    if (/long.?haul|6,?000\s*km|3,500/.test(scenario)) return { min: 350, max: 520, currency: 'GBP' };
+    return { min: 220, max: 350, currency: 'GBP' };
+  }
+  return null;
+}
+
+function scoreTimeSensitivity(type: DisputeType, scenario: string): 'high' | 'medium' | 'low' {
+  // UK261 has a 6-year limitation but eligibility windows; energy back-
+  // billing is 12 months; FOS final response window is 8 weeks. Flag
+  // 'high' when the scenario implies a near-term deadline.
+  if (/14[- ]?day|7[- ]?day|tomorrow|this\s*week|expires/.test(scenario.toLowerCase())) return 'high';
+  if (type === 'travel' || type === 'finance' || type === 'broadband') return 'medium';
+  return 'low';
+}
+
+function extractCustomerResponse(letter: string, rationale: string, statute?: string): string {
+  // Prefer a paragraph from the engine's draft. Strip headers / addresses
+  // by skipping until we hit "Dear" or a paragraph that mentions the
+  // statute by name.
+  const body = letter.replace(/^\s*[\s\S]*?Dear[\s\S]*?\n\n/, '').trim();
+  const firstPara = body.split(/\n\n+/)[0] ?? '';
+  if (firstPara.length > 80) return firstPara.slice(0, 600);
+  return statute
+    ? `Under ${statute}, the customer has rights here. ${rationale}`
+    : rationale;
 }

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -157,7 +157,8 @@ export async function handleB2bCheckoutCompleted(
     }
   }
 
-  // Founder ping
+  // Founder ping — Telegram + email on every sale (free pilots ping
+  // separately from /api/v1/free-pilot).
   const tgToken = process.env.TELEGRAM_BOT_TOKEN;
   const tgChat = process.env.TELEGRAM_FOUNDER_CHAT_ID;
   if (tgToken && tgChat) {
@@ -170,6 +171,24 @@ export async function handleB2bCheckoutCompleted(
           text: `💰 *B2B API sale*\n\n*${tier}* tier · ${customerEmail}\nCompany: ${company || '(not given)'}\nKey prefix: \`${minted.prefix}\``,
           parse_mode: 'Markdown',
         }),
+      });
+    } catch {}
+  }
+  if (process.env.RESEND_API_KEY) {
+    try {
+      await resend.emails.send({
+        from: process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>',
+        to: process.env.FOUNDER_EMAIL || 'business@paybacker.co.uk',
+        replyTo: customerEmail,
+        subject: `💰 B2B sale — ${company || customerEmail} (${tier})`,
+        html: `<div style="font-family:-apple-system,sans-serif;max-width:560px;margin:auto;color:#0f172a;">
+          <h2 style="margin:0 0 6px;">B2B API sale</h2>
+          <p style="margin:0 0 4px;"><strong>${escapeHtml(company || '(not given)')}</strong> — ${escapeHtml(tier)}</p>
+          <p style="margin:0 0 4px;">Contact: ${escapeHtml(contactName || '—')} · <a href="mailto:${escapeHtml(customerEmail)}">${escapeHtml(customerEmail)}</a></p>
+          <p style="margin:0 0 12px;">Key prefix: <code>${minted.prefix}</code> · Subscription: <code>${escapeHtml(subscriptionId || '—')}</code></p>
+          <p style="background:#ecfdf5;border-left:3px solid #047857;padding:10px 14px;color:#065f46;border-radius:6px;font-size:14px;">Customer has been emailed their plaintext key once. Send a personal welcome reply within 24h to land the relationship.</p>
+          <p><a href="https://paybacker.co.uk/dashboard/admin/b2b" style="background:#0f172a;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;display:inline-block;">Open admin</a></p>
+        </div>`,
       });
     } catch {}
   }

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -86,8 +86,23 @@ export async function handleB2bCheckoutCompleted(
   const customerId = session.customer as string | null;
 
   if (!customerEmail) {
-    console.error('[b2b stripe] no email on session, cannot mint key');
-    return;
+    throw new Error('[b2b stripe] no email on checkout session — cannot mint key');
+  }
+
+  // Idempotency: Stripe can replay checkout.session.completed. If a
+  // non-revoked key already exists for this subscription, no-op so we
+  // don't mint duplicates and email conflicting credentials.
+  if (subscriptionId) {
+    const { data: dupe } = await supabase
+      .from('b2b_api_keys')
+      .select('id')
+      .eq('stripe_subscription_id', subscriptionId)
+      .is('revoked_at', null)
+      .maybeSingle();
+    if (dupe) {
+      console.log(`[b2b stripe] idempotent skip — key already exists for sub ${subscriptionId}`);
+      return;
+    }
   }
 
   // Mark waitlist row converted (if any).
@@ -110,8 +125,10 @@ export async function handleB2bCheckoutCompleted(
     notes: `Stripe checkout · contact: ${contactName} · session: ${session.id}`,
   });
   if (error) {
-    console.error('[b2b stripe] insert key failed:', error.message);
-    return;
+    // Throw so the webhook returns 500 and Stripe retries delivery —
+    // a transient Supabase failure must not leave a paid customer
+    // without a provisioned key.
+    throw new Error(`[b2b stripe] key insert failed: ${error.message}`);
   }
 
   // Email plaintext to customer ONCE — sent from business@ so replies

--- a/supabase/migrations/20260428040000_b2b_waitlist_checkout_status.sql
+++ b/supabase/migrations/20260428040000_b2b_waitlist_checkout_status.sql
@@ -1,0 +1,21 @@
+-- Extend b2b_waitlist to track checkout intent + abandonment so the
+-- /for-business buy flow can capture leads BEFORE Stripe redirects
+-- and the webhook can mark conversion / abandonment retrospectively.
+--
+-- (This migration was applied to remote on 2026-04-28 ahead of the
+-- code that depends on it — committing the SQL afterwards keeps the
+-- repo migration history canonical for fresh environments.)
+
+ALTER TABLE b2b_waitlist DROP CONSTRAINT IF EXISTS b2b_waitlist_status_check;
+ALTER TABLE b2b_waitlist ADD CONSTRAINT b2b_waitlist_status_check
+  CHECK (status IN ('new', 'qualified', 'contacted', 'rejected', 'converted', 'checkout_started', 'checkout_abandoned'));
+
+ALTER TABLE b2b_waitlist
+  ADD COLUMN IF NOT EXISTS intended_tier TEXT,
+  ADD COLUMN IF NOT EXISTS stripe_session_id TEXT;
+
+-- Checkout-driven leads don't fill the use-case / volume fields, so
+-- relax those NOT NULL constraints to accommodate both lead sources.
+ALTER TABLE b2b_waitlist ALTER COLUMN expected_volume DROP NOT NULL;
+ALTER TABLE b2b_waitlist ALTER COLUMN use_case DROP NOT NULL;
+ALTER TABLE b2b_waitlist DROP CONSTRAINT IF EXISTS b2b_waitlist_use_case_check;

--- a/supabase/migrations/20260428050000_b2b_portal_tokens.sql
+++ b/supabase/migrations/20260428050000_b2b_portal_tokens.sql
@@ -1,0 +1,16 @@
+-- Single-use, time-limited portal tokens for B2B customers to access
+-- /dashboard/api-keys without a Paybacker user account. Issued via
+-- /api/v1/portal-login by emailing the work_email on the key. We
+-- store only a SHA-256 hash so a leaked DB row cannot be used.
+CREATE TABLE IF NOT EXISTS b2b_portal_tokens (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  email TEXT NOT NULL,
+  token_hash TEXT NOT NULL,
+  used_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS b2b_portal_tokens_hash_idx
+  ON b2b_portal_tokens (token_hash) WHERE used_at IS NULL;
+CREATE INDEX IF NOT EXISTS b2b_portal_tokens_email_idx
+  ON b2b_portal_tokens (email);


### PR DESCRIPTION
Customer self-serve portal at /dashboard/api-keys (passwordless email link), augmented /v1/disputes response (dispute_type, regulator, customer_facing_response, agent_talking_points, claim_value_estimate, time_sensitivity), founder email on every sale, and rewrites /for-business docs + coverage in B2B-engineer/CX-buyer voice.