### PR TITLE
feat(b2b): sessions + sign-out + in-portal upgrade

### DIFF
--- a/src/app/api/v1/portal-billing/route.ts
+++ b/src/app/api/v1/portal-billing/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
 import Stripe from 'stripe';
+import { authPortal } from '@/lib/b2b/session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -34,12 +35,10 @@ async function verifyToken(supabase: any, token: string, email: string): Promise
 export async function POST(request: NextRequest) {
   let body: any;
   try { body = await request.json(); } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }); }
-  const token = String(body?.token || '');
-  const email = String(body?.email || '').toLowerCase();
-  if (!token || !email) return NextResponse.json({ error: 'token + email required' }, { status: 400 });
-
+  const auth = await authPortal(request, body, null);
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  if (!(await verifyToken(supabase, token, email))) return NextResponse.json({ error: 'Link expired.' }, { status: 401 });
 
   const { resolveOwner } = await import('../portal-members/route');
   const { owner } = await resolveOwner(supabase as any, email);

--- a/src/app/api/v1/portal-export/route.ts
+++ b/src/app/api/v1/portal-export/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
+import { authPortal } from '@/lib/b2b/session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -32,22 +33,11 @@ function csvEscape(v: unknown): string {
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
-  const token = url.searchParams.get('token') ?? '';
-  const email = (url.searchParams.get('email') ?? '').toLowerCase();
   const type = url.searchParams.get('type') ?? 'usage';
