### PR TITLE
feat(yapily): Hosted Pages migration + renew/disconnect bug fixes (clean)

### DIFF
--- a/src/app/api/auth/yapily/route.ts
+++ b/src/app/api/auth/yapily/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { createAccountAuthorisation } from '@/lib/yapily';
+import { createClient as createAdmin } from '@supabase/supabase-js';
+import {
+  createAccountAuthorisation,
+  createHostedConsentRequest,
+  isHostedPagesEnabled,
+} from '@/lib/yapily';
 import { UPCOMING_FEATURE_SCOPES } from '@/lib/yapily/upcoming';
 import { TIER_CONFIG, type BankTier } from '@/lib/bank-tier-config';
 
@@ -89,29 +94,87 @@ export async function GET(request: NextRequest) {
     'https://paybacker.co.uk/api/yapily/callback';
 
   // ── Create authorisation request ──
-  try {
-    // Encode user ID + institution ID + returnTo as state for CSRF protection + post-callback redirect
-    const returnTo = searchParams.get('returnTo') || '/dashboard/money-hub';
-    const state = Buffer.from(
-      JSON.stringify({ userId: user.id, institutionId, returnTo })
-    ).toString('base64');
+  // Encode user ID + institution ID + returnTo as state for CSRF protection
+  // + post-callback redirect.
+  const returnTo = searchParams.get('returnTo') || '/dashboard/money-hub';
+  const state = Buffer.from(
+    JSON.stringify({ userId: user.id, institutionId, returnTo })
+  ).toString('base64');
+  const redirectWithState = `${callbackUrl}?state=${encodeURIComponent(state)}`;
 
-    // Include the upcoming-payments feature scopes so new consents
-    // are granted enough access to read scheduled + periodic
-    // payments + direct debits + pending transactions. Existing
-    // bank_connections continue to work on their original consent;
-    // the expanded scope applies from the next renewal onward.
+  try {
+    if (isHostedPagesEnabled()) {
+      // Hosted Pages flow (Migle's onboarding plan, 29 Apr 2026).
+      // Yapily renders the bank-picker / consent / decoupled-auth
+      // screens on its own domain; we get back a hostedUrl + a
+      // consentRequestId we'll use in the callback to retrieve the
+      // consentId + consentToken via GET /hosted/consent-requests/{id}.
+      //
+      // We DO set institutionId because our UI already picks the bank,
+      // so Yapily skips its own picker (per HostedAccountRequest spec
+      // — institutionIdentifiers + institutionId pre-selects).
+      //
+      // featureScope (resolved 29 Apr from the OpenAPI spec): passed
+      // via the `accountRequest.featureScope` body field. Mirrors the
+      // upcoming-payments scopes we already request on the legacy
+      // /account-auth-requests path.
+      const hosted = await createHostedConsentRequest({
+        applicationUserId: user.id,
+        redirectUrl: redirectWithState,
+        institutionCountryCode: 'GB',
+        institutionId,
+        language: 'EN',
+        location: 'GB',
+        featureScope: UPCOMING_FEATURE_SCOPES,
+      });
+
+      // Track this in-flight request so the abandonment poller can
+      // chase it if the user never returns. Best-effort: a failure to
+      // record the pending row should not block the user from being
+      // redirected to Yapily.
+      try {
+        const admin = createAdmin(
+          process.env.NEXT_PUBLIC_SUPABASE_URL!,
+          process.env.SUPABASE_SERVICE_ROLE_KEY!,
+        );
+        await admin.from('yapily_pending_consent_requests').insert({
+          user_id: user.id,
+          consent_request_id: hosted.consentRequestId,
+          institution_id: institutionId,
+          redirect_url: redirectWithState,
+          status: 'pending',
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'unknown';
+        console.error(`[yapily.auth] pending row insert failed (non-fatal): ${msg}`);
+      }
+
+      console.log(
+        `Yapily auth (hosted): created hosted consent for user=${user.id} institution=${institutionId} consentRequestId=${hosted.consentRequestId}`
+      );
+      return NextResponse.json({
+        // Frontend-facing URL — kept under both names so existing
+        // consumers reading authorisationUrl don't break during the
+        // cutover, and any new code can prefer hostedUrl.
+        authorisationUrl: hosted.hostedUrl,
+        hostedUrl: hosted.hostedUrl,
+        consentRequestId: hosted.consentRequestId,
+        // No consentId at this stage; we'll fetch it in the callback
+        // alongside the consentToken.
+      });
+    }
+
+    // Legacy flow — kept reachable behind the flag so we can roll back
+    // by flipping one env var.
     const authData = await createAccountAuthorisation(
       institutionId,
-      `${callbackUrl}?state=${encodeURIComponent(state)}`,
+      redirectWithState,
       user.id,
       UPCOMING_FEATURE_SCOPES,
     );
-
     console.log(
-      `Yapily auth: created authorisation for user=${user.id} institution=${institutionId}`
+      `Yapily auth (legacy): created authorisation for user=${user.id} institution=${institutionId}`
     );
-
     return NextResponse.json({
       authorisationUrl: authData.authorisationUrl,
       consentId: authData.id,

--- a/src/app/api/bank/disconnect/route.ts
+++ b/src/app/api/bank/disconnect/route.ts
@@ -46,6 +46,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createClient as createAdmin } from '@supabase/supabase-js';
+import { deleteConsent } from '@/lib/yapily';
 
 type DisconnectMode = 'keep_history' | 'delete_transactions' | 'erase_all';
 
@@ -54,6 +55,26 @@ function getAdmin() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
   );
+}
+
+/**
+ * Best-effort revoke of the upstream Yapily consent. We never block local
+ * cleanup on this — if Yapily is down, we still want the user's bank
+ * disappearing from their dashboard. Logged failures get surfaced via the
+ * standard error path (Sentry / Telegram alerts) so we can chase them.
+ *
+ * 404 from Yapily means the consent is already gone, which is the exact
+ * end-state we're trying to achieve, so deleteConsent() treats it as
+ * success (no throw).
+ */
+async function revokeYapilyConsentIfPossible(consentId: string | null | undefined): Promise<void> {
+  if (!consentId) return; // legacy connection without yapily_consent_id — nothing to revoke
+  try {
+    await deleteConsent(consentId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    console.error(`[bank.disconnect] yapily deleteConsent failed for ${consentId}: ${msg}`);
+  }
 }
 
 export async function POST(request: NextRequest) {
@@ -75,6 +96,18 @@ export async function POST(request: NextRequest) {
   if (!connectionId) {
     // Legacy "revoke everything" path for callers that don't pass an id.
     // Stays at keep_history semantics for backwards compatibility.
+    // Best-effort revoke each consent on Yapily's side too — we can't
+    // tell from here which provider each row uses, so we just attempt
+    // the call and let yapily_consent_id being null short-circuit it.
+    const adminBulk = getAdmin();
+    const { data: bulkRows } = await adminBulk
+      .from('bank_connections')
+      .select('yapily_consent_id')
+      .eq('user_id', user.id)
+      .in('status', ['active', 'expired', 'token_expired', 'expired_legacy', 'expiring_soon']);
+    if (bulkRows?.length) {
+      await Promise.all(bulkRows.map((r) => revokeYapilyConsentIfPossible(r.yapily_consent_id)));
+    }
     const { error } = await supabase
       .from('bank_connections')
       .update({ status: 'revoked', updated_at: new Date().toISOString() })
@@ -86,11 +119,11 @@ export async function POST(request: NextRequest) {
 
   // Look up the connection so we can record bank_name/provider in the
   // audit row (especially important for erase_all where we then delete
-  // the row).
+  // the row) and revoke the upstream Yapily consent.
   const admin = getAdmin();
   const { data: conn, error: connErr } = await admin
     .from('bank_connections')
-    .select('id, user_id, bank_name, provider, status, account_ids, account_display_names')
+    .select('id, user_id, bank_name, provider, status, account_ids, account_display_names, yapily_consent_id')
     .eq('id', connectionId)
     .eq('user_id', user.id)
     .maybeSingle();
@@ -125,6 +158,17 @@ export async function POST(request: NextRequest) {
         .filter((n): n is string => n !== null)
     : [];
   const willRevokeConnection = !isAccountScoped || remainingAccountIds.length === 0;
+
+  // If this disconnect is going to revoke the entire connection (rather
+  // than just trim one account off a multi-account consent), revoke the
+  // upstream Yapily consent too. We do this BEFORE the local mutations
+  // so a Yapily-side success isn't followed by a local failure that
+  // leaves us out of sync. Per Migle's compliance requirement (29 Apr
+  // call): user-initiated disconnect must reach Yapily, not just flip
+  // local rows.
+  if (willRevokeConnection) {
+    await revokeYapilyConsentIfPossible(conn.yapily_consent_id);
+  }
 
   let transactionsAffected = 0;
 

--- a/src/app/api/bank/renew-consent/route.ts
+++ b/src/app/api/bank/renew-consent/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
 
   const { data: connection, error: connError } = await admin
     .from('bank_connections')
-    .select('id, user_id, consent_token, status, bank_name')
+    .select('id, user_id, consent_token, yapily_consent_id, status, bank_name')
     .eq('id', connectionId)
     .single();
 
@@ -80,12 +80,18 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // ── Check consent token exists ──
-  if (!connection.consent_token) {
+  // ── Check consent identifiers exist ──
+  // reconfirmConsent calls PUT /account-auth-requests/{consentId} — that's
+  // the opaque Yapily consent identifier, NOT the consent_token (the
+  // credential we attach to data calls). The pre-2026-04-27 callback stored
+  // only consent_token, so legacy connections may have null yapily_consent_id;
+  // in that case the user must full-reconnect, since we don't have the URL
+  // path component the renew endpoint requires.
+  if (!connection.yapily_consent_id) {
     return NextResponse.json(
       {
         error:
-          'No consent token found. Please disconnect and reconnect your bank account.',
+          'This bank connection predates our 90-day renewal flow. Please disconnect and reconnect to enable in-place renewal.',
       },
       { status: 400 }
     );
@@ -93,7 +99,7 @@ export async function POST(request: NextRequest) {
 
   // ── Call Yapily reconfirmConsent ──
   try {
-    await reconfirmConsent(connection.consent_token);
+    await reconfirmConsent(connection.yapily_consent_id);
 
     // Success — extend consent by 90 days
     const now = new Date();

--- a/src/app/api/cron/sync-upcoming/route.ts
+++ b/src/app/api/cron/sync-upcoming/route.ts
@@ -11,6 +11,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { decrypt } from '@/lib/encrypt';
+import { supportsFeature } from '@/lib/yapily';
 import {
   getScheduledPayments,
   getPeriodicPayments,
@@ -37,8 +38,10 @@ interface BankConnection {
   user_id: string;
   provider: string;
   provider_id: string | null;
+  institution_id: string | null;
   consent_token: string | null;
   consent_expires_at: string | null;
+  upcoming_endpoints_fetched_at: string | null;
   account_ids: string[] | null;
   status: string;
 }
@@ -70,7 +73,7 @@ export async function GET(request: NextRequest) {
   // Pull active Yapily connections with a non-expired consent.
   const { data: connections, error: connErr } = await supabase
     .from('bank_connections')
-    .select('id, user_id, provider, provider_id, consent_token, consent_expires_at, account_ids, status')
+    .select('id, user_id, provider, provider_id, institution_id, consent_token, consent_expires_at, upcoming_endpoints_fetched_at, account_ids, status')
     .eq('provider', 'yapily')
     .eq('status', 'active')
     .is('archived_at', null);
@@ -119,16 +122,48 @@ export async function GET(request: NextRequest) {
       continue;
     }
 
+    // Single-use semantics (Migle, 29 Apr): the deterministic
+    // upcoming-payments endpoints are callable ONCE per consent.
+    // If we've already pulled them on this consent, skip the calls
+    // and rely on the recurrence detector + transaction history (run
+    // unconditionally below) to keep predicted rows fresh.
+    // upcoming_endpoints_fetched_at is reset to NULL on reconnect by
+    // upsertYapilyConnection.
+    const alreadyFetchedDeterministic = !!conn.upcoming_endpoints_fetched_at;
+
+    // Per-institution feature check (Migle's spec: ~70% of UK banks
+    // support these). Looking once per connection — for all accounts
+    // on the same consent the feature flags are identical. Defaults
+    // to true when institution_id is missing (legacy rows pre-migration)
+    // so we don't regress existing behaviour for connections without
+    // metadata.
+    const instId = conn.institution_id ?? '';
+    const [hasScheduled, hasPeriodic, hasDirectDebits] = alreadyFetchedDeterministic
+      ? [false, false, false]
+      : instId
+        ? await Promise.all([
+            supportsFeature(instId, 'ACCOUNT_SCHEDULED_PAYMENTS'),
+            supportsFeature(instId, 'ACCOUNT_PERIODIC_PAYMENTS'),
+            supportsFeature(instId, 'ACCOUNT_DIRECT_DEBITS'),
+          ])
+        : [true, true, true];
+
     for (const accountId of conn.account_ids) {
       const rows: UpsertRow[] = [];
 
-      // Deterministic endpoints — small wrapper so one failing
-      // source doesn't block the others.
-      const endpoints: Array<[string, () => Promise<UpcomingRow[]>]> = [
-        ['scheduled-payments', () => getScheduledPayments(accountId, decrypted)],
-        ['periodic-payments',  () => getPeriodicPayments(accountId, decrypted)],
-        ['direct-debits',      () => getDirectDebits(accountId, decrypted)],
-      ];
+      // Deterministic endpoints — short-circuit when the institution
+      // doesn't expose the feature so we don't burn API quota on a
+      // guaranteed 404. Each call still wrapped in try/catch so a
+      // mid-flight Yapily blip on one source doesn't block the others.
+      const endpoints: Array<[string, () => Promise<UpcomingRow[]>]> = [];
+      if (hasScheduled) endpoints.push(['scheduled-payments', () => getScheduledPayments(accountId, decrypted)]);
+      if (hasPeriodic)  endpoints.push(['periodic-payments',  () => getPeriodicPayments(accountId, decrypted)]);
+      if (hasDirectDebits) endpoints.push(['direct-debits',   () => getDirectDebits(accountId, decrypted)]);
+      if (endpoints.length === 0) {
+        console.log(
+          `[sync-upcoming] institution=${instId || 'unknown'} account=${accountId} — no upcoming-payment features supported, skipping`,
+        );
+      }
 
       for (const [label, fn] of endpoints) {
         try {
@@ -236,6 +271,23 @@ export async function GET(request: NextRequest) {
         } else {
           summary.predictedRowsUpserted += predictedRows.length;
         }
+      }
+    }
+
+    // Stamp upcoming_endpoints_fetched_at so the next cron tick
+    // skips the deterministic endpoints (single-use semantics). We
+    // only stamp when we actually attempted to call them on this
+    // tick — if alreadyFetchedDeterministic was true we don't need
+    // to re-stamp, the original timestamp stands. We also stamp
+    // even if the calls returned no rows / threw — Yapily counts
+    // the call regardless of outcome.
+    if (!alreadyFetchedDeterministic && (hasScheduled || hasPeriodic || hasDirectDebits)) {
+      const { error: stampErr } = await supabase
+        .from('bank_connections')
+        .update({ upcoming_endpoints_fetched_at: new Date().toISOString() })
+        .eq('id', conn.id);
+      if (stampErr) {
+        console.error(`[sync-upcoming] stamp failed for conn=${conn.id}:`, stampErr.message);
       }
     }
 

--- a/src/app/api/cron/yapily-consent-abandonment/route.ts
+++ b/src/app/api/cron/yapily-consent-abandonment/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { getHostedConsentRequest } from '@/lib/yapily';
+
+export const maxDuration = 60;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+/**
+ * Hosted Pages abandonment poller.
+ *
+ * Spec source: Vitally checklist GH2 + Hosted Pages tutorial step 4.
+ *   - Start polling /hosted/consent-requests/{id} 5 minutes after the
+ *     hosted URL was issued, if no callback received.
+ *   - Poll every 5–10 seconds until status resolves OR 15 minutes elapse.
+ *   - Past 15 minutes, treat as abandoned.
+ *
+ * Implementation note on cadence: a Vercel cron tick gives us a 5-minute
+ * floor, not seconds-level polling. That's fine for our purposes —
+ * abandonment handling is non-realtime housekeeping. The "every 5–10s"
+ * recommendation matters for client-side polling during an active
+ * journey; for server-side reconciliation a 5-minute cron is enough.
+ *
+ * The cron does three things on each tick:
+ *   1. Find pending requests aged 5–15 minutes → poll Yapily once. If
+ *      AUTHORIZED but no callback ever arrived (rare; user closed the
+ *      tab between bank-side success and our callback), log it. Without
+ *      a state cookie we can't safely auto-create the connection on
+ *      their behalf — surface this for ops review.
+ *   2. Find pending requests aged > 15 minutes → mark abandoned.
+ *   3. Fold any FAILED / REJECTED / REVOKED responses into the row's
+ *      status so the funnel-analysis surface is honest.
+ *
+ * This route is idempotent — re-running it is safe.
+ *
+ * Auth: Bearer ${CRON_SECRET}, same pattern as the other crons.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+  const now = new Date();
+  const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
+  const fifteenMinAgo = new Date(now.getTime() - 15 * 60 * 1000).toISOString();
+
+  let polled = 0;
+  let markedAbandoned = 0;
+  let markedFailed = 0;
+  let authoredButNoCallback = 0;
+
+  // ── Step 1: poll the still-young pending rows ──
+  const { data: youngPending, error: youngErr } = await admin
+    .from('yapily_pending_consent_requests')
+    .select('id, consent_request_id, user_id')
+    .eq('status', 'pending')
+    .lte('created_at', fiveMinAgo)
+    .gt('created_at', fifteenMinAgo);
+
+  if (youngErr) {
+    console.error('[yapily.abandonment] young-pending lookup failed:', youngErr.message);
+    return NextResponse.json({ error: 'lookup failed' }, { status: 500 });
+  }
+
+  for (const row of youngPending ?? []) {
+    polled++;
+    try {
+      const hosted = await getHostedConsentRequest(row.consent_request_id);
+      const status = (hosted.status || '').toUpperCase();
+      const updates: Record<string, unknown> = {
+        last_polled_at: now.toISOString(),
+        yapily_status: hosted.status ?? null,
+      };
+
+      if (status === 'FAILED' || status === 'REVOKED' || status === 'REJECTED') {
+        updates.status = 'failed';
+        updates.resolved_at = now.toISOString();
+        markedFailed++;
+      } else if (status === 'AUTHORIZED' || status === 'AUTHORISED') {
+        // Yapily reports success but our callback never persisted a
+        // connection. The user likely closed the tab between bank-side
+        // success and our callback. We CAN'T auto-create the connection
+        // without their session cookie — log so ops can reach out.
+        authoredButNoCallback++;
+        console.warn(
+          `[yapily.abandonment] consentRequestId=${row.consent_request_id} user=${row.user_id} authorised but no callback — flagged for ops`,
+        );
+      }
+      // else: still in flight, leave as 'pending'.
+
+      const { error: updErr } = await admin
+        .from('yapily_pending_consent_requests')
+        .update(updates)
+        .eq('id', row.id);
+      if (updErr) {
+        console.error(`[yapily.abandonment] row update failed for ${row.id}: ${updErr.message}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown';
+      console.error(`[yapily.abandonment] poll failed for ${row.consent_request_id}: ${msg}`);
+    }
+  }
+
+  // ── Step 2: any pending row older than 15 min is abandoned ──
+  const { data: stale, error: staleErr } = await admin
+    .from('yapily_pending_consent_requests')
+    .select('id')
+    .eq('status', 'pending')
+    .lte('created_at', fifteenMinAgo);
+
+  if (staleErr) {
+    console.error('[yapily.abandonment] stale lookup failed:', staleErr.message);
+  } else if (stale && stale.length > 0) {
+    const ids = stale.map((r: { id: string }) => r.id);
+    const { error: bulkErr } = await admin
+      .from('yapily_pending_consent_requests')
+      .update({ status: 'abandoned', resolved_at: now.toISOString() })
+      .in('id', ids);
+    if (bulkErr) {
+      console.error('[yapily.abandonment] bulk abandon update failed:', bulkErr.message);
+    } else {
+      markedAbandoned = ids.length;
+    }
+  }
+
+  console.log(
+    `[yapily.abandonment] complete — polled=${polled} abandoned=${markedAbandoned} failed=${markedFailed} no_callback_logged=${authoredButNoCallback}`,
+  );
+
+  return NextResponse.json({
+    ok: true,
+    polled,
+    markedAbandoned,
+    markedFailed,
+    authoredButNoCallback,
+  });
+}

--- a/src/app/api/yapily/callback/route.ts
+++ b/src/app/api/yapily/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { getAccounts } from '@/lib/yapily';
+import { createClient as createAdmin } from '@supabase/supabase-js';
+import { getAccounts, getHostedConsentRequest } from '@/lib/yapily';
 import { snapshotAccounts, upsertYapilyConnection } from '@/lib/yapily/connection-store';
 
 /**
@@ -29,15 +30,19 @@ export const maxDuration = 60;
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const consentToken = searchParams.get('consent');
-  // Yapily returns consent-id as both ?consent-id and (sometimes) as
-  // a separate field — we accept either query-param form. The id is
-  // distinct from the consent token: token is the credential we use
-  // for API calls, id identifies the consent for re-authorise.
-  const yapilyConsentId =
+  // Hosted Pages returns ONLY consentRequestId on the redirect — the
+  // consentToken comes from GET /hosted/consent-requests/{id} below.
+  // Legacy /account-auth-requests returns ?consent=<token>&consent-id=<id>.
+  // We detect which mode we're in by which params are present.
+  const consentRequestId =
+    searchParams.get('consentRequestId') ||
+    searchParams.get('consent-request-id') ||
+    '';
+  let consentToken = searchParams.get('consent') || '';
+  let yapilyConsentId =
     searchParams.get('consent-id') ||
     searchParams.get('consentId') ||
-    searchParams.get('id') ||
+    (consentRequestId ? '' : searchParams.get('id') || '') ||
     '';
   const state = searchParams.get('state');
   const errorParam = searchParams.get('error');
@@ -50,7 +55,9 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  if (!consentToken || !state) {
+  // We need either a consentToken (legacy) or a consentRequestId (hosted)
+  // and always need state for CSRF.
+  if ((!consentToken && !consentRequestId) || !state) {
     return NextResponse.redirect(
       new URL('/dashboard/money-hub?error=invalid_callback', request.url),
     );
@@ -80,6 +87,65 @@ export async function GET(request: NextRequest) {
 
   const institutionId = stateData.institutionId;
   const returnTo = stateData.returnTo || '/dashboard/money-hub';
+
+  // ── Hosted Pages: resolve consentToken + consentId from consentRequestId ──
+  // On the legacy flow Yapily puts both in the redirect query. On Hosted
+  // Pages we get only consentRequestId — fetch the rest before continuing.
+  // Tutorial step 4: check status before proceeding.
+  //
+  // Schema (verified against Yapily OpenAPI 12.3.4 on 29 Apr 2026):
+  //   data.consentRequestId  — the request handle (already in our query)
+  //   data.consentId         — the underlying consent identifier; the
+  //                             same shape /account-auth-requests/{id}
+  //                             accepts. THIS is what we persist into
+  //                             bank_connections.yapily_consent_id so
+  //                             renew + delete keep working.
+  //   data.consentToken      — the credential we attach to data calls.
+  //   data.status            — AUTHORIZED once the user has completed
+  //                             the bank-side flow.
+  if (consentRequestId && !consentToken) {
+    try {
+      const hosted = await getHostedConsentRequest(consentRequestId);
+      const hostedStatus = (hosted.status || '').toUpperCase();
+      if (hostedStatus !== 'AUTHORIZED' && hostedStatus !== 'AUTHORISED') {
+        console.warn(
+          `[yapily.callback] hosted consent ${consentRequestId} status=${hostedStatus} — redirecting user back to retry`,
+        );
+        return NextResponse.redirect(
+          new URL(`/dashboard/money-hub?error=hosted_consent_${hostedStatus.toLowerCase() || 'unknown'}`, request.url),
+        );
+      }
+      if (!hosted.consentToken) {
+        console.error(`[yapily.callback] hosted consent ${consentRequestId} authorised but no consentToken returned`);
+        return NextResponse.redirect(
+          new URL('/dashboard/money-hub?error=hosted_consent_token_missing', request.url),
+        );
+      }
+      if (!hosted.consentId) {
+        // AUTHORIZED responses MUST carry consentId per OpenAPI 12.3.4.
+        // If Yapily ever returns AUTHORIZED without one, we bail rather
+        // than persist the consentRequestId in the wrong slot — the
+        // renew + disconnect flows would silently break otherwise.
+        console.error(`[yapily.callback] hosted consent ${consentRequestId} authorised but no consentId returned`);
+        return NextResponse.redirect(
+          new URL('/dashboard/money-hub?error=hosted_consent_id_missing', request.url),
+        );
+      }
+      consentToken = hosted.consentToken;
+      yapilyConsentId = hosted.consentId;
+    } catch (err) {
+      console.error(`[yapily.callback] hosted consent fetch failed for ${consentRequestId}:`, err);
+      return NextResponse.redirect(
+        new URL('/dashboard/money-hub?error=hosted_consent_fetch_failed', request.url),
+      );
+    }
+  }
+
+  if (!consentToken) {
+    return NextResponse.redirect(
+      new URL('/dashboard/money-hub?error=invalid_callback', request.url),
+    );
+  }
 
   // ── Fetch the accounts the user just authorised ──
   let accounts: Awaited<ReturnType<typeof getAccounts>>;
@@ -113,6 +179,7 @@ export async function GET(request: NextRequest) {
       bankName,
       consentToken,
       yapilyConsentId,
+      yapilyConsentRequestId: consentRequestId || null,
       consentExpiresAt,
       accounts: accountSnapshots,
     });
@@ -128,6 +195,25 @@ export async function GET(request: NextRequest) {
     `[yapily.callback] ${upsertResult.reused ? 'reused' : 'inserted'} connection ${upsertResult.connectionId}` +
     (upsertResult.previousConnectionIds.length ? ` (demoted ${upsertResult.previousConnectionIds.length} stale rows)` : ''),
   );
+
+  // ── Mark the pending Hosted Pages request resolved (if any) ──
+  // The abandonment poller treats anything still 'pending' after 15 min
+  // as abandoned. Closing the loop here keeps its working set small.
+  if (consentRequestId) {
+    try {
+      const adminBg = createAdmin(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      );
+      await adminBg
+        .from('yapily_pending_consent_requests')
+        .update({ status: 'completed', resolved_at: new Date().toISOString() })
+        .eq('consent_request_id', consentRequestId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown';
+      console.error(`[yapily.callback] pending row update failed (non-fatal): ${msg}`);
+    }
+  }
 
   // ── Award loyalty points ──
   import('@/lib/loyalty')

--- a/src/app/api/yapily/initial-sync/route.ts
+++ b/src/app/api/yapily/initial-sync/route.ts
@@ -50,22 +50,55 @@ export async function POST(request: NextRequest) {
 
   const supabase = getAdmin();
 
-  const twelveMonthsAgo = new Date();
-  twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
-  const fromDate = twelveMonthsAgo.toISOString().split('T')[0];
+  // Yapily's 5-minute deadline (Migle, 29 Apr): if historical
+  // transactions older than 90 days aren't pulled within 5 minutes
+  // of consent grant, some banks return 403 and force a fresh
+  // consent. Our maxDuration matches that ceiling, but a multi-
+  // account bank with 12 months of paginated data can easily
+  // overflow.
+  //
+  // Two-pass strategy:
+  //   PASS 1 — last 90 days for every account first. Always within
+  //   the 5-min window, always succeeds, gives the user the bulk
+  //   of useful data immediately.
+  //
+  //   PASS 2 — 91-365 days for each account. Best-effort, gated
+  //   by elapsed time. Stops at 4m30s (270s) so we exit cleanly
+  //   before the function's 5-min ceiling AND before Yapily's
+  //   server-side deadline. Accounts that didn't get older history
+  //   are logged loudly so we can backfill via consent renewal or
+  //   a follow-up sync.
+  const HISTORICAL_BUDGET_MS = 270 * 1000; // 4m30s — safety margin under Yapily's 5min
+  const startedAt = Date.now();
 
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
   const toDate = tomorrow.toISOString().split('T')[0];
 
+  const ninetyDaysAgo = new Date();
+  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+  const ninetyDaysAgoIso = ninetyDaysAgo.toISOString().split('T')[0];
+
+  const twelveMonthsAgo = new Date();
+  twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
+  const twelveMonthsAgoIso = twelveMonthsAgo.toISOString().split('T')[0];
+
   let totalInserted = 0;
   let totalDuplicateSkipped = 0;
   let totalNoHashSkipped = 0;
   let apiCallsMade = 0;
+  let historicalSkipped = 0;
 
+  // PASS 1 — last 90 days for every account. Sequential per
+  // Migle's "wait for response before next request" rule.
   for (const account of accountSnapshots) {
     try {
-      const transactions = await getTransactions(account.yapilyAccountId, consentToken, fromDate, toDate);
+      const transactions = await getTransactions(
+        account.yapilyAccountId,
+        consentToken,
+        ninetyDaysAgoIso,
+        toDate,
+      );
       apiCallsMade++;
       if (transactions.length === 0) continue;
 
@@ -79,7 +112,43 @@ export async function POST(request: NextRequest) {
       totalDuplicateSkipped += result.skippedAsDuplicate;
       totalNoHashSkipped += result.skippedNoHash;
     } catch (err) {
-      console.error(`[yapily.initial-sync] account ${account.yapilyAccountId} failed:`, err);
+      console.error(`[yapily.initial-sync] pass1 account ${account.yapilyAccountId} failed:`, err);
+    }
+  }
+
+  // PASS 2 — older history (-91d to -365d). Time-budget gated so
+  // we never blow Yapily's 5-min historical window. The day-90
+  // boundary is exclusive on the older side (bank's day -90 is
+  // already in pass 1) and inclusive on the older side at -365.
+  for (const account of accountSnapshots) {
+    if (Date.now() - startedAt > HISTORICAL_BUDGET_MS) {
+      historicalSkipped++;
+      console.warn(
+        `[yapily.initial-sync] pass2 budget exhausted — skipping older history for account=${account.yapilyAccountId}`,
+      );
+      continue;
+    }
+    try {
+      const transactions = await getTransactions(
+        account.yapilyAccountId,
+        consentToken,
+        twelveMonthsAgoIso,
+        ninetyDaysAgoIso,
+      );
+      apiCallsMade++;
+      if (transactions.length === 0) continue;
+
+      const result = await upsertYapilyTransactions({
+        userId,
+        connectionId,
+        account,
+        transactions,
+      });
+      totalInserted += result.inserted;
+      totalDuplicateSkipped += result.skippedAsDuplicate;
+      totalNoHashSkipped += result.skippedNoHash;
+    } catch (err) {
+      console.error(`[yapily.initial-sync] pass2 account ${account.yapilyAccountId} failed:`, err);
     }
   }
 
@@ -125,7 +194,8 @@ export async function POST(request: NextRequest) {
 
   console.log(
     `[yapily.initial-sync] complete: inserted=${totalInserted}, dup_skipped=${totalDuplicateSkipped}, ` +
-    `no_hash_skipped=${totalNoHashSkipped}, accounts=${accountSnapshots.length}, api_calls=${apiCallsMade}`,
+    `no_hash_skipped=${totalNoHashSkipped}, accounts=${accountSnapshots.length}, api_calls=${apiCallsMade}, ` +
+    `historical_skipped=${historicalSkipped}, elapsed_ms=${Date.now() - startedAt}`,
   );
 
   // Push newly-synced transactions to the user's connected Google Sheet (if any).
@@ -137,5 +207,7 @@ export async function POST(request: NextRequest) {
     duplicatesSkipped: totalDuplicateSkipped,
     noHashSkipped: totalNoHashSkipped,
     apiCalls: apiCallsMade,
+    historicalSkipped,
+    elapsedMs: Date.now() - startedAt,
   });
 }

--- a/src/lib/yapily.test.ts
+++ b/src/lib/yapily.test.ts
@@ -1,0 +1,381 @@
+// src/lib/yapily.test.ts
+//
+// Unit tests for the Yapily helpers. Run with Node's built-in test
+// runner (same pattern as src/lib/category-taxonomy.test.ts):
+//
+//   node --experimental-strip-types --test src/lib/yapily.test.ts
+//
+// We mock globalThis.fetch per-test so we can assert on the request
+// shape (URL, headers, body) and shape the response. Yapily is never
+// hit during tests.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createHostedConsentRequest,
+  getHostedConsentRequest,
+  deleteConsent,
+  isHostedPagesEnabled,
+} from './yapily.ts';
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+let originalFetch: typeof fetch;
+let originalUuid: string | undefined;
+let originalSecret: string | undefined;
+let recorded: RecordedCall[] = [];
+
+function setEnvFor(testCase: () => void): void {
+  process.env.YAPILY_APPLICATION_UUID = 'test-uuid';
+  process.env.YAPILY_APPLICATION_SECRET = 'test-secret';
+  testCase();
+}
+
+function mockFetch(
+  status: number,
+  body: unknown,
+): typeof fetch {
+  return (async (input: FetchInput, init?: FetchInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    let parsedBody: unknown;
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        parsedBody = JSON.parse(init.body);
+      } catch {
+        parsedBody = init.body;
+      }
+    }
+    const headersObj: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const k of Object.keys(h)) headersObj[k] = h[k];
+    }
+    recorded.push({
+      url,
+      method: (init?.method as string) || 'GET',
+      headers: headersObj,
+      body: parsedBody,
+    });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalUuid = process.env.YAPILY_APPLICATION_UUID;
+  originalSecret = process.env.YAPILY_APPLICATION_SECRET;
+  recorded = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalUuid !== undefined) process.env.YAPILY_APPLICATION_UUID = originalUuid;
+  else delete process.env.YAPILY_APPLICATION_UUID;
+  if (originalSecret !== undefined) process.env.YAPILY_APPLICATION_SECRET = originalSecret;
+  else delete process.env.YAPILY_APPLICATION_SECRET;
+});
+
+describe('isHostedPagesEnabled', () => {
+  const originalFlag = process.env.YAPILY_HOSTED_PAGES_ENABLED;
+
+  it('returns false when the flag is absent', () => {
+    delete process.env.YAPILY_HOSTED_PAGES_ENABLED;
+    assert.equal(isHostedPagesEnabled(), false);
+  });
+
+  it('returns false for arbitrary non-true values', () => {
+    process.env.YAPILY_HOSTED_PAGES_ENABLED = 'yes';
+    assert.equal(isHostedPagesEnabled(), false);
+    process.env.YAPILY_HOSTED_PAGES_ENABLED = '1';
+    assert.equal(isHostedPagesEnabled(), false);
+  });
+
+  it('returns true only for the exact string "true" (case-insensitive)', () => {
+    process.env.YAPILY_HOSTED_PAGES_ENABLED = 'true';
+    assert.equal(isHostedPagesEnabled(), true);
+    process.env.YAPILY_HOSTED_PAGES_ENABLED = 'TRUE';
+    assert.equal(isHostedPagesEnabled(), true);
+  });
+
+  if (originalFlag === undefined) delete process.env.YAPILY_HOSTED_PAGES_ENABLED;
+  else process.env.YAPILY_HOSTED_PAGES_ENABLED = originalFlag;
+});
+
+describe('createHostedConsentRequest', () => {
+  it('POSTs the canonical Hosted Pages body shape', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      meta: { tracingId: 't-1' },
+      data: {
+        consentRequestId: 'consent-req-123',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'natwest', institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/abc',
+      },
+    });
+
+    const result = await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback?state=xx',
+      institutionCountryCode: 'GB',
+      institutionId: 'natwest',
+      language: 'EN',
+      location: 'GB',
+    });
+
+    assert.equal(result.consentRequestId, 'consent-req-123');
+    assert.equal(result.hostedUrl, 'https://hosted.yapily.com/abc');
+    assert.equal(recorded.length, 1);
+    const call = recorded[0]!;
+    assert.equal(call.method, 'POST');
+    assert.match(call.url, /\/hosted\/consent-requests$/);
+    assert.match(call.headers['Authorization'] ?? '', /^Basic /);
+    const body = call.body as Record<string, unknown>;
+    assert.equal(body.redirectUrl, 'https://paybacker.co.uk/api/yapily/callback?state=xx');
+    assert.equal(body.applicationUserId, 'user-abc');
+    assert.deepEqual(body.institutionIdentifiers, {
+      institutionCountryCode: 'GB',
+      institutionId: 'natwest',
+    });
+    assert.deepEqual(body.userSettings, { language: 'EN', location: 'GB' });
+  });
+
+  it('omits institutionId when not provided (lets Yapily render bank-picker)', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-456',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/def',
+      },
+    });
+
+    await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+      institutionCountryCode: 'GB',
+    });
+
+    const body = recorded[0]!.body as Record<string, unknown>;
+    assert.deepEqual(body.institutionIdentifiers, { institutionCountryCode: 'GB' });
+  });
+
+  it('defaults language=EN and location=GB when caller omits them', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-789',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'hsbc', institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/ghi',
+      },
+    });
+
+    await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+      institutionCountryCode: 'GB',
+      institutionId: 'hsbc',
+    });
+
+    const body = recorded[0]!.body as Record<string, unknown>;
+    assert.deepEqual(body.userSettings, { language: 'EN', location: 'GB' });
+  });
+
+  it('passes featureScope through accountRequest, not at the top level', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-fs',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'natwest', institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/jkl',
+      },
+    });
+
+    await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+      institutionCountryCode: 'GB',
+      institutionId: 'natwest',
+      featureScope: ['ACCOUNT_DIRECT_DEBITS', 'ACCOUNT_PERIODIC_PAYMENTS'],
+    });
+
+    const body = recorded[0]!.body as Record<string, unknown>;
+    // Top-level featureScope is NOT in the OpenAPI — it lives inside
+    // accountRequest, which is mirrored back as accountRequestDetails
+    // on the response.
+    assert.equal('featureScope' in body, false);
+    assert.deepEqual(
+      (body.accountRequest as Record<string, unknown>).featureScope,
+      ['ACCOUNT_DIRECT_DEBITS', 'ACCOUNT_PERIODIC_PAYMENTS'],
+    );
+  });
+
+  it('omits accountRequest entirely when no scopes / dates are passed', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-noar',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/mno',
+      },
+    });
+
+    await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+      institutionCountryCode: 'GB',
+    });
+
+    const body = recorded[0]!.body as Record<string, unknown>;
+    assert.equal('accountRequest' in body, false);
+  });
+
+  it('throws when Yapily returns a 200 with no hostedUrl', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-bad',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'natwest', institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        createHostedConsentRequest({
+          applicationUserId: 'user-abc',
+          redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+          institutionCountryCode: 'GB',
+        }),
+      /hostedUrl/,
+    );
+  });
+
+  it('surfaces Yapily error messages on non-2xx', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(400, {
+      error: {
+        code: 400,
+        status: 'Bad Request',
+        message: 'institutionCountryCode is required',
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        createHostedConsentRequest({
+          applicationUserId: 'user-abc',
+          redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+          institutionCountryCode: '',
+        }),
+      /institutionCountryCode is required/,
+    );
+  });
+});
+
+describe('getHostedConsentRequest', () => {
+  it('GETs /hosted/consent-requests/{id} and returns the consent record', async () => {
+    setEnvFor(() => {});
+    // Per Yapily OpenAPI 12.3.4: AUTHORIZED responses surface
+    // consentRequestId, consentId (used by /account-auth-requests/{id}),
+    // and consentToken (used as the data-call header).
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-123',
+        consentId: 'b22a1fe6-1e91-45b3-8ba0-6fdb1708e7bd',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'natwest', institutionCountryCode: 'GB' },
+        status: 'AUTHORIZED',
+        createdAt: '2026-04-29T10:00:00Z',
+        consentToken: 'eyJjb25zZW50dG9rZW4iLi4u',
+      },
+    });
+
+    const result = await getHostedConsentRequest('consent-req-123');
+
+    assert.equal(result.consentRequestId, 'consent-req-123');
+    assert.equal(result.consentId, 'b22a1fe6-1e91-45b3-8ba0-6fdb1708e7bd');
+    assert.equal(result.status, 'AUTHORIZED');
+    assert.equal(result.consentToken, 'eyJjb25zZW50dG9rZW4iLi4u');
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.method, 'GET');
+    assert.match(recorded[0]!.url, /\/hosted\/consent-requests\/consent-req-123$/);
+  });
+
+  it('surfaces error message on non-2xx (e.g. expired hostedUrl)', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(404, {
+      error: {
+        code: 404,
+        status: 'Not Found',
+        message: 'consent request not found',
+      },
+    });
+
+    await assert.rejects(
+      () => getHostedConsentRequest('missing-id'),
+      /consent request not found/,
+    );
+  });
+});
+
+describe('deleteConsent', () => {
+  it('DELETEs /account-auth-requests/{id}', async () => {
+    setEnvFor(() => {});
+    // Yapily returns 200 on a successful delete in the API; we test
+    // both that and the 404-already-gone path below. A test using 204
+    // wouldn't work — the global Response constructor refuses a 204
+    // with a body, which the mockFetch helper always emits.
+    globalThis.fetch = mockFetch(200, {});
+
+    await deleteConsent('consent-abc');
+
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.method, 'DELETE');
+    assert.match(recorded[0]!.url, /\/account-auth-requests\/consent-abc$/);
+    assert.match(recorded[0]!.headers['Authorization'] ?? '', /^Basic /);
+  });
+
+  it('treats 404 as success (consent already gone)', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(404, {
+      error: { code: 404, status: 'Not Found', message: 'gone' },
+    });
+
+    // No throw — Yapily-side absence IS the desired end state.
+    await deleteConsent('consent-already-gone');
+  });
+
+  it('throws on other non-2xx responses', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(500, {
+      error: { code: 500, status: 'Internal Server Error', message: 'boom' },
+    });
+
+    await assert.rejects(
+      () => deleteConsent('consent-broken'),
+      /boom|delete-consent error/,
+    );
+  });
+});

--- a/src/lib/yapily.test.ts
+++ b/src/lib/yapily.test.ts
@@ -341,7 +341,7 @@ describe('getHostedConsentRequest', () => {
 });
 
 describe('deleteConsent', () => {
-  it('DELETEs /account-auth-requests/{id}', async () => {
+  it('DELETEs /consents/{id}', async () => {
     setEnvFor(() => {});
     // Yapily returns 200 on a successful delete in the API; we test
     // both that and the 404-already-gone path below. A test using 204
@@ -353,7 +353,7 @@ describe('deleteConsent', () => {
 
     assert.equal(recorded.length, 1);
     assert.equal(recorded[0]!.method, 'DELETE');
-    assert.match(recorded[0]!.url, /\/account-auth-requests\/consent-abc$/);
+    assert.match(recorded[0]!.url, /\/consents\/consent-abc$/);
     assert.match(recorded[0]!.headers['Authorization'] ?? '', /^Basic /);
   });
 

--- a/src/lib/yapily.ts
+++ b/src/lib/yapily.ts
@@ -5,6 +5,8 @@ import type {
   YapilyApiResponse,
   YapilyAuthResponse,
   YapilyErrorResponse,
+  YapilyHostedConsentRequest,
+  YapilyHostedConsentResponse,
 } from '@/types/yapily';
 
 const YAPILY_BASE_URL = 'https://api.yapily.com';
@@ -50,16 +52,32 @@ async function yapilyRequest<T>(
   });
 
   if (!res.ok) {
+    // Tracing-Id capture (Vitally Support requirement). Yapily surfaces
+    // it in two places — pluck both so however ops finds the failure
+    // (Sentry, Telegram, Vercel logs) the ID is right there in the
+    // message and there's no chasing a separate header lookup.
     let errorMessage = `Yapily API error: ${res.status} ${res.statusText}`;
+    let tracingId: string | undefined;
     try {
       const errorBody = (await res.json()) as YapilyErrorResponse;
+      tracingId = errorBody.error?.tracingId;
       if (errorBody.error?.message) {
         errorMessage = `Yapily API error: ${errorBody.error.message} (${res.status})`;
       }
     } catch {
       // Body not parseable — use default message
     }
-    throw new Error(errorMessage);
+    if (!tracingId) {
+      // Some auth + 5xx paths short-circuit before the JSON body —
+      // fall back to the response header Yapily includes on every
+      // request.
+      tracingId = res.headers.get('Tracing-Id') || res.headers.get('tracing-id') || undefined;
+    }
+    if (tracingId) errorMessage += ` [tracingId=${tracingId}]`;
+    const err = new Error(errorMessage) as Error & { status?: number; tracingId?: string };
+    err.status = res.status;
+    err.tracingId = tracingId;
+    throw err;
   }
 
   return res.json() as Promise<T>;
@@ -67,10 +85,23 @@ async function yapilyRequest<T>(
 
 // ── Institutions ──
 
+// Module-level cache of the full Yapily institution list. Sized small
+// enough to live in any Vercel function instance and refreshed at most
+// once per hour. Per-instance caching is fine for this surface — the
+// data is stable, the worst case is a few extra API calls when a fresh
+// instance boots, and Yapily's recommendation is "refresh once a week"
+// (we go more aggressive for safety).
+const FEATURE_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+let _institutionsCache: { value: YapilyInstitution[]; loadedAt: number } | null = null;
+
 /**
- * Fetches all Yapily-supported institutions, filtered to UK only (country code GB).
+ * Fetches all Yapily-supported institutions, filtered to UK only
+ * (country code GB). Cached for 1 hour at the module level.
  */
 export async function getInstitutions(): Promise<YapilyInstitution[]> {
+  if (_institutionsCache && Date.now() - _institutionsCache.loadedAt < FEATURE_CACHE_TTL_MS) {
+    return _institutionsCache.value;
+  }
   const response = await yapilyRequest<YapilyApiResponse<YapilyInstitution[]>>(
     '/institutions'
   );
@@ -78,9 +109,48 @@ export async function getInstitutions(): Promise<YapilyInstitution[]> {
   const institutions = response.data || [];
 
   // Filter to UK institutions only
-  return institutions.filter((inst) =>
+  const uk = institutions.filter((inst) =>
     inst.countries?.some((c) => c.countryCode2 === 'GB')
   );
+  _institutionsCache = { value: uk, loadedAt: Date.now() };
+  return uk;
+}
+
+/**
+ * Returns the Yapily feature flags exposed by a given institution.
+ * Backed by the same cache as getInstitutions(). On a cache miss or
+ * an unknown institution returns an empty array — callers should
+ * treat absence as "feature unsupported".
+ *
+ * Source of feature names: Yapily institution metadata. Examples:
+ *   ACCOUNT_DIRECT_DEBITS, ACCOUNT_PERIODIC_PAYMENTS,
+ *   ACCOUNT_SCHEDULED_PAYMENTS, ACCOUNT_TRANSACTIONS,
+ *   INITIATE_DOMESTIC_SINGLE_PAYMENT, etc.
+ */
+export async function getInstitutionFeatures(institutionId: string): Promise<string[]> {
+  if (!institutionId) return [];
+  try {
+    const all = await getInstitutions();
+    const match = all.find((i) => i.id === institutionId);
+    return match?.features ?? [];
+  } catch (err) {
+    console.error('[yapily.getInstitutionFeatures] failed', err);
+    return [];
+  }
+}
+
+/**
+ * Returns true if `institutionId` exposes `feature`. Defaults to false
+ * on any lookup failure — Migle's spec says ~70% of UK banks support
+ * the upcoming-payments endpoints, so the safe default is to skip the
+ * call when in doubt rather than burn an API quota on a 404.
+ */
+export async function supportsFeature(
+  institutionId: string,
+  feature: string,
+): Promise<boolean> {
+  const features = await getInstitutionFeatures(institutionId);
+  return features.includes(feature);
 }
 
 // ── Account Authorisation ──
@@ -210,6 +280,201 @@ export async function getConsent(
     `/account-auth-requests/${consentId}`,
   );
   return response.data;
+}
+
+// ── Hosted Pages (Beta) ──
+//
+// Migle's onboarding plan (29 Apr 2026) requires the Hosted Pages flow
+// for build sign-off. Tutorial:
+//   https://docs.yapily.com/tools-and-services/hosted-pages/payment-tutorial-hosted-data
+//
+// Flow:
+//   1. POST /hosted/consent-requests → { hostedUrl, consentRequestId }
+//   2. Redirect user to hostedUrl (top-level, no iframe)
+//   3. User completes journey → Yapily redirects to redirectUrl with
+//      consentRequestId in query
+//   4. GET /hosted/consent-requests/{consentRequestId} → consentToken + status
+//   5. Use consentToken on /accounts and /transactions as before
+//
+// Both helpers below are guarded behind YAPILY_HOSTED_PAGES_ENABLED at
+// the call-site (src/app/api/auth/yapily/route.ts) — keeping the helpers
+// importable even when the flag is off so unit tests can exercise them.
+
+export interface CreateHostedConsentRequestInput {
+  /**
+   * The user's stable application id. We pass profile.id so Yapily can
+   * group multiple consents under the same end-user.
+   */
+  applicationUserId: string;
+  /**
+   * Where Yapily should send the user after the consent journey
+   * completes. Must include any state-bearing query params we care
+   * about — Yapily appends consentRequestId on top.
+   */
+  redirectUrl: string;
+  /**
+   * Two-letter country code for institutions allowed in this consent
+   * (Vitally checklist C1: must be set correctly per market).
+   */
+  institutionCountryCode: string;
+  /**
+   * Pre-select a specific institution so Yapily skips its own
+   * bank-picker UI. We render our own institution list, so we always
+   * pass this when the user has chosen.
+   */
+  institutionId?: string;
+  /**
+   * Two-letter language code for the hosted UI (default 'EN').
+   */
+  language?: string;
+  /**
+   * Two-letter location code for the hosted UI (default 'GB').
+   */
+  location?: string;
+  /**
+   * Yapily AccountRequest scopes — passed via the `accountRequest`
+   * field per the OpenAPI spec (mirrored back as `accountRequestDetails`
+   * on the response). Use to request ACCOUNT_SCHEDULED_PAYMENTS /
+   * ACCOUNT_PERIODIC_PAYMENTS / ACCOUNT_DIRECT_DEBITS etc. Omitted by
+   * default — Yapily applies sensible AIS defaults.
+   */
+  featureScope?: readonly string[];
+  /**
+   * Earliest transaction date to make available on this consent.
+   * Optional; useful for retrieving older history on banks that
+   * support it.
+   */
+  transactionFrom?: string;
+  /**
+   * Latest transaction date to make available on this consent.
+   * Optional.
+   */
+  transactionTo?: string;
+}
+
+/**
+ * Creates a hosted consent request. Returns the hostedUrl (short-lived,
+ * ~10min) the user must be redirected to plus the consentRequestId
+ * we'll use to look up status after the user completes the flow.
+ *
+ * NOTE on the response shape: per the Yapily OpenAPI 12.3.4, the POST
+ * response carries `consentRequestId` + `hostedUrl` but does NOT carry
+ * `consentId` or `consentToken` — those are only populated on the GET
+ * once the user has completed the bank-side journey. Don't try to
+ * persist them from this call.
+ */
+export async function createHostedConsentRequest(
+  input: CreateHostedConsentRequestInput,
+): Promise<YapilyHostedConsentRequest> {
+  const body: Record<string, unknown> = {
+    redirectUrl: input.redirectUrl,
+    institutionIdentifiers: {
+      institutionCountryCode: input.institutionCountryCode,
+      ...(input.institutionId ? { institutionId: input.institutionId } : {}),
+    },
+    applicationUserId: input.applicationUserId,
+    userSettings: {
+      language: input.language ?? 'EN',
+      location: input.location ?? 'GB',
+    },
+  };
+
+  // accountRequest (request side) ↔ accountRequestDetails (response
+  // side). Only emit it when at least one nested field is set so the
+  // serialised body stays minimal.
+  const accountRequest: Record<string, unknown> = {};
+  if (input.featureScope && input.featureScope.length) {
+    accountRequest.featureScope = Array.from(input.featureScope);
+  }
+  if (input.transactionFrom) accountRequest.transactionFrom = input.transactionFrom;
+  if (input.transactionTo) accountRequest.transactionTo = input.transactionTo;
+  if (Object.keys(accountRequest).length) body.accountRequest = accountRequest;
+
+  const response = await yapilyRequest<YapilyHostedConsentResponse>(
+    '/hosted/consent-requests',
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.data?.hostedUrl) {
+    throw new Error('Yapily did not return a hostedUrl for the consent request');
+  }
+  if (!response.data.consentRequestId) {
+    throw new Error('Yapily did not return a consentRequestId');
+  }
+  return response.data;
+}
+
+/**
+ * Reads the current state of a hosted consent request. After Yapily
+ * redirects back to our app we call this to confirm status before
+ * proceeding (recommended by the tutorial). Also used by the
+ * abandonment poller for users who don't return to the callback URL.
+ */
+export async function getHostedConsentRequest(
+  consentRequestId: string,
+): Promise<YapilyHostedConsentRequest> {
+  const response = await yapilyRequest<YapilyHostedConsentResponse>(
+    `/hosted/consent-requests/${consentRequestId}`,
+  );
+  return response.data;
+}
+
+/**
+ * Single source of truth for whether the Hosted Pages flow is on. Read
+ * once per request — the flag is meant to be flipped via env, not
+ * mid-process. Defaults to false so existing /account-auth-requests
+ * code stays the canonical path until we cut over.
+ */
+export function isHostedPagesEnabled(): boolean {
+  return process.env.YAPILY_HOSTED_PAGES_ENABLED?.toLowerCase() === 'true';
+}
+
+// ── Consent Deletion ──
+
+/**
+ * Revokes a consent on Yapily's side. Required by Migle for the
+ * compliance build review — the user-facing disconnect button must
+ * actually call Yapily, not just flip a local flag.
+ *
+ * Idempotent on Yapily's side: a 404 means the consent is already
+ * gone, which is what we wanted anyway. Callers should treat 404 as
+ * success and only surface other failures.
+ */
+export async function deleteConsent(consentId: string): Promise<void> {
+  const url = `${YAPILY_BASE_URL}/account-auth-requests/${consentId}`;
+
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      Authorization: getAuthHeader(),
+      'Content-Type': 'application/json',
+    },
+  });
+
+  // 404 = already revoked → success.
+  if (res.status === 404) return;
+
+  if (!res.ok) {
+    let errorMessage = `Yapily delete-consent error: ${res.status} ${res.statusText}`;
+    let tracingId: string | undefined;
+    try {
+      const errorBody = (await res.json()) as YapilyErrorResponse;
+      tracingId = errorBody.error?.tracingId;
+      if (errorBody.error?.message) {
+        errorMessage = `Yapily delete-consent error: ${errorBody.error.message} (${res.status})`;
+      }
+    } catch {
+      // body not parseable — keep default message
+    }
+    if (!tracingId) {
+      tracingId = res.headers.get('Tracing-Id') || res.headers.get('tracing-id') || undefined;
+    }
+    if (tracingId) errorMessage += ` [tracingId=${tracingId}]`;
+    throw new Error(errorMessage);
+  }
 }
 
 // ── Account-identity helpers ──

--- a/src/lib/yapily.ts
+++ b/src/lib/yapily.ts
@@ -250,22 +250,34 @@ export async function getTransactions(
 
 /**
  * Reconfirms (extends) an existing consent for the UK 90-day renewal cycle.
- * Uses PUT /account-auth-requests/{consentId}. Preserves the consent-id
- * and consent-token — no new connection row should be created on our
- * side after a successful reconfirm.
+ * Uses POST /consents/{consentId}/extend per Migle (6 May 2026) — the
+ * /account-auth-requests/{consentId} path with PUT was the legacy one and
+ * isn't part of the current API surface. Preserves the consentId and
+ * consentToken; no new connection row should be created on our side after
+ * a successful extend.
+ *
+ * Aliased as extendConsent below — same operation, more accurate name —
+ * so call sites can pick whichever reads clearer in context.
  */
 export async function reconfirmConsent(
   consentId: string
 ): Promise<YapilyAuthResponse['data']> {
   const response = await yapilyRequest<YapilyAuthResponse>(
-    `/account-auth-requests/${consentId}`,
+    `/consents/${consentId}/extend`,
     {
-      method: 'PUT',
+      method: 'POST',
     }
   );
 
   return response.data;
 }
+
+/**
+ * Alias of reconfirmConsent — POST /consents/{consentId}/extend. Use
+ * this name in 403-retry flows where "extend" reads more naturally
+ * than "reconfirm" (the API call is identical).
+ */
+export const extendConsent = reconfirmConsent;
 
 /**
  * Returns the metadata for an account-auth-request (consent), including
@@ -277,7 +289,7 @@ export async function getConsent(
   consentId: string
 ): Promise<YapilyAuthResponse['data']> {
   const response = await yapilyRequest<YapilyAuthResponse>(
-    `/account-auth-requests/${consentId}`,
+    `/consents/${consentId}`,
   );
   return response.data;
 }
@@ -444,7 +456,7 @@ export function isHostedPagesEnabled(): boolean {
  * success and only surface other failures.
  */
 export async function deleteConsent(consentId: string): Promise<void> {
-  const url = `${YAPILY_BASE_URL}/account-auth-requests/${consentId}`;
+  const url = `${YAPILY_BASE_URL}/consents/${consentId}`;
 
   const res = await fetch(url, {
     method: 'DELETE',
@@ -497,4 +509,61 @@ export function buildYapilyAccountDisplayName(account: import('@/types/yapily').
     account.type ||
     'Account'
   );
+}
+
+// ── 403 extend-first wrapper ──
+//
+// Migle (6 May 2026): when /accounts (or any consent-protected GET)
+// returns 403, the right behaviour is to call POST
+// /consents/{consentId}/extend FIRST, retry the original call once,
+// and only if THAT also 403s should the caller trigger a full
+// re-consent via POST /hosted/consent-requests. This wrapper
+// encapsulates that pattern — wrap any consent-protected call you
+// want self-healing.
+//
+// Throws ConsentExpiredError when extend → retry still 403s, so the
+// caller can flip the bank_connection to expired and surface the
+// reconfirm-consent UI.
+
+export class ConsentExpiredError extends Error {
+  consentId: string;
+  originalStatus: number;
+  constructor(consentId: string, originalStatus: number) {
+    super(`Consent ${consentId} expired beyond extend (got ${originalStatus} twice)`);
+    this.name = 'ConsentExpiredError';
+    this.consentId = consentId;
+    this.originalStatus = originalStatus;
+  }
+}
+
+function isYapily403(err: unknown): err is Error & { status?: number } {
+  return err instanceof Error && (err as Error & { status?: number }).status === 403;
+}
+
+export async function withConsentRetry<T>(
+  consentId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isYapily403(err)) throw err;
+    // First 403 → try extend.
+    try {
+      await extendConsent(consentId);
+    } catch (extendErr) {
+      // If extend itself fails, surface the original 403 — extend is
+      // best-effort.
+      throw new ConsentExpiredError(consentId, 403);
+    }
+    // Extend succeeded; retry once.
+    try {
+      return await fn();
+    } catch (retryErr) {
+      if (isYapily403(retryErr)) {
+        throw new ConsentExpiredError(consentId, 403);
+      }
+      throw retryErr;
+    }
+  }
 }

--- a/src/lib/yapily/connection-store.ts
+++ b/src/lib/yapily/connection-store.ts
@@ -56,15 +56,31 @@ export interface AccountSnapshot {
  * Project a Yapily account list into the snapshot shape the rest of
  * this module operates on. Computed once in the callback, passed to
  * the sync — keeps the hashing logic in one place.
+ *
+ * Suppresses Monzo "POT" accounts. Per Yapily docs (Vitally GA2):
+ * Monzo doesn't return transaction data for type=POT, so they show
+ * up as ghost accounts in the UI with eternally-empty histories.
+ * We hide them here so they never enter bank_connections.account_ids,
+ * never appear in the dashboard, and aren't fetched by any sync.
  */
 export function snapshotAccounts(accounts: YapilyAccount[]): AccountSnapshot[] {
-  return accounts.map((a) => ({
-    yapilyAccountId: a.id,
-    displayName: buildYapilyAccountDisplayName(a),
-    accountIdentificationsHash: buildAccountIdentificationsHash(a.accountIdentifications || []),
-    accountIdentificationsRaw: a.accountIdentifications || [],
-    currency: a.currency || 'GBP',
-  }));
+  return accounts
+    .filter((a) => {
+      const t = (a.type ?? '').toUpperCase();
+      const at = (a.accountType ?? '').toUpperCase();
+      const isPot = t === 'POT' || at === 'POT';
+      if (isPot) {
+        console.log(`[yapily.snapshotAccounts] skipping Monzo POT account id=${a.id}`);
+      }
+      return !isPot;
+    })
+    .map((a) => ({
+      yapilyAccountId: a.id,
+      displayName: buildYapilyAccountDisplayName(a),
+      accountIdentificationsHash: buildAccountIdentificationsHash(a.accountIdentifications || []),
+      accountIdentificationsRaw: a.accountIdentifications || [],
+      currency: a.currency || 'GBP',
+    }));
 }
 
 export interface ConnectionUpsertInput {
@@ -73,6 +89,14 @@ export interface ConnectionUpsertInput {
   bankName: string | null;
   consentToken: string;
   yapilyConsentId: string;
+  /**
+   * Hosted Pages flow only — the consentRequestId Yapily returned from
+   * POST /hosted/consent-requests. Distinct from yapilyConsentId; we
+   * keep both so the renew flow keeps using consentId while the
+   * abandonment poller uses consentRequestId. Optional so the legacy
+   * /account-auth-requests path stays a no-op.
+   */
+  yapilyConsentRequestId?: string | null;
   consentExpiresAt: string;
   accounts: AccountSnapshot[];
 }
@@ -153,8 +177,15 @@ export async function upsertYapilyConnection(
         bank_name: input.bankName,
         consent_token: encrypt(input.consentToken),
         yapily_consent_id: input.yapilyConsentId,
+        ...(input.yapilyConsentRequestId !== undefined
+          ? { yapily_consent_request_id: input.yapilyConsentRequestId }
+          : {}),
         consent_granted_at: now,
         consent_expires_at: input.consentExpiresAt,
+        // Reset the single-use tracking flag — a reconnect means a new
+        // consent, so the upcoming-payments endpoints become callable
+        // again. Null is the "ready to pull" sentinel the cron checks.
+        upcoming_endpoints_fetched_at: null,
         account_ids: incomingAccountIds,
         account_display_names: incomingDisplayNames,
         account_identifications_hashes: incomingHashes.length === incomingAccountIds.length
@@ -208,6 +239,9 @@ export async function upsertYapilyConnection(
       bank_name: input.bankName,
       consent_token: encrypt(input.consentToken),
       yapily_consent_id: input.yapilyConsentId,
+      ...(input.yapilyConsentRequestId !== undefined
+        ? { yapily_consent_request_id: input.yapilyConsentRequestId }
+        : {}),
       consent_granted_at: now,
       consent_expires_at: input.consentExpiresAt,
       account_ids: incomingAccountIds,

--- a/src/lib/yapily/upcoming.ts
+++ b/src/lib/yapily/upcoming.ts
@@ -23,7 +23,7 @@ function authHeader(): string {
 interface YapilyEnvelope<T> {
   meta?: unknown;
   data?: T;
-  error?: { message?: string };
+  error?: { message?: string; tracingId?: string };
 }
 
 interface RawAmount {
@@ -79,14 +79,21 @@ async function yapilyGet<T>(path: string, consentToken: string): Promise<T> {
 
   if (!res.ok) {
     let msg = `Yapily ${res.status} ${res.statusText}`;
+    let tracingId: string | undefined;
     try {
       const body = (await res.json()) as YapilyEnvelope<unknown>;
+      tracingId = body?.error?.tracingId;
       if (body?.error?.message) msg += ` — ${body.error.message}`;
     } catch {
       // ignore parse error
     }
-    const err = new Error(msg) as Error & { status?: number };
+    if (!tracingId) {
+      tracingId = res.headers.get('Tracing-Id') || res.headers.get('tracing-id') || undefined;
+    }
+    if (tracingId) msg += ` [tracingId=${tracingId}]`;
+    const err = new Error(msg) as Error & { status?: number; tracingId?: string };
     err.status = res.status;
+    err.tracingId = tracingId;
     throw err;
   }
 

--- a/src/types/yapily.ts
+++ b/src/types/yapily.ts
@@ -110,6 +110,73 @@ export interface YapilyAuthResponse {
   };
 }
 
+// ── Hosted Pages (Beta) ──
+//
+// Schema source: Yapily OpenAPI 12.3.4 — verified against
+// docs.yapily.com/api-reference/hosted-consent-pages on 29 Apr 2026.
+// Distinct from the /account-auth-requests path: Yapily renders the
+// bank-picker, the post-consent page, and any QR/decoupled-auth flows
+// itself, then redirects back to our redirectUrl with consentRequestId
+// in the query string.
+//
+// Two important nuances baked into the type:
+//
+//   1. POST /hosted/consent-requests creates the request. Its response
+//      contains consentRequestId + hostedUrl but does NOT contain
+//      consentId or consentToken — those don't exist until the user
+//      completes the flow and a Consent is created at the bank side.
+//      So consentId and consentToken are optional on this type.
+//
+//   2. GET /hosted/consent-requests/{consentRequestId} returns the
+//      same envelope but, once status is AUTHORIZED, also surfaces
+//      consentId (the underlying /account-auth-requests/{id} handle
+//      used by renew + delete) and consentToken (the credential we
+//      attach to data calls). The callback uses the GET to extract
+//      both before persisting the connection.
+//
+// hostedUrl is short-lived (~10 minutes per Migle's call notes).
+
+export interface YapilyHostedInstitutionIdentifiers {
+  institutionId?: string;
+  institutionCountryCode: string;
+}
+
+export interface YapilyHostedUserSettings {
+  language?: string;
+  location?: string;
+}
+
+export interface YapilyHostedAccountRequestDetails {
+  featureScope?: string[];
+  transactionFrom?: string;
+  transactionTo?: string;
+  expiresAt?: string;
+}
+
+export interface YapilyHostedConsentRequest {
+  consentRequestId: string;
+  userId?: string;
+  applicationUserId?: string;
+  applicationId?: string;
+  institutionIdentifiers?: YapilyHostedInstitutionIdentifiers;
+  userSettings?: YapilyHostedUserSettings;
+  redirectUrl?: string;
+  accountRequestDetails?: YapilyHostedAccountRequestDetails;
+  hostedUrl?: string;
+  createdAt?: string;
+  authorisationExpiresAt?: string;
+  // GET-only fields, present once the user completes the journey:
+  status?: string;
+  consentId?: string;
+  consentToken?: string;
+  phases?: Array<{ phaseName: string; phaseCreatedAt: string }>;
+}
+
+export interface YapilyHostedConsentResponse {
+  meta?: { tracingId?: string };
+  data: YapilyHostedConsentRequest;
+}
+
 export interface YapilyErrorResponse {
   error: {
     code: number;

--- a/supabase/migrations/20260429210000_yapily_hosted_pages_consent_request_id.sql
+++ b/supabase/migrations/20260429210000_yapily_hosted_pages_consent_request_id.sql
@@ -1,0 +1,29 @@
+-- Yapily Hosted Pages migration — Phase 1 (additive only).
+--
+-- Migle (Yapily Implementation Engineer) confirmed in our 29 Apr 2026
+-- onboarding call + follow-up email that build sign-off requires the
+-- Hosted Pages auth flow (POST /hosted/consent-requests), not the
+-- existing /account-auth-requests path. The Hosted Pages response
+-- carries a consentRequestId that's distinct from the underlying
+-- consentId we already store. We need to retain both so:
+--
+--   - the renew flow keeps using yapily_consent_id for
+--     PUT /account-auth-requests/{consentId}
+--   - the abandonment poller uses yapily_consent_request_id for
+--     GET /hosted/consent-requests/{consentRequestId}
+--   - rollback to /account-auth-requests is one env flag away — the
+--     new column being null on legacy rows is harmless.
+--
+-- Strictly additive. No DROP / no ALTER-to-remove. Honours the
+-- production-safety rules in CLAUDE.md.
+
+ALTER TABLE bank_connections
+  ADD COLUMN IF NOT EXISTS yapily_consent_request_id TEXT;
+
+-- Lookup index — the abandonment poller scans by status='pending' and
+-- then reads the request id; the index keeps that lookup cheap. Partial
+-- so we don't pay the cost on the millions of legacy / TrueLayer rows
+-- that will never have one.
+CREATE INDEX IF NOT EXISTS bank_connections_yapily_consent_request_idx
+  ON bank_connections (yapily_consent_request_id)
+  WHERE yapily_consent_request_id IS NOT NULL;

--- a/supabase/migrations/20260429210500_yapily_pending_consent_requests.sql
+++ b/supabase/migrations/20260429210500_yapily_pending_consent_requests.sql
@@ -1,0 +1,74 @@
+-- Yapily Hosted Pages — pending consent request tracking.
+--
+-- The Vitally checklist (GH2) and the Hosted Pages tutorial both call
+-- for an abandonment-handling pattern: if the user never returns to the
+-- callback URL, start polling /hosted/consent-requests/{id} after 5 min,
+-- every 5–10s, and treat as abandoned after 15 min. To do that, we need
+-- to know which consentRequestIds we've issued without yet seeing a
+-- successful callback.
+--
+-- Why a dedicated table rather than a status flag on bank_connections:
+--   - bank_connections is the live "what banks does the user have"
+--     surface. Abandoned consents shouldn't pollute it; they're an
+--     ops concern, not a user-facing one.
+--   - Keeps the flag-gated rollout clean — flipping
+--     YAPILY_HOSTED_PAGES_ENABLED=false reverts to the legacy flow
+--     without leaving orphan rows in the live table.
+--   - Lets us keep a clean audit trail of attempted connects (for
+--     funnel analysis later — drop-off at consent is meaningful).
+--
+-- Strictly additive. Honours the production-safety rules in CLAUDE.md.
+
+CREATE TABLE IF NOT EXISTS yapily_pending_consent_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  consent_request_id TEXT NOT NULL,
+  institution_id TEXT NOT NULL,
+  redirect_url TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+    'pending',     -- request created, waiting for user redirect-back
+    'completed',   -- callback fired, connection persisted
+    'abandoned',   -- 15+ min elapsed and never resolved
+    'failed'       -- Yapily reported FAILED / REVOKED / REJECTED
+  )),
+  yapily_status TEXT,
+  yapily_tracing_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at TIMESTAMPTZ,
+  last_polled_at TIMESTAMPTZ
+);
+
+-- Lookup index for the abandonment poller — "give me everything still
+-- pending after N minutes". Conditional on status='pending' so the
+-- index stays small as historical rows accumulate.
+CREATE INDEX IF NOT EXISTS yapily_pending_consent_requests_pending_idx
+  ON yapily_pending_consent_requests (created_at)
+  WHERE status = 'pending';
+
+-- Lookup by consent_request_id for the callback resolver.
+CREATE UNIQUE INDEX IF NOT EXISTS yapily_pending_consent_requests_request_idx
+  ON yapily_pending_consent_requests (consent_request_id);
+
+-- Lookup by user for any future "your in-flight bank connect" UI.
+CREATE INDEX IF NOT EXISTS yapily_pending_consent_requests_user_idx
+  ON yapily_pending_consent_requests (user_id, created_at DESC);
+
+-- RLS: users can read their own rows for diagnostic surfaces; only the
+-- service role mutates them (auth/callback/cron). No INSERT/UPDATE
+-- policy for end users.
+ALTER TABLE yapily_pending_consent_requests ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'yapily_pending_consent_requests'
+      AND policyname = 'Users read own pending consents'
+  ) THEN
+    CREATE POLICY "Users read own pending consents"
+      ON yapily_pending_consent_requests
+      FOR SELECT
+      USING (auth.uid() = user_id);
+  END IF;
+END $$;

--- a/supabase/migrations/20260429220000_yapily_upcoming_endpoints_fetched_at.sql
+++ b/supabase/migrations/20260429220000_yapily_upcoming_endpoints_fetched_at.sql
@@ -1,0 +1,29 @@
+-- Yapily upcoming-payments endpoints — single-use tracking.
+--
+-- Migle's onboarding-call clarification (29 Apr 2026): the three
+-- deterministic endpoints
+--
+--   GET /accounts/{id}/scheduled-payments
+--   GET /accounts/{id}/periodic-payments
+--   GET /accounts/{id}/direct-debits
+--
+-- are callable ONCE per consent. Re-fetching after that requires a
+-- fresh consent (full user re-auth). Today our /api/cron/sync-upcoming
+-- calls them on every cron tick, which violates the rule and can
+-- result in cached / empty responses on subsequent calls.
+--
+-- This migration adds the bookkeeping column the cron uses to gate
+-- those calls. NULL means "haven't fetched yet for this consent" → the
+-- cron can pull. NON-NULL means "already pulled for this consent" →
+-- skip the deterministic endpoints (the recurrence detector still
+-- runs against transaction history every cron tick, so predicted
+-- rows stay fresh).
+--
+-- The reset to NULL happens in src/lib/yapily/connection-store.ts
+-- upsertYapilyConnection — when a user reconnects we get a new consent,
+-- so we want the next cron tick to pull again.
+--
+-- Strictly additive — production-safety rules in CLAUDE.md.
+
+ALTER TABLE bank_connections
+  ADD COLUMN IF NOT EXISTS upcoming_endpoints_fetched_at TIMESTAMPTZ;

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,7 @@
     { "path": "/api/cron/telegram-scheduler",        "schedule": "0 5,8,9,10,13,18 * * *" },
     { "path": "/api/cron/whatsapp-alerts",           "schedule": "0 */6 * * *" },
     { "path": "/api/cron/consent-renewal",           "schedule": "0 7 * * *" },
+    { "path": "/api/cron/yapily-consent-abandonment", "schedule": "*/5 * * * *" },
     { "path": "/api/cron/email-monitor",             "schedule": "0 14 * * *" },
     { "path": "/api/cron/detect-subscriptions",      "schedule": "0 4 * * *" },
     { "path": "/api/cron/sync-upcoming",             "schedule": "0 6 * * *" },


### PR DESCRIPTION
# Yapily Hosted Pages migration + renew/disconnect bug fixes

Squashed re-apply of the 8 Yapily commits onto current master. Replaces #366 (which was forked off PR #365's sprint branch and bloated to 430 commits / 276 files).

## Bug fixes (always-on)
- /api/bank/renew-consent now passes yapily_consent_id (not consent_token) to reconfirmConsent. Legacy rows without one get a clear 400 prompting full reconnect.
- /api/bank/disconnect now calls Yapily DELETE /account-auth-requests/{consentId}. 404-tolerant. Local cleanup never blocked on Yapily-side failures.

## Hosted Pages migration (flag-gated, default off)
Behind YAPILY_HOSTED_PAGES_ENABLED. Default false — production runs the existing /account-auth-requests flow until the flag flips after build sign-off.

- New createHostedConsentRequest + getHostedConsentRequest helpers.
- New types matching Yapily OpenAPI 12.3.4 — consentRequestId AND consentId as separate fields once AUTHORIZED.
- Additive migration adds yapily_consent_request_id TEXT to bank_connections.
- /api/auth/yapily returns hostedUrl (aliased to authorisationUrl for compat) + consentRequestId when flag on.
- /api/yapily/callback handles both legacy and Hosted Pages query-param shapes.
- featureScope passed via accountRequest body field per the OpenAPI spec.

## Abandonment polling (Vitally GH2)
- New yapily_pending_consent_requests table tracks in-flight Hosted Pages requests with RLS.
- New cron /api/cron/yapily-consent-abandonment runs every 5 minutes.
- Marks abandoned past 15 min, folds in FAILED/REVOKED/REJECTED, flags AUTHORIZED-but-no-callback for ops review.

## Robustness for UAT
- Tracing-Id capture on every Yapily error.
- Per-institution feature check (supportsFeature, 1-hour cache) — skips scheduled/periodic/direct-debits on banks that don't expose them. ~70% UK coverage per Migle.
- Single-use semantics: those endpoints callable ONCE per consent. New upcoming_endpoints_fetched_at column, reset to NULL on reconnect.
- 5-minute historical-data window: initial-sync runs in two passes — last 90 days first, then 91-365 days within a 4m30s budget.
- Monzo POT account suppression in snapshotAccounts.

## Rollback
One env-var flip (YAPILY_HOSTED_PAGES_ENABLED=false) reverts to /account-auth-requests. Migrations are additive — already applied to production via Supabase MCP.

## Tests
- npx tsc --noEmit clean
- node --experimental-strip-types --test src/lib/yapily.test.ts — 15/15 pass
