### PR TITLE
feat(admin): legal-refs auto-overwrite + full-baseline re-verify (PR α)

### DIFF
--- a/src/app/api/admin/legal-refs/verify-all/route.ts
+++ b/src/app/api/admin/legal-refs/verify-all/route.ts
@@ -1,0 +1,223 @@
+/**
+ * POST /api/admin/legal-refs/verify-all
+ *
+ * Founder-gated full re-verify. Reads every row in legal_references and
+ * runs each through the same logic the per-id `/verify` endpoint uses,
+ * in batches of 25 with 200 ms gaps between calls.
+ *
+ * Returns a JSON summary (counts + per-id results) at the end. We chose
+ * a single final response over streaming because Vercel's serverless
+ * boundary makes streaming JSON-lines fiddly to consume from the admin
+ * page — the modal already shows progress against the existing
+ * `/verify` endpoint when wired to a "verify all" button, and a 112-row
+ * pass at <5 s/row finishes well inside `maxDuration = 800`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import { logPerplexityCall } from '@/lib/cost-ledger';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 800;
+
+const PERPLEXITY_MODEL = 'sonar-pro';
+const BATCH = 25;
+const INTER_CALL_GAP_MS = 200;
+
+function getAdminEmails(): string[] {
+  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim()
+  );
+}
+
+interface LegalRefRow {
+  id: string;
+  law_name: string;
+  section: string | null;
+  source_url: string;
+  source_type: string | null;
+  summary: string;
+  category: string;
+  created_at: string;
+}
+
+interface PerplexityVerdict {
+  valid: boolean;
+  current_url: string | null;
+  superseded_by: string | null;
+  confidence: 'high' | 'medium' | 'low';
+  notes: string;
+}
+
+function buildPrompt(ref: LegalRefRow): string {
+  const yearMatch = ref.created_at?.match(/^(\d{4})/);
+  const year = yearMatch ? yearMatch[1] : 'unknown';
+  const titleParts = [ref.law_name, ref.section].filter(Boolean).join(' — ');
+  const source = ref.source_type || 'unknown';
+  return [
+    `Verify this UK legal citation:`,
+    `title='${titleParts}',`,
+    `source='${source}' (${year}),`,
+    `current URL='${ref.source_url}'.`,
+    `Confirm: (a) does the URL still resolve to the right document,`,
+    `(b) is the citation accurate,`,
+    `(c) has it been superseded by a newer reference.`,
+    `Return STRICT JSON only, no markdown, no commentary:`,
+    `{"valid": bool, "current_url": string|null, "superseded_by": string|null, "confidence": "high"|"medium"|"low", "notes": string}`,
+  ].join(' ');
+}
+
+async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          { role: 'system', content: 'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.' },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 500,
+        temperature: 0.1,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const content: string = data?.choices?.[0]?.message?.content || '';
+    const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]);
+    const conf = parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low' ? parsed.confidence : 'low';
+    return {
+      valid: !!parsed.valid,
+      current_url: typeof parsed.current_url === 'string' ? parsed.current_url : null,
+      superseded_by: typeof parsed.superseded_by === 'string' ? parsed.superseded_by : null,
+      confidence: conf,
+      notes: typeof parsed.notes === 'string' ? parsed.notes : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseSuperseded(s: string): { law_name: string; url: string | null } {
+  const urlMatch = s.match(/https?:\/\/\S+/);
+  const url = urlMatch ? urlMatch[0].replace(/[)\].,;]+$/, '') : null;
+  const title = s
+    .replace(urlMatch?.[0] ?? '', '')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[—–\-:]\s*/, '');
+  return { law_name: title || s.trim(), url };
+}
+
+function deriveStatus(verdict: PerplexityVerdict): string {
+  if (verdict.superseded_by) return 'superseded';
+  if (!verdict.valid) return 'broken';
+  if (verdict.valid && verdict.confidence !== 'low') return 'verified';
+  return 'needs_review';
+}
+
+export async function POST(_request: NextRequest) {
+  let userId: string | null = null;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const allow = getAdminEmails();
+    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    userId = user.id;
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+  const { data: refs, error } = await admin
+    .from('legal_references')
+    .select('id, law_name, section, source_url, source_type, summary, category, created_at');
+
+  if (error || !refs) {
+    return NextResponse.json({ error: error?.message || 'Failed to read refs' }, { status: 500 });
+  }
+
+  const counts = { total: refs.length, verified: 0, updated: 0, superseded: 0, needs_review: 0, broken: 0, error: 0, auto_corrected: 0 };
+  const perId: Array<{ id: string; status: string; auto_corrected: boolean }> = [];
+
+  for (let i = 0; i < refs.length; i += BATCH) {
+    const chunk = refs.slice(i, i + BATCH);
+    for (const ref of chunk) {
+      const verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
+      if (!verdict) {
+        counts.error += 1;
+        perId.push({ id: ref.id, status: 'error', auto_corrected: false });
+        continue;
+      }
+      logPerplexityCall({
+        model: PERPLEXITY_MODEL,
+        endpoint: '/api/admin/legal-refs/verify-all',
+        userId,
+        metadata: { legal_reference_id: ref.id },
+      });
+
+      let status = deriveStatus(verdict);
+      const notes = verdict.superseded_by
+        ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
+        : verdict.notes;
+      const update: Record<string, unknown> = {
+        last_verified: new Date().toISOString(),
+        verification_notes: notes || null,
+      };
+      if (verdict.current_url) update.verified_url = verdict.current_url;
+
+      let autoCorrected = false;
+      if (verdict.confidence === 'high' && verdict.superseded_by) {
+        const parsed = parseSuperseded(verdict.superseded_by);
+        update.law_name = parsed.law_name;
+        if (parsed.url) update.source_url = parsed.url;
+        else if (verdict.current_url) update.source_url = verdict.current_url;
+        status = 'superseded';
+        autoCorrected = true;
+      } else if (verdict.confidence === 'high' && verdict.valid === false && verdict.current_url) {
+        update.source_url = verdict.current_url;
+        status = 'updated';
+        autoCorrected = true;
+      } else if (verdict.confidence === 'medium') {
+        status = 'needs_review';
+      } else if (verdict.confidence === 'low') {
+        status = 'broken';
+      }
+
+      update.verification_status = status;
+      if (autoCorrected) update.auto_corrected = true;
+
+      await admin.from('legal_references').update(update).eq('id', ref.id);
+
+      if (status === 'verified') counts.verified += 1;
+      else if (status === 'updated') counts.updated += 1;
+      else if (status === 'superseded') counts.superseded += 1;
+      else if (status === 'needs_review') counts.needs_review += 1;
+      else if (status === 'broken') counts.broken += 1;
+      if (autoCorrected) counts.auto_corrected += 1;
+
+      perId.push({ id: ref.id, status, auto_corrected: autoCorrected });
+      await new Promise((r) => setTimeout(r, INTER_CALL_GAP_MS));
+    }
+  }
+
+  return NextResponse.json({ ok: true, counts, results: perId });
+}

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -142,6 +142,25 @@ function deriveStatus(verdict: PerplexityVerdict): string {
   return 'needs_review';
 }
 
