### PR TITLE
feat(admin): legal-refs auto-overwrite + full-baseline re-verify

### DIFF
--- a/src/app/api/admin/legal-refs/verify-all/route.ts
+++ b/src/app/api/admin/legal-refs/verify-all/route.ts
@@ -1,0 +1,223 @@
+/**
+ * POST /api/admin/legal-refs/verify-all
+ *
+ * Founder-gated full re-verify. Reads every row in legal_references and
+ * runs each through the same logic the per-id `/verify` endpoint uses,
+ * in batches of 25 with 200 ms gaps between calls.
+ *
+ * Returns a JSON summary (counts + per-id results) at the end. We chose
+ * a single final response over streaming because Vercel's serverless
+ * boundary makes streaming JSON-lines fiddly to consume from the admin
+ * page — the modal already shows progress against the existing
+ * `/verify` endpoint when wired to a "verify all" button, and a 112-row
+ * pass at <5 s/row finishes well inside `maxDuration = 800`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import { logPerplexityCall } from '@/lib/cost-ledger';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 800;
+
+const PERPLEXITY_MODEL = 'sonar-pro';
+const BATCH = 25;
+const INTER_CALL_GAP_MS = 200;
+
+function getAdminEmails(): string[] {
+  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim()
+  );
+}
+
+interface LegalRefRow {
+  id: string;
+  law_name: string;
+  section: string | null;
+  source_url: string;
+  source_type: string | null;
+  summary: string;
+  category: string;
+  created_at: string;
+}
+
+interface PerplexityVerdict {
+  valid: boolean;
+  current_url: string | null;
+  superseded_by: string | null;
+  confidence: 'high' | 'medium' | 'low';
+  notes: string;
+}
+
+function buildPrompt(ref: LegalRefRow): string {
+  const yearMatch = ref.created_at?.match(/^(\d{4})/);
+  const year = yearMatch ? yearMatch[1] : 'unknown';
+  const titleParts = [ref.law_name, ref.section].filter(Boolean).join(' — ');
+  const source = ref.source_type || 'unknown';
+  return [
+    `Verify this UK legal citation:`,
+    `title='${titleParts}',`,
+    `source='${source}' (${year}),`,
+    `current URL='${ref.source_url}'.`,
+    `Confirm: (a) does the URL still resolve to the right document,`,
+    `(b) is the citation accurate,`,
+    `(c) has it been superseded by a newer reference.`,
+    `Return STRICT JSON only, no markdown, no commentary:`,
+    `{"valid": bool, "current_url": string|null, "superseded_by": string|null, "confidence": "high"|"medium"|"low", "notes": string}`,
+  ].join(' ');
+}
+
+async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          { role: 'system', content: 'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.' },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 500,
+        temperature: 0.1,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const content: string = data?.choices?.[0]?.message?.content || '';
+    const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]);
+    const conf = parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low' ? parsed.confidence : 'low';
+    return {
+      valid: !!parsed.valid,
+      current_url: typeof parsed.current_url === 'string' ? parsed.current_url : null,
+      superseded_by: typeof parsed.superseded_by === 'string' ? parsed.superseded_by : null,
+      confidence: conf,
+      notes: typeof parsed.notes === 'string' ? parsed.notes : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseSuperseded(s: string): { law_name: string; url: string | null } {
+  const urlMatch = s.match(/https?:\/\/\S+/);
+  const url = urlMatch ? urlMatch[0].replace(/[)\].,;]+$/, '') : null;
+  const title = s
+    .replace(urlMatch?.[0] ?? '', '')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[—–\-:]\s*/, '');
+  return { law_name: title || s.trim(), url };
+}
+
+function deriveStatus(verdict: PerplexityVerdict): string {
+  if (verdict.superseded_by) return 'superseded';
+  if (!verdict.valid) return 'broken';
+  if (verdict.valid && verdict.confidence !== 'low') return 'verified';
+  return 'needs_review';
+}
+
+export async function POST(_request: NextRequest) {
+  let userId: string | null = null;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const allow = getAdminEmails();
+    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    userId = user.id;
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+  const { data: refs, error } = await admin
+    .from('legal_references')
+    .select('id, law_name, section, source_url, source_type, summary, category, created_at');
+
+  if (error || !refs) {
+    return NextResponse.json({ error: error?.message || 'Failed to read refs' }, { status: 500 });
+  }
+
+  const counts = { total: refs.length, verified: 0, updated: 0, superseded: 0, needs_review: 0, broken: 0, error: 0, auto_corrected: 0 };
+  const perId: Array<{ id: string; status: string; auto_corrected: boolean }> = [];
+
+  for (let i = 0; i < refs.length; i += BATCH) {
+    const chunk = refs.slice(i, i + BATCH);
+    for (const ref of chunk) {
+      const verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
+      if (!verdict) {
+        counts.error += 1;
+        perId.push({ id: ref.id, status: 'error', auto_corrected: false });
+        continue;
+      }
+      logPerplexityCall({
+        model: PERPLEXITY_MODEL,
+        endpoint: '/api/admin/legal-refs/verify-all',
+        userId,
+        metadata: { legal_reference_id: ref.id },
+      });
+
+      let status = deriveStatus(verdict);
+      const notes = verdict.superseded_by
+        ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
+        : verdict.notes;
+      const update: Record<string, unknown> = {
+        last_verified: new Date().toISOString(),
+        verification_notes: notes || null,
+      };
+      if (verdict.current_url) update.verified_url = verdict.current_url;
+
+      let autoCorrected = false;
+      if (verdict.confidence === 'high' && verdict.superseded_by) {
+        const parsed = parseSuperseded(verdict.superseded_by);
+        update.law_name = parsed.law_name;
+        if (parsed.url) update.source_url = parsed.url;
+        else if (verdict.current_url) update.source_url = verdict.current_url;
+        status = 'superseded';
+        autoCorrected = true;
+      } else if (verdict.confidence === 'high' && verdict.valid === false && verdict.current_url) {
+        update.source_url = verdict.current_url;
+        status = 'updated';
+        autoCorrected = true;
+      } else if (verdict.confidence === 'medium') {
+        status = 'needs_review';
+      } else if (verdict.confidence === 'low') {
+        status = 'broken';
+      }
+
+      update.verification_status = status;
+      if (autoCorrected) update.auto_corrected = true;
+
+      await admin.from('legal_references').update(update).eq('id', ref.id);
+
+      if (status === 'verified') counts.verified += 1;
+      else if (status === 'updated') counts.updated += 1;
+      else if (status === 'superseded') counts.superseded += 1;
+      else if (status === 'needs_review') counts.needs_review += 1;
+      else if (status === 'broken') counts.broken += 1;
+      if (autoCorrected) counts.auto_corrected += 1;
+
+      perId.push({ id: ref.id, status, auto_corrected: autoCorrected });
+      await new Promise((r) => setTimeout(r, INTER_CALL_GAP_MS));
+    }
+  }
+
+  return NextResponse.json({ ok: true, counts, results: perId });
+}

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -142,6 +142,25 @@ function deriveStatus(verdict: PerplexityVerdict): string {
   return 'needs_review';
 }
 
