### PR TITLE
fix(admin): correct bank connection count + MRR calc, add deal health drill-in

### DIFF
--- a/src/app/api/admin/deals/route.ts
+++ b/src/app/api/admin/deals/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { getDealHealth } from '@/lib/admin-metrics';
+
+export const runtime = 'nodejs';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+  const supabase = getAdmin();
+  const summary = await getDealHealth(supabase);
+  return NextResponse.json(summary);
+}

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { computeMrrGbp, getActiveBankConnectionCount } from '@/lib/admin-metrics';
 
 export const runtime = 'nodejs';
 
@@ -26,24 +27,30 @@ export async function GET(request: NextRequest) {
     subscriptionsResult,
     tiersResult,
     complaintsResult,
-    bankConnectionsResult,
+    bankConnectionsCount,
     agentRunsResult,
     recentSignupsResult,
     transactionsResult,
     merchantRulesResult,
     socialPostsResult,
+    mrrSummary,
   ] = await Promise.all([
     supabase.from('profiles').select('id', { count: 'exact', head: true }),
     supabase.from('waitlist_signups').select('id', { count: 'exact', head: true }),
     supabase.from('subscriptions').select('id', { count: 'exact', head: true }).is('dismissed_at', null),
     supabase.from('profiles').select('subscription_tier'),
     supabase.from('tasks').select('id', { count: 'exact', head: true }).eq('type', 'complaint_letter'),
-    supabase.from('bank_connections').select('id', { count: 'exact', head: true }).eq('status', 'active'),
+    // See src/lib/admin-metrics.ts — counts every non-deleted, non-revoked
+    // connection across providers (TrueLayer + Yapily). Previously filtered
+    // status='active' only, which silently hid every TrueLayer row after
+    // the Yapily migration bulk-flipped them to 'expired_legacy'.
+    getActiveBankConnectionCount(supabase),
     supabase.from('agent_runs').select('id', { count: 'exact', head: true }),
     supabase.from('profiles').select('id, email, full_name, subscription_tier, subscription_status, created_at').order('created_at', { ascending: false }).limit(20),
     supabase.from('bank_transactions').select('id', { count: 'exact', head: true }),
     supabase.from('merchant_rules').select('id', { count: 'exact', head: true }),
     supabase.from('social_posts').select('id', { count: 'exact', head: true }),
+    computeMrrGbp(supabase),
   ]);
 
   // Calculate tier breakdown
@@ -53,16 +60,13 @@ export async function GET(request: NextRequest) {
     tierBreakdown[tier] = (tierBreakdown[tier] || 0) + 1;
   }
 