+/**
+ * Best-effort parse of a free-text supersession string into a structured
+ * (law_name, section, url) tuple. Perplexity returns things like:
+ *   "Consumer Rights Act 2015, s.20 (https://...)" — extract the URL,
+ *   strip it from the title, and use what remains as the new law_name.
+ * If we can't pull a URL out, return only the trimmed title.
+ */
+function parseSuperseded(s: string): { law_name: string; url: string | null } {
+  const urlMatch = s.match(/https?:\/\/\S+/);
+  const url = urlMatch ? urlMatch[0].replace(/[)\].,;]+$/, '') : null;
+  const title = s
+    .replace(urlMatch?.[0] ?? '', '')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[—–\-:]\s*/, '');
+  return { law_name: title || s.trim(), url };
+}
+
 async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
   const admin = getAdmin();
   const { data: ref, error } = await admin
@@ -173,19 +192,51 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
     metadata: { legal_reference_id: id },
   });
 
-  const status = deriveStatus(verdict);
+  let status = deriveStatus(verdict);
   const notes = verdict.superseded_by
     ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
     : verdict.notes;
 
   const update: Record<string, unknown> = {
-    verification_status: status,
     last_verified: new Date().toISOString(),
     verification_notes: notes || null,
   };
   if (verdict.current_url) {
     update.verified_url = verdict.current_url;
   }