+/**
+ * Best-effort parse of a free-text supersession string into a structured
+ * (law_name, section, url) tuple. Perplexity returns things like:
+ *   "Consumer Rights Act 2015, s.20 (https://...)" — extract the URL,
+ *   strip it from the title, and use what remains as the new law_name.
+ * If we can't pull a URL out, return only the trimmed title.
+ */
+function parseSuperseded(s: string): { law_name: string; url: string | null } {
+  const urlMatch = s.match(/https?:\/\/\S+/);
+  const url = urlMatch ? urlMatch[0].replace(/[)\].,;]+$/, '') : null;
+  const title = s
+    .replace(urlMatch?.[0] ?? '', '')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[—–\-:]\s*/, '');
+  return { law_name: title || s.trim(), url };
+}
+
 async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
   const admin = getAdmin();
   const { data: ref, error } = await admin
@@ -173,19 +192,51 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
     metadata: { legal_reference_id: id },
   });
 
-  const status = deriveStatus(verdict);
+  let status = deriveStatus(verdict);
   const notes = verdict.superseded_by
     ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
     : verdict.notes;
 
   const update: Record<string, unknown> = {
-    verification_status: status,
     last_verified: new Date().toISOString(),
     verification_notes: notes || null,
   };
   if (verdict.current_url) {
     update.verified_url = verdict.current_url;
   }
