### PR TITLE
feat(admin): legal-refs review list + Perplexity AI verifier

### DIFF
--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -1,0 +1,259 @@
+/**
+ * POST /api/admin/legal-refs/verify
+ *
+ * Founder-gated AI verification of a single legal_references row (or up
+ * to 25 rows in a batch). Calls Perplexity sonar-pro with a strict-JSON
+ * prompt asking whether the citation is still accurate, whether the URL
+ * still resolves to the right document, and whether it has been
+ * superseded. Updates the row with the result and logs the spend to the
+ * api_cost_ledger via logPerplexityCall.
+ *
+ * Body (single):  { id: string }
+ * Body (batch):   { ids: string[] }   // max 25
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import { logPerplexityCall } from '@/lib/cost-ledger';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const MAX_BATCH = 25;
+const PERPLEXITY_MODEL = 'sonar-pro';
+
+function getAdminEmails(): string[] {
+  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim()
+  );
+}
+
+interface LegalRefRow {
+  id: string;
+  law_name: string;
+  section: string | null;
+  source_url: string;
+  source_type: string | null;
+  summary: string;
+  category: string;
+  created_at: string;
+}
+
+interface PerplexityVerdict {
+  valid: boolean;
+  current_url: string | null;
+  superseded_by: string | null;
+  confidence: 'high' | 'medium' | 'low';
+  notes: string;
+}
+
+interface VerifyResult {
+  id: string;
+  status: string;
+  current_url: string | null;
+  notes: string;
+  error?: string;
+}
+
+function buildPrompt(ref: LegalRefRow): string {
+  const yearMatch = ref.created_at?.match(/^(\d{4})/);
+  const year = yearMatch ? yearMatch[1] : 'unknown';
+  const titleParts = [ref.law_name, ref.section].filter(Boolean).join(' — ');
+  const source = ref.source_type || 'unknown';
+  return [
+    `Verify this UK legal citation:`,
+    `title='${titleParts}',`,
+    `source='${source}' (${year}),`,
+    `current URL='${ref.source_url}'.`,
+    `Confirm: (a) does the URL still resolve to the right document,`,
+    `(b) is the citation accurate,`,
+    `(c) has it been superseded by a newer reference.`,
+    `Return STRICT JSON only, no markdown, no commentary:`,
+    `{"valid": bool, "current_url": string|null, "superseded_by": string|null, "confidence": "high"|"medium"|"low", "notes": string}`,
+  ].join(' ');
+}
+
+async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) {
+    console.warn('[legal-refs/verify] PERPLEXITY_API_KEY not set');
+    return null;
+  }
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.',
+          },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 500,
+        temperature: 0.1,
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[legal-refs/verify] Perplexity ${res.status}`);
+      return null;
+    }
+    const data = await res.json();
+    const content: string = data?.choices?.[0]?.message?.content || '';
+    const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]);
+    const conf = parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low'
+      ? parsed.confidence
+      : 'low';
+    return {
+      valid: !!parsed.valid,
+      current_url: typeof parsed.current_url === 'string' ? parsed.current_url : null,
+      superseded_by: typeof parsed.superseded_by === 'string' ? parsed.superseded_by : null,
+      confidence: conf,
+      notes: typeof parsed.notes === 'string' ? parsed.notes : '',
+    };
+  } catch (err: any) {
+    console.error('[legal-refs/verify] Perplexity error:', err?.message || err);
+    return null;
+  }
+}
+
+function deriveStatus(verdict: PerplexityVerdict): string {
+  if (verdict.superseded_by) return 'superseded';
+  if (!verdict.valid) return 'broken';
+  if (verdict.valid && verdict.confidence !== 'low') return 'verified';
+  return 'needs_review';
+}
+
+async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
+  const admin = getAdmin();
+  const { data: ref, error } = await admin
+    .from('legal_references')
+    .select('id, law_name, section, source_url, source_type, summary, category, created_at')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error || !ref) {
+    return { id, status: 'error', current_url: null, notes: '', error: 'Reference not found' };
+  }
+
+  const verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
+  if (!verdict) {
+    return {
+      id,
+      status: 'error',
+      current_url: null,
+      notes: '',
+      error: 'Perplexity call failed',
+    };
+  }
+
+  // Log spend (fire-and-forget).
+  logPerplexityCall({
+    model: PERPLEXITY_MODEL,
+    endpoint: '/api/admin/legal-refs/verify',
+    userId,
+    metadata: { legal_reference_id: id },
+  });
+
+  const status = deriveStatus(verdict);
+  const notes = verdict.superseded_by
+    ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
+    : verdict.notes;
+
+  const update: Record<string, unknown> = {
+    verification_status: status,
+    last_verified: new Date().toISOString(),
+    verification_notes: notes || null,
+  };
+  if (verdict.current_url) {
+    update.verified_url = verdict.current_url;
+  }
+
+  const { error: updateError } = await admin
+    .from('legal_references')
+    .update(update)
+    .eq('id', id);
+
+  if (updateError) {
+    return {
+      id,
+      status: 'error',
+      current_url: verdict.current_url,
+      notes,
+      error: `DB update failed: ${updateError.message}`,
+    };
+  }
+
+  return {
+    id,
+    status,
+    current_url: verdict.current_url,
+    notes,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  // Founder gate.
+  let userId: string | null = null;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const allow = getAdminEmails();
+    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    userId = user.id;
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { id?: string; ids?: string[] };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (body.id && typeof body.id === 'string') {
+    const result = await verifyOne(body.id, userId);
+    return NextResponse.json({ updated: result });
+  }
+
+  if (Array.isArray(body.ids) && body.ids.length > 0) {
+    if (body.ids.length > MAX_BATCH) {
+      return NextResponse.json(
+        { error: `Too many ids — max ${MAX_BATCH} per request` },
+        { status: 400 }
+      );
+    }
+    const results: VerifyResult[] = [];
+    // Sequential to avoid Perplexity rate limits.
+    for (const id of body.ids) {
+      if (typeof id !== 'string') continue;
+      // eslint-disable-next-line no-await-in-loop
+      const r = await verifyOne(id, userId);
+      results.push(r);
+    }
+    return NextResponse.json({ results });
+  }
+
+  return NextResponse.json({ error: 'Body must be { id } or { ids: [...] }' }, { status: 400 });
+}

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -27,7 +27,36 @@ interface LegalRef {
   last_verified: string | null;
   last_changed: string | null;
   verification_notes: string | null;
+  verified_url: string | null;
   created_at: string;
+}
+
+const PERPLEXITY_COST_PER_ROW_GBP = 0.005 * 0.79; // sonar-pro flat rate × USD→GBP
+
+function relativeTime(d: string | null): string {
+  if (!d) return 'Never';
+  const then = new Date(d).getTime();
+  const diff = Date.now() - then;
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  if (days < 1) return 'Today';
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${days} days ago`;
+  const months = Math.floor(days / 30);
+  if (months === 1) return '1 month ago';
+  if (months < 12) return `${months} months ago`;
+  const years = Math.floor(days / 365);
+  return years === 1 ? '1 year ago' : `${years} years ago`;
+}
+
+const REVIEW_STATUSES = new Set(['needs_review', 'broken', 'stale', 'error', 'superseded']);
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+
+function isReviewable(r: LegalRef): boolean {
+  if (REVIEW_STATUSES.has(r.verification_status)) return true;
+  if (!r.last_verified) return true;
+  const verifiedAt = new Date(r.last_verified).getTime();
+  if (isNaN(verifiedAt)) return true;
+  return Date.now() - verifiedAt > SIXTY_DAYS_MS;
 }
 
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof CheckCircle; className: string }> = {
@@ -71,6 +100,12 @@ export default function LegalRefsAdminPage() {
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState<string>('all');
   const [filterCategory, setFilterCategory] = useState<string>('all');
+  const [aiVerifyingIds, setAiVerifyingIds] = useState<Set<string>>(new Set());
+  const [aiResults, setAiResults] = useState<Record<string, { status: string; notes: string; ok: boolean }>>({});
+  const [batchProgress, setBatchProgress] = useState<{ done: number; total: number } | null>(null);
+  const [reviewPage, setReviewPage] = useState(0);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const REVIEW_PAGE_SIZE = 50;
   const supabase = createClient();
 
   useEffect(() => {
@@ -117,6 +152,94 @@ export default function LegalRefsAdminPage() {
       setVerifyResult(`Failed: ${err.message}`);
     } finally {
       setVerifying(false);
+    }
+  };
+
+  const verifyWithAi = async (ids: string[]) => {
+    if (ids.length === 0) return;
+    const single = ids.length === 1;
+    setAiVerifyingIds(prev => {
+      const next = new Set(prev);
+      ids.forEach(id => next.add(id));
+      return next;
+    });
+    try {
+      if (single) {
+        const res = await fetch('/api/admin/legal-refs/verify', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: ids[0] }),
+        });
+        const data = await res.json();
+        const u = data?.updated;
+        if (u) {
+          setAiResults(prev => ({
+            ...prev,
+            [u.id]: {
+              status: u.status,
+              notes: u.error || u.notes || '',
+              ok: u.status !== 'error',
+            },
+          }));
+          setRefs(prev => prev.map(r => (r.id === u.id ? {
+            ...r,
+            verification_status: u.status === 'error' ? r.verification_status : u.status,
+            verified_url: u.current_url ?? r.verified_url,
+            verification_notes: u.notes ?? r.verification_notes,
+            last_verified: u.status === 'error' ? r.last_verified : new Date().toISOString(),
+          } : r)));
+        }
+      } else {
+        // Batch in chunks of 25.
+        setBatchProgress({ done: 0, total: ids.length });
+        let done = 0;
+        for (let i = 0; i < ids.length; i += 25) {
+          const chunk = ids.slice(i, i + 25);
+          // eslint-disable-next-line no-await-in-loop
+          const res = await fetch('/api/admin/legal-refs/verify', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ids: chunk }),
+          });
+          // eslint-disable-next-line no-await-in-loop
+          const data = await res.json();
+          const results: Array<{ id: string; status: string; current_url: string | null; notes: string; error?: string }> = data?.results || [];
+          setAiResults(prev => {
+            const next = { ...prev };
+            results.forEach(r => {
+              next[r.id] = { status: r.status, notes: r.error || r.notes || '', ok: r.status !== 'error' };
+            });
+            return next;
+          });
+          setRefs(prev => prev.map(r => {
+            const u = results.find(x => x.id === r.id);
+            if (!u || u.status === 'error') return r;
+            return {
+              ...r,
+              verification_status: u.status,
+              verified_url: u.current_url ?? r.verified_url,
+              verification_notes: u.notes ?? r.verification_notes,
+              last_verified: new Date().toISOString(),
+            };
+          }));
+          done += chunk.length;
+          setBatchProgress({ done, total: ids.length });
+        }
+      }
+    } catch (err: any) {
+      console.error('verifyWithAi failed', err);
+      ids.forEach(id => {
+        setAiResults(prev => ({ ...prev, [id]: { status: 'error', notes: err?.message || 'Request failed', ok: false } }));
+      });
+    } finally {
+      setAiVerifyingIds(prev => {
+        const next = new Set(prev);
+        ids.forEach(id => next.delete(id));
+        return next;
+      });
+      setTimeout(() => setBatchProgress(null), 2000);
     }
   };
 
@@ -353,6 +476,209 @@ export default function LegalRefsAdminPage() {
           </div>
         )}
       </div>
+
+      {/* Review queue — AI-assisted manual verification */}
+      {(() => {
+        const reviewable = refs
+          .filter(isReviewable)
+          .sort((a, b) => {
+            // last_verified NULLS FIRST, then created_at DESC
+            if (!a.last_verified && b.last_verified) return -1;
+            if (a.last_verified && !b.last_verified) return 1;
+            if (a.last_verified && b.last_verified) {
+              const at = new Date(a.last_verified).getTime();
+              const bt = new Date(b.last_verified).getTime();
+              if (at !== bt) return at - bt;
+            }
+            return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+          });
+        const totalPages = Math.max(1, Math.ceil(reviewable.length / REVIEW_PAGE_SIZE));
+        const page = Math.min(reviewPage, totalPages - 1);
+        const slice = reviewable.slice(page * REVIEW_PAGE_SIZE, (page + 1) * REVIEW_PAGE_SIZE);
+        const allIds = reviewable.map(r => r.id);
+        const totalCost = (reviewable.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(3);
+        const anyVerifying = aiVerifyingIds.size > 0;
+        return (
+          <div className="mt-10">
+            <div className="flex flex-wrap items-end justify-between gap-3 mb-3">
+              <div>
+                <h2 className="text-2xl font-bold text-slate-900 font-[family-name:var(--font-heading)]">
+                  Review queue
+                </h2>
+                <p className="text-slate-600 text-sm mt-1">
+                  {reviewable.length} reference{reviewable.length === 1 ? '' : 's'} need attention
+                  {' '}— needs review, broken, stale, errored, never verified, or last verified &gt; 60 days ago.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {batchProgress && (
+                  <span className="text-xs text-slate-600">
+                    Verifying {batchProgress.done} of {batchProgress.total}…
+                  </span>
+                )}
+                <button
+                  onClick={() => setConfirmOpen(true)}
+                  disabled={anyVerifying || reviewable.length === 0}
+                  className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
+                >
+                  {anyVerifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  Verify all with AI
+                </button>
+              </div>
+            </div>
+
+            {confirmOpen && (
+              <div
+                className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+                onClick={() => setConfirmOpen(false)}
+              >
+                <div
+                  className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl border border-slate-200"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <h3 className="text-lg font-bold text-slate-900 mb-2">Confirm AI verification</h3>
+                  <p className="text-sm text-slate-600 mb-5">
+                    This will run Perplexity verification on {reviewable.length} row
+                    {reviewable.length === 1 ? '' : 's'} at ~£0.004 each = £{totalCost} total.
+                    Proceed?
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setConfirmOpen(false)}
+                      className="px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 rounded-lg"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => {
+                        setConfirmOpen(false);
+                        verifyWithAi(allIds);
+                      }}
+                      className="px-4 py-2 text-sm font-semibold bg-emerald-500 hover:bg-emerald-600 text-slate-900 rounded-lg"
+                    >
+                      Run verification
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-slate-200">
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Title / Source</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden md:table-cell">Year</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden md:table-cell">URL</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Status</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden lg:table-cell">Last verified</th>
+                      <th className="px-5 py-3 text-right text-xs font-semibold text-slate-600 uppercase tracking-wide">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {slice.map((ref) => {
+                      const status = STATUS_CONFIG[ref.verification_status] || STATUS_CONFIG.needs_review;
+                      const StatusIcon = status.icon;
+                      const verifying = aiVerifyingIds.has(ref.id);
+                      const result = aiResults[ref.id];
+                      const year = (ref.created_at || '').slice(0, 4) || '—';
+                      const truncated = ref.source_url.length > 50
+                        ? ref.source_url.slice(0, 47) + '…'
+                        : ref.source_url;
+                      return (
+                        <tr key={ref.id} className="border-b border-slate-200 hover:bg-slate-50 transition-colors">
+                          <td className="px-5 py-4">
+                            <p className="text-slate-900 text-sm font-medium">{ref.law_name}</p>
+                            <p className="text-slate-600 text-xs mt-0.5">{ref.source_type || '—'}{ref.section ? ` · ${ref.section}` : ''}</p>
+                          </td>
+                          <td className="px-5 py-4 text-slate-700 text-sm hidden md:table-cell">{year}</td>
+                          <td className="px-5 py-4 hidden md:table-cell">
+                            <a
+                              href={ref.source_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-emerald-600 hover:text-emerald-500 text-xs"
+                              title={ref.source_url}
+                            >
+                              {truncated}
+                            </a>
+                          </td>
+                          <td className="px-5 py-4">
+                            <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full ${status.className}`}>
+                              <StatusIcon className="h-3 w-3" />
+                              {status.label}
+                            </span>
+                          </td>
+                          <td className="px-5 py-4 hidden lg:table-cell text-slate-600 text-xs">
+                            {relativeTime(ref.last_verified)}
+                          </td>
+                          <td className="px-5 py-4">
+                            <div className="flex items-center justify-end gap-2 flex-wrap">
+                              <a
+                                href={ref.source_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-xs text-slate-700 hover:text-slate-900 px-2.5 py-1.5 border border-slate-200 rounded-lg"
+                              >
+                                <ExternalLink className="h-3 w-3" />
+                                Open URL
+                              </a>
+                              <button
+                                onClick={() => verifyWithAi([ref.id])}
+                                disabled={verifying}
+                                className="inline-flex items-center gap-1 text-xs font-semibold bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 px-2.5 py-1.5 rounded-lg"
+                              >
+                                {verifying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                                Verify with AI
+                              </button>
+                            </div>
+                            {result && (
+                              <p className={`text-[11px] mt-1.5 text-right ${result.ok ? 'text-emerald-600' : 'text-red-500'}`}>
+                                {result.ok ? '✓ ' : '✗ '}{result.ok ? `Verified · ${result.status}` : result.notes || 'Failed'}
+                              </p>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              {reviewable.length === 0 && (
+                <div className="py-12 text-center">
+                  <CheckCircle className="h-10 w-10 text-emerald-500 mx-auto mb-2" />
+                  <p className="text-slate-600 text-sm">All references are up to date.</p>
+                </div>
+              )}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between mt-3">
+                <p className="text-slate-600 text-xs">
+                  Page {page + 1} of {totalPages} · showing {slice.length} of {reviewable.length}
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setReviewPage(Math.max(0, page - 1))}
+                    disabled={page === 0}
+                    className="px-3 py-1.5 text-xs border border-slate-200 rounded-lg disabled:opacity-40"
+                  >
+                    Previous
+                  </button>
+                  <button
+                    onClick={() => setReviewPage(Math.min(totalPages - 1, page + 1))}
+                    disabled={page >= totalPages - 1}
+                    className="px-3 py-1.5 text-xs border border-slate-200 rounded-lg disabled:opacity-40"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       <p className="text-slate-600 text-xs mt-4 text-center">
         Verification runs automatically on the 1st of each month. Statutes are checked via legislation.gov.uk. Regulator rules are compared with a fast AI model.

--- a/supabase/migrations/20260430050000_legal_refs_verification_extra.sql
+++ b/supabase/migrations/20260430050000_legal_refs_verification_extra.sql
@@ -1,0 +1,11 @@
+-- Additive: extra columns for AI-assisted legal reference verification.
+-- verification_notes already exists on legal_references (see
+-- 20260327020000_legal_references.sql), but adding IF NOT EXISTS keeps
+-- this migration safe to re-run. verified_url is new — it stores the
+-- canonical URL Perplexity confirms during a manual review pass, so the
+-- founder can spot when the citation has moved without overwriting the
+-- original `source_url`.
+
+ALTER TABLE public.legal_references
+  ADD COLUMN IF NOT EXISTS verified_url TEXT,
+  ADD COLUMN IF NOT EXISTS verification_notes TEXT;


### PR DESCRIPTION
## Why
Founder was blocked on the existing `/dashboard/admin/legal-refs` page. The stats panel showed "28 needs review" but offered no way to drill into those rows or take action — so the cron-flagged refs just piled up. This PR ships the missing review surface + an AI-assisted verifier so the founder can clear the queue one click at a time (or all at once).

## Changes

### `src/app/dashboard/admin/legal-refs/page.tsx`
- Added a "Review queue" section below the existing table. Surfaces every row where `verification_status IN (needs_review, broken, stale, error, superseded)` OR `last_verified IS NULL` OR `last_verified > 60 days ago`.
- Sort: `last_verified` NULLS FIRST, then `created_at DESC`.
- Columns: Title / Source / Year / URL (truncated, opens in new tab) / Status badge / Last verified (relative) / Actions.
- Per-row: **Open URL** (target=_blank rel=noopener) + **Verify with AI** (single-row POST with inline spinner + ✓/✗ toast).
- **Verify all with AI** button with cost-confirmation modal: "This will run Perplexity verification on N rows at ~£0.004 each = £X total. Proceed?" Batches of 25 with live "Verifying X of N" progress indicator.
- Pagination at 50 rows per page.
- Optimistic state update — verified rows immediately re-badge inline after a response.

### `src/app/api/admin/legal-refs/verify/route.ts` (new)
- `POST` accepts `{ id }` (single) or `{ ids: string[] }` (max 25, returns 400 above).
- **Founder gate**: server-reads `NEXT_PUBLIC_ADMIN_EMAILS`, validates `auth.email` against the allowlist (same source-of-truth as `src/app/dashboard/admin/layout.tsx`).
- Builds a strict-JSON prompt for Perplexity `sonar-pro` covering URL resolution, citation accuracy, and supersession.
- Reuses the JSON-cleaning pattern from `src/lib/cancellation-provider.ts` (strip markdown fences, regex-extract first `{…}` block).
- Status derivation: `superseded` if `superseded_by` present, `broken` if `!valid`, `verified` if `valid && confidence !== 'low'`, else keep `needs_review`.
- Updates `verification_status`, `last_verified`, `verification_notes`, and `verified_url` (when present).
- Logs cost via `logPerplexityCall` (model `sonar-pro` → £0.005 × USD→GBP).
- Batch path is sequential to avoid Perplexity rate limits.

### `supabase/migrations/20260430050000_legal_refs_verification_extra.sql` (new)
- Additive only: `ADD COLUMN IF NOT EXISTS verified_url TEXT`, `ADD COLUMN IF NOT EXISTS verification_notes TEXT`.

## Judgment calls
- **Schema differs from spec.** Spec mentioned `last_verified_at`, `title`, `url`, `source`, `year` — the actual table (see `20260327020000_legal_references.sql`) uses `last_verified`, `law_name`, `source_url`, `source_type`, no `year` column. I derived year from `created_at` and used the real column names everywhere.
- **`verification_notes` already exists in production** (it's in the original 2026-03-27 migration). Keeping the migration in with `IF NOT EXISTS` per the spec — it's idempotent and harmless. Only `verified_url` is genuinely new.
- **Statuses extended.** Existing rows use `current` / `updated` / `needs_review` / `outdated`. The new endpoint introduces `verified`, `superseded`, and `broken` so that "AI says citation is fine" is distinguishable from the legacy automated `current`. The page renders unknown statuses with the `needs_review` config so nothing breaks.
- **Founder gate done in-route, not via existing `authorizeAdminOrCron`.** The shared helper hardcodes a single `aireypaul@googlemail.com`; the new endpoint reads `NEXT_PUBLIC_ADMIN_EMAILS` per the spec, so adding a second admin later doesn't require code changes.
- **No `@/lib/admin-auth` reuse.** Same reason — that helper supports cron Bearer too, which we don't need here.

## tsc status
`npx tsc --noEmit` is clean (exit 0) for the entire repo on this branch — no pre-existing errors surfaced today.

## B2C / B2B surface
B2C admin only. No `b2b_*`, `/for-business`, `/api/v1`, or `src/lib/b2b` files touched.

## Test plan
- [ ] Hit `/dashboard/admin/legal-refs` as founder — review queue renders with the expected count.
- [ ] Click "Verify with AI" on a single row — spinner, then status badge updates inline + ✓ toast.
- [ ] Click "Verify all with AI" — cost modal shows correct row count and total. Cancel = no fire.
- [ ] Confirm modal — batches of 25, progress counter ticks, badges update as results stream in.
- [ ] Hit endpoint without admin email — 401.
- [ ] Hit endpoint with `ids` length 26 — 400 with "max 25" message.
- [ ] After a verification, check `api_cost_ledger` for a `provider=perplexity` row tagged with `legal_reference_id`.
- [ ] Apply migration to staging — `verified_url` column appears, `verification_notes` already-existing column unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)