### PR TITLE
feat(b2b): one-time-link key delivery + CLAUDE.md awareness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,27 @@ This project has an existing production codebase with real users and live data. 
 **Company:** Paybacker LTD (UK registered)
 **Website:** paybacker.co.uk
 **Founded:** March 2026
-**Contact:** hello@paybacker.co.uk
+**Contact:** hello@paybacker.co.uk (consumer) · business@paybacker.co.uk (B2B)
 
-Paybacker is an AI-powered savings platform for UK consumers. It helps people dispute unfair bills, track every subscription and contract, scan their bank account and email inbox for hidden costs, and take control of their finances. The AI generates professional complaint letters citing exact UK consumer law in 30 seconds.
+Paybacker ships **two products from one codebase**:
 
-**Target audience:** UK consumers aged 25-50, tech-savvy professionals who are time-poor and overpaying on bills without realising it.
+### 1. Consumer app (B2C) — paybacker.co.uk
+AI-powered savings platform for UK consumers. Disputes unfair bills, tracks every subscription / contract, scans bank + email inbox for hidden costs. The AI generates professional complaint letters citing exact UK consumer law in 30 seconds. **Target audience:** UK consumers aged 25-50, time-poor professionals overpaying on bills.
+
+### 2. UK Consumer Rights API (B2B) — paybacker.co.uk/for-business
+The same engine exposed as a single REST endpoint for UK fintechs, insurers, energy retailers, and claims platforms. `POST /v1/disputes` returns the cited statute, sector classification, regulator, entitlement summary, customer-facing response, agent talking points, claim value estimate, time sensitivity, escalation path, and draft letter — in one call. Launched 2026-04-28.
+
+- **Tiers:** Starter (free, 1k calls/mo, self-serve mint), Growth (£499/mo, 10k calls), Enterprise (£1,999/mo, 100k calls + SLA).
+- **Decision rule:** 10 qualified UK fintech signups in 30 days post-launch (≈ 28 May 2026) → green-light deeper build. <10 → archive `/for-business`.
+- **Tables:** `b2b_waitlist`, `b2b_api_keys`, `b2b_api_usage`, `b2b_portal_tokens`.
+- **Key files:** `src/lib/b2b/{auth,disputes,stripe-webhook,key-reveal}.ts`, `src/app/api/v1/{disputes,checkout,free-pilot,portal-login,portal-keys,key-reveal}/route.ts`, `src/app/for-business/{page,docs,coverage,thanks}/`, `src/app/dashboard/api-keys/`, `src/app/dashboard/admin/b2b/`.
+- **Auth model:** bearer token `pbk_<8hex>_<32hex>`; SHA-256 hash + 8-char prefix in DB. Plaintext shown ONCE via single-use email link, never persisted, never logged.
+- **Stripe:** live products `prod_UPqX0DuQzRRqjI` (Growth) and `prod_UPqXc86ZeTqXFL` (Enterprise). Env vars `STRIPE_PRICE_API_GROWTH_MONTHLY`, `STRIPE_PRICE_API_ENTERPRISE_MONTHLY`. Webhook `we_1TDVvr7qw7mEWYpy2hLTs9S3` subscribes to `checkout.session.{completed,expired}` + sub lifecycle. **Always idempotent on `checkout.session.completed`** (Stripe replays).
+- **Crons:** `/api/cron/b2b-nurture` daily 10:00 UTC drips d1/d3/d7/d14 emails to non-converters; uses `notes` column tag like `[nurture:d3]` for dedup.
+- **Daily B2B alerts** (Telegram + founder email): free-pilot mint, Stripe checkout started, sale, abandonment.
+- **Customer portal:** `/dashboard/api-keys` (token-gated via passwordless email link, 30-min expiry, single-use on mutating actions). Reveal/Re-issue/Revoke.
+
+**B2B-product rule for future Claude sessions:** the engine + statute index is shared. Don't fork. Any change to `src/lib/agents/complaints-agent.ts` or to `legal_references` schema affects BOTH products — flag it. The B2B API response shape (`DisputeResponse` in `src/lib/b2b/disputes.ts`) is a public contract — don't break it without a `/v2` path. Keep CLAUDE.md updated when new B2B endpoints, env vars, or Stripe prices are added.
 
 ---
 

