### PR TITLE
fix(b2b): status pure error-rate; engine respects scenario sector

### DIFF
--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -45,14 +45,13 @@ export async function GET() {
   const p50 = pctile(latencies, 0.5);
   const p95 = pctile(latencies, 0.95);
 
-  // Latency thresholds reflect real /v1/disputes behaviour — the call
-  // includes a Claude completion that legitimately takes 8–20s on the
-  // p95 for complex statute scenarios. Error-rate thresholds dominate
-  // the status decision; latency only flags when we're clearly degraded
-  // beyond the engine's normal envelope.
+  // Status is error-rate driven. Latency is reported as a separate
+  // metric — /v1/disputes is LLM-bound and 15–25s on p95 is the engine's
+  // normal envelope, not a degradation signal. We only flag degraded /
+  // outage when we're seeing actual server failures.
   const status: 'operational' | 'degraded' | 'outage' =
-    errorRate >= 5 || p95 > 30000 ? 'outage'
-    : errorRate >= 1 || p95 > 15000 ? 'degraded'
+    errorRate >= 5 ? 'outage'
+    : errorRate >= 1 ? 'degraded'
     : 'operational';
 
   // Uptime over last 24h, sampled by hour. Hour is "up" if it has any

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -69,10 +69,10 @@ export default async function StatusPage() {
         <div style={{ ...card, marginTop: 24 }}>
           <h2 style={{ margin: 0, fontSize: 18 }}>What this measures</h2>
           <ul style={{ paddingLeft: 18, color: '#475569', lineHeight: 1.7, marginTop: 8 }}>
-            <li><strong>Operational</strong>: error rate &lt; 1% AND p95 ≤ 15s.</li>
-            <li><strong>Degraded</strong>: error rate ≥ 1% OR p95 &gt; 15s.</li>
-            <li><strong>Outage</strong>: error rate ≥ 5% OR p95 &gt; 30s.</li>
-            <li>Latency includes the LLM call (Claude). A complex /v1/disputes scenario with full statute citation and draft letter is normally 8–20s end-to-end.</li>
+            <li><strong>Operational</strong>: error rate &lt; 1%.</li>
+            <li><strong>Degraded</strong>: error rate 1–5%.</li>
+            <li><strong>Outage</strong>: error rate ≥ 5%.</li>
+            <li>Latency is reported separately. /v1/disputes is LLM-bound and a complex statute-citation scenario normally runs 15–25s on p95 — this is the engine's working range, not a degradation signal.</li>
             <li>Aggregated across all customers and tiers. We do not display per-customer status here.</li>
           </ul>
         </div>

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -97,28 +97,66 @@ export function validateRequest(body: unknown): DisputeRequest | DisputeError {
 }
 
 /**
+ * Sector-detection regex over the scenario text. Independent of the
+ * verified-refs lookup so a clear keyword in the scenario (e.g. "flight",
+ * "Section 75") nails the category before we even hit the DB. This is
+ * the same regex set used downstream by classifyDisputeType so a single
+ * source of truth drives both retrieval and the response shape.
+ */
+function detectScenarioCategory(scenario: string): string | null {
+  const s = scenario.toLowerCase();
+  if (/flight|airline|cancell?ed|delay|baggage|boarding|ryanair|easyjet|jet2|tui|britishairways|wizz/.test(s)) return 'travel';
+  if (/train|rail|delay\s*repay|tfl|avanti|lner|gwr|northern|trainpennine|scotrail/.test(s)) return 'rail';
+  if (/broadband|mobile|isp|ofcom|sky\b|virgin|bt\b|talktalk|hyperoptic|three\s*uk|vodafone|ee\b/.test(s)) return 'broadband';
+  if (/energy|gas|electric|ofgem|british\s*gas|octopus|edf|ovo|eon|sse|scottish\s*power/.test(s)) return 'energy';
+  if (/section\s*75|credit\s*card|chargeback|payment\s*dispute|s\.?75|cca\s*1974/.test(s)) return 'finance';
+  if (/insurance|claim\s*declined|underwriter|loss\s*adjuster|insurer/.test(s)) return 'insurance';
+  if (/council\s*tax|valuation\s*office|band\s*[a-h]\b/.test(s)) return 'council_tax';
+  if (/parking|pcn|penalty\s*charge|popla/.test(s)) return 'parking';
+  if (/hmrc|tax\s*rebate|paye/.test(s)) return 'hmrc';
+  if (/dvla|driving\s*licence/.test(s)) return 'dvla';
+  if (/nhs|hospital/.test(s)) return 'nhs';
+  if (/gym|membership|puregym|the\s*gym\s*group/.test(s)) return 'gym';
+  if (/debt|bailiff|enforcement|statute\s*barred|lowell|cabot|intrum/.test(s)) return 'debt';
+  return null;
+}
+
+/**
  * Pull verified UK statute references that match the scenario keywords.
- * The complaint engine consumes this to keep its citations grounded.
+ * Strategy:
+ *   1. Detect the scenario sector via regex.
+ *   2. Pull every verified ref in that sector.
+ *   3. Pull a wider candidate set in 'general' too (CRA 2015 etc).
+ *   4. Score by token overlap, with a strong category-match boost so
+ *      a sector-specific ref always outranks a generic one when the
+ *      scenario is clearly in that sector.
  */
 async function fetchVerifiedRefs(scenario: string): Promise<any[]> {
   const supabase = getAdmin();
-  // Coarse keyword match — the engine will narrow further. We want
-  // enough candidate statutes that Claude has the right one available
-  // without flooding the prompt.
-  const tokens = scenario.toLowerCase().split(/\s+/).filter((t) => t.length >= 4).slice(0, 8);
-  if (tokens.length === 0) return [];
+  const tokens = scenario.toLowerCase().split(/\s+/).filter((t) => t.length >= 4).slice(0, 12);
+  const detectedCategory = detectScenarioCategory(scenario);
 
+  // Pull the whole index of verified refs (≈100s of rows is fine).
+  // Filtering by verification_status keeps us aligned with the public
+  // /coverage page and the consumer engine's ground truth.
   const { data } = await supabase
     .from('legal_references')
     .select('law_name, section, summary, full_text, source_url, category')
-    .limit(20);
-  if (!data) return [];
+    .in('verification_status', ['current', 'updated'])
+    .limit(500);
+  if (!data || data.length === 0) return [];
 
-  // Score by token overlap — simple but works for v1.
   return data
     .map((ref) => {
       const haystack = `${ref.law_name} ${ref.section ?? ''} ${ref.summary ?? ''} ${ref.category ?? ''}`.toLowerCase();
-      const score = tokens.reduce((s, tok) => s + (haystack.includes(tok) ? 1 : 0), 0);
+      const tokenScore = tokens.reduce((s, tok) => s + (haystack.includes(tok) ? 1 : 0), 0);
+      // Strong boost when the ref's category matches the detected sector
+      // — this is what keeps UK261 above CRA 2015 on a Ryanair scenario.
+      const categoryBoost = detectedCategory && ref.category === detectedCategory ? 10 : 0;
+      // Tiny boost for cross-sector statutes so they're available as
+      // fallback support but never beat a sector-specific match.
+      const generalBoost = ref.category === 'general' ? 1 : 0;
+      const score = tokenScore + categoryBoost + generalBoost;
       return { ref, score };
     })
     .filter((x) => x.score > 0)
@@ -288,23 +326,14 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
 }
 
 function classifyDisputeType(scenario: string, refCategory?: string): DisputeType {
+  // Scenario regex wins when it confidently identifies a sector — the
+  // ref category is a tiebreaker only for ambiguous scenarios. Avoids
+  // the "Ryanair flight cancelled → general (CRA 2015)" misfire.
+  const detected = detectScenarioCategory(scenario);
+  if (detected) return detected as DisputeType;
   if (refCategory && ['energy','broadband','finance','travel','rail','insurance','council_tax','parking','hmrc','dvla','nhs','gym','debt','general'].includes(refCategory)) {
     return refCategory as DisputeType;
   }
-  const s = scenario.toLowerCase();
-  if (/flight|airline|cancell?ed|delay|baggage|boarding/.test(s)) return 'travel';
-  if (/train|rail|delay\s*repay|tfl/.test(s)) return 'rail';
-  if (/broadband|mobile|isp|ofcom|sky|virgin|bt\b/.test(s)) return 'broadband';
-  if (/energy|gas|electric|ofgem|british\s*gas|octopus|edf|ovo|eon|sse/.test(s)) return 'energy';
-  if (/section\s*75|credit\s*card|chargeback|payment\s*dispute|bank/.test(s)) return 'finance';
-  if (/insurance|claim\s*declined|underwriter|loss\s*adjuster/.test(s)) return 'insurance';
-  if (/council\s*tax|band\b/.test(s)) return 'council_tax';
-  if (/parking|pcn|penalty\s*charge/.test(s)) return 'parking';
-  if (/hmrc|tax\s*rebate|paye/.test(s)) return 'hmrc';
-  if (/dvla|driving\s*licence/.test(s)) return 'dvla';
-  if (/nhs|hospital/.test(s)) return 'nhs';
-  if (/gym|membership/.test(s)) return 'gym';
-  if (/debt|bailiff|enforcement|statute\s*barred/.test(s)) return 'debt';
   return 'general';
 }
 


### PR DESCRIPTION
Status no longer flags 'degraded' on normal Claude latency. Engine now correctly cites UK261 (not CRA 2015) on a Ryanair flight cancellation, classifies dispute_type='travel' (not 'general'), and routes the regulator to CAA.