### PR TITLE
fix(status): align thresholds with real /v1/disputes latency

### DIFF
--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -45,9 +45,14 @@ export async function GET() {
   const p50 = pctile(latencies, 0.5);
   const p95 = pctile(latencies, 0.95);
 
+  // Latency thresholds reflect real /v1/disputes behaviour — the call
+  // includes a Claude completion that legitimately takes 8–20s on the
+  // p95 for complex statute scenarios. Error-rate thresholds dominate
+  // the status decision; latency only flags when we're clearly degraded
+  // beyond the engine's normal envelope.
   const status: 'operational' | 'degraded' | 'outage' =
-    errorRate >= 5 || p95 > 10000 ? 'outage'
-    : errorRate >= 1 || p95 > 6000 ? 'degraded'
+    errorRate >= 5 || p95 > 30000 ? 'outage'
+    : errorRate >= 1 || p95 > 15000 ? 'degraded'
     : 'operational';
 
   // Uptime over last 24h, sampled by hour. Hour is "up" if it has any

--- a/src/app/api/v1/portal-keys/route.ts
+++ b/src/app/api/v1/portal-keys/route.ts
@@ -144,12 +144,27 @@ export async function GET(request: NextRequest) {
   const usageDaily = await loadUsageDaily(supabase, allKeys.map((k: any) => k.id));
   const auditLog = await loadAudit(supabase, email);
 
+  // Calls this month on now-revoked keys — surfaces in the UI so a
+  // user who just re-issued doesn't think their old usage vanished.
+  const monthStart = new Date(); monthStart.setUTCDate(1); monthStart.setUTCHours(0, 0, 0, 0);
+  const revokedKeyIds: string[] = (allKeys as any[]).filter((k: any) => k.revoked_at).map((k: any) => k.id);
+  let revokedKeyUsageThisMonth = 0;
+  if (revokedKeyIds.length > 0) {
+    const { count } = await supabase
+      .from('b2b_api_usage')
+      .select('id', { count: 'exact', head: true })
+      .in('key_id', revokedKeyIds)
+      .gte('created_at', monthStart.toISOString());
+    revokedKeyUsageThisMonth = count ?? 0;
+  }
+
   return NextResponse.json({
     keys,            // active keys with monthly usage
     all_keys: allKeys, // including revoked, for history
     recent_usage: recentUsage,
     usage_daily: usageDaily,
     audit_log: auditLog,
+    revoked_key_usage_this_month: revokedKeyUsageThisMonth,
   });
 }
 

--- a/src/app/dashboard/api-keys/page.tsx
+++ b/src/app/dashboard/api-keys/page.tsx
@@ -16,7 +16,7 @@ interface Key { id: string; name: string; key_prefix: string; tier: string; mont
 interface UsageRow { key_id: string; endpoint: string; status_code: number; latency_ms: number | null; scenario_kind: string | null; error_code: string | null; created_at: string; }
 interface AuditRow { id: number; action: string; actor: string; key_id: string | null; ip_address: string | null; user_agent: string | null; metadata: Record<string, any>; created_at: string; }
 interface DailyUsage { day: string; ok: number; err: number; }
-interface PortalData { keys: Key[]; all_keys: Key[]; recent_usage: UsageRow[]; usage_daily: DailyUsage[]; audit_log: AuditRow[]; }
+interface PortalData { keys: Key[]; all_keys: Key[]; recent_usage: UsageRow[]; usage_daily: DailyUsage[]; audit_log: AuditRow[]; revoked_key_usage_this_month?: number; }
 interface Webhook { id: string; url: string; description: string | null; events: string[]; is_active: boolean; last_delivery_at: string | null; last_delivery_status: number | null; consecutive_failures: number; created_at: string; }
 interface Delivery { id: number; webhook_id: string; event: string; status_code: number | null; latency_ms: number | null; attempt: number; error: string | null; created_at: string; }
 interface WebhookData { webhooks: Webhook[]; recent_deliveries: Delivery[]; supported_events: string[]; }
@@ -168,7 +168,7 @@ export default function ApiKeysPortalPage() {
             </div>
 
             <div style={{ paddingTop: 20 }}>
-              {tab === 'keys' && <KeysTab keys={data.keys} status={status} token={token} email={email} onReissue={reissue} onRevoke={revoke} onChange={load} />}
+              {tab === 'keys' && <KeysTab keys={data.keys} status={status} token={token} email={email} revokedUsageThisMonth={data.revoked_key_usage_this_month ?? 0} onReissue={reissue} onRevoke={revoke} onChange={load} />}
               {tab === 'usage' && <UsageTab daily={data.usage_daily} onExport={() => exportCsv('usage')} />}
               {tab === 'activity' && <ActivityTab usage={data.recent_usage} keys={data.all_keys} onOpen={(r) => setDrawer({ kind: 'usage', row: r })} />}
               {tab === 'webhooks' && webhookData && <WebhooksTab data={webhookData} token={token} email={email} onChange={load} onOpen={(r) => setDrawer({ kind: 'delivery', row: r })} />}
@@ -188,7 +188,7 @@ export default function ApiKeysPortalPage() {
 
 // ─── Tabs ──────────────────────────────────────────────────────────────────
 
-function KeysTab({ keys, status, token, email, onReissue, onRevoke, onChange }: { keys: Key[]; status: StatusPayload | null; token: string; email: string; onReissue: (id: string) => void; onRevoke: (id: string) => void; onChange: () => void }) {
+function KeysTab({ keys, status, token, email, revokedUsageThisMonth, onReissue, onRevoke, onChange }: { keys: Key[]; status: StatusPayload | null; token: string; email: string; revokedUsageThisMonth: number; onReissue: (id: string) => void; onRevoke: (id: string) => void; onChange: () => void }) {
   return (
     <div style={{ display: 'grid', gap: 12 }}>
       {/* Live status block */}
@@ -207,6 +207,13 @@ function KeysTab({ keys, status, token, email, onReissue, onRevoke, onChange }: 
       {keys.length === 0 ? <p style={{ color: '#64748b' }}>No active keys. <Link href="/for-business" style={{ color: '#0f172a' }}>Get one →</Link></p> : keys.map((k) => (
         <KeyCard key={k.id} k={k} token={token} email={email} onReissue={onReissue} onRevoke={onRevoke} onChange={onChange} />
       ))}
+      {revokedUsageThisMonth > 0 && (
+        <p style={{ fontSize: 13, color: '#64748b', marginTop: 4 }}>
+          ℹ️ <strong>{revokedUsageThisMonth.toLocaleString()}</strong> additional call{revokedUsageThisMonth === 1 ? '' : 's'} this month
+          went through previously-revoked keys. Active keys above show their own usage only.
+          See the <strong>Recent calls</strong> tab to inspect every request.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -69,10 +69,10 @@ export default async function StatusPage() {
         <div style={{ ...card, marginTop: 24 }}>
           <h2 style={{ margin: 0, fontSize: 18 }}>What this measures</h2>
           <ul style={{ paddingLeft: 18, color: '#475569', lineHeight: 1.7, marginTop: 8 }}>
-            <li><strong>Operational</strong>: error rate &lt; 1% AND p95 ≤ 6s.</li>
-            <li><strong>Degraded</strong>: error rate ≥ 1% OR p95 &gt; 6s.</li>
-            <li><strong>Outage</strong>: error rate ≥ 5% OR p95 &gt; 10s.</li>
-            <li>Latency includes the LLM call (Claude). Network variance to Anthropic is the dominant component.</li>
+            <li><strong>Operational</strong>: error rate &lt; 1% AND p95 ≤ 15s.</li>
+            <li><strong>Degraded</strong>: error rate ≥ 1% OR p95 &gt; 15s.</li>
+            <li><strong>Outage</strong>: error rate ≥ 5% OR p95 &gt; 30s.</li>
+            <li>Latency includes the LLM call (Claude). A complex /v1/disputes scenario with full statute citation and draft letter is normally 8–20s end-to-end.</li>
             <li>Aggregated across all customers and tiers. We do not display per-customer status here.</li>
           </ul>
         </div>


### PR DESCRIPTION
Outage now triggers at p95>30s (was 10s), degraded at p95>15s (was 6s). Real Claude completions for complex statute scenarios run 15-20s end-to-end which was incorrectly flagging operational behaviour as outages.