--- a/src/app/api/v1/free-pilot/route.ts
+++ b/src/app/api/v1/free-pilot/route.ts
@@ -11,6 +11,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { generateKey } from '@/lib/b2b/auth';
+import { createKeyRevealLink } from '@/lib/b2b/key-reveal';
 import { resend } from '@/lib/resend';
 
 export const runtime = 'nodejs';
@@ -79,27 +80,24 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Could not mint key' }, { status: 500 });
   }
 
-  // Email plaintext to customer ONCE.
+  // Email a SINGLE-USE reveal link instead of plaintext. Forwarded
+  // and archived emails can't be replayed once the link is consumed.
   if (process.env.RESEND_API_KEY) {
     try {
+      const revealLink = await createKeyRevealLink(minted.plaintext, lower);
       await resend.emails.send({
         from: process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>',
         to: lower,
         replyTo: 'business@paybacker.co.uk',
-        subject: 'Your Paybacker API key (Starter — 1,000 calls/month)',
+        subject: 'Your Paybacker API key — view once',
         html: `
           <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:560px;margin:auto;color:#0f172a;">
             <p>Hi ${escapeHtml(name)},</p>
-            <p>Your Paybacker UK Consumer Rights API key is ready.</p>
-            <p style="background:#0f172a;color:#e2e8f0;padding:16px;border-radius:8px;font-family:ui-monospace,Menlo,monospace;font-size:14px;word-break:break-all;">${minted.plaintext}</p>
-            <p><strong>Save this now — it is only shown once.</strong> If you lose it, contact us to revoke and re-issue.</p>
-            <p>Tier: <strong>Starter</strong> · Monthly cap: <strong>1,000 calls</strong> · Resets on the 1st (UTC).</p>
-            <p>Docs: <a href="https://paybacker.co.uk/for-business/docs">paybacker.co.uk/for-business/docs</a></p>
-            <p>Quick test:</p>
-            <pre style="background:#f1f5f9;padding:12px;border-radius:6px;overflow:auto;font-size:12px;">curl -X POST https://paybacker.co.uk/api/v1/disputes \\
-  -H "Authorization: Bearer ${minted.plaintext}" \\
-  -H "Content-Type: application/json" \\
-  -d '{"scenario":"Ryanair cancelled my flight 6h before departure, refusing compensation","amount":350}'</pre>
+            <p>Your Paybacker UK Consumer Rights API key is ready. Click below to reveal it — the link works once and expires in 24 hours.</p>
+            <p style="margin:24px 0;"><a href="${revealLink}" style="background:#0f172a;color:#fff;padding:12px 22px;border-radius:8px;text-decoration:none;font-weight:600;">View my API key</a></p>
+            <p style="color:#64748b;font-size:13px;">Tier: <strong>Starter</strong> · Monthly cap: <strong>1,000 calls</strong> · Resets on the 1st (UTC).</p>
+            <p style="color:#64748b;font-size:13px;">Docs: <a href="https://paybacker.co.uk/for-business/docs">paybacker.co.uk/for-business/docs</a> · Portal: <a href="https://paybacker.co.uk/dashboard/api-keys">paybacker.co.uk/dashboard/api-keys</a></p>
+            <p style="color:#64748b;font-size:13px;">Lost the key after viewing? Sign in to the portal and click <strong>Re-issue</strong> — that revokes the old key and issues a new one.</p>
             <p>Reply to this email with what you build — Paul, founder.</p>
           </div>`,
       });

--- a/src/app/api/v1/key-reveal/route.ts
+++ b/src/app/api/v1/key-reveal/route.ts
@@ -1,0 +1,61 @@
+/**
+ * GET /api/v1/key-reveal?token=...&email=... — single-use plaintext reveal.
+ *
+ * On first GET: returns plaintext, clears the payload, marks token used.
+ * On subsequent GET: returns 410 Gone with a "request a new key" message.
+ *
+ * Used by the email-link delivery flow that replaces direct plaintext-in-email.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'node:crypto';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get('token') ?? '';
+  const email = (url.searchParams.get('email') ?? '').toLowerCase();
+  if (!token || !email) {
+    return NextResponse.json({ error: 'Missing token or email' }, { status: 400 });
+  }
+
+  const supabase = getAdmin();
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const { data } = await supabase
+    .from('b2b_portal_tokens')
+    .select('id, expires_at, used_at, payload, purpose, email')
+    .eq('token_hash', tokenHash)
+    .eq('email', email)
+    .maybeSingle();
+
+  if (!data || data.purpose !== 'reveal_key') {
+    return NextResponse.json({ error: 'Link invalid.' }, { status: 404 });
+  }
+  if (data.used_at || !data.payload) {
+    return NextResponse.json(
+      { error: 'This link has already been used. For a new key, sign in to the portal and click Re-issue.' },
+      { status: 410 },
+    );
+  }
+  if (new Date(data.expires_at) < new Date()) {
+    return NextResponse.json({ error: 'Link expired. Sign in to the portal and click Re-issue.' }, { status: 410 });
+  }
+
+  // Burn it: clear payload + mark used in a single update.
+  await supabase
+    .from('b2b_portal_tokens')
+    .update({ used_at: new Date().toISOString(), payload: null })
+    .eq('id', data.id);
+
+  return NextResponse.json({ ok: true, plaintext: data.payload });
+}

--- a/src/app/dashboard/api-keys/reveal/page.tsx
+++ b/src/app/dashboard/api-keys/reveal/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+/**
+ * /dashboard/api-keys/reveal — one-time plaintext key reveal page.
+ *
+ * The customer arrives via a one-shot link emailed at provisioning.
+ * On first load we ask the API for the plaintext; the API returns it
+ * and burns the token. We render the plaintext clearly with a copy
+ * button and a "I've saved it" confirmation.
+ *
+ * On second load (back button, refresh, archived email replay) the
+ * API returns 410 and we tell them to use Re-issue from the portal.
+ */
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+
+export default function RevealKeyPage() {
+  const params = useSearchParams();
+  const token = params.get('token');
+  const email = params.get('email');
+
+  const [loading, setLoading] = useState(true);
+  const [plaintext, setPlaintext] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!token || !email) { setError('Missing token or email.'); setLoading(false); return; }
+    (async () => {
+      try {
+        const r = await fetch(`/api/v1/key-reveal?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`);
+        const j = await r.json();
+        if (!r.ok) {
+          setError(j.error || 'Could not reveal key.');
+        } else {
+          setPlaintext(j.plaintext);
+        }
+      } catch {
+        setError('Network error. Refresh in 30 seconds; if still failing, sign in to the portal and re-issue.');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [token, email]);
+
+  return (
+    <main style={page}>
+      <div style={card}>
+        <h1 style={{ margin: 0, fontSize: 28, letterSpacing: '-0.01em' }}>Your Paybacker API key</h1>
+        <p style={{ color: '#475569' }}>
+          For <strong>{email ?? '—'}</strong>. This key is shown once. Save it now.
+        </p>
+
+        {loading && <p style={{ color: '#64748b' }}>Decrypting…</p>}
+
+        {!loading && error && (
+          <div style={errorBox}>
+            <strong>Couldn&rsquo;t reveal the key.</strong>
+            <p style={{ margin: '6px 0 0' }}>{error}</p>
+            <p style={{ margin: '12px 0 0' }}>
+              <Link href="/dashboard/api-keys" style={btn}>Sign in &amp; re-issue</Link>
+            </p>
+          </div>
+        )}
+
+        {!loading && plaintext && (
+          <>
+            <pre style={key}>{plaintext}</pre>
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(plaintext);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              }}
+              style={btn}
+            >
+              {copied ? '✓ Copied' : 'Copy to clipboard'}
+            </button>
+
+            <div style={tipBox}>
+              <strong>Save it now.</strong> Push it to your secret manager
+              (1Password, AWS Secrets Manager, Vault, Doppler) immediately.
+              We never store the plaintext — only a hash. If you lose this
+              key, sign in to the <Link href="/dashboard/api-keys" style={{ color: '#0f172a', fontWeight: 600 }}>portal</Link> and click <strong>Re-issue</strong>.
+            </div>
+
+            <h3 style={{ marginTop: 24, fontSize: 14, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.04em' }}>Quick test</h3>
+            <pre style={code}>{`curl -X POST https://paybacker.co.uk/api/v1/disputes \\
+  -H "Authorization: Bearer ${plaintext}" \\
+  -H "Content-Type: application/json" \\
+  -d '{"scenario":"Ryanair cancelled my flight 6h before departure, refusing compensation","amount":350}'`}</pre>
+
+            <p style={{ marginTop: 24, fontSize: 14, color: '#64748b' }}>
+              Next: <Link href="/for-business/docs" style={{ color: '#0f172a' }}>read the docs →</Link>
+            </p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+const page: React.CSSProperties = {
+  minHeight: '100vh', background: '#f8fafc', display: 'flex', alignItems: 'center', justifyContent: 'center',
+  padding: 24, fontFamily: '-apple-system, "Segoe UI", system-ui, sans-serif', color: '#0f172a',
+};
+const card: React.CSSProperties = {
+  background: '#fff', border: '1px solid #e2e8f0', borderRadius: 14, padding: 32, maxWidth: 640, width: '100%', display: 'grid', gap: 12,
+};
+const key: React.CSSProperties = {
+  background: '#0f172a', color: '#e2e8f0', padding: 16, borderRadius: 8, overflow: 'auto',
+  fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 14, wordBreak: 'break-all', whiteSpace: 'pre-wrap',
+};
+const code: React.CSSProperties = { ...key, fontSize: 12, lineHeight: 1.6 };
+const btn: React.CSSProperties = {
+  background: '#0f172a', color: '#fff', border: 0, padding: '10px 16px', borderRadius: 8,
+  fontWeight: 600, cursor: 'pointer', fontSize: 14, textDecoration: 'none', display: 'inline-block',
+};
+const tipBox: React.CSSProperties = {
+  background: '#fefce8', border: '1px solid #fde68a', padding: '12px 16px', borderRadius: 8, color: '#713f12', fontSize: 14,
+};
+const errorBox: React.CSSProperties = {
+  background: '#fef2f2', border: '1px solid #fecaca', padding: '14px 18px', borderRadius: 8, color: '#7f1d1d',
+};

--- a/src/lib/b2b/key-reveal.ts
+++ b/src/lib/b2b/key-reveal.ts
@@ -1,0 +1,50 @@
+/**
+ * One-time-link key delivery.
+ *
+ * Instead of emailing the plaintext API key directly, we email a
+ * single-use link that reveals it once. After the customer clicks,
+ * the plaintext is wiped from the token row and the token is marked
+ * used. Forwarded / archived emails can't be replayed.
+ *
+ * Trade-off vs direct email: one extra click for the customer.
+ * Worth it for security posture and for the conversation when a
+ * prospect asks "do you email plaintext keys?" — answer is no.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'node:crypto';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+/**
+ * Create a single-use reveal link for a freshly-minted plaintext key.
+ * Token expires in 24h — long enough that a customer who archived the
+ * email overnight can still recover, short enough to limit blast radius.
+ *
+ * Returns the absolute URL to email.
+ */
+export async function createKeyRevealLink(
+  plaintext: string,
+  email: string,
+): Promise<string> {
+  const supabase = getAdmin();
+  const token = crypto.randomBytes(32).toString('base64url');
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+  await supabase.from('b2b_portal_tokens').insert({
+    email: email.toLowerCase(),
+    token_hash: tokenHash,
+    payload: plaintext,
+    purpose: 'reveal_key',
+    expires_at: expiresAt,
+  });
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://paybacker.co.uk';
+  return `${baseUrl}/dashboard/api-keys/reveal?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email.toLowerCase())}`;
+}

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -9,6 +9,7 @@
 import type Stripe from 'stripe';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { generateKey } from './auth';
+import { createKeyRevealLink } from './key-reveal';
 import { resend } from '@/lib/resend';
 
 const TIER_LIMITS: Record<string, number> = {
@@ -131,24 +132,25 @@ export async function handleB2bCheckoutCompleted(
     throw new Error(`[b2b stripe] key insert failed: ${error.message}`);
   }
 
-  // Email plaintext to customer ONCE — sent from business@ so replies
-  // route to the B2B inbox the founder watches separately.
+  // Email a single-use reveal link rather than plaintext. Better
+  // security posture (forwarded emails can't be replayed) and the
+  // answer to any prospect who asks "do you email plaintext keys?".
   if (process.env.RESEND_API_KEY) {
     try {
+      const revealLink = await createKeyRevealLink(minted.plaintext, customerEmail.toLowerCase());
       await resend.emails.send({
         from: process.env.B2B_FROM_EMAIL || process.env.RESEND_FROM_EMAIL || 'Paybacker for Business <noreply@paybacker.co.uk>',
         to: customerEmail,
         replyTo: 'business@paybacker.co.uk',
-        subject: `Your Paybacker API key (${tier} — ${monthlyLimit.toLocaleString()} calls/month)`,
+        subject: `Your Paybacker API key (${tier} — ${monthlyLimit.toLocaleString()} calls/month) — view once`,
         html: `
           <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:560px;margin:auto;color:#0f172a;">
             <p>Hi ${escapeHtml(contactName || 'there')},</p>
-            <p>Your subscription is live — here is your API key:</p>
-            <p style="background:#0f172a;color:#e2e8f0;padding:16px;border-radius:8px;font-family:ui-monospace,Menlo,monospace;font-size:14px;word-break:break-all;">${minted.plaintext}</p>
-            <p><strong>Save this now — it is only shown once.</strong> If you lose it, contact us at hello@paybacker.co.uk to revoke and re-issue.</p>
-            <p>Tier: <strong>${tier}</strong> · Monthly cap: <strong>${monthlyLimit.toLocaleString()} calls</strong> · Resets on the 1st (UTC).</p>
-            <p>Docs: <a href="https://paybacker.co.uk/for-business/docs">paybacker.co.uk/for-business/docs</a></p>
-            <p>Manage your subscription: <a href="https://paybacker.co.uk/dashboard/api-keys">paybacker.co.uk/dashboard/api-keys</a></p>
+            <p>Your subscription is live. Click below to reveal your API key — the link works once and expires in 24 hours.</p>
+            <p style="margin:24px 0;"><a href="${revealLink}" style="background:#0f172a;color:#fff;padding:12px 22px;border-radius:8px;text-decoration:none;font-weight:600;">View my API key</a></p>
+            <p style="color:#64748b;font-size:13px;">Tier: <strong>${tier}</strong> · Monthly cap: <strong>${monthlyLimit.toLocaleString()} calls</strong> · Resets on the 1st (UTC).</p>
+            <p style="color:#64748b;font-size:13px;">Docs: <a href="https://paybacker.co.uk/for-business/docs">paybacker.co.uk/for-business/docs</a> · Portal: <a href="https://paybacker.co.uk/dashboard/api-keys">paybacker.co.uk/dashboard/api-keys</a></p>
+            <p style="color:#64748b;font-size:13px;">Lost the key after viewing? Sign in to the portal and click <strong>Re-issue</strong>.</p>
             <p>— Paul, founder</p>
           </div>`,
       });

--- a/supabase/migrations/20260428060000_b2b_portal_tokens_reveal.sql
+++ b/supabase/migrations/20260428060000_b2b_portal_tokens_reveal.sql
@@ -1,0 +1,9 @@
+-- One-time-link delivery for newly minted API keys.
+-- We previously emailed the plaintext key directly; now we email a
+-- single-use link that, on first GET, shows the plaintext and burns
+-- the token. Improves the security posture: forwarded / archived
+-- emails can't be replayed to recover the key.
+ALTER TABLE b2b_portal_tokens
+  ADD COLUMN IF NOT EXISTS purpose TEXT NOT NULL DEFAULT 'signin'
+    CHECK (purpose IN ('signin', 'reveal_key')),
+  ADD COLUMN IF NOT EXISTS payload TEXT;


### PR DESCRIPTION
Replaces plaintext-in-email with a single-use reveal link (24h, burns on first view). Better security posture. Updates CLAUDE.md so future Claude sessions know Paybacker ships two products from one codebase.