+
+  // Auto-overwrite logic (PR α). High-confidence corrections rewrite the
+  // canonical fields so a single "Verify all" run establishes a clean
+  // baseline. Medium / low confidence never touches the canonical row —
+  // founder reviews via the "auto_corrected" badge before relying on it.
+  let autoCorrected = false;
+  if (verdict.confidence === 'high' && verdict.superseded_by) {
+    const parsed = parseSuperseded(verdict.superseded_by);
+    update.law_name = parsed.law_name;
+    if (parsed.url) update.source_url = parsed.url;
+    else if (verdict.current_url) update.source_url = verdict.current_url;
+    status = 'superseded';
+    autoCorrected = true;
+  } else if (
+    verdict.confidence === 'high' &&
+    verdict.valid === false &&
+    verdict.current_url
+  ) {
+    update.source_url = verdict.current_url;
+    status = 'updated';
+    autoCorrected = true;
+  } else if (verdict.confidence === 'medium') {
+    // Never overwrite canonical on medium — keep status as needs_review
+    // regardless of what deriveStatus returned. Only verified_url +
+    // notes are written above.
+    status = 'needs_review';
+  } else if (verdict.confidence === 'low') {
+    // Leave canonical untouched. Mark broken so the founder sees it.
+    status = 'broken';
+  }
+
+  update.verification_status = status;
+  if (autoCorrected) update.auto_corrected = true;
 
   const { error: updateError } = await admin
     .from('legal_references')

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -1,0 +1,259 @@
+/**
+ * POST /api/admin/legal-refs/verify
+ *
+ * Founder-gated AI verification of a single legal_references row (or up
+ * to 25 rows in a batch). Calls Perplexity sonar-pro with a strict-JSON
+ * prompt asking whether the citation is still accurate, whether the URL
+ * still resolves to the right document, and whether it has been
+ * superseded. Updates the row with the result and logs the spend to the
+ * api_cost_ledger via logPerplexityCall.
+ *
+ * Body (single):  { id: string }
+ * Body (batch):   { ids: string[] }   // max 25
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import { logPerplexityCall } from '@/lib/cost-ledger';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const MAX_BATCH = 25;
+const PERPLEXITY_MODEL = 'sonar-pro';
+
+function getAdminEmails(): string[] {
+  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim()
+  );
+}
+
+interface LegalRefRow {
+  id: string;
+  law_name: string;
+  section: string | null;
+  source_url: string;
+  source_type: string | null;
+  summary: string;
+  category: string;
+  created_at: string;
+}
+
+interface PerplexityVerdict {
+  valid: boolean;
+  current_url: string | null;
+  superseded_by: string | null;
+  confidence: 'high' | 'medium' | 'low';
+  notes: string;
+}
+
+interface VerifyResult {
+  id: string;
+  status: string;
+  current_url: string | null;
+  notes: string;
+  error?: string;
+}
+
+function buildPrompt(ref: LegalRefRow): string {
+  const yearMatch = ref.created_at?.match(/^(\d{4})/);
+  const year = yearMatch ? yearMatch[1] : 'unknown';
+  const titleParts = [ref.law_name, ref.section].filter(Boolean).join(' — ');
+  const source = ref.source_type || 'unknown';
+  return [
+    `Verify this UK legal citation:`,
+    `title='${titleParts}',`,
+    `source='${source}' (${year}),`,
+    `current URL='${ref.source_url}'.`,
+    `Confirm: (a) does the URL still resolve to the right document,`,
+    `(b) is the citation accurate,`,
+    `(c) has it been superseded by a newer reference.`,
+    `Return STRICT JSON only, no markdown, no commentary:`,
+    `{"valid": bool, "current_url": string|null, "superseded_by": string|null, "confidence": "high"|"medium"|"low", "notes": string}`,
+  ].join(' ');
+}
+
+async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) {
+    console.warn('[legal-refs/verify] PERPLEXITY_API_KEY not set');
+    return null;
+  }
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.',
+          },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 500,
+        temperature: 0.1,
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[legal-refs/verify] Perplexity ${res.status}`);
+      return null;
+    }
+    const data = await res.json();
+    const content: string = data?.choices?.[0]?.message?.content || '';
+    const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]);
+    const conf = parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low'
+      ? parsed.confidence
+      : 'low';
+    return {
+      valid: !!parsed.valid,
+      current_url: typeof parsed.current_url === 'string' ? parsed.current_url : null,
+      superseded_by: typeof parsed.superseded_by === 'string' ? parsed.superseded_by : null,
+      confidence: conf,
+      notes: typeof parsed.notes === 'string' ? parsed.notes : '',
+    };
+  } catch (err: any) {
+    console.error('[legal-refs/verify] Perplexity error:', err?.message || err);
+    return null;
+  }
+}
+
+function deriveStatus(verdict: PerplexityVerdict): string {
+  if (verdict.superseded_by) return 'superseded';
+  if (!verdict.valid) return 'broken';
+  if (verdict.valid && verdict.confidence !== 'low') return 'verified';
+  return 'needs_review';
+}
+
+async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
+  const admin = getAdmin();
+  const { data: ref, error } = await admin
+    .from('legal_references')
+    .select('id, law_name, section, source_url, source_type, summary, category, created_at')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error || !ref) {
+    return { id, status: 'error', current_url: null, notes: '', error: 'Reference not found' };
+  }
+
+  const verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
+  if (!verdict) {
+    return {
+      id,
+      status: 'error',
+      current_url: null,
+      notes: '',
+      error: 'Perplexity call failed',
+    };
+  }
+
+  // Log spend (fire-and-forget).
+  logPerplexityCall({
+    model: PERPLEXITY_MODEL,
+    endpoint: '/api/admin/legal-refs/verify',
+    userId,
+    metadata: { legal_reference_id: id },
+  });
+
+  const status = deriveStatus(verdict);
+  const notes = verdict.superseded_by
+    ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
+    : verdict.notes;
+
+  const update: Record<string, unknown> = {
+    verification_status: status,
+    last_verified: new Date().toISOString(),
+    verification_notes: notes || null,
+  };
+  if (verdict.current_url) {
+    update.verified_url = verdict.current_url;
+  }
+
+  const { error: updateError } = await admin
+    .from('legal_references')
+    .update(update)
+    .eq('id', id);
+
+  if (updateError) {
+    return {
+      id,
+      status: 'error',
+      current_url: verdict.current_url,
+      notes,
+      error: `DB update failed: ${updateError.message}`,
+    };
+  }
+
+  return {
+    id,
+    status,
+    current_url: verdict.current_url,
+    notes,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  // Founder gate.
+  let userId: string | null = null;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const allow = getAdminEmails();
+    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    userId = user.id;
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { id?: string; ids?: string[] };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (body.id && typeof body.id === 'string') {
+    const result = await verifyOne(body.id, userId);
+    return NextResponse.json({ updated: result });
+  }
+
+  if (Array.isArray(body.ids) && body.ids.length > 0) {
+    if (body.ids.length > MAX_BATCH) {
+      return NextResponse.json(
+        { error: `Too many ids — max ${MAX_BATCH} per request` },
+        { status: 400 }
+      );
+    }
+    const results: VerifyResult[] = [];
+    // Sequential to avoid Perplexity rate limits.
+    for (const id of body.ids) {
+      if (typeof id !== 'string') continue;
+      // eslint-disable-next-line no-await-in-loop
+      const r = await verifyOne(id, userId);
+      results.push(r);
+    }
+    return NextResponse.json({ results });
+  }
+
+  return NextResponse.json({ error: 'Body must be { id } or { ids: [...] }' }, { status: 400 });
+}

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -28,6 +28,7 @@ interface LegalRef {
   last_changed: string | null;
   verification_notes: string | null;
   verified_url: string | null;
+  auto_corrected?: boolean | null;
   created_at: string;
 }
 
@@ -105,6 +106,9 @@ export default function LegalRefsAdminPage() {
   const [batchProgress, setBatchProgress] = useState<{ done: number; total: number } | null>(null);
   const [reviewPage, setReviewPage] = useState(0);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmAllOpen, setConfirmAllOpen] = useState(false);
+  const [verifyAllRunning, setVerifyAllRunning] = useState(false);
+  const [verifyAllResult, setVerifyAllResult] = useState<string | null>(null);
   const REVIEW_PAGE_SIZE = 50;
   const supabase = createClient();
 
@@ -436,6 +440,12 @@ export default function LegalRefsAdminPage() {
                         <StatusIcon className="h-3 w-3" />
                         {status.label}
                       </span>
+                      {ref.auto_corrected && (
+                        <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
+                          <AlertTriangle className="h-3 w-3" />
+                          AI auto-correction
+                        </div>
+                      )}
                     </td>
                     <td className="px-5 py-4 hidden lg:table-cell">
                       <div className="flex items-center gap-1.5 text-slate-600 text-xs">
@@ -518,14 +528,91 @@ export default function LegalRefsAdminPage() {
                 )}
                 <button
                   onClick={() => setConfirmOpen(true)}
-                  disabled={anyVerifying || reviewable.length === 0}
+                  disabled={anyVerifying || verifyAllRunning || reviewable.length === 0}
                   className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
                 >
                   {anyVerifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-                  Verify all with AI
+                  Verify needs-review only
+                </button>
+                <button
+                  onClick={() => setConfirmAllOpen(true)}
+                  disabled={anyVerifying || verifyAllRunning || refs.length === 0}
+                  className="flex items-center gap-2 bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
+                  title="Re-verify every legal_references row to establish a clean baseline"
+                >
+                  {verifyAllRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  Re-verify ALL refs (full baseline)
                 </button>
               </div>
             </div>
+
+            {verifyAllResult && (
+              <div className={`mb-3 px-4 py-3 rounded-xl text-sm font-medium border ${
+                verifyAllResult.startsWith('Done') ? 'bg-green-500/10 border-green-500/20 text-green-700' : 'bg-red-500/10 border-red-500/20 text-red-500'
+              }`}>
+                {verifyAllResult}
+              </div>
+            )}
+
+            {confirmAllOpen && (
+              <div
+                className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+                onClick={() => setConfirmAllOpen(false)}
+              >
+                <div
+                  className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl border border-slate-200"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <h3 className="text-lg font-bold text-slate-900 mb-2">Re-verify ALL references</h3>
+                  <p className="text-sm text-slate-600 mb-5">
+                    This will re-verify all {refs.length} refs to establish a clean
+                    compliance baseline. Cost ~£{(refs.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(2)}.
+                    High-confidence corrections will auto-overwrite the canonical
+                    citation fields and be flagged with an amber badge for your review.
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setConfirmAllOpen(false)}
+                      className="px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 rounded-lg"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={async () => {
+                        setConfirmAllOpen(false);
+                        setVerifyAllRunning(true);
+                        setVerifyAllResult(null);
+                        try {
+                          const res = await fetch('/api/admin/legal-refs/verify-all', {
+                            method: 'POST',
+                            credentials: 'include',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({}),
+                          });
+                          const data = await res.json();
+                          if (data.ok && data.counts) {
+                            const c = data.counts;
+                            setVerifyAllResult(
+                              `Done. ${c.verified} verified · ${c.updated} auto-updated · ${c.superseded} superseded · ${c.needs_review} needs review · ${c.broken} broken · ${c.error} errors · ${c.auto_corrected} auto-corrected (review).`
+                            );
+                            await fetchRefs();
+                          } else {
+                            setVerifyAllResult(`Error: ${data.error || 'Unknown error'}`);
+                          }
+                        } catch (err: any) {
+                          setVerifyAllResult(`Failed: ${err?.message || 'Request failed'}`);
+                        } finally {
+                          setVerifyAllRunning(false);
+                        }
+                      }}
+                      className="px-4 py-2 text-sm font-semibold bg-amber-500 hover:bg-amber-600 text-slate-900 rounded-lg"
+                    >
+                      Run full baseline
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
 
             {confirmOpen && (
               <div
@@ -609,6 +696,12 @@ export default function LegalRefsAdminPage() {
                               <StatusIcon className="h-3 w-3" />
                               {status.label}
                             </span>
+                            {ref.auto_corrected && (
+                              <span className="ml-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
+                                <AlertTriangle className="h-3 w-3" />
+                                AI auto-correction — please review
+                              </span>
+                            )}
                           </td>
                           <td className="px-5 py-4 hidden lg:table-cell text-slate-600 text-xs">
                             {relativeTime(ref.last_verified)}

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -27,7 +27,36 @@ interface LegalRef {
   last_verified: string | null;
   last_changed: string | null;
   verification_notes: string | null;
+  verified_url: string | null;
   created_at: string;
+}
+
+const PERPLEXITY_COST_PER_ROW_GBP = 0.005 * 0.79; // sonar-pro flat rate × USD→GBP
+
+function relativeTime(d: string | null): string {
+  if (!d) return 'Never';
+  const then = new Date(d).getTime();
+  const diff = Date.now() - then;
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  if (days < 1) return 'Today';
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${days} days ago`;
+  const months = Math.floor(days / 30);
+  if (months === 1) return '1 month ago';
+  if (months < 12) return `${months} months ago`;
+  const years = Math.floor(days / 365);
+  return years === 1 ? '1 year ago' : `${years} years ago`;
+}
+
+const REVIEW_STATUSES = new Set(['needs_review', 'broken', 'stale', 'error', 'superseded']);
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+
+function isReviewable(r: LegalRef): boolean {
+  if (REVIEW_STATUSES.has(r.verification_status)) return true;
+  if (!r.last_verified) return true;
+  const verifiedAt = new Date(r.last_verified).getTime();
+  if (isNaN(verifiedAt)) return true;
+  return Date.now() - verifiedAt > SIXTY_DAYS_MS;
 }
 
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof CheckCircle; className: string }> = {
@@ -71,6 +100,12 @@ export default function LegalRefsAdminPage() {
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState<string>('all');
   const [filterCategory, setFilterCategory] = useState<string>('all');
+  const [aiVerifyingIds, setAiVerifyingIds] = useState<Set<string>>(new Set());
+  const [aiResults, setAiResults] = useState<Record<string, { status: string; notes: string; ok: boolean }>>({});
+  const [batchProgress, setBatchProgress] = useState<{ done: number; total: number } | null>(null);
+  const [reviewPage, setReviewPage] = useState(0);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const REVIEW_PAGE_SIZE = 50;
   const supabase = createClient();
 
   useEffect(() => {
@@ -117,6 +152,94 @@ export default function LegalRefsAdminPage() {
       setVerifyResult(`Failed: ${err.message}`);
     } finally {
       setVerifying(false);
+    }
+  };
+
+  const verifyWithAi = async (ids: string[]) => {
+    if (ids.length === 0) return;
+    const single = ids.length === 1;
+    setAiVerifyingIds(prev => {
+      const next = new Set(prev);
+      ids.forEach(id => next.add(id));
+      return next;
+    });
+    try {
+      if (single) {
+        const res = await fetch('/api/admin/legal-refs/verify', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: ids[0] }),
+        });
+        const data = await res.json();
+        const u = data?.updated;
+        if (u) {
+          setAiResults(prev => ({
+            ...prev,
+            [u.id]: {
+              status: u.status,
+              notes: u.error || u.notes || '',
+              ok: u.status !== 'error',
+            },
+          }));
+          setRefs(prev => prev.map(r => (r.id === u.id ? {
+            ...r,
+            verification_status: u.status === 'error' ? r.verification_status : u.status,
+            verified_url: u.current_url ?? r.verified_url,
+            verification_notes: u.notes ?? r.verification_notes,
+            last_verified: u.status === 'error' ? r.last_verified : new Date().toISOString(),
+          } : r)));
+        }
+      } else {
+        // Batch in chunks of 25.
+        setBatchProgress({ done: 0, total: ids.length });
+        let done = 0;
+        for (let i = 0; i < ids.length; i += 25) {
+          const chunk = ids.slice(i, i + 25);
+          // eslint-disable-next-line no-await-in-loop
+          const res = await fetch('/api/admin/legal-refs/verify', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ids: chunk }),
+          });
+          // eslint-disable-next-line no-await-in-loop
+          const data = await res.json();
+          const results: Array<{ id: string; status: string; current_url: string | null; notes: string; error?: string }> = data?.results || [];
+          setAiResults(prev => {
+            const next = { ...prev };
+            results.forEach(r => {
+              next[r.id] = { status: r.status, notes: r.error || r.notes || '', ok: r.status !== 'error' };
+            });
+            return next;
+          });
+          setRefs(prev => prev.map(r => {
+            const u = results.find(x => x.id === r.id);
+            if (!u || u.status === 'error') return r;
+            return {
+              ...r,
+              verification_status: u.status,
+              verified_url: u.current_url ?? r.verified_url,
+              verification_notes: u.notes ?? r.verification_notes,
+              last_verified: new Date().toISOString(),
+            };
+          }));
+          done += chunk.length;
+          setBatchProgress({ done, total: ids.length });
+        }
+      }
+    } catch (err: any) {
+      console.error('verifyWithAi failed', err);
+      ids.forEach(id => {
+        setAiResults(prev => ({ ...prev, [id]: { status: 'error', notes: err?.message || 'Request failed', ok: false } }));
+      });
+    } finally {
+      setAiVerifyingIds(prev => {
+        const next = new Set(prev);
+        ids.forEach(id => next.delete(id));
+        return next;
+      });
+      setTimeout(() => setBatchProgress(null), 2000);
     }
   };
 
@@ -353,6 +476,209 @@ export default function LegalRefsAdminPage() {
           </div>
         )}
       </div>
+
+      {/* Review queue — AI-assisted manual verification */}
+      {(() => {
+        const reviewable = refs
+          .filter(isReviewable)
+          .sort((a, b) => {
+            // last_verified NULLS FIRST, then created_at DESC
+            if (!a.last_verified && b.last_verified) return -1;
+            if (a.last_verified && !b.last_verified) return 1;
+            if (a.last_verified && b.last_verified) {
+              const at = new Date(a.last_verified).getTime();
+              const bt = new Date(b.last_verified).getTime();
+              if (at !== bt) return at - bt;
+            }
+            return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+          });
+        const totalPages = Math.max(1, Math.ceil(reviewable.length / REVIEW_PAGE_SIZE));
+        const page = Math.min(reviewPage, totalPages - 1);
+        const slice = reviewable.slice(page * REVIEW_PAGE_SIZE, (page + 1) * REVIEW_PAGE_SIZE);
+        const allIds = reviewable.map(r => r.id);
+        const totalCost = (reviewable.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(3);
+        const anyVerifying = aiVerifyingIds.size > 0;
+        return (
+          <div className="mt-10">
+            <div className="flex flex-wrap items-end justify-between gap-3 mb-3">
+              <div>
+                <h2 className="text-2xl font-bold text-slate-900 font-[family-name:var(--font-heading)]">
+                  Review queue
+                </h2>
+                <p className="text-slate-600 text-sm mt-1">
+                  {reviewable.length} reference{reviewable.length === 1 ? '' : 's'} need attention
+                  {' '}— needs review, broken, stale, errored, never verified, or last verified &gt; 60 days ago.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {batchProgress && (
+                  <span className="text-xs text-slate-600">
+                    Verifying {batchProgress.done} of {batchProgress.total}…
+                  </span>
+                )}
+                <button
+                  onClick={() => setConfirmOpen(true)}
+                  disabled={anyVerifying || reviewable.length === 0}
+                  className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
+                >
+                  {anyVerifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  Verify all with AI
+                </button>
+              </div>
+            </div>
+
+            {confirmOpen && (
+              <div
+                className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+                onClick={() => setConfirmOpen(false)}
+              >
+                <div
+                  className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl border border-slate-200"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <h3 className="text-lg font-bold text-slate-900 mb-2">Confirm AI verification</h3>
+                  <p className="text-sm text-slate-600 mb-5">
+                    This will run Perplexity verification on {reviewable.length} row
+                    {reviewable.length === 1 ? '' : 's'} at ~£0.004 each = £{totalCost} total.
+                    Proceed?
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setConfirmOpen(false)}
+                      className="px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 rounded-lg"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => {
+                        setConfirmOpen(false);
+                        verifyWithAi(allIds);
+                      }}
+                      className="px-4 py-2 text-sm font-semibold bg-emerald-500 hover:bg-emerald-600 text-slate-900 rounded-lg"
+                    >
+                      Run verification
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-slate-200">
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Title / Source</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden md:table-cell">Year</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden md:table-cell">URL</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Status</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden lg:table-cell">Last verified</th>
+                      <th className="px-5 py-3 text-right text-xs font-semibold text-slate-600 uppercase tracking-wide">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {slice.map((ref) => {
+                      const status = STATUS_CONFIG[ref.verification_status] || STATUS_CONFIG.needs_review;
+                      const StatusIcon = status.icon;
+                      const verifying = aiVerifyingIds.has(ref.id);
+                      const result = aiResults[ref.id];
+                      const year = (ref.created_at || '').slice(0, 4) || '—';
+                      const truncated = ref.source_url.length > 50
+                        ? ref.source_url.slice(0, 47) + '…'
+                        : ref.source_url;
+                      return (
+                        <tr key={ref.id} className="border-b border-slate-200 hover:bg-slate-50 transition-colors">
+                          <td className="px-5 py-4">
+                            <p className="text-slate-900 text-sm font-medium">{ref.law_name}</p>
+                            <p className="text-slate-600 text-xs mt-0.5">{ref.source_type || '—'}{ref.section ? ` · ${ref.section}` : ''}</p>
+                          </td>
+                          <td className="px-5 py-4 text-slate-700 text-sm hidden md:table-cell">{year}</td>
+                          <td className="px-5 py-4 hidden md:table-cell">
+                            <a
+                              href={ref.source_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-emerald-600 hover:text-emerald-500 text-xs"
+                              title={ref.source_url}
+                            >
+                              {truncated}
+                            </a>
+                          </td>
+                          <td className="px-5 py-4">
+                            <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full ${status.className}`}>
+                              <StatusIcon className="h-3 w-3" />
+                              {status.label}
+                            </span>
+                          </td>
+                          <td className="px-5 py-4 hidden lg:table-cell text-slate-600 text-xs">
+                            {relativeTime(ref.last_verified)}
+                          </td>
+                          <td className="px-5 py-4">
+                            <div className="flex items-center justify-end gap-2 flex-wrap">
+                              <a
+                                href={ref.source_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-xs text-slate-700 hover:text-slate-900 px-2.5 py-1.5 border border-slate-200 rounded-lg"
+                              >
+                                <ExternalLink className="h-3 w-3" />
+                                Open URL
+                              </a>
+                              <button
+                                onClick={() => verifyWithAi([ref.id])}
+                                disabled={verifying}
+                                className="inline-flex items-center gap-1 text-xs font-semibold bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 px-2.5 py-1.5 rounded-lg"
+                              >
+                                {verifying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                                Verify with AI
+                              </button>
+                            </div>
+                            {result && (
+                              <p className={`text-[11px] mt-1.5 text-right ${result.ok ? 'text-emerald-600' : 'text-red-500'}`}>
+                                {result.ok ? '✓ ' : '✗ '}{result.ok ? `Verified · ${result.status}` : result.notes || 'Failed'}
+                              </p>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              {reviewable.length === 0 && (
+                <div className="py-12 text-center">
+                  <CheckCircle className="h-10 w-10 text-emerald-500 mx-auto mb-2" />
+                  <p className="text-slate-600 text-sm">All references are up to date.</p>
+                </div>
+              )}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between mt-3">
+                <p className="text-slate-600 text-xs">
+                  Page {page + 1} of {totalPages} · showing {slice.length} of {reviewable.length}
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setReviewPage(Math.max(0, page - 1))}
+                    disabled={page === 0}
+                    className="px-3 py-1.5 text-xs border border-slate-200 rounded-lg disabled:opacity-40"
+                  >
+                    Previous
+                  </button>
+                  <button
+                    onClick={() => setReviewPage(Math.min(totalPages - 1, page + 1))}
+                    disabled={page >= totalPages - 1}
+                    className="px-3 py-1.5 text-xs border border-slate-200 rounded-lg disabled:opacity-40"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       <p className="text-slate-600 text-xs mt-4 text-center">
         Verification runs automatically on the 1st of each month. Statutes are checked via legislation.gov.uk. Regulator rules are compared with a fast AI model.

--- a/supabase/migrations/20260430050000_legal_refs_verification_extra.sql
+++ b/supabase/migrations/20260430050000_legal_refs_verification_extra.sql
@@ -1,0 +1,11 @@
+-- Additive: extra columns for AI-assisted legal reference verification.
+-- verification_notes already exists on legal_references (see
+-- 20260327020000_legal_references.sql), but adding IF NOT EXISTS keeps
+-- this migration safe to re-run. verified_url is new — it stores the
+-- canonical URL Perplexity confirms during a manual review pass, so the
+-- founder can spot when the citation has moved without overwriting the
+-- original `source_url`.
+
+ALTER TABLE public.legal_references
+  ADD COLUMN IF NOT EXISTS verified_url TEXT,
+  ADD COLUMN IF NOT EXISTS verification_notes TEXT;

--- a/supabase/migrations/20260430070000_legal_refs_auto_correct_flag.sql
+++ b/supabase/migrations/20260430070000_legal_refs_auto_correct_flag.sql
@@ -1,0 +1,4 @@
+-- Additive: track when Perplexity verifier auto-overwrote canonical fields
+-- so the admin UI can surface a "review auto-correction" badge.
+ALTER TABLE public.legal_references
+  ADD COLUMN IF NOT EXISTS auto_corrected BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- Perplexity verifier now AUTO-OVERWRITES canonical citation fields when confidence='high' (URL fix or supersession). Medium/low confidence never touches canonical — founder reviews via the new badge.
- New `auto_corrected` flag on `legal_references` (additive migration) so the admin UI can surface "AI auto-correction — please review" amber badge.
- New founder-gated endpoint `POST /api/admin/legal-refs/verify-all` — full baseline re-verify, batches of 25, 200ms gaps, ~£0.56 for 112 refs.
- Admin page now has two buttons: "Verify needs-review only" (existing) and "Re-verify ALL refs (full baseline)" with stronger confirmation modal.

## Confidence rules
| Confidence | URL change | Supersession | Action |
|---|---|---|---|
| high | yes | no | overwrite `source_url`, status='updated', `auto_corrected=true` |
| high | — | yes | overwrite `law_name`+`source_url`, status='superseded', `auto_corrected=true` |
| medium | — | — | only `verified_url`+notes; status='needs_review' |
| low | — | — | canonical untouched; status='broken' |

## Files
- `src/app/api/admin/legal-refs/verify/route.ts` — auto-overwrite logic
- `src/app/api/admin/legal-refs/verify-all/route.ts` — new endpoint
- `src/app/dashboard/admin/legal-refs/page.tsx` — second button + amber badge
- `supabase/migrations/20260430070000_legal_refs_auto_correct_flag.sql` — additive

## Test plan
- [ ] Apply migration on prod
- [ ] Run "Verify needs-review only" — confirm existing flow still works
- [ ] Run "Re-verify ALL refs" — confirm baseline + amber badges appear
- [ ] tsc --noEmit clean (verified locally)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>