### PR TITLE
fix(b2b): rate limit per owner — closes re-issue bypass

### DIFF
--- a/src/app/api/v1/portal-keys/route.ts
+++ b/src/app/api/v1/portal-keys/route.ts
@@ -56,24 +56,28 @@ async function loadKeys(supabase: any, email: string) {
     .is('revoked_at', null)
     .order('created_at', { ascending: false });
 
-  // Compute monthly_used for each
+  // Owner-wide monthly usage — sum across every key (active + revoked)
+  // because the rate limit in /lib/b2b/auth.ts is enforced per-owner,
+  // not per-key. Each active key card shows the SAME owner total so
+  // there's no confusion about "I made 3 calls but it shows 1".
   const monthStart = new Date();
   monthStart.setUTCDate(1);
   monthStart.setUTCHours(0, 0, 0, 0);
-  const ids = (keys ?? []).map((k: any) => k.id);
-  const usageByKey = new Map<string, number>();
-  if (ids.length > 0) {
-    const { data: usage } = await supabase
+  const { data: allOwnerKeys } = await supabase
+    .from('b2b_api_keys')
+    .select('id')
+    .eq('owner_email', email);
+  const allKeyIds = (allOwnerKeys ?? []).map((k: any) => k.id as string);
+  let ownerMonthlyUsed = 0;
+  if (allKeyIds.length > 0) {
+    const { count } = await supabase
       .from('b2b_api_usage')
-      .select('key_id')
-      .in('key_id', ids)
+      .select('id', { count: 'exact', head: true })
+      .in('key_id', allKeyIds)
       .gte('created_at', monthStart.toISOString());
-    for (const row of usage ?? []) {
-      const k = (row as any).key_id as string;
-      usageByKey.set(k, (usageByKey.get(k) ?? 0) + 1);
-    }
+    ownerMonthlyUsed = count ?? 0;
   }
-  return (keys ?? []).map((k: any) => ({ ...k, monthly_used: usageByKey.get(k.id) ?? 0 }));
+  return (keys ?? []).map((k: any) => ({ ...k, monthly_used: ownerMonthlyUsed }));
 }
 
 async function loadAudit(supabase: any, email: string, limit = 25) {

--- a/src/app/dashboard/api-keys/page.tsx
+++ b/src/app/dashboard/api-keys/page.tsx
@@ -243,10 +243,8 @@ function KeysTab({ keys, status, token, email, revokedUsageThisMonth, onReissue,
         <KeyCard key={k.id} k={k} token={token} email={email} onReissue={onReissue} onRevoke={onRevoke} onChange={onChange} />
       ))}
       {revokedUsageThisMonth > 0 && (
-        <p style={{ fontSize: 13, color: '#64748b', marginTop: 4 }}>
-          ℹ️ <strong>{revokedUsageThisMonth.toLocaleString()}</strong> additional call{revokedUsageThisMonth === 1 ? '' : 's'} this month
-          went through previously-revoked keys. Active keys above show their own usage only.
-          See the <strong>Recent calls</strong> tab to inspect every request.
+        <p style={{ fontSize: 12, color: '#94a3b8', marginTop: 4 }}>
+          Of this month&rsquo;s usage, <strong>{revokedUsageThisMonth.toLocaleString()}</strong> call{revokedUsageThisMonth === 1 ? '' : 's'} went through previously-revoked keys. See the <strong>Recent calls</strong> tab to inspect every request.
         </p>
       )}
     </div>
@@ -287,7 +285,7 @@ function KeyCard({ k, token, email, onReissue, onRevoke, onChange }: { k: Key; t
         </div>
       </div>
       <div style={{ marginTop: 14, fontSize: 13, color: '#64748b' }}>
-        Usage this month: <strong style={{ color: '#0f172a' }}>{k.monthly_used.toLocaleString()}</strong> / {k.monthly_limit.toLocaleString()} ({pct}%)
+        Account usage this month: <strong style={{ color: '#0f172a' }}>{k.monthly_used.toLocaleString()}</strong> / {k.monthly_limit.toLocaleString()} ({pct}%) <span style={{ color: '#94a3b8' }}>· counted across every key on this account</span>
       </div>
       <div style={{ height: 6, background: '#f1f5f9', borderRadius: 3, marginTop: 6, overflow: 'hidden' }}>
         <div style={{ width: `${pct}%`, height: '100%', background: pct >= 90 ? '#dc2626' : pct >= 60 ? '#d97706' : '#059669' }} />

--- a/src/lib/b2b/auth.ts
+++ b/src/lib/b2b/auth.ts
@@ -108,21 +108,29 @@ export async function authenticate(authHeader: string | null, clientIp?: string 
     }
   }
 
-  // Live count of usage this calendar month.
+  // Rate limit is per OWNER per calendar month — sum usage across
+  // every key (active + revoked) for this owner_email. Otherwise a
+  // customer who re-issues N times would effectively get N× their
+  // tier cap, since each new key starts at 0.
   const monthStart = new Date();
   monthStart.setUTCDate(1);
   monthStart.setUTCHours(0, 0, 0, 0);
+  const { data: ownerKeys } = await supabase
+    .from('b2b_api_keys')
+    .select('id')
+    .eq('owner_email', keyRow.owner_email);
+  const ownerKeyIds = (ownerKeys ?? []).map((k: any) => k.id as string);
   const { count } = await supabase
     .from('b2b_api_usage')
     .select('id', { count: 'exact', head: true })
-    .eq('key_id', keyRow.id)
+    .in('key_id', ownerKeyIds.length > 0 ? ownerKeyIds : [keyRow.id])
     .gte('created_at', monthStart.toISOString());
   const monthlyUsed = count ?? 0;
 
   if (monthlyUsed >= keyRow.monthly_limit) {
     return {
       ok: false,
-      error: `Monthly call limit reached (${keyRow.monthly_limit} on tier "${keyRow.tier}"). Upgrade or wait until the 1st.`,
+      error: `Monthly call limit reached (${keyRow.monthly_limit} on tier "${keyRow.tier}", counted across all keys on this account). Upgrade or wait until the 1st.`,
       status: 429,
     };
   }


### PR DESCRIPTION
Per-key counter let customers reset usage by re-issuing. Now counts across all keys for the owner_email. Portal labels updated to reflect 'Account usage'.