-  if (!token || !email) return NextResponse.json({ error: 'token + email required' }, { status: 400 });
-
+  const auth = await authPortal(request, null, { token: url.searchParams.get('token'), email: url.searchParams.get('email') });
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
-  const { data: tk } = await supabase
-    .from('b2b_portal_tokens')
-    .select('id, expires_at, used_at')
-    .eq('token_hash', tokenHash)
-    .eq('email', email)
-    .maybeSingle();
-  if (!tk || tk.used_at || new Date(tk.expires_at) < new Date()) {
-    return NextResponse.json({ error: 'Link expired.' }, { status: 401 });
-  }
 
   if (type === 'usage') {
     const { data: keys } = await supabase

--- a/src/app/api/v1/portal-key-config/route.ts
+++ b/src/app/api/v1/portal-key-config/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
 import { audit, extractClientMeta } from '@/lib/b2b/audit';
+import { authPortal } from '@/lib/b2b/session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -35,13 +36,12 @@ export async function POST(request: NextRequest) {
   try { body = await request.json(); } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
-  const token = String(body?.token || '');
-  const email = String(body?.email || '').toLowerCase();
   const id = String(body?.id || '');
-  if (!token || !email || !id) return NextResponse.json({ error: 'token + email + id required' }, { status: 400 });
-
+  if (!id) return NextResponse.json({ error: 'id required' }, { status: 400 });
+  const auth = await authPortal(request, body, null);
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  if (!(await verifyToken(supabase, token, email))) return NextResponse.json({ error: 'Link expired.' }, { status: 401 });
 
   // Resolve owner; member must be admin to mutate.
   const { resolveOwner } = await import('../portal-members/route');

--- a/src/app/api/v1/portal-keys/route.ts
+++ b/src/app/api/v1/portal-keys/route.ts
@@ -16,6 +16,7 @@ import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
 import { generateKey } from '@/lib/b2b/auth';
 import { audit, extractClientMeta } from '@/lib/b2b/audit';
+import { authPortal } from '@/lib/b2b/session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -118,13 +119,10 @@ async function loadUsageDaily(supabase: any, keyIds: string[]) {
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
-  const token = url.searchParams.get('token') ?? '';
-  const email = (url.searchParams.get('email') ?? '').toLowerCase();
-  if (!token || !email) return NextResponse.json({ error: 'Missing token or email' }, { status: 400 });
-
+  const auth = await authPortal(request, null, { token: url.searchParams.get('token'), email: url.searchParams.get('email') });
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  const ok = await verifyToken(supabase, token, email, false);
-  if (!ok) return NextResponse.json({ error: 'Invalid or expired link. Request a new one.' }, { status: 401 });
 
   // Log a portal_signin event the first time a token is read in a session.
   // We don't dedupe across reads — each load is one event. The portal UI
@@ -184,17 +182,15 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
-  const token = String(body?.token || '');
-  const email = String(body?.email || '').toLowerCase();
   const action = body?.action;
   const id = body?.id;
-  if (!token || !email || !action || !id) {
-    return NextResponse.json({ error: 'token, email, action, id required' }, { status: 400 });
+  if (!action || !id) {
+    return NextResponse.json({ error: 'action + id required' }, { status: 400 });
   }
-
+  const auth = await authPortal(request, body, null);
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  const ok = await verifyToken(supabase, token, email, true);
-  if (!ok) return NextResponse.json({ error: 'Invalid or expired link. Request a new one.' }, { status: 401 });
 
   // Mutations must respect the member→owner mapping so admins on a
   // teammate-invited account can revoke / reissue keys they can see.

--- a/src/app/api/v1/portal-members/route.ts
+++ b/src/app/api/v1/portal-members/route.ts
@@ -13,6 +13,7 @@ import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
 import { resend } from '@/lib/resend';
 import { audit, extractClientMeta } from '@/lib/b2b/audit';
+import { authPortal } from '@/lib/b2b/session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -59,12 +60,10 @@ export async function resolveOwner(supabase: any, email: string): Promise<{ owne
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
-  const token = url.searchParams.get('token') ?? '';
-  const email = (url.searchParams.get('email') ?? '').toLowerCase();
-  if (!token || !email) return NextResponse.json({ error: 'token + email required' }, { status: 400 });
-
+  const auth = await authPortal(request, null, { token: url.searchParams.get('token'), email: url.searchParams.get('email') });
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  if (!(await verifyToken(supabase, token, email, false))) return NextResponse.json({ error: 'Link expired.' }, { status: 401 });
 
   const { owner, role } = await resolveOwner(supabase, email);
   const { data: members } = await supabase
@@ -73,7 +72,7 @@ export async function GET(request: NextRequest) {
     .eq('owner_email', owner)
     .order('invited_at', { ascending: false });
 
-  return NextResponse.json({ owner, your_role: role, members: members ?? [] });
+  return NextResponse.json({ owner, your_email: email, your_role: role, members: members ?? [] });
 }
 
 export async function POST(request: NextRequest) {
@@ -81,15 +80,13 @@ export async function POST(request: NextRequest) {
   try { body = await request.json(); } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
-  const token = String(body?.token || '');
-  const email = String(body?.email || '').toLowerCase();
   const action = String(body?.action || '');
   const memberEmail = String(body?.member_email || '').toLowerCase();
   const role: 'admin' | 'viewer' = body?.role === 'admin' ? 'admin' : 'viewer';
-  if (!token || !email) return NextResponse.json({ error: 'token + email required' }, { status: 400 });
-
+  const auth = await authPortal(request, body, null);
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  if (!(await verifyToken(supabase, token, email, true))) return NextResponse.json({ error: 'Link expired.' }, { status: 401 });
 
   const { owner, role: yourRole } = await resolveOwner(supabase, email);
   if (yourRole !== 'admin') return NextResponse.json({ error: 'Only admins can manage team members.' }, { status: 403 });

--- a/src/app/api/v1/portal-session/route.ts
+++ b/src/app/api/v1/portal-session/route.ts
@@ -1,0 +1,69 @@
+/**
+ * POST /api/v1/portal-session — exchange a magic-link token for a
+ * long-lived session cookie. Burns the magic-link token in the process.
+ *
+ * Body: { token, email }
+ *
+ * After this, the customer's portal cookie is good for 30 days; they
+ * don't need another magic link unless they sign out or the session
+ * expires. Members invited to an account each get their own session.
+ *
+ * DELETE — sign out (revoke the current session + clear cookie).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import crypto from 'node:crypto';
+import { createSession, setSessionCookie, clearSessionCookie, readSessionCookie, revokeSession } from '@/lib/b2b/session';
+import { audit, extractClientMeta } from '@/lib/b2b/audit';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export async function POST(request: NextRequest) {
+  let body: any;
+  try { body = await request.json(); } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  const token = String(body?.token || '');
+  const email = String(body?.email || '').toLowerCase();
+  if (!token || !email) return NextResponse.json({ error: 'token + email required' }, { status: 400 });
+
+  const supabase = getAdmin();
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const { data } = await supabase
+    .from('b2b_portal_tokens')
+    .select('id, expires_at, used_at, purpose')
+    .eq('token_hash', tokenHash)
+    .eq('email', email)
+    .maybeSingle();
+  if (!data || data.used_at || data.purpose !== 'signin' || new Date(data.expires_at) < new Date()) {
+    return NextResponse.json({ error: 'Link expired or invalid. Request a new one.' }, { status: 401 });
+  }
+
+  // Burn the magic-link token — single use.
+  await supabase.from('b2b_portal_tokens').update({ used_at: new Date().toISOString() }).eq('id', data.id);
+
+  const meta = extractClientMeta(request);
+  const sessionToken = await createSession(email, meta.ip_address, meta.user_agent);
+  audit({ email, action: 'portal_signin', ...meta, metadata: { via: 'magic_link_to_session' } });
+
+  const res = NextResponse.json({ ok: true });
+  setSessionCookie(res, sessionToken);
+  return res;
+}
+
+export async function DELETE(request: NextRequest) {
+  const cookie = readSessionCookie(request);
+  await revokeSession(cookie);
+  const res = NextResponse.json({ ok: true });
+  clearSessionCookie(res);
+  return res;
+}

--- a/src/app/api/v1/portal-upgrade/route.ts
+++ b/src/app/api/v1/portal-upgrade/route.ts
@@ -1,0 +1,101 @@
+/**
+ * POST /api/v1/portal-upgrade — in-portal Stripe Checkout for free→paid upgrade.
+ *
+ * Body: { tier: 'growth' | 'enterprise' }
+ *
+ * Auth: portal session (cookie) or magic-link token. The customer's
+ * email + currently-owned starter key drive the Stripe session metadata
+ * so the webhook can revoke the free key cleanly after the new paid
+ * key is minted. No re-typing the form, no losing audit history.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import Stripe from 'stripe';
+import { authPortal } from '@/lib/b2b/session';
+import { audit, extractClientMeta } from '@/lib/b2b/audit';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+const TIER_PRICE_ENV: Record<string, string> = {
+  growth: 'STRIPE_PRICE_API_GROWTH_MONTHLY',
+  enterprise: 'STRIPE_PRICE_API_ENTERPRISE_MONTHLY',
+};
+
+export async function POST(request: NextRequest) {
+  let body: any;
+  try { body = await request.json(); } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }); }
+  const tier = String(body?.tier || '');
+  const envKey = TIER_PRICE_ENV[tier];
+  if (!envKey) return NextResponse.json({ error: '`tier` must be growth or enterprise' }, { status: 400 });
+
+  const auth = await authPortal(request, body, null);
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
+
+  const supabase = getAdmin();
+  const { resolveOwner } = await import('../portal-members/route');
+  const { owner, role } = await resolveOwner(supabase as any, email);
+  if (role !== 'admin') return NextResponse.json({ error: 'Admin role required to upgrade.' }, { status: 403 });
+
+  if (!process.env.STRIPE_SECRET_KEY) return NextResponse.json({ error: 'Stripe not configured' }, { status: 500 });
+  const priceId = process.env[envKey];
+  if (!priceId) return NextResponse.json({ error: `${envKey} not set` }, { status: 500 });
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://paybacker.co.uk';
+
+  // Find any starter key on this owner so the webhook can revoke it
+  // post-conversion. Multiple starter keys → revoke them all.
+  const { data: starterKeys } = await supabase
+    .from('b2b_api_keys')
+    .select('id')
+    .eq('owner_email', owner)
+    .eq('tier', 'starter')
+    .is('revoked_at', null);
+  const starterIds = (starterKeys ?? []).map((k: any) => k.id).join(',');
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      customer_email: owner,
+      success_url: `${baseUrl}/dashboard/api-keys?upgraded=1`,
+      cancel_url: `${baseUrl}/dashboard/api-keys?upgrade_cancelled=1`,
+      metadata: {
+        product: 'b2b_api',
+        tier,
+        contact_name: email,
+        company: '',
+        upgrading_from_free: '1',
+        revoke_starter_ids: starterIds,
+      },
+      subscription_data: {
+        metadata: {
+          product: 'b2b_api',
+          tier,
+          contact_name: email,
+          company: '',
+          upgrading_from_free: '1',
+          revoke_starter_ids: starterIds,
+        },
+      },
+      allow_promotion_codes: true,
+    });
+
+    const meta = extractClientMeta(request);
+    audit({ email, action: 'plan_changed', ...meta, metadata: { op: 'upgrade_initiated', tier, starter_ids: starterIds } });
+
+    return NextResponse.json({ url: session.url, id: session.id });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'Stripe error' }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/portal-webhooks/route.ts
+++ b/src/app/api/v1/portal-webhooks/route.ts
@@ -17,6 +17,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
 import { audit, extractClientMeta } from '@/lib/b2b/audit';
+import { authPortal } from '@/lib/b2b/session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -64,14 +65,10 @@ function generateSecret(): { plaintext: string; hash: string } {
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
-  const token = url.searchParams.get('token') ?? '';
-  const email = (url.searchParams.get('email') ?? '').toLowerCase();
-  if (!token || !email) return NextResponse.json({ error: 'token + email required' }, { status: 400 });
-
+  const auth = await authPortal(request, null, { token: url.searchParams.get('token'), email: url.searchParams.get('email') });
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  if (!(await verifyToken(supabase, token, email, false))) {
-    return NextResponse.json({ error: 'Link expired or invalid.' }, { status: 401 });
-  }
 
   const { data: hooks } = await supabase
     .from('b2b_webhooks')
@@ -104,15 +101,11 @@ export async function POST(request: NextRequest) {
   try { body = await request.json(); } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
-  const token = String(body?.token || '');
-  const email = String(body?.email || '').toLowerCase();
   const action = (body?.action as string) || 'create';
-  if (!token || !email) return NextResponse.json({ error: 'token + email required' }, { status: 400 });
-
+  const auth = await authPortal(request, body, null);
+  if (!auth) return NextResponse.json({ error: 'Not signed in.' }, { status: 401 });
+  const email = auth.email;
   const supabase = getAdmin();
-  if (!(await verifyToken(supabase, token, email, true))) {
-    return NextResponse.json({ error: 'Link expired or invalid.' }, { status: 401 });
-  }
   const meta = extractClientMeta(request);
 
   if (action === 'create') {

--- a/src/app/dashboard/api-keys/page.tsx
+++ b/src/app/dashboard/api-keys/page.tsx
@@ -22,7 +22,7 @@ interface Delivery { id: number; webhook_id: string; event: string; status_code:
 interface WebhookData { webhooks: Webhook[]; recent_deliveries: Delivery[]; supported_events: string[]; }
 
 interface Member { id: string; member_email: string; role: 'admin' | 'viewer'; invited_at: string; accepted_at: string | null; invited_by: string | null; }
-interface MembersData { owner: string; your_role: 'admin' | 'viewer'; members: Member[]; }
+interface MembersData { owner: string; your_email: string; your_role: 'admin' | 'viewer'; members: Member[]; }
 interface StatusPayload { status: string; last_24h: { uptime_pct: number; p50_latency_ms: number; p95_latency_ms: number; total_calls: number; error_rate_pct: number }; }
 
 type Tab = 'keys' | 'usage' | 'activity' | 'webhooks' | 'members' | 'explorer' | 'audit' | 'account';
@@ -31,8 +31,9 @@ export const dynamic = 'force-dynamic';
 
 export default function ApiKeysPortalPage() {
   const params = useSearchParams();
-  const token = params.get('token');
-  const email = params.get('email');
+  const [token, setTokenState] = useState<string | null>(params.get('token'));
+  const [email, setEmailState] = useState<string | null>(params.get('email'));
+  const [hasSession, setHasSession] = useState(false);
   const [tab, setTab] = useState<Tab>('keys');
 
   const [requestEmail, setRequestEmail] = useState('');
@@ -49,21 +50,22 @@ export default function ApiKeysPortalPage() {
   const [drawer, setDrawer] = useState<{ kind: 'usage' | 'audit' | 'delivery'; row: any } | null>(null);
 
   async function load() {
-    if (!token || !email) return;
     setLoading(true);
     setError(null);
     try {
       const [r1, r2, r3, r4] = await Promise.all([
-        fetch(`/api/v1/portal-keys?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`),
-        fetch(`/api/v1/portal-webhooks?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`),
-        fetch(`/api/v1/portal-members?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`),
-        fetch(`/api/status`),
+        fetch('/api/v1/portal-keys', { credentials: 'include' }),
+        fetch('/api/v1/portal-webhooks', { credentials: 'include' }),
+        fetch('/api/v1/portal-members', { credentials: 'include' }),
+        fetch('/api/status'),
       ]);
       const j1 = await r1.json();
       const j2 = await r2.json();
       const j3 = await r3.json();
       const j4 = await r4.json();
+      if (r1.status === 401) { setHasSession(false); setLoading(false); return; }
       if (!r1.ok) throw new Error(j1.error || 'Could not load portal');
+      setHasSession(true);
       setData(j1);
       if (r2.ok) setWebhookData(j2);
       if (r3.ok) setMembersData(j3);
@@ -72,7 +74,36 @@ export default function ApiKeysPortalPage() {
       setError(e?.message || 'Failed');
     } finally { setLoading(false); }
   }
-  useEffect(() => { load(); }, [token, email]);
+  // First mount: if we have a magic-link token, exchange it for a
+  // 30-day session cookie, then strip the query params from the URL
+  // and reload data without them. Otherwise just attempt to load —
+  // if the cookie is valid, we're already signed in; if not, the
+  // sign-in form renders.
+  useEffect(() => {
+    (async () => {
+      if (token && email) {
+        try {
+          const r = await fetch('/api/v1/portal-session', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ token, email }) });
+          if (r.ok) {
+            history.replaceState({}, '', '/dashboard/api-keys');
+            setHasSession(true);
+          }
+        } catch {}
+      } else {
+        // Probe — try loading; load() will set error if not signed in.
+        setHasSession(true);
+      }
+      load();
+    })();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function signOut() {
+    await fetch('/api/v1/portal-session', { method: 'DELETE' });
+    setTokenState(null); setEmailState(null); setHasSession(false);
+    setData(null); setWebhookData(null); setMembersData(null);
+    history.replaceState({}, '', '/dashboard/api-keys');
+  }
 
   async function requestLink(e: React.FormEvent) {
     e.preventDefault();
@@ -102,16 +133,16 @@ export default function ApiKeysPortalPage() {
     window.open(`/api/v1/portal-export?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}&type=${type}`, '_blank');
   }
 
-  // No token → request link
-  if (!token || !email) {
+  // Not signed in → request link
+  if (!hasSession && !loading) {
     return (
       <main style={signinPage}>
         <div style={signinCard}>
           <h1 style={{ margin: 0, fontSize: 28, letterSpacing: '-0.01em' }}>API portal sign-in</h1>
-          <p style={{ color: '#475569' }}>Enter the work email your Paybacker API key is registered to. We&rsquo;ll send a one-time link.</p>
+          <p style={{ color: '#475569' }}>Enter the work email your Paybacker API key is registered to. We&rsquo;ll send a one-time link. After that, you&rsquo;ll stay signed in for 30 days.</p>
           {requestSent ? (
             <div style={{ background: '#ecfdf5', border: '1px solid #6ee7b7', padding: 12, borderRadius: 8, color: '#065f46' }}>
-              If a key exists for that email, a link has been sent. Expires in 30 minutes.
+              If you have access, a link has been sent. Expires in 30 minutes.
             </div>
           ) : (
             <form onSubmit={requestLink} style={{ display: 'grid', gap: 10 }}>
@@ -132,12 +163,13 @@ export default function ApiKeysPortalPage() {
           <div>
             <Link href="/for-business" style={{ color: '#64748b', fontSize: 13, textDecoration: 'none' }}>← paybacker.co.uk/for-business</Link>
             <h1 style={{ margin: '8px 0 4px', fontSize: 28, letterSpacing: '-0.01em' }}>API portal</h1>
-            <p style={{ color: '#475569', margin: 0 }}>Signed in as <strong>{email}</strong></p>
+            <p style={{ color: '#475569', margin: 0 }}>Signed in as <strong>{membersData?.your_email ?? '—'}</strong>{membersData?.your_role === 'viewer' && ' (viewer)'}</p>
           </div>
-          <div style={{ display: 'flex', gap: 12, fontSize: 13, color: '#64748b', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', gap: 12, fontSize: 13, color: '#64748b', flexWrap: 'wrap', alignItems: 'center' }}>
             <Link href="/for-business/docs" style={navLink}>Docs</Link>
             <Link href="/for-business/coverage" style={navLink}>Coverage</Link>
             <a href="mailto:business@paybacker.co.uk" style={navLink}>Support</a>
+            <button onClick={signOut} style={{ ...btnGhost, fontSize: 12 }}>Sign out</button>
           </div>
         </header>
 
@@ -168,14 +200,14 @@ export default function ApiKeysPortalPage() {
             </div>
 
             <div style={{ paddingTop: 20 }}>
-              {tab === 'keys' && <KeysTab keys={data.keys} status={status} token={token} email={email} revokedUsageThisMonth={data.revoked_key_usage_this_month ?? 0} onReissue={reissue} onRevoke={revoke} onChange={load} />}
+              {tab === 'keys' && <KeysTab keys={data.keys} status={status} token={token ?? ''} email={email ?? ''} revokedUsageThisMonth={data.revoked_key_usage_this_month ?? 0} onReissue={reissue} onRevoke={revoke} onChange={load} />}
               {tab === 'usage' && <UsageTab daily={data.usage_daily} onExport={() => exportCsv('usage')} />}
               {tab === 'activity' && <ActivityTab usage={data.recent_usage} keys={data.all_keys} onOpen={(r) => setDrawer({ kind: 'usage', row: r })} />}
-              {tab === 'webhooks' && webhookData && <WebhooksTab data={webhookData} token={token} email={email} onChange={load} onOpen={(r) => setDrawer({ kind: 'delivery', row: r })} />}
-              {tab === 'members' && <MembersTab data={membersData} token={token} email={email} onChange={load} />}
+              {tab === 'webhooks' && webhookData && <WebhooksTab data={webhookData} token={token ?? ''} email={email ?? ''} onChange={load} onOpen={(r) => setDrawer({ kind: 'delivery', row: r })} />}
+              {tab === 'members' && <MembersTab data={membersData} token={token ?? ''} email={email ?? ''} onChange={load} />}
               {tab === 'explorer' && <ExplorerTab keys={data.keys} />}
               {tab === 'audit' && <AuditTab audit={data.audit_log} keys={data.all_keys} onOpen={(r) => setDrawer({ kind: 'audit', row: r })} onExport={() => exportCsv('audit')} />}
-              {tab === 'account' && <AccountTab email={email} keys={data.all_keys} />}
+              {tab === 'account' && <AccountTab email={membersData?.your_email ?? email ?? ''} keys={data.all_keys} />}
             </div>
           </>
         )}
@@ -260,9 +292,21 @@ function KeyCard({ k, token, email, onReissue, onRevoke, onChange }: { k: Key; t
       {pct >= 90 && (
         <div style={{ marginTop: 12, padding: 12, background: '#fef2f2', border: '1px solid #fecaca', borderRadius: 8, color: '#991b1b' }}>
           <strong>{pct >= 100 ? 'Monthly limit reached.' : 'Approaching monthly limit.'}</strong> Calls beyond your cap will return 429 until the 1st (UTC).
-          {isStarter && <span> Upgrade to <strong>Growth (£499/mo, 10k calls)</strong> to keep going.</span>}
-          <div style={{ marginTop: 10 }}>
-            <Link href="/for-business#buy" style={btn}>Upgrade tier →</Link>
+          {isStarter && <span> Upgrade to <strong>Growth (£499/mo, 10k calls)</strong> to keep going. We&rsquo;ll auto-revoke this free key once your paid key is active — your audit log and history stay attached to your email.</span>}
+          <div style={{ marginTop: 10, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            {isStarter && <button onClick={async () => {
+              const r = await fetch('/api/v1/portal-upgrade', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ tier: 'growth' }) });
+              const j = await r.json();
+              if (!r.ok) { alert(j.error || 'Could not start upgrade'); return; }
+              window.location.href = j.url;
+            }} style={btn}>Upgrade to Growth — £499/mo →</button>}
+            {isStarter && <button onClick={async () => {
+              const r = await fetch('/api/v1/portal-upgrade', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ tier: 'enterprise' }) });
+              const j = await r.json();
+              if (!r.ok) { alert(j.error || 'Could not start upgrade'); return; }
+              window.location.href = j.url;
+            }} style={btnGhost}>Or Enterprise — £1,999/mo</button>}
+            {!isStarter && <Link href="/for-business#buy" style={btn}>Upgrade tier →</Link>}
           </div>
         </div>
       )}

--- a/src/lib/b2b/session.ts
+++ b/src/lib/b2b/session.ts
@@ -1,0 +1,127 @@
+/**
+ * Session-based portal auth for B2B customers.
+ *
+ * Magic-link is used for *first* sign-in and after a 30-day session
+ * expiry. After consuming a magic link, we mint a long-lived session
+ * cookie (HttpOnly, Secure, SameSite=Lax) so the customer signs in
+ * once per month, not every time they open the portal.
+ *
+ * Multi-seat: each member has their own session keyed to their own
+ * email. resolveOwner() handles the visibility model.
+ */
+
+import crypto from 'node:crypto';
+import { createClient } from '@supabase/supabase-js';
+import type { NextRequest } from 'next/server';
+import type { NextResponse } from 'next/server';
+
+export const SESSION_COOKIE = 'pbk_b2b_session';
+const SESSION_TTL_DAYS = 30;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export async function createSession(email: string, ip: string | null, ua: string | null): Promise<string> {
+  const supabase = getAdmin();
+  const token = crypto.randomBytes(32).toString('base64url');
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const expiresAt = new Date(Date.now() + SESSION_TTL_DAYS * 86400_000).toISOString();
+  await supabase.from('b2b_sessions').insert({
+    email: email.toLowerCase(),
+    token_hash: tokenHash,
+    expires_at: expiresAt,
+    ip_address: ip,
+    user_agent: ua,
+  });
+  return token;
+}
+
+/**
+ * Verify a session cookie. Returns the email on success, or null.
+ * Bumps last_used_at so we know which sessions are active.
+ */
+export async function verifySession(token: string | null | undefined): Promise<string | null> {
+  if (!token) return null;
+  const supabase = getAdmin();
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const { data } = await supabase
+    .from('b2b_sessions')
+    .select('id, email, expires_at, revoked_at')
+    .eq('token_hash', tokenHash)
+    .maybeSingle();
+  if (!data) return null;
+  if (data.revoked_at) return null;
+  if (new Date(data.expires_at) < new Date()) return null;
+  // Don't await — fire and forget bump.
+  void supabase.from('b2b_sessions').update({ last_used_at: new Date().toISOString() }).eq('id', data.id);
+  return data.email as string;
+}
+
+export async function revokeSession(token: string | null | undefined): Promise<void> {
+  if (!token) return;
+  const supabase = getAdmin();
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  await supabase.from('b2b_sessions').update({ revoked_at: new Date().toISOString() }).eq('token_hash', tokenHash);
+}
+
+export function setSessionCookie(response: NextResponse, token: string): void {
+  response.cookies.set(SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SESSION_TTL_DAYS * 86400,
+  });
+}
+
+export function clearSessionCookie(response: NextResponse): void {
+  response.cookies.set(SESSION_COOKIE, '', {
+    httpOnly: true, secure: true, sameSite: 'lax', path: '/', maxAge: 0,
+  });
+}
+
+export function readSessionCookie(request: NextRequest): string | null {
+  return request.cookies.get(SESSION_COOKIE)?.value ?? null;
+}
+
+/**
+ * Unified portal auth: returns the authenticated email if either a
+ * valid session cookie OR a valid magic-link token is presented.
+ *
+ * Magic-link path also validates the original 30-min one-time token
+ * via b2b_portal_tokens — used on first sign-in.
+ */
+export async function authPortal(
+  request: NextRequest,
+  body?: { token?: string; email?: string } | null,
+  searchParams?: { token?: string | null; email?: string | null } | null,
+): Promise<{ email: string; via: 'session' | 'magic' } | null> {
+  // 1) Session cookie
+  const cookie = readSessionCookie(request);
+  const sessionEmail = await verifySession(cookie);
+  if (sessionEmail) return { email: sessionEmail, via: 'session' };
+
+  // 2) Magic-link token (body or query)
+  const token = body?.token ?? searchParams?.token ?? null;
+  const email = (body?.email ?? searchParams?.email ?? '').toLowerCase();
+  if (token && email) {
+    const supabase = getAdmin();
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const { data } = await supabase
+      .from('b2b_portal_tokens')
+      .select('id, expires_at, used_at')
+      .eq('token_hash', tokenHash)
+      .eq('email', email)
+      .maybeSingle();
+    if (data && !data.used_at && new Date(data.expires_at) >= new Date()) {
+      // Don't burn the token here — let the calling endpoint decide
+      // (mutating endpoints burn, GETs don't).
+      return { email, via: 'magic' };
+    }
+  }
+  return null;
+}

--- a/src/lib/b2b/stripe-webhook.ts
+++ b/src/lib/b2b/stripe-webhook.ts
@@ -141,6 +141,27 @@ export async function handleB2bCheckoutCompleted(
     metadata: { tier, source: 'stripe_checkout', subscription_id: subscriptionId, prefix: minted.prefix },
   });
 
+  // Free→paid upgrade flow: portal-upgrade tags the session with
+  // upgrading_from_free=1 and a CSV of starter key IDs to revoke
+  // once the paid key is provisioned. Audit log + recent calls
+  // remain attached to the email, so the customer's history is
+  // preserved across the upgrade.
+  if (session.metadata?.upgrading_from_free === '1') {
+    const starterIds = String(session.metadata?.revoke_starter_ids || '').split(',').filter(Boolean);
+    if (starterIds.length > 0) {
+      const { error: revErr } = await supabase
+        .from('b2b_api_keys')
+        .update({ revoked_at: new Date().toISOString(), notes: `Auto-revoked at upgrade to ${tier}` })
+        .in('id', starterIds);
+      if (revErr) console.error('[b2b stripe] starter auto-revoke failed:', revErr.message);
+      else {
+        for (const sid of starterIds) {
+          audit({ email: customerEmail.toLowerCase(), action: 'key_revoked', actor: 'stripe', key_id: sid, metadata: { reason: 'free_to_paid_upgrade', new_tier: tier } });
+        }
+      }
+    }
+  }
+
   // Email a single-use reveal link rather than plaintext. Better
   // security posture (forwarded emails can't be replayed) and the
   // answer to any prospect who asks "do you email plaintext keys?".

--- a/supabase/migrations/20260428100000_b2b_sessions.sql
+++ b/supabase/migrations/20260428100000_b2b_sessions.sql
@@ -1,0 +1,19 @@
+-- Long-lived portal sessions for B2B customers. Magic-link flow mints
+-- a 30-day cookie-bound session so customers don't have to check their
+-- email every time they want to view the portal. SAMESITE=Lax cookies,
+-- HttpOnly, Secure. Hashed token at rest.
+CREATE TABLE IF NOT EXISTS b2b_sessions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  email TEXT NOT NULL,
+  token_hash TEXT NOT NULL UNIQUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  ip_address TEXT,
+  user_agent TEXT,
+  last_used_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS b2b_sessions_email_idx
+  ON b2b_sessions (email, expires_at DESC);
+CREATE INDEX IF NOT EXISTS b2b_sessions_hash_idx
+  ON b2b_sessions (token_hash) WHERE revoked_at IS NULL;


### PR DESCRIPTION
Magic link only on first sign-in. 30-day cookie session. Sign out clears it. Free→paid upgrade now happens inside the portal — Stripe Checkout prefilled with the customer's email, webhook auto-revokes their starter key, audit log + history persist.