### PR TITLE
feat(b2b): enterprise-grade portal — audit, usage chart, recent calls, history

### DIFF
--- a/src/app/api/v1/free-pilot/route.ts
+++ b/src/app/api/v1/free-pilot/route.ts
@@ -12,6 +12,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { generateKey } from '@/lib/b2b/auth';
 import { createKeyRevealLink } from '@/lib/b2b/key-reveal';
+import { audit, extractClientMeta } from '@/lib/b2b/audit';
 import { resend } from '@/lib/resend';
 
 export const runtime = 'nodejs';
@@ -66,7 +67,7 @@ export async function POST(request: NextRequest) {
   }
 
   const minted = generateKey();
-  const { error } = await supabase.from('b2b_api_keys').insert({
+  const { data: inserted, error } = await supabase.from('b2b_api_keys').insert({
     name: `${company} (free pilot)`,
     key_hash: minted.hash,
     key_prefix: minted.prefix,
@@ -74,11 +75,13 @@ export async function POST(request: NextRequest) {
     monthly_limit: 1000,
     owner_email: lower,
     notes: `Free pilot · contact: ${name} · use case: ${use_case.slice(0, 200)}`,
-  });
+  }).select('id').single();
   if (error) {
     console.error('[v1/free-pilot] insert failed', error.message);
     return NextResponse.json({ error: 'Could not mint key' }, { status: 500 });
   }
+  const meta = extractClientMeta(request);
+  audit({ email: lower, action: 'key_created', key_id: inserted?.id ?? null, ...meta, metadata: { tier: 'starter', source: 'free_pilot', company, prefix: minted.prefix } });
 
   // Email a SINGLE-USE reveal link instead of plaintext. Forwarded
   // and archived emails can't be replayed once the link is consumed.

--- a/src/app/api/v1/key-reveal/route.ts
+++ b/src/app/api/v1/key-reveal/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
+import { audit, extractClientMeta } from '@/lib/b2b/audit';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -56,6 +57,9 @@ export async function GET(request: NextRequest) {
     .from('b2b_portal_tokens')
     .update({ used_at: new Date().toISOString(), payload: null })
     .eq('id', data.id);
+
+  const meta = extractClientMeta(request);
+  audit({ email, action: 'reveal_link_used', ...meta });
 
   return NextResponse.json({ ok: true, plaintext: data.payload });
 }

--- a/src/app/api/v1/portal-keys/route.ts
+++ b/src/app/api/v1/portal-keys/route.ts
@@ -15,6 +15,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
 import { generateKey } from '@/lib/b2b/auth';
+import { audit, extractClientMeta } from '@/lib/b2b/audit';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -74,6 +75,47 @@ async function loadKeys(supabase: any, email: string) {
   return (keys ?? []).map((k: any) => ({ ...k, monthly_used: usageByKey.get(k.id) ?? 0 }));
 }
 
+async function loadAudit(supabase: any, email: string, limit = 25) {
+  const { data } = await supabase
+    .from('b2b_audit_log')
+    .select('id, action, actor, key_id, ip_address, user_agent, metadata, created_at')
+    .eq('email', email)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  return data ?? [];
+}
+
+async function loadRecentUsage(supabase: any, keyIds: string[], limit = 50) {
+  if (keyIds.length === 0) return [];
+  const { data } = await supabase
+    .from('b2b_api_usage')
+    .select('key_id, endpoint, status_code, latency_ms, scenario_kind, error_code, created_at')
+    .in('key_id', keyIds)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  return data ?? [];
+}
+
+async function loadUsageDaily(supabase: any, keyIds: string[]) {
+  if (keyIds.length === 0) return [];
+  const since = new Date(Date.now() - 30 * 86400_000).toISOString();
+  const { data } = await supabase
+    .from('b2b_api_usage')
+    .select('created_at, status_code')
+    .in('key_id', keyIds)
+    .gte('created_at', since);
+  // Group by day in JS — simpler than custom RPC, fine at 100k/mo cap.
+  const byDay = new Map<string, { ok: number; err: number }>();
+  for (const r of (data ?? []) as Array<{ created_at: string; status_code: number }>) {
+    const day = r.created_at.slice(0, 10);
+    const cur = byDay.get(day) ?? { ok: 0, err: 0 };
+    if (r.status_code >= 400) cur.err++;
+    else cur.ok++;
+    byDay.set(day, cur);
+  }
+  return Array.from(byDay.entries()).sort(([a], [b]) => a.localeCompare(b)).map(([day, v]) => ({ day, ...v }));
+}
+
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const token = url.searchParams.get('token') ?? '';
@@ -84,8 +126,35 @@ export async function GET(request: NextRequest) {
   const ok = await verifyToken(supabase, token, email, false);
   if (!ok) return NextResponse.json({ error: 'Invalid or expired link. Request a new one.' }, { status: 401 });
 
+  // Log a portal_signin event the first time a token is read in a session.
+  // We don't dedupe across reads — each load is one event. The portal UI
+  // pulls audit on every page render, so over-counting is bounded by user
+  // interaction, not refresh-spamming.
+  const meta = extractClientMeta(request);
+  audit({ email, action: 'portal_signin', ...meta });
+
   const keys = await loadKeys(supabase, email);
-  return NextResponse.json({ keys });
+  const allKeys = await loadAllKeys(supabase, email);
+  const recentUsage = await loadRecentUsage(supabase, allKeys.map((k: any) => k.id));
+  const usageDaily = await loadUsageDaily(supabase, allKeys.map((k: any) => k.id));
+  const auditLog = await loadAudit(supabase, email);
+
+  return NextResponse.json({
+    keys,            // active keys with monthly usage
+    all_keys: allKeys, // including revoked, for history
+    recent_usage: recentUsage,
+    usage_daily: usageDaily,
+    audit_log: auditLog,
+  });
+}
+
+async function loadAllKeys(supabase: any, email: string) {
+  const { data } = await supabase
+    .from('b2b_api_keys')
+    .select('id, name, key_prefix, tier, monthly_limit, last_used_at, revoked_at, created_at')
+    .eq('owner_email', email)
+    .order('created_at', { ascending: false });
+  return data ?? [];
 }
 
 export async function POST(request: NextRequest) {
@@ -116,11 +185,14 @@ export async function POST(request: NextRequest) {
     .maybeSingle();
   if (!row) return NextResponse.json({ error: 'Key not found' }, { status: 404 });
 
+  const meta = extractClientMeta(request);
+
   if (action === 'revoke') {
     await supabase
       .from('b2b_api_keys')
       .update({ revoked_at: new Date().toISOString() })
       .eq('id', id);
+    audit({ email, action: 'key_revoked', key_id: id, ...meta, metadata: { name: row.name } });
     return NextResponse.json({ ok: true });
   }
 
@@ -130,9 +202,10 @@ export async function POST(request: NextRequest) {
       .from('b2b_api_keys')
       .update({ revoked_at: new Date().toISOString() })
       .eq('id', id);
+    audit({ email, action: 'key_revoked', key_id: id, ...meta, metadata: { name: row.name, reason: 'reissue_revoke' } });
 
     const minted = generateKey();
-    const { error } = await supabase.from('b2b_api_keys').insert({
+    const { data: inserted, error } = await supabase.from('b2b_api_keys').insert({
       name: `${row.name} (re-issued)`,
       key_hash: minted.hash,
       key_prefix: minted.prefix,
@@ -140,8 +213,9 @@ export async function POST(request: NextRequest) {
       monthly_limit: row.monthly_limit,
       owner_email: email,
       notes: `Self-serve re-issue at ${new Date().toISOString()}`,
-    });
+    }).select('id').single();
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    audit({ email, action: 'key_reissued', key_id: inserted?.id ?? null, ...meta, metadata: { tier: row.tier, prefix: minted.prefix } });
     return NextResponse.json({ ok: true, plaintext: minted.plaintext });
   }
 

--- a/src/app/api/v1/portal-login/route.ts
+++ b/src/app/api/v1/portal-login/route.ts
@@ -15,6 +15,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
 import { resend } from '@/lib/resend';
+import { audit, extractClientMeta } from '@/lib/b2b/audit';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -40,6 +41,10 @@ export async function POST(request: NextRequest) {
   }
 
   const supabase = getAdmin();
+
+  // Always log the request so we have an audit trail of who tried.
+  const { ip_address, user_agent } = extractClientMeta(request);
+  audit({ email, action: 'login_link_requested', ip_address, user_agent });
 
   // We always return ok=true even if no key exists for this email, so
   // the response can't be used as an enumeration oracle.

--- a/src/app/dashboard/api-keys/page.tsx
+++ b/src/app/dashboard/api-keys/page.tsx
@@ -4,15 +4,14 @@
  * /dashboard/api-keys — B2B customer self-serve portal.
  *
  * Token-gated (not Supabase auth) — link is delivered by email via
- * /api/v1/portal-login. Customer can:
- *   - See their key prefix, tier, monthly usage, last-used timestamp
- *   - Re-issue (revoke + mint replacement, plaintext shown ONCE)
- *   - Revoke a key
- *
- * The plaintext key is never re-displayed for an existing key — that
- * is the whole point of hashing. To recover from a lost key, customers
- * use Re-issue: it revokes the old key and shows the new plaintext
- * once on this page.
+ * /api/v1/portal-login. Sections:
+ *   1. Active keys — prefix, tier, this-month usage bar, last-used,
+ *      Re-issue / Revoke buttons.
+ *   2. Usage chart (last 30 days, ok vs error).
+ *   3. Recent API calls (last 50: timestamp, endpoint, status, latency).
+ *   4. Audit log (logins, key actions, IP + user agent).
+ *   5. Key history (revoked + active).
+ *   6. Account info, billing portal link, support contact.
  */
 
 import { useEffect, useState } from 'react';
@@ -31,6 +30,41 @@ interface Key {
   created_at: string;
 }
 
+interface UsageRow {
+  key_id: string;
+  endpoint: string;
+  status_code: number;
+  latency_ms: number | null;
+  scenario_kind: string | null;
+  error_code: string | null;
+  created_at: string;
+}
+
+interface AuditRow {
+  id: number;
+  action: string;
+  actor: string;
+  key_id: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  metadata: Record<string, any>;
+  created_at: string;
+}
+
+interface DailyUsage {
+  day: string;
+  ok: number;
+  err: number;
+}
+
+interface PortalData {
+  keys: Key[];
+  all_keys: Key[];
+  recent_usage: UsageRow[];
+  usage_daily: DailyUsage[];
+  audit_log: AuditRow[];
+}
+
 export const dynamic = 'force-dynamic';
 
 export default function ApiKeysPortalPage() {
@@ -41,10 +75,11 @@ export default function ApiKeysPortalPage() {
   const [requestEmail, setRequestEmail] = useState('');
   const [requestSent, setRequestSent] = useState(false);
   const [requesting, setRequesting] = useState(false);
-  const [keys, setKeys] = useState<Key[] | null>(null);
+  const [data, setData] = useState<PortalData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reissued, setReissued] = useState<{ id: string; plaintext: string } | null>(null);
+  const [tab, setTab] = useState<'keys' | 'usage' | 'activity' | 'audit' | 'account'>('keys');
 
   async function load() {
     if (!token || !email) return;
@@ -53,8 +88,8 @@ export default function ApiKeysPortalPage() {
     try {
       const r = await fetch(`/api/v1/portal-keys?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`);
       const j = await r.json();
-      if (!r.ok) throw new Error(j.error || 'Could not load keys');
-      setKeys(j.keys ?? []);
+      if (!r.ok) throw new Error(j.error || 'Could not load portal');
+      setData(j);
     } catch (e: any) {
       setError(e?.message || 'Failed');
     } finally {
@@ -93,7 +128,7 @@ export default function ApiKeysPortalPage() {
   }
 
   async function revoke(id: string) {
-    if (!confirm('Revoke this key? Calls will fail immediately.')) return;
+    if (!confirm('Revoke this key? Calls using it will fail immediately.')) return;
     const r = await fetch('/api/v1/portal-keys', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -105,8 +140,8 @@ export default function ApiKeysPortalPage() {
   // No token → render request-link form
   if (!token || !email) {
     return (
-      <main style={pageWrap}>
-        <div style={card}>
+      <main style={signinPage}>
+        <div style={signinCard}>
           <h1 style={{ margin: 0, fontSize: 28, letterSpacing: '-0.01em' }}>API portal sign-in</h1>
           <p style={{ color: '#475569' }}>
             Enter the work email your Paybacker API key is registered to. We&rsquo;ll send a one-time link.
@@ -117,19 +152,12 @@ export default function ApiKeysPortalPage() {
             </div>
           ) : (
             <form onSubmit={requestLink} style={{ display: 'grid', gap: 10 }}>
-              <input
-                type="email"
-                required
-                value={requestEmail}
-                onChange={(e) => setRequestEmail(e.target.value)}
-                placeholder="you@company.com"
-                style={input}
-              />
+              <input type="email" required value={requestEmail} onChange={(e) => setRequestEmail(e.target.value)} placeholder="you@company.com" style={inputStyle} />
               <button type="submit" disabled={requesting} style={btn}>{requesting ? 'Sending…' : 'Send sign-in link'}</button>
             </form>
           )}
           <p style={{ color: '#64748b', fontSize: 13, marginTop: 24 }}>
-            Don&rsquo;t have a key yet? <Link href="/for-business" style={{ color: '#0f172a' }}>Get one →</Link>
+            No key yet? <Link href="/for-business" style={{ color: '#0f172a' }}>Get one →</Link>
           </p>
         </div>
       </main>
@@ -137,13 +165,23 @@ export default function ApiKeysPortalPage() {
   }
 
   return (
-    <main style={pageWrap}>
-      <div style={{ ...card, maxWidth: 720 }}>
-        <h1 style={{ margin: 0, fontSize: 28, letterSpacing: '-0.01em' }}>Your API keys</h1>
-        <p style={{ color: '#475569' }}>Signed in as <strong>{email}</strong></p>
+    <main style={page}>
+      <div style={shell}>
+        <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 16, marginBottom: 24 }}>
+          <div>
+            <Link href="/for-business" style={{ color: '#64748b', fontSize: 13, textDecoration: 'none' }}>← paybacker.co.uk/for-business</Link>
+            <h1 style={{ margin: '8px 0 4px', fontSize: 28, letterSpacing: '-0.01em' }}>API portal</h1>
+            <p style={{ color: '#475569', margin: 0 }}>Signed in as <strong>{email}</strong></p>
+          </div>
+          <div style={{ display: 'flex', gap: 12, fontSize: 13, color: '#64748b', flexWrap: 'wrap' }}>
+            <Link href="/for-business/docs" style={navLink}>Docs</Link>
+            <Link href="/for-business/coverage" style={navLink}>Coverage</Link>
+            <a href="mailto:business@paybacker.co.uk" style={navLink}>Support</a>
+          </div>
+        </header>
 
         {reissued && (
-          <div style={{ background: '#fefce8', border: '1px solid #fde68a', padding: 16, borderRadius: 8, marginTop: 16 }}>
+          <div style={{ background: '#fefce8', border: '1px solid #fde68a', padding: 16, borderRadius: 10, marginBottom: 16 }}>
             <strong style={{ color: '#854d0e' }}>New key — copy now, it is shown ONCE:</strong>
             <pre style={{ marginTop: 8, background: '#0f172a', color: '#e2e8f0', padding: 12, borderRadius: 6, overflow: 'auto', fontSize: 13 }}>{reissued.plaintext}</pre>
           </div>
@@ -152,66 +190,329 @@ export default function ApiKeysPortalPage() {
         {loading && <p>Loading…</p>}
         {error && <p style={{ color: '#b91c1c' }}>{error}</p>}
 
-        {keys?.length === 0 && (
-          <p style={{ color: '#64748b' }}>No active keys for this email. <Link href="/for-business">Get one →</Link></p>
+        {data && (
+          <>
+            {/* Stats */}
+            <div style={statRow}>
+              <Stat label="Active keys" value={data.keys.length} />
+              <Stat label="Calls (30d)" value={data.usage_daily.reduce((a, d) => a + d.ok + d.err, 0)} />
+              <Stat label="Errors (30d)" value={data.usage_daily.reduce((a, d) => a + d.err, 0)} accent={data.usage_daily.reduce((a, d) => a + d.err, 0) > 0 ? 'amber' : undefined} />
+              <Stat label="Audit events" value={data.audit_log.length} />
+            </div>
+
+            {/* Tabs */}
+            <div style={{ display: 'flex', gap: 4, marginTop: 24, borderBottom: '1px solid #e2e8f0', flexWrap: 'wrap' }}>
+              {(['keys', 'usage', 'activity', 'audit', 'account'] as const).map((t) => (
+                <button key={t} onClick={() => setTab(t)} style={tab === t ? tabActive : tabBtn}>
+                  {labelFor(t)}
+                </button>
+              ))}
+            </div>
+
+            <div style={{ paddingTop: 20 }}>
+              {tab === 'keys' && <KeysTab keys={data.keys} onReissue={reissue} onRevoke={revoke} />}
+              {tab === 'usage' && <UsageTab daily={data.usage_daily} />}
+              {tab === 'activity' && <ActivityTab usage={data.recent_usage} keys={data.all_keys} />}
+              {tab === 'audit' && <AuditTab audit={data.audit_log} keys={data.all_keys} />}
+              {tab === 'account' && <AccountTab email={email} keys={data.all_keys} />}
+            </div>
+          </>
         )}
-
-        <div style={{ display: 'grid', gap: 12, marginTop: 16 }}>
-          {keys?.map((k) => {
-            const pct = k.monthly_limit > 0 ? Math.min(100, Math.round((k.monthly_used / k.monthly_limit) * 100)) : 0;
-            return (
-              <div key={k.id} style={{ border: '1px solid #e2e8f0', borderRadius: 10, padding: 16 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16, flexWrap: 'wrap' }}>
-                  <div>
-                    <div style={{ fontWeight: 600 }}>{k.name}</div>
-                    <div style={{ color: '#64748b', fontSize: 13, marginTop: 2 }}>
-                      Prefix <code style={codeInline}>{k.key_prefix}</code> · Tier <strong style={{ color: '#0f172a' }}>{k.tier}</strong>
-                    </div>
-                  </div>
-                  <div style={{ display: 'flex', gap: 8 }}>
-                    <button onClick={() => reissue(k.id)} style={{ ...btn, background: '#0f172a' }}>Re-issue</button>
-                    <button onClick={() => revoke(k.id)} style={{ ...btn, background: '#b91c1c' }}>Revoke</button>
-                  </div>
-                </div>
-                <div style={{ marginTop: 12, fontSize: 13, color: '#64748b' }}>
-                  Usage this month: <strong style={{ color: '#0f172a' }}>{k.monthly_used.toLocaleString()}</strong> / {k.monthly_limit.toLocaleString()} ({pct}%)
-                </div>
-                <div style={{ height: 6, background: '#f1f5f9', borderRadius: 3, marginTop: 6, overflow: 'hidden' }}>
-                  <div style={{ width: `${pct}%`, height: '100%', background: pct >= 90 ? '#dc2626' : pct >= 60 ? '#d97706' : '#059669' }} />
-                </div>
-                {k.last_used_at && (
-                  <div style={{ fontSize: 12, color: '#94a3b8', marginTop: 8 }}>
-                    Last used {new Date(k.last_used_at).toLocaleString('en-GB')}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-
-        <p style={{ color: '#64748b', fontSize: 13, marginTop: 24 }}>
-          <Link href="/for-business/docs" style={{ color: '#0f172a' }}>API docs</Link> ·
-          {' '}<Link href="/for-business/coverage" style={{ color: '#0f172a' }}>Statute coverage</Link> ·
-          {' '}<a href="mailto:business@paybacker.co.uk" style={{ color: '#0f172a' }}>business@paybacker.co.uk</a>
-        </p>
       </div>
     </main>
   );
 }
 
-const pageWrap: React.CSSProperties = {
-  minHeight: '100vh', background: '#f8fafc', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24,
+function labelFor(t: 'keys' | 'usage' | 'activity' | 'audit' | 'account') {
+  return ({
+    keys: 'Keys',
+    usage: 'Usage',
+    activity: 'Recent calls',
+    audit: 'Audit log',
+    account: 'Account',
+  } as const)[t];
+}
+
+function KeysTab({ keys, onReissue, onRevoke }: { keys: Key[]; onReissue: (id: string) => void; onRevoke: (id: string) => void }) {
+  if (keys.length === 0) return <p style={{ color: '#64748b' }}>No active keys. <Link href="/for-business" style={{ color: '#0f172a' }}>Get one →</Link></p>;
+  return (
+    <div style={{ display: 'grid', gap: 12 }}>
+      {keys.map((k) => {
+        const pct = k.monthly_limit > 0 ? Math.min(100, Math.round((k.monthly_used / k.monthly_limit) * 100)) : 0;
+        return (
+          <div key={k.id} style={card}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16, flexWrap: 'wrap' }}>
+              <div>
+                <div style={{ fontWeight: 600, fontSize: 15 }}>{k.name}</div>
+                <div style={{ color: '#64748b', fontSize: 13, marginTop: 4 }}>
+                  Prefix <code style={inlineCode}>{k.key_prefix}</code> · Tier <strong style={{ color: '#0f172a', textTransform: 'capitalize' }}>{k.tier}</strong> · Issued {new Date(k.created_at).toLocaleDateString('en-GB')}
+                </div>
+              </div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button onClick={() => onReissue(k.id)} style={btn}>Re-issue</button>
+                <button onClick={() => onRevoke(k.id)} style={{ ...btn, background: '#b91c1c' }}>Revoke</button>
+              </div>
+            </div>
+            <div style={{ marginTop: 14, fontSize: 13, color: '#64748b' }}>
+              Usage this month: <strong style={{ color: '#0f172a' }}>{k.monthly_used.toLocaleString()}</strong> / {k.monthly_limit.toLocaleString()} ({pct}%)
+            </div>
+            <div style={{ height: 6, background: '#f1f5f9', borderRadius: 3, marginTop: 6, overflow: 'hidden' }}>
+              <div style={{ width: `${pct}%`, height: '100%', background: pct >= 90 ? '#dc2626' : pct >= 60 ? '#d97706' : '#059669' }} />
+            </div>
+            {k.last_used_at && (
+              <div style={{ fontSize: 12, color: '#94a3b8', marginTop: 8 }}>
+                Last used {new Date(k.last_used_at).toLocaleString('en-GB')}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function UsageTab({ daily }: { daily: DailyUsage[] }) {
+  const total = daily.reduce((a, d) => a + d.ok + d.err, 0);
+  const totalErr = daily.reduce((a, d) => a + d.err, 0);
+  const errRate = total > 0 ? (totalErr / total) * 100 : 0;
+  const max = Math.max(1, ...daily.map((d) => d.ok + d.err));
+  return (
+    <div style={card}>
+      <h3 style={sectionTitle}>Last 30 days</h3>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, marginTop: 8 }}>
+        <Mini label="Total calls" value={total.toLocaleString()} />
+        <Mini label="Errors" value={totalErr.toLocaleString()} />
+        <Mini label="Error rate" value={`${errRate.toFixed(1)}%`} />
+      </div>
+      <div style={{ marginTop: 24, display: 'flex', alignItems: 'flex-end', gap: 4, height: 120, borderBottom: '1px solid #e2e8f0', paddingBottom: 4 }}>
+        {daily.length === 0 ? (
+          <div style={{ flex: 1, color: '#94a3b8', alignSelf: 'center', textAlign: 'center', fontSize: 13 }}>No traffic yet — make your first call.</div>
+        ) : daily.map((d) => {
+          const total = d.ok + d.err;
+          const okH = (d.ok / max) * 116;
+          const errH = (d.err / max) * 116;
+          return (
+            <div key={d.day} style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', minWidth: 0 }} title={`${d.day}: ${d.ok} ok / ${d.err} err`}>
+              {d.err > 0 && <div style={{ height: errH, background: '#dc2626', borderRadius: '2px 2px 0 0' }} />}
+              <div style={{ height: okH, background: '#059669', borderRadius: d.err === 0 ? '2px 2px 0 0' : 0 }} />
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: '#94a3b8', marginTop: 4 }}>
+        <span>{daily[0]?.day ?? ''}</span>
+        <span>today</span>
+      </div>
+      <div style={{ display: 'flex', gap: 14, fontSize: 12, color: '#64748b', marginTop: 12 }}>
+        <span><span style={{ display: 'inline-block', width: 10, height: 10, background: '#059669', borderRadius: 2, marginRight: 6 }} />OK (2xx)</span>
+        <span><span style={{ display: 'inline-block', width: 10, height: 10, background: '#dc2626', borderRadius: 2, marginRight: 6 }} />Errors (4xx/5xx)</span>
+      </div>
+    </div>
+  );
+}
+
+function ActivityTab({ usage, keys }: { usage: UsageRow[]; keys: Key[] }) {
+  const keyName = (id: string) => keys.find((k) => k.id === id)?.key_prefix ?? id.slice(0, 8);
+  if (usage.length === 0) return <p style={{ color: '#64748b' }}>No calls yet — make your first request to see it here.</p>;
+  return (
+    <div style={{ ...card, padding: 0, overflow: 'hidden' }}>
+      <table style={tableStyle}>
+        <thead>
+          <tr style={trHead}>
+            <th style={th}>When</th>
+            <th style={th}>Key</th>
+            <th style={th}>Endpoint</th>
+            <th style={th}>Status</th>
+            <th style={th}>Latency</th>
+            <th style={th}>Detail</th>
+          </tr>
+        </thead>
+        <tbody>
+          {usage.map((u, i) => (
+            <tr key={i} style={{ borderTop: '1px solid #f1f5f9' }}>
+              <td style={td}>{new Date(u.created_at).toLocaleString('en-GB')}</td>
+              <td style={td}><code style={inlineCode}>{keyName(u.key_id)}</code></td>
+              <td style={td}><code style={inlineCode}>{u.endpoint}</code></td>
+              <td style={td}>
+                <span style={statusBadge(u.status_code)}>{u.status_code}</span>
+              </td>
+              <td style={td}>{u.latency_ms != null ? `${u.latency_ms}ms` : '—'}</td>
+              <td style={{ ...td, color: '#64748b' }}>{u.error_code ?? u.scenario_kind ?? '—'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function AuditTab({ audit, keys }: { audit: AuditRow[]; keys: Key[] }) {
+  const keyPrefix = (id: string | null) => id ? (keys.find((k) => k.id === id)?.key_prefix ?? id.slice(0, 8)) : '—';
+  if (audit.length === 0) return <p style={{ color: '#64748b' }}>No audit events yet.</p>;
+  return (
+    <div style={{ ...card, padding: 0, overflow: 'hidden' }}>
+      <table style={tableStyle}>
+        <thead>
+          <tr style={trHead}>
+            <th style={th}>When</th>
+            <th style={th}>Action</th>
+            <th style={th}>Actor</th>
+            <th style={th}>Key</th>
+            <th style={th}>IP</th>
+            <th style={th}>User agent</th>
+          </tr>
+        </thead>
+        <tbody>
+          {audit.map((a) => (
+            <tr key={a.id} style={{ borderTop: '1px solid #f1f5f9' }}>
+              <td style={td}>{new Date(a.created_at).toLocaleString('en-GB')}</td>
+              <td style={td}><span style={actionBadge(a.action)}>{labelAction(a.action)}</span></td>
+              <td style={{ ...td, textTransform: 'capitalize' }}>{a.actor}</td>
+              <td style={td}><code style={inlineCode}>{keyPrefix(a.key_id)}</code></td>
+              <td style={{ ...td, color: '#64748b' }}>{a.ip_address ?? '—'}</td>
+              <td style={{ ...td, color: '#64748b', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={a.user_agent ?? ''}>{shortenUA(a.user_agent)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function AccountTab({ email, keys }: { email: string; keys: Key[] }) {
+  return (
+    <div style={{ display: 'grid', gap: 16 }}>
+      <div style={card}>
+        <h3 style={sectionTitle}>Account</h3>
+        <p style={{ margin: '8px 0', color: '#475569' }}>Owner email: <strong>{email}</strong></p>
+        <p style={{ margin: '8px 0', color: '#475569' }}>Total keys issued: <strong>{keys.length}</strong> ({keys.filter((k) => !k.revoked_at).length} active, {keys.filter((k) => k.revoked_at).length} revoked)</p>
+      </div>
+
+      <div style={card}>
+        <h3 style={sectionTitle}>Key history</h3>
+        {keys.length === 0 ? <p style={{ color: '#64748b' }}>No keys yet.</p> : (
+          <table style={tableStyle}>
+            <thead>
+              <tr style={trHead}>
+                <th style={th}>Name</th>
+                <th style={th}>Prefix</th>
+                <th style={th}>Tier</th>
+                <th style={th}>Issued</th>
+                <th style={th}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {keys.map((k) => (
+                <tr key={k.id} style={{ borderTop: '1px solid #f1f5f9' }}>
+                  <td style={td}>{k.name}</td>
+                  <td style={td}><code style={inlineCode}>{k.key_prefix}</code></td>
+                  <td style={{ ...td, textTransform: 'capitalize' }}>{k.tier}</td>
+                  <td style={td}>{new Date(k.created_at).toLocaleDateString('en-GB')}</td>
+                  <td style={td}>
+                    {k.revoked_at
+                      ? <span style={{ ...badge, background: '#fee2e2', color: '#991b1b' }}>Revoked {new Date(k.revoked_at).toLocaleDateString('en-GB')}</span>
+                      : <span style={{ ...badge, background: '#d1fae5', color: '#065f46' }}>Active</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div style={card}>
+        <h3 style={sectionTitle}>Billing</h3>
+        <p style={{ margin: '8px 0 12px', color: '#475569' }}>Manage your Stripe subscription, update card, view invoices.</p>
+        <a href="https://billing.stripe.com/p/login/9AUaH4dWj9Hf6Wk000" target="_blank" rel="noreferrer" style={btn}>Open Stripe customer portal ↗</a>
+        <p style={{ margin: '12px 0 0', color: '#64748b', fontSize: 13 }}>Free Starter pilot? No subscription to manage. Upgrade at <Link href="/for-business" style={{ color: '#0f172a' }}>/for-business</Link>.</p>
+      </div>
+
+      <div style={card}>
+        <h3 style={sectionTitle}>Security &amp; data handling</h3>
+        <ul style={{ paddingLeft: 18, color: '#475569', lineHeight: 1.7, margin: '8px 0' }}>
+          <li>API keys are hashed with SHA-256. The plaintext is shown once via a single-use 24h reveal link and never stored after first view.</li>
+          <li>Request bodies are not retained. We log only endpoint, status, latency, and an optional coarse <code style={inlineCode}>scenario_kind</code> for debugging.</li>
+          <li>Portal sign-in is passwordless via 30-min single-use email links; mutating actions burn the token.</li>
+          <li>Every key action and login attempt is appended to the immutable audit log on this page.</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function shortenUA(ua: string | null) {
+  if (!ua) return '—';
+  // Take first browser-token-ish chunk for quick scanning.
+  const m = ua.match(/(Chrome|Safari|Firefox|Edg|curl|node|Postman|Insomnia)\/?[\d.]*/i);
+  return m ? m[0] : ua.slice(0, 30);
+}
+function labelAction(a: string) {
+  return a.replace(/_/g, ' ');
+}
+
+function statusBadge(code: number): React.CSSProperties {
+  const isOk = code >= 200 && code < 300;
+  const isClient = code >= 400 && code < 500;
+  return {
+    background: isOk ? '#d1fae5' : isClient ? '#fef3c7' : '#fee2e2',
+    color: isOk ? '#065f46' : isClient ? '#92400e' : '#991b1b',
+    padding: '2px 8px',
+    borderRadius: 4,
+    fontSize: 12,
+    fontWeight: 600,
+  };
+}
+function actionBadge(action: string): React.CSSProperties {
+  const palette: Record<string, [string, string]> = {
+    key_created: ['#d1fae5', '#065f46'],
+    key_revoked: ['#fee2e2', '#991b1b'],
+    key_reissued: ['#fef3c7', '#92400e'],
+    reveal_link_used: ['#dbeafe', '#1e40af'],
+    portal_signin: ['#e0e7ff', '#3730a3'],
+    login_link_requested: ['#f1f5f9', '#475569'],
+    plan_changed: ['#cffafe', '#155e75'],
+  };
+  const [bg, fg] = palette[action] ?? ['#f1f5f9', '#475569'];
+  return { background: bg, color: fg, padding: '2px 8px', borderRadius: 4, fontSize: 11, fontWeight: 600, textTransform: 'capitalize' };
+}
+
+const page: React.CSSProperties = {
+  minHeight: '100vh', background: '#f8fafc', padding: 24,
   fontFamily: '-apple-system, "Segoe UI", system-ui, sans-serif', color: '#0f172a',
 };
-const card: React.CSSProperties = {
+const shell: React.CSSProperties = { maxWidth: 1100, margin: '0 auto' };
+const signinPage: React.CSSProperties = { ...page, display: 'flex', alignItems: 'center', justifyContent: 'center' };
+const signinCard: React.CSSProperties = {
   background: '#fff', border: '1px solid #e2e8f0', borderRadius: 14, padding: 32, maxWidth: 480, width: '100%', display: 'grid', gap: 12,
 };
-const input: React.CSSProperties = {
-  border: '1px solid #cbd5e1', borderRadius: 8, padding: '12px 14px', font: 'inherit', fontSize: 15,
-};
-const btn: React.CSSProperties = {
-  background: '#0f172a', color: '#fff', border: 0, padding: '10px 16px', borderRadius: 8, fontWeight: 600, cursor: 'pointer', fontSize: 14,
-};
-const codeInline: React.CSSProperties = {
-  background: '#f1f5f9', padding: '1px 6px', borderRadius: 4, fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 13,
-};
+const card: React.CSSProperties = { background: '#fff', border: '1px solid #e2e8f0', borderRadius: 12, padding: 20 };
+const inputStyle: React.CSSProperties = { border: '1px solid #cbd5e1', borderRadius: 8, padding: '12px 14px', font: 'inherit', fontSize: 15 };
+const btn: React.CSSProperties = { background: '#0f172a', color: '#fff', border: 0, padding: '8px 14px', borderRadius: 6, fontWeight: 600, cursor: 'pointer', fontSize: 13, textDecoration: 'none', display: 'inline-block' };
+const inlineCode: React.CSSProperties = { background: '#f1f5f9', padding: '1px 6px', borderRadius: 4, fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12 };
+const navLink: React.CSSProperties = { color: '#475569', textDecoration: 'none' };
+const tabBtn: React.CSSProperties = { background: 'transparent', border: 0, padding: '10px 14px', fontSize: 14, color: '#64748b', cursor: 'pointer', fontWeight: 500, borderBottom: '2px solid transparent' };
+const tabActive: React.CSSProperties = { ...tabBtn, color: '#0f172a', borderBottom: '2px solid #0f172a', fontWeight: 600 };
+const sectionTitle: React.CSSProperties = { margin: 0, fontSize: 16, letterSpacing: '-0.005em' };
+const statRow: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 12 };
+const tableStyle: React.CSSProperties = { width: '100%', borderCollapse: 'collapse', fontSize: 13 };
+const trHead: React.CSSProperties = { background: '#f8fafc' };
+const th: React.CSSProperties = { textAlign: 'left', padding: '10px 14px', fontWeight: 600, color: '#64748b', fontSize: 12, textTransform: 'uppercase', letterSpacing: '0.04em' };
+const td: React.CSSProperties = { padding: '10px 14px', verticalAlign: 'top', color: '#0f172a' };
+const badge: React.CSSProperties = { padding: '2px 8px', borderRadius: 4, fontSize: 11, fontWeight: 600 };
+
+function Stat({ label, value, accent }: { label: string; value: number | string; accent?: 'amber' | 'red' }) {
+  return (
+    <div style={{ ...card, padding: 14 }}>
+      <div style={{ fontSize: 11, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 600 }}>{label}</div>
+      <div style={{ marginTop: 4, fontSize: 24, fontWeight: 700, color: accent === 'amber' ? '#d97706' : accent === 'red' ? '#b91c1c' : '#0f172a' }}>{value}</div>
+    </div>
+  );
+}
+function Mini({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <div style={{ fontSize: 11, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 600 }}>{label}</div>
+      <div style={{ marginTop: 2, fontSize: 18, fontWeight: 600 }}>{value}</div>
+    </div>
+  );
+}

--- a/src/lib/b2b/audit.ts
+++ b/src/lib/b2b/audit.ts
@@ -1,0 +1,67 @@
+/**
+ * Append-only audit log helper for B2B customer events.
+ * Fire-and-forget — audit logging must never block a user-facing path.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import type { NextRequest } from 'next/server';
+
+export type AuditAction =
+  | 'key_created'
+  | 'key_revoked'
+  | 'key_reissued'
+  | 'key_viewed'
+  | 'portal_signin'
+  | 'login_link_requested'
+  | 'reveal_link_used'
+  | 'plan_changed';
+
+export type AuditActor = 'customer' | 'founder' | 'system' | 'stripe';
+
+export interface AuditEvent {
+  email: string;
+  action: AuditAction;
+  actor?: AuditActor;
+  key_id?: string | null;
+  ip_address?: string | null;
+  user_agent?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export function audit(ev: AuditEvent): void {
+  // Fire and forget. We never want a failed audit insert to surface as
+  // a customer-visible 500 — the value is the trail, not strict
+  // synchronous correctness.
+  void (async () => {
+    try {
+      const supabase = getAdmin();
+      await supabase.from('b2b_audit_log').insert({
+        email: ev.email.toLowerCase(),
+        action: ev.action,
+        actor: ev.actor ?? 'customer',
+        key_id: ev.key_id ?? null,
+        ip_address: ev.ip_address ?? null,
+        user_agent: ev.user_agent ?? null,
+        metadata: ev.metadata ?? {},
+      });
+    } catch (e: any) {
+      console.error('[audit] insert failed:', e?.message);
+    }
+  })();
+}
+
+export function extractClientMeta(request: NextRequest): { ip_address: string | null; user_agent: string | null } {
+  const forwarded = request.headers.get('x-forwarded-for');
+  const ip = forwarded ? forwarded.split(',')[0].trim() : (request.headers.get('x-real-ip') || null);
+  return {
+    ip_address: ip,
+    user_agent: request.headers.get('user-agent'),
+  };
+}

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -10,6 +10,7 @@ import type Stripe from 'stripe';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { generateKey } from './auth';
 import { createKeyRevealLink } from './key-reveal';
+import { audit } from './audit';
 import { resend } from '@/lib/resend';
 
 const TIER_LIMITS: Record<string, number> = {
@@ -114,7 +115,7 @@ export async function handleB2bCheckoutCompleted(
 
   // Mint key
   const minted = generateKey();
-  const { error } = await supabase.from('b2b_api_keys').insert({
+  const { data: inserted, error } = await supabase.from('b2b_api_keys').insert({
     name: company ? `${company} (${tier})` : `${customerEmail} (${tier})`,
     key_hash: minted.hash,
     key_prefix: minted.prefix,
@@ -124,13 +125,21 @@ export async function handleB2bCheckoutCompleted(
     stripe_subscription_id: subscriptionId,
     stripe_customer_id: customerId,
     notes: `Stripe checkout · contact: ${contactName} · session: ${session.id}`,
-  });
+  }).select('id').single();
   if (error) {
     // Throw so the webhook returns 500 and Stripe retries delivery —
     // a transient Supabase failure must not leave a paid customer
     // without a provisioned key.
     throw new Error(`[b2b stripe] key insert failed: ${error.message}`);
   }
+
+  audit({
+    email: customerEmail.toLowerCase(),
+    action: 'key_created',
+    actor: 'stripe',
+    key_id: inserted?.id ?? null,
+    metadata: { tier, source: 'stripe_checkout', subscription_id: subscriptionId, prefix: minted.prefix },
+  });
 
   // Email a single-use reveal link rather than plaintext. Better
   // security posture (forwarded emails can't be replayed) and the

--- a/supabase/migrations/20260428070000_b2b_audit_log.sql
+++ b/supabase/migrations/20260428070000_b2b_audit_log.sql
@@ -1,0 +1,21 @@
+-- Audit trail of every B2B-customer-impacting event so the portal
+-- can show the engineering buyer "who did what when" — table-stakes
+-- for security review on the buying side. Append-only, never updated.
+CREATE TABLE IF NOT EXISTS b2b_audit_log (
+  id BIGSERIAL PRIMARY KEY,
+  email TEXT NOT NULL,
+  key_id UUID REFERENCES b2b_api_keys(id) ON DELETE SET NULL,
+  action TEXT NOT NULL CHECK (action IN (
+    'key_created','key_revoked','key_reissued','key_viewed',
+    'portal_signin','login_link_requested','reveal_link_used','plan_changed'
+  )),
+  actor TEXT NOT NULL DEFAULT 'customer' CHECK (actor IN ('customer','founder','system','stripe')),
+  ip_address TEXT,
+  user_agent TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS b2b_audit_log_email_idx
+  ON b2b_audit_log (email, created_at DESC);
+CREATE INDEX IF NOT EXISTS b2b_audit_log_key_idx
+  ON b2b_audit_log (key_id, created_at DESC) WHERE key_id IS NOT NULL;


### PR DESCRIPTION
Upgrades /dashboard/api-keys from a single page into a 5-tab portal: Keys / Usage / Recent calls / Audit log / Account. Adds b2b_audit_log table and instruments every key + sign-in event. Stat row, 30-day stacked bar chart, latency-tracked recent-calls table, IP+UA on every audit event, full key history, Stripe billing portal link, and a security/data-handling summary buyers can forward to procurement.