-  // Calculate MRR
-  const mrr = (tierBreakdown.essential || 0) * 9.99 + (tierBreakdown.pro || 0) * 19.99;
-
   return NextResponse.json({
     generated: new Date().toISOString(),
     overview: {
       total_users: usersResult.count || 0,
       waitlist_signups: waitlistResult.count || 0,
       active_subscriptions: subscriptionsResult.count || 0,
-      bank_connections: bankConnectionsResult.count || 0,
+      bank_connections: bankConnectionsCount,
       bank_transactions: transactionsResult.count || 0,
       complaints_generated: complaintsResult.count || 0,
       agent_runs: agentRunsResult.count || 0,
@@ -70,11 +74,12 @@ export async function GET(request: NextRequest) {
       social_posts: socialPostsResult.count || 0,
     },
     revenue: {
-      mrr: parseFloat(mrr.toFixed(2)),
-      arr: parseFloat((mrr * 12).toFixed(2)),
+      mrr: mrrSummary.mrr,
+      arr: mrrSummary.arr,
       paying_customers: (tierBreakdown.essential || 0) + (tierBreakdown.pro || 0),
       free_users: tierBreakdown.free || 0,
     },
+    mrr_breakdown: mrrSummary.breakdown,
     tier_breakdown: tierBreakdown,
     recent_signups: (recentSignupsResult.data || []).map((u: any) => ({
       id: u.id,

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -42,6 +42,18 @@ interface Member {
   bank_transactions: number;
 }
 
+interface AdminDeal {
+  id: string;
+  provider: string;
+  category: string;
+  plan_name: string;
+  affiliate_url: string;
+  is_active: boolean;
+  last_verified_at: string | null;
+  price_monthly: number;
+  price_changed_at: string | null;
+}
+
 interface MemberDetail {
   profile: any;
   stats: Record<string, number>;
@@ -59,8 +71,19 @@ export default function AdminPage() {
   const [loading, setLoading] = useState(true);
   const [meetingOpen, setMeetingOpen] = useState(false);
   const [tab, setTab] = useState<'overview' | 'members' | 'tickets' | 'leads' | 'ai_team'>('overview');
-  const [dealHealth, setDealHealth] = useState<{ active: number; inactive: number; stale: number; lastVerified: string | null } | null>(null);
+  const [dealHealth, setDealHealth] = useState<{
+    active: number;
+    inactive: number;
+    stale: number;
+    lastVerified: string | null;
+    broken: AdminDeal[];
+    staleList: AdminDeal[];
+    healthy: AdminDeal[];
+  } | null>(null);
   const [verifyingDeals, setVerifyingDeals] = useState(false);
+  const [dealFilter, setDealFilter] = useState<'all' | 'broken' | 'stale' | 'healthy'>('all');
+  const [dealSearch, setDealSearch] = useState('');
+  const [showHealthy, setShowHealthy] = useState(false);
   const supabase = createClient();
 
   useEffect(() => {
@@ -77,34 +100,27 @@ export default function AdminPage() {
       // No bearer secret needed — the cookie travels with same-origin fetch.
       const [metricsRes, dealsRes] = await Promise.all([
         fetch('/api/admin/metrics', { credentials: 'include' }).then(r => r.json()),
-        // Fetch all deals (active + inactive) for health stats
-        supabase.from('affiliate_deals').select('is_active, last_verified_at'),
+        fetch('/api/admin/deals', { credentials: 'include' }).then(r => r.json()),
       ]);
 
       if (metricsRes.overview) {
         setMetrics(metricsRes);
       }
 
-      // Compute deal health stats
-      const allDeals = dealsRes.data || [];
-      const now = Date.now();
-      const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
-      let active = 0, inactive = 0, stale = 0;
-      let latestVerified: string | null = null;
-      for (const d of allDeals) {
-        if (d.is_active) {
-          active++;
-          if (d.last_verified_at && (now - new Date(d.last_verified_at).getTime()) > thirtyDaysMs) {
-            stale++;
-          }
-        } else {
-          inactive++;
-        }
-        if (d.last_verified_at && (!latestVerified || d.last_verified_at > latestVerified)) {
-          latestVerified = d.last_verified_at;
-        }
+      if (dealsRes && Array.isArray(dealsRes.broken)) {
+        const broken: AdminDeal[] = dealsRes.broken || [];
+        const staleList: AdminDeal[] = dealsRes.stale || [];
+        const healthy: AdminDeal[] = dealsRes.healthy || [];
+        setDealHealth({
+          active: healthy.length + staleList.length,
+          inactive: broken.length,
+          stale: staleList.length,
+          lastVerified: dealsRes.lastVerifiedAt ?? null,
+          broken,
+          staleList,
+          healthy,
+        });
       }
-      setDealHealth({ active, inactive, stale, lastVerified: latestVerified });
 
       setLoading(false);
     };
@@ -373,6 +389,22 @@ export default function AdminPage() {
                         method: 'POST',
                         headers: { Authorization: `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''}` },
                       });
+                      // Refresh the drill-in list once the bulk job returns.
+                      const fresh = await fetch('/api/admin/deals', { credentials: 'include' }).then(r => r.json());
+                      if (fresh && Array.isArray(fresh.broken)) {
+                        const broken: AdminDeal[] = fresh.broken || [];
+                        const staleList: AdminDeal[] = fresh.stale || [];
+                        const healthy: AdminDeal[] = fresh.healthy || [];
+                        setDealHealth({
+                          active: healthy.length + staleList.length,
+                          inactive: broken.length,
+                          stale: staleList.length,
+                          lastVerified: fresh.lastVerifiedAt ?? null,
+                          broken,
+                          staleList,
+                          healthy,
+                        });
+                      }
                     } catch (e) { console.error('verify-deals failed', e); }
                     setVerifyingDeals(false);
                   }}
@@ -404,6 +436,132 @@ export default function AdminPage() {
                   </p>
                   <p className="text-slate-500 text-xs">Last Verification</p>
                 </div>
+              </div>
+
+              {/* Deal drill-in: founder needs to see WHICH deals are broken/stale */}
+              <div className="mt-6 pt-6 border-t border-slate-200/60">
+                <div className="flex flex-wrap items-center gap-2 mb-3">
+                  {(['all', 'broken', 'stale', 'healthy'] as const).map((f) => (
+                    <button
+                      key={f}
+                      onClick={() => setDealFilter(f)}
+                      className={`px-3 py-1 rounded-md text-xs font-medium transition-all ${
+                        dealFilter === f ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'
+                      }`}
+                    >
+                      {f === 'all' ? 'All' : f.charAt(0).toUpperCase() + f.slice(1)}
+                      {f === 'broken' && dealHealth.broken.length > 0 && (
+                        <span className="ml-1 text-red-500">({dealHealth.broken.length})</span>
+                      )}
+                      {f === 'stale' && dealHealth.staleList.length > 0 && (
+                        <span className="ml-1 text-amber-600">({dealHealth.staleList.length})</span>
+                      )}
+                      {f === 'healthy' && (
+                        <span className="ml-1 text-green-600">({dealHealth.healthy.length})</span>
+                      )}
+                    </button>
+                  ))}
+                  <input
+                    value={dealSearch}
+                    onChange={(e) => setDealSearch(e.target.value)}
+                    placeholder="Search provider..."
+                    className="ml-auto px-3 py-1 rounded-md text-xs border border-slate-200 bg-white focus:outline-none focus:border-emerald-500 w-40"
+                  />
+                </div>
+
+                {(() => {
+                  const matchSearch = (d: AdminDeal) =>
+                    !dealSearch ||
+                    d.provider.toLowerCase().includes(dealSearch.toLowerCase()) ||
+                    d.plan_name.toLowerCase().includes(dealSearch.toLowerCase());
+                  const renderRow = (d: AdminDeal, kind: 'broken' | 'stale' | 'healthy') => (
+                    <div
+                      key={d.id}
+                      className="flex items-center justify-between bg-slate-50/50 rounded-lg px-3 py-2 border border-slate-200/50 text-sm"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-slate-900 font-medium truncate">{d.provider}</span>
+                          <span className="text-xs text-slate-500 bg-slate-100 px-1.5 py-0.5 rounded shrink-0">{d.category}</span>
+                          <span
+                            className={`text-xs px-1.5 py-0.5 rounded shrink-0 ${
+                              kind === 'broken'
+                                ? 'bg-red-500/10 text-red-500'
+                                : kind === 'stale'
+                                ? 'bg-amber-500/10 text-amber-600'
+                                : 'bg-green-500/10 text-green-600'
+                            }`}
+                          >
+                            {kind}
+                          </span>
+                        </div>
+                        <div className="text-xs text-slate-500 truncate mt-0.5">
+                          {d.plan_name} · £{Number(d.price_monthly).toFixed(2)}/mo · last verified{' '}
+                          {d.last_verified_at
+                            ? new Date(d.last_verified_at).toLocaleDateString('en-GB')
+                            : 'never'}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2 ml-3 shrink-0">
+                        <a
+                          href={d.affiliate_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-emerald-700 hover:underline"
+                        >
+                          Open URL
+                        </a>
+                      </div>
+                    </div>
+                  );
+
+                  const showBroken = dealFilter === 'all' || dealFilter === 'broken';
+                  const showStale = dealFilter === 'all' || dealFilter === 'stale';
+                  const showHealthyGroup = dealFilter === 'healthy' || (dealFilter === 'all' && showHealthy);
+                  const brokenList = dealHealth.broken.filter(matchSearch);
+                  const staleListFiltered = dealHealth.staleList.filter(matchSearch);
+                  const healthyList = dealHealth.healthy.filter(matchSearch);
+
+                  return (
+                    <div className="space-y-4">
+                      {showBroken && brokenList.length > 0 && (
+                        <div>
+                          <h4 className="text-xs font-semibold text-red-500 uppercase tracking-wider mb-2">
+                            Broken ({brokenList.length})
+                          </h4>
+                          <div className="space-y-1">{brokenList.map((d) => renderRow(d, 'broken'))}</div>
+                        </div>
+                      )}
+                      {showStale && staleListFiltered.length > 0 && (
+                        <div>
+                          <h4 className="text-xs font-semibold text-amber-600 uppercase tracking-wider mb-2">
+                            Stale — needs verification ({staleListFiltered.length})
+                          </h4>
+                          <div className="space-y-1">{staleListFiltered.map((d) => renderRow(d, 'stale'))}</div>
+                        </div>
+                      )}
+                      {dealFilter === 'all' && (
+                        <button
+                          onClick={() => setShowHealthy((v) => !v)}
+                          className="text-xs text-slate-500 hover:text-slate-900"
+                        >
+                          {showHealthy ? 'Hide' : 'Show'} healthy ({dealHealth.healthy.length})
+                        </button>
+                      )}
+                      {showHealthyGroup && healthyList.length > 0 && (
+                        <div>
+                          <h4 className="text-xs font-semibold text-green-600 uppercase tracking-wider mb-2">
+                            Healthy ({healthyList.length})
+                          </h4>
+                          <div className="space-y-1">{healthyList.map((d) => renderRow(d, 'healthy'))}</div>
+                        </div>
+                      )}
+                      {brokenList.length === 0 && staleListFiltered.length === 0 && healthyList.length === 0 && (
+                        <p className="text-sm text-slate-500 text-center py-6">No deals match.</p>
+                      )}
+                    </div>
+                  );
+                })()}
               </div>
             </div>
           )}

--- a/src/lib/admin-metrics.ts
+++ b/src/lib/admin-metrics.ts
@@ -1,0 +1,169 @@
+/**
+ * Admin metrics helpers — single source of truth for the
+ * /dashboard/admin Overview tab and the upcoming Business Costs tab.
+ *
+ * History (28 Apr 2026):
+ *  - Bank-connection counter was filtering `status = 'active'`, but the
+ *    Yapily migration (20260402050000) bulk-flipped every existing
+ *    TrueLayer row to `status = 'expired_legacy'`. Production users
+ *    are still connected via TrueLayer (Yapily is gated on approval —
+ *    see CLAUDE.md memory). The correct counter is "any non-deleted
+ *    connection that isn't permanently revoked" across all providers.
+ *  - MRR was using stale prices (£9.99 essential / £19.99 pro).
+ *    Authoritative pricing is in CLAUDE.md and src/lib/stripe.ts:
+ *      Essential: £4.99 / mo  or £44.99 / yr  (yearly ≈ £3.75/mo eqv)
+ *      Pro:       £9.99 / mo  or £94.99 / yr  (yearly ≈ £7.92/mo eqv)
+ *    `profiles.subscription_tier` does not record billing interval, so
+ *    until that column exists we approximate MRR as
+ *    count × monthly headline price. The error from yearly subs is at
+ *    most a small under/overstatement per yearly subscriber, not the
+ *    £100 gap previously reported (that was the wrong-prices bug).
+ *  - B2C surface only. B2B subs live in `b2b_api_keys` (entirely
+ *    separate table) so no filter is needed here to exclude them.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const ESSENTIAL_MONTHLY_GBP = 4.99;
+export const PRO_MONTHLY_GBP = 9.99;
+
+export interface AdminDeal {
+  id: string;
+  provider: string;
+  category: string;
+  plan_name: string;
+  affiliate_url: string;
+  is_active: boolean;
+  last_verified_at: string | null;
+  price_monthly: number;
+  price_changed_at: string | null;
+}
+
+export interface DealHealthSummary {
+  active: number;
+  broken: AdminDeal[];
+  stale: AdminDeal[];
+  healthy: AdminDeal[];
+  lastVerifiedAt: string | null;
+}
+
+const STALE_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Count active bank connections across all providers (TrueLayer +
+ * Yapily). A connection counts as active if it hasn't been hard-
+ * deleted and isn't `revoked`. We deliberately keep `expired_legacy`
+ * and `expired`/`token_expired` — those are still real connections
+ * with real transaction history, just needing a re-auth.
+ */
+export async function getActiveBankConnectionCount(
+  supabase: SupabaseClient,
+): Promise<number> {
+  const { count, error } = await supabase
+    .from('bank_connections')
+    .select('id', { count: 'exact', head: true })
+    .is('deleted_at', null)
+    .neq('status', 'revoked');
+
+  if (error) {
+    console.error('[admin-metrics] bank connection count error', error);
+    return 0;
+  }
+  return count ?? 0;
+}
+
+/**
+ * Compute B2C MRR from `profiles.subscription_tier`. See file header
+ * for the yearly-vs-monthly caveat.
+ */
+export async function computeMrrGbp(
+  supabase: SupabaseClient,
+): Promise<{
+  mrr: number;
+  arr: number;
+  breakdown: { tier: string; count: number; monthly: number }[];
+}> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('subscription_tier');
+
+  if (error) {
+    console.error('[admin-metrics] mrr query error', error);
+    return { mrr: 0, arr: 0, breakdown: [] };
+  }
+
+  let essential = 0;
+  let pro = 0;
+  for (const row of data || []) {
+    if (row.subscription_tier === 'essential') essential++;
+    else if (row.subscription_tier === 'pro') pro++;
+  }
+
+  // MRR formula: per-tier paying-customer count × monthly headline price.
+  // (Yearly subscribers pay less per month — see file header. The fix is
+  // a billing_interval column, tracked separately.)
+  const essentialMrr = essential * ESSENTIAL_MONTHLY_GBP;
+  const proMrr = pro * PRO_MONTHLY_GBP;
+  const mrr = essentialMrr + proMrr;
+
+  return {
+    mrr: round2(mrr),
+    arr: round2(mrr * 12),
+    breakdown: [
+      { tier: 'essential', count: essential, monthly: round2(essentialMrr) },
+      { tier: 'pro', count: pro, monthly: round2(proMrr) },
+    ],
+  };
+}
+
+/**
+ * Group affiliate deals into broken / stale / healthy buckets and
+ * return the most recent verification timestamp.
+ */
+export async function getDealHealth(
+  supabase: SupabaseClient,
+): Promise<DealHealthSummary> {
+  const { data, error } = await supabase
+    .from('affiliate_deals')
+    .select('id, provider, category, plan_name, affiliate_url, is_active, last_verified_at, price_monthly, price_changed_at')
+    .order('provider', { ascending: true });
+
+  if (error) {
+    console.error('[admin-metrics] deal health query error', error);
+    return { active: 0, broken: [], stale: [], healthy: [], lastVerifiedAt: null };
+  }
+
+  const now = Date.now();
+  const broken: AdminDeal[] = [];
+  const stale: AdminDeal[] = [];
+  const healthy: AdminDeal[] = [];
+  let lastVerifiedAt: string | null = null;
+
+  for (const raw of data || []) {
+    const d = raw as AdminDeal;
+    if (d.last_verified_at && (!lastVerifiedAt || d.last_verified_at > lastVerifiedAt)) {
+      lastVerifiedAt = d.last_verified_at;
+    }
+    if (!d.is_active) {
+      broken.push(d);
+      continue;
+    }
+    const verifiedMs = d.last_verified_at ? new Date(d.last_verified_at).getTime() : 0;
+    if (!verifiedMs || now - verifiedMs > STALE_THRESHOLD_MS) {
+      stale.push(d);
+    } else {
+      healthy.push(d);
+    }
+  }
+
+  return {
+    active: broken.length === 0 ? (data?.length ?? 0) : (data?.length ?? 0) - broken.length,
+    broken,
+    stale,
+    healthy,
+    lastVerifiedAt,
+  };
+}
+
+function round2(n: number): number {
+  return parseFloat(n.toFixed(2));
+}


### PR DESCRIPTION
## Summary

Three bugs on the `/dashboard/admin` Overview + Deal Health card.

### Bug 1 — Bank Connections counter showed 0 (had 3,874 transactions)
- **Root cause:** `/api/admin/metrics` filtered `bank_connections.status = 'active'`. The 2 Apr 2026 Yapily migration (`20260402050000_yapily_migration.sql`) bulk-flipped every existing TrueLayer row to `'expired_legacy'`. Prod is still on TrueLayer (Yapily blocked on approval — see CLAUDE.md memory).
- **Fix:** New helper `getActiveBankConnectionCount` in `src/lib/admin-metrics.ts` counts every non-deleted, non-revoked connection across providers. Wired into `src/app/api/admin/metrics/route.ts:35`.

### Bug 2 — MRR £199.87 with 6 essential + 7 pro (expected £99.87)
- **Root cause:** stale hardcoded prices in `src/app/api/admin/metrics/route.ts:57` (was £9.99 essential / £19.99 pro). Authoritative pricing in CLAUDE.md and `src/lib/stripe.ts` is £4.99 / £9.99 monthly. 6×9.99 + 7×19.99 = £199.87 exactly.
- **Fix:** New helper `computeMrrGbp` in `src/lib/admin-metrics.ts` uses canonical constants and returns a per-tier breakdown for reuse on the upcoming Business Costs tab.
- **Caveat:** `profiles` has no `billing_interval` column, so MRR treats every paying user at the monthly headline price. Documented inline. The reported £100 gap was the stale-prices bug, not yearly subs.

### Bug 3 — Deal Health had no drill-in
- New `/api/admin/deals` returns `{broken, stale, healthy, lastVerifiedAt}` via `getDealHealth` helper.
- `src/app/dashboard/admin/page.tsx` renders a filterable, searchable list under the 4-stat card: broken first, then stale, with a collapsed Healthy group. Each row shows provider, category, plan, last-verified date, and a click-to-open affiliate URL.
- The bulk `Verify Deals Now` button now refreshes the list when it returns. Per-row Perplexity verification is a separate PR.

### Constraints honoured
- B2C surface only. No edits under `src/app/for-business/**`, `src/app/api/v1/**`, `src/lib/b2b/**`, `src/app/dashboard/admin/b2b/**`.
- No edits under `src/app/dashboard/admin/legal-refs/**` or `src/app/api/admin/legal-refs/**` (parallel session).
- No migrations needed.
- `tsc --noEmit` clean.

## Test plan
- [ ] Visit `/dashboard/admin` Overview as the founder
- [ ] Verify Bank Connections counter > 0 (matches actual TrueLayer + Yapily user count)
- [ ] Verify MRR = (essential count × £4.99) + (pro count × £9.99)
- [ ] Filter the Deal Health drill-in by Broken / Stale / Healthy
- [ ] Search by provider name
- [ ] Click an Open URL link — opens affiliate URL in a new tab
- [ ] Hit Verify Deals Now — list refreshes after the bulk job returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)