+
+  // Auto-overwrite logic (PR α). High-confidence corrections rewrite the
+  // canonical fields so a single "Verify all" run establishes a clean
+  // baseline. Medium / low confidence never touches the canonical row —
+  // founder reviews via the "auto_corrected" badge before relying on it.
+  let autoCorrected = false;
+  if (verdict.confidence === 'high' && verdict.superseded_by) {
+    const parsed = parseSuperseded(verdict.superseded_by);
+    update.law_name = parsed.law_name;
+    if (parsed.url) update.source_url = parsed.url;
+    else if (verdict.current_url) update.source_url = verdict.current_url;
+    status = 'superseded';
+    autoCorrected = true;
+  } else if (
+    verdict.confidence === 'high' &&
+    verdict.valid === false &&
+    verdict.current_url
+  ) {
+    update.source_url = verdict.current_url;
+    status = 'updated';
+    autoCorrected = true;
+  } else if (verdict.confidence === 'medium') {
+    // Never overwrite canonical on medium — keep status as needs_review
+    // regardless of what deriveStatus returned. Only verified_url +
+    // notes are written above.
+    status = 'needs_review';
+  } else if (verdict.confidence === 'low') {
+    // Leave canonical untouched. Mark broken so the founder sees it.
+    status = 'broken';
+  }
+
+  update.verification_status = status;
+  if (autoCorrected) update.auto_corrected = true;
 
   const { error: updateError } = await admin
     .from('legal_references')

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -28,6 +28,7 @@ interface LegalRef {
   last_changed: string | null;
   verification_notes: string | null;
   verified_url: string | null;
+  auto_corrected?: boolean | null;
   created_at: string;
 }
 
@@ -105,6 +106,9 @@ export default function LegalRefsAdminPage() {
   const [batchProgress, setBatchProgress] = useState<{ done: number; total: number } | null>(null);
   const [reviewPage, setReviewPage] = useState(0);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmAllOpen, setConfirmAllOpen] = useState(false);
+  const [verifyAllRunning, setVerifyAllRunning] = useState(false);
+  const [verifyAllResult, setVerifyAllResult] = useState<string | null>(null);
   const REVIEW_PAGE_SIZE = 50;
   const supabase = createClient();
 
@@ -436,6 +440,12 @@ export default function LegalRefsAdminPage() {
                         <StatusIcon className="h-3 w-3" />
                         {status.label}
                       </span>
+                      {ref.auto_corrected && (
+                        <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
+                          <AlertTriangle className="h-3 w-3" />
+                          AI auto-correction
+                        </div>
+                      )}
                     </td>
                     <td className="px-5 py-4 hidden lg:table-cell">
                       <div className="flex items-center gap-1.5 text-slate-600 text-xs">
@@ -518,14 +528,91 @@ export default function LegalRefsAdminPage() {
                 )}
                 <button
                   onClick={() => setConfirmOpen(true)}
