### PR TITLE
fix: align cancellation-info code to existing provider_cancellation_info schema

### DIFF
--- a/src/app/api/subscriptions/cancellation-info/route.ts
+++ b/src/app/api/subscriptions/cancellation-info/route.ts
@@ -24,8 +24,8 @@ export async function GET(request: NextRequest) {
 
   const { data, error } = await admin
     .from('provider_cancellation_info')
-    .select('provider_name, city, method, email, phone, url, tips, notice_period_days, last_verified_at, confidence, data_source')
-    .eq('provider_key', key)
+    .select('provider, display_name, city, method, email, phone, url, tips, notice_period_days, last_verified_at, confidence, data_source')
+    .eq('provider', key)
     .maybeSingle();
 
   if (error) {

--- a/src/lib/cancellation-provider.ts
+++ b/src/lib/cancellation-provider.ts
@@ -37,8 +37,17 @@ export function detectUkCity(providerName: string): string | null {
   return null;
 }
 
+// Produces the same shape used as the `provider` unique key in the
+// 20260424070000 seed (e.g. "virgin media", "now tv", "puregym"). Keep
+// in sync with the `normalise()` helper used by getCancellationInfo so
+// reads, writes, and substring lookups all share one key space.
 export function providerKey(providerName: string): string {
-  return providerName.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '').slice(0, 80);
+  return providerName
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80);
 }
 
 export function buildCancellationPrompt(providerName: string): string {
@@ -136,7 +145,7 @@ export async function researchCancellationForProvider(
     const { data: existing } = await admin
       .from('provider_cancellation_info')
       .select('id')
-      .eq('provider_key', key)
+      .eq('provider', key)
       .maybeSingle();
     if (existing) return; // already researched
   } catch (err: any) {
@@ -146,14 +155,14 @@ export async function researchCancellationForProvider(
 
   const prompt = buildCancellationPrompt(providerName);
   const result = await askPerplexity(prompt);
-  if (!result) return;
+  if (!result || !result.method) return;
 
   const city = detectUkCity(providerName);
   const dataSource = opts.dataSource || 'ai-on-create';
 
   await admin.from('provider_cancellation_info').upsert({
-    provider_name: providerName,
-    provider_key: key,
+    provider: key,
+    display_name: providerName,
     city,
     method: result.method,
     email: result.email,
@@ -165,7 +174,7 @@ export async function researchCancellationForProvider(
     confidence: 'medium',
     last_verified_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
-  }, { onConflict: 'provider_key' }).then(({ error }) => {
+  }, { onConflict: 'provider' }).then(({ error }) => {
     if (error) console.error('[cancellation-provider] upsert failed:', error.message);
   });
 }

--- a/supabase/migrations/20260430000000_provider_cancellation_info.sql
+++ b/supabase/migrations/20260430000000_provider_cancellation_info.sql
@@ -1,39 +1,15 @@
--- Provider-level cancellation intelligence cache.
--- Populated on subscription creation (ai-on-create) and refreshed weekly by
--- /api/cron/refresh-cancellation-info. Branch-aware: when a UK locality is
--- detected in the provider name, branch contact details are preferred over
--- corporate.
-CREATE TABLE IF NOT EXISTS provider_cancellation_info (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  provider_name TEXT NOT NULL,
-  provider_key TEXT NOT NULL,
-  city TEXT,
-  method TEXT,
-  email TEXT,
-  phone TEXT,
-  url TEXT,
-  tips TEXT,
-  notice_period_days INTEGER,
-  data_source TEXT DEFAULT 'ai-on-create',
-  confidence TEXT DEFAULT 'medium' CHECK (confidence IN ('low', 'medium', 'high')),
-  last_verified_at TIMESTAMPTZ DEFAULT NOW(),
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW(),
-  UNIQUE(provider_key)
-);
+-- Additive extension to provider_cancellation_info (created in
+-- 20260424070000_provider_cancellation_info.sql). The original PR #369
+-- shipped this file as a CREATE TABLE IF NOT EXISTS with a different
+-- column shape (provider_name / provider_key / city / notice_period_days),
+-- which made it a silent no-op in environments where the original table
+-- already existed. The fix: ALTER the existing table to add the two
+-- genuinely new columns the on-create research path needs.
+--
+-- The on-create writer and the /api/subscriptions/cancellation-info reader
+-- have been re-aligned to the original `provider` unique key, so we DO NOT
+-- introduce a separate provider_key column.
 
-CREATE INDEX IF NOT EXISTS idx_provider_cancellation_info_provider_key
-  ON provider_cancellation_info(provider_key);
-
-DO $$ BEGIN
-  ALTER TABLE provider_cancellation_info ENABLE ROW LEVEL SECURITY;
-EXCEPTION WHEN OTHERS THEN NULL;
-END $$;
-
--- Anyone authenticated can read. Writes are service-role only (cron + helper).
-DO $$ BEGIN
-  CREATE POLICY "provider_cancellation_info_read"
-    ON provider_cancellation_info FOR SELECT
-    USING (auth.role() = 'authenticated');
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+ALTER TABLE public.provider_cancellation_info
+  ADD COLUMN IF NOT EXISTS city TEXT,
+  ADD COLUMN IF NOT EXISTS notice_period_days INTEGER;


### PR DESCRIPTION
## Why
PR #369 shipped a `CREATE TABLE IF NOT EXISTS` with a different column shape (`provider_name` / `provider_key` / `city` / `notice_period_days`) than the production table created in `20260424070000` (`provider` / `display_name` / `aliases` / `category`).

Result: the migration was a silent no-op, and both `researchCancellationForProvider` (the on-create research trigger) and `/api/subscriptions/cancellation-info` (the "How to cancel" pill loader) were writing/querying columns that don't exist. Every call would 500 in production.

The cron `refresh-cancellation-info` was unaffected — it correctly uses the original schema.

## What
1. Replace the dead `CREATE TABLE IF NOT EXISTS` migration with an additive `ALTER TABLE ... ADD COLUMN IF NOT EXISTS city TEXT, notice_period_days INTEGER` against the existing table.
2. Realign `researchCancellationForProvider` to write `provider` (unique key), `display_name` (human-readable), and the additive `city` + `notice_period_days` columns. Switch `onConflict` to `'provider'`.
3. Update `/api/subscriptions/cancellation-info` to query by `provider` and select columns that actually exist.
4. Rework `providerKey()` to produce the same shape used in the 0424 seed (`'virgin media'`, `'now tv'`, `'puregym'`) so on-create writes don't duplicate seeded rows. Now keeps single spaces, strips non-alphanumeric, lowercases, slices to 80.

## Verification
- `tsc --noEmit` clean for changed files
- UI consumption unchanged: the popover only reads `method/email/phone/url/tips/data_source` which exist in both schemas
- Existing seeded rows (PureGym, Sky, Netflix, Virgin Media etc.) will now be hit by exact match when a user adds those subscriptions