-                  disabled={anyVerifying || reviewable.length === 0}
+                  disabled={anyVerifying || verifyAllRunning || reviewable.length === 0}
                   className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
                 >
                   {anyVerifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-                  Verify all with AI
+                  Verify needs-review only
+                </button>
+                <button
+                  onClick={() => setConfirmAllOpen(true)}
+                  disabled={anyVerifying || verifyAllRunning || refs.length === 0}
+                  className="flex items-center gap-2 bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
+                  title="Re-verify every legal_references row to establish a clean baseline"
+                >
+                  {verifyAllRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  Re-verify ALL refs (full baseline)
                 </button>
               </div>
             </div>
+
+            {verifyAllResult && (
+              <div className={`mb-3 px-4 py-3 rounded-xl text-sm font-medium border ${
+                verifyAllResult.startsWith('Done') ? 'bg-green-500/10 border-green-500/20 text-green-700' : 'bg-red-500/10 border-red-500/20 text-red-500'
+              }`}>
+                {verifyAllResult}
+              </div>
+            )}
+
+            {confirmAllOpen && (
+              <div
+                className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+                onClick={() => setConfirmAllOpen(false)}
+              >
+                <div
+                  className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl border border-slate-200"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <h3 className="text-lg font-bold text-slate-900 mb-2">Re-verify ALL references</h3>
+                  <p className="text-sm text-slate-600 mb-5">
+                    This will re-verify all {refs.length} refs to establish a clean
+                    compliance baseline. Cost ~£{(refs.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(2)}.
+                    High-confidence corrections will auto-overwrite the canonical
+                    citation fields and be flagged with an amber badge for your review.
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setConfirmAllOpen(false)}
+                      className="px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 rounded-lg"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={async () => {
+                        setConfirmAllOpen(false);
+                        setVerifyAllRunning(true);
+                        setVerifyAllResult(null);
+                        try {
+                          const res = await fetch('/api/admin/legal-refs/verify-all', {
+                            method: 'POST',
+                            credentials: 'include',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({}),
+                          });
+                          const data = await res.json();
+                          if (data.ok && data.counts) {
+                            const c = data.counts;
+                            setVerifyAllResult(
+                              `Done. ${c.verified} verified · ${c.updated} auto-updated · ${c.superseded} superseded · ${c.needs_review} needs review · ${c.broken} broken · ${c.error} errors · ${c.auto_corrected} auto-corrected (review).`
+                            );
+                            await fetchRefs();
+                          } else {
+                            setVerifyAllResult(`Error: ${data.error || 'Unknown error'}`);
+                          }
+                        } catch (err: any) {
+                          setVerifyAllResult(`Failed: ${err?.message || 'Request failed'}`);
+                        } finally {
+                          setVerifyAllRunning(false);
+                        }
+                      }}
+                      className="px-4 py-2 text-sm font-semibold bg-amber-500 hover:bg-amber-600 text-slate-900 rounded-lg"
+                    >
+                      Run full baseline
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
 
             {confirmOpen && (
               <div
@@ -609,6 +696,12 @@ export default function LegalRefsAdminPage() {
                               <StatusIcon className="h-3 w-3" />
                               {status.label}
                             </span>
+                            {ref.auto_corrected && (
+                              <span className="ml-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
+                                <AlertTriangle className="h-3 w-3" />
+                                AI auto-correction — please review
+                              </span>
+                            )}
                           </td>
                           <td className="px-5 py-4 hidden lg:table-cell text-slate-600 text-xs">
                             {relativeTime(ref.last_verified)}

--- a/supabase/migrations/20260430070000_legal_refs_auto_correct_flag.sql
+++ b/supabase/migrations/20260430070000_legal_refs_auto_correct_flag.sql
@@ -1,0 +1,4 @@
+-- Additive: track when Perplexity verifier auto-overwrote canonical fields
+-- so the admin UI can surface a "review auto-correction" badge.
+ALTER TABLE public.legal_references
+  ADD COLUMN IF NOT EXISTS auto_corrected BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Why
PR #373 ships a Perplexity verifier that writes results to `verified_url` + notes but never overwrites the canonical citation fields. Founder still has to hand-edit any high-confidence corrections. This PR adds the auto-overwrite path so a single "Re-verify ALL refs" click establishes a clean compliance baseline; medium/low confidence is still left untouched for manual review.

Stacked on `feat/admin-legal-refs-review-tools` (PR #373). Will rebase onto master automatically once #373 merges.

## Changes

### `src/app/api/admin/legal-refs/verify/route.ts`
- Added confidence-gated auto-overwrite logic:
  - `confidence='high'` + `superseded_by` → parse the supersession into `law_name` + `source_url` (best-effort URL extraction from the free-text), set `verification_status='superseded'`, set `auto_corrected=true`.
  - `confidence='high'` + `valid=false` + `current_url` → overwrite `source_url`, set `verification_status='updated'`, set `auto_corrected=true`.
  - `confidence='medium'` → never touch canonical; only `verified_url` + notes; status forced to `needs_review`.
  - `confidence='low'` → leave canonical untouched, status `broken`.
- `last_verified` always bumped to NOW().

### `src/app/api/admin/legal-refs/verify-all/route.ts` (new)
- Founder-gated POST. Reads every row, processes in batches of 25 with 200 ms gaps. Returns a single JSON summary at the end (counts + per-id results).
- Same overwrite logic as the per-id endpoint.
- `maxDuration = 800` so a 112-row pass finishes inside the Vercel boundary.

### `supabase/migrations/20260430070000_legal_refs_auto_correct_flag.sql`
- Strictly additive: `ADD COLUMN IF NOT EXISTS auto_corrected BOOLEAN NOT NULL DEFAULT FALSE`.

### `src/app/dashboard/admin/legal-refs/page.tsx`
- Renamed the existing "Verify all with AI" button to **"Verify needs-review only"** (no behaviour change — still hits the per-id endpoint with the review-queue ids).
- Added **"Re-verify ALL refs (full baseline)"** with a stronger amber-styled confirmation modal showing total row count and projected cost (~£0.56 for 112 refs). Hits `/verify-all`.
- Added an amber "AI auto-correction — please review" badge next to status in BOTH the main table and the review queue table whenever `auto_corrected=true`.
- Result banner reports the seven-bucket summary (verified / updated / superseded / needs review / broken / errors / auto-corrected).

## Judgment calls
- **Single JSON response over streaming** for `/verify-all`. Streaming JSON-lines through Vercel's serverless proxy is fiddly to consume from the admin page; a 112-row pass at ~5 s/row finishes in under 10 minutes well inside `maxDuration = 800`. The cost-confirmation modal still shows "Re-verify ALL" loading state and the result banner ticks in once when complete.
- **`parseSuperseded` is best-effort.** Perplexity returns supersession strings like `"Consumer Rights Act 2015, s.20 (https://...)"`. We extract the URL via regex and use the remainder as the new `law_name`. If no URL is in the string we fall back to `current_url` for `source_url`. The new `auto_corrected=true` flag means founder has a UI prompt to verify the parsed result before relying on it — that's the safety net.
- **Medium-confidence verdicts never touch canonical.** Spec said only `verified_url` + notes update; we honour that and force `verification_status='needs_review'` even if `deriveStatus` would have returned `verified` or `superseded`.

## tsc status
`npx tsc --noEmit` is clean for the worktree.

## B2C / B2B surface
B2C admin only. No B2B paths touched. The `legal_references` table is shared between products; the schema change is strictly additive (`auto_corrected` column with safe default).

## Test plan
- [ ] Apply migration to staging — `auto_corrected` column appears with default FALSE.
- [ ] Hit `/dashboard/admin/legal-refs` as founder — both buttons render.
- [ ] Click "Verify needs-review only" — existing flow unchanged.
- [ ] Click "Re-verify ALL refs" — modal shows correct row count and ~£0.56 cost. Cancel = no fire.
- [ ] Confirm — result banner shows seven-bucket summary; auto-corrected rows show amber badge.
- [ ] Pick a row known to have a superseded URL — verify canonical `source_url` updated and `auto_corrected=true`.
- [ ] Hit `/verify-all` without admin email — 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)