### PR TITLE
feat(legal-refs): pre-send guardrail (B2C + B2B) — pre-flight + post-flight

### DIFF
--- a/src/app/api/admin/legal-refs/verify-all/route.ts
+++ b/src/app/api/admin/legal-refs/verify-all/route.ts
@@ -1,0 +1,223 @@
+/**
+ * POST /api/admin/legal-refs/verify-all
+ *
+ * Founder-gated full re-verify. Reads every row in legal_references and
+ * runs each through the same logic the per-id `/verify` endpoint uses,
+ * in batches of 25 with 200 ms gaps between calls.
+ *
+ * Returns a JSON summary (counts + per-id results) at the end. We chose
+ * a single final response over streaming because Vercel's serverless
+ * boundary makes streaming JSON-lines fiddly to consume from the admin
+ * page — the modal already shows progress against the existing
+ * `/verify` endpoint when wired to a "verify all" button, and a 112-row
+ * pass at <5 s/row finishes well inside `maxDuration = 800`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import { logPerplexityCall } from '@/lib/cost-ledger';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 800;
+
+const PERPLEXITY_MODEL = 'sonar-pro';
+const BATCH = 25;
+const INTER_CALL_GAP_MS = 200;
+
+function getAdminEmails(): string[] {
+  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim()
+  );
+}
+
+interface LegalRefRow {
+  id: string;
+  law_name: string;
+  section: string | null;
+  source_url: string;
+  source_type: string | null;
+  summary: string;
+  category: string;
+  created_at: string;
+}
+
+interface PerplexityVerdict {
+  valid: boolean;
+  current_url: string | null;
+  superseded_by: string | null;
+  confidence: 'high' | 'medium' | 'low';
+  notes: string;
+}
+
+function buildPrompt(ref: LegalRefRow): string {
+  const yearMatch = ref.created_at?.match(/^(\d{4})/);
+  const year = yearMatch ? yearMatch[1] : 'unknown';
+  const titleParts = [ref.law_name, ref.section].filter(Boolean).join(' — ');
+  const source = ref.source_type || 'unknown';
+  return [
+    `Verify this UK legal citation:`,
+    `title='${titleParts}',`,
+    `source='${source}' (${year}),`,
+    `current URL='${ref.source_url}'.`,
+    `Confirm: (a) does the URL still resolve to the right document,`,
+    `(b) is the citation accurate,`,
+    `(c) has it been superseded by a newer reference.`,
+    `Return STRICT JSON only, no markdown, no commentary:`,
+    `{"valid": bool, "current_url": string|null, "superseded_by": string|null, "confidence": "high"|"medium"|"low", "notes": string}`,
+  ].join(' ');
+}
+
+async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          { role: 'system', content: 'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.' },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 500,
+        temperature: 0.1,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const content: string = data?.choices?.[0]?.message?.content || '';
+    const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]);
+    const conf = parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low' ? parsed.confidence : 'low';
+    return {
+      valid: !!parsed.valid,
+      current_url: typeof parsed.current_url === 'string' ? parsed.current_url : null,
+      superseded_by: typeof parsed.superseded_by === 'string' ? parsed.superseded_by : null,
+      confidence: conf,
+      notes: typeof parsed.notes === 'string' ? parsed.notes : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseSuperseded(s: string): { law_name: string; url: string | null } {
+  const urlMatch = s.match(/https?:\/\/\S+/);
+  const url = urlMatch ? urlMatch[0].replace(/[)\].,;]+$/, '') : null;
+  const title = s
+    .replace(urlMatch?.[0] ?? '', '')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[—–\-:]\s*/, '');
+  return { law_name: title || s.trim(), url };
+}
+
+function deriveStatus(verdict: PerplexityVerdict): string {
+  if (verdict.superseded_by) return 'superseded';
+  if (!verdict.valid) return 'broken';
+  if (verdict.valid && verdict.confidence !== 'low') return 'verified';
+  return 'needs_review';
+}
+
+export async function POST(_request: NextRequest) {
+  let userId: string | null = null;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const allow = getAdminEmails();
+    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    userId = user.id;
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+  const { data: refs, error } = await admin
+    .from('legal_references')
+    .select('id, law_name, section, source_url, source_type, summary, category, created_at');
+
+  if (error || !refs) {
+    return NextResponse.json({ error: error?.message || 'Failed to read refs' }, { status: 500 });
+  }
+
+  const counts = { total: refs.length, verified: 0, updated: 0, superseded: 0, needs_review: 0, broken: 0, error: 0, auto_corrected: 0 };
+  const perId: Array<{ id: string; status: string; auto_corrected: boolean }> = [];
+
+  for (let i = 0; i < refs.length; i += BATCH) {
+    const chunk = refs.slice(i, i + BATCH);
+    for (const ref of chunk) {
+      const verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
+      if (!verdict) {
+        counts.error += 1;
+        perId.push({ id: ref.id, status: 'error', auto_corrected: false });
+        continue;
+      }
+      logPerplexityCall({
+        model: PERPLEXITY_MODEL,
+        endpoint: '/api/admin/legal-refs/verify-all',
+        userId,
+        metadata: { legal_reference_id: ref.id },
+      });
+
+      let status = deriveStatus(verdict);
+      const notes = verdict.superseded_by
+        ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
+        : verdict.notes;
+      const update: Record<string, unknown> = {
+        last_verified: new Date().toISOString(),
+        verification_notes: notes || null,
+      };
+      if (verdict.current_url) update.verified_url = verdict.current_url;
+
+      let autoCorrected = false;
+      if (verdict.confidence === 'high' && verdict.superseded_by) {
+        const parsed = parseSuperseded(verdict.superseded_by);
+        update.law_name = parsed.law_name;
+        if (parsed.url) update.source_url = parsed.url;
+        else if (verdict.current_url) update.source_url = verdict.current_url;
+        status = 'superseded';
+        autoCorrected = true;
+      } else if (verdict.confidence === 'high' && verdict.valid === false && verdict.current_url) {
+        update.source_url = verdict.current_url;
+        status = 'updated';
+        autoCorrected = true;
+      } else if (verdict.confidence === 'medium') {
+        status = 'needs_review';
+      } else if (verdict.confidence === 'low') {
+        status = 'broken';
+      }
+
+      update.verification_status = status;
+      if (autoCorrected) update.auto_corrected = true;
+
+      await admin.from('legal_references').update(update).eq('id', ref.id);
+
+      if (status === 'verified') counts.verified += 1;
+      else if (status === 'updated') counts.updated += 1;
+      else if (status === 'superseded') counts.superseded += 1;
+      else if (status === 'needs_review') counts.needs_review += 1;
+      else if (status === 'broken') counts.broken += 1;
+      if (autoCorrected) counts.auto_corrected += 1;
+
+      perId.push({ id: ref.id, status, auto_corrected: autoCorrected });
+      await new Promise((r) => setTimeout(r, INTER_CALL_GAP_MS));
+    }
+  }
+
+  return NextResponse.json({ ok: true, counts, results: perId });
+}

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -142,6 +142,25 @@ function deriveStatus(verdict: PerplexityVerdict): string {
   return 'needs_review';
 }
 
+/**
+ * Best-effort parse of a free-text supersession string into a structured
+ * (law_name, section, url) tuple. Perplexity returns things like:
+ *   "Consumer Rights Act 2015, s.20 (https://...)" — extract the URL,
+ *   strip it from the title, and use what remains as the new law_name.
+ * If we can't pull a URL out, return only the trimmed title.
+ */
+function parseSuperseded(s: string): { law_name: string; url: string | null } {
+  const urlMatch = s.match(/https?:\/\/\S+/);
+  const url = urlMatch ? urlMatch[0].replace(/[)\].,;]+$/, '') : null;
+  const title = s
+    .replace(urlMatch?.[0] ?? '', '')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[—–\-:]\s*/, '');
+  return { law_name: title || s.trim(), url };
+}
+
 async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
   const admin = getAdmin();
   const { data: ref, error } = await admin
@@ -173,19 +192,51 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
     metadata: { legal_reference_id: id },
   });
 
-  const status = deriveStatus(verdict);
+  let status = deriveStatus(verdict);
   const notes = verdict.superseded_by
     ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
     : verdict.notes;
 
   const update: Record<string, unknown> = {
-    verification_status: status,
     last_verified: new Date().toISOString(),
     verification_notes: notes || null,
   };
   if (verdict.current_url) {
     update.verified_url = verdict.current_url;
   }
+
+  // Auto-overwrite logic (PR α). High-confidence corrections rewrite the
+  // canonical fields so a single "Verify all" run establishes a clean
+  // baseline. Medium / low confidence never touches the canonical row —
+  // founder reviews via the "auto_corrected" badge before relying on it.
+  let autoCorrected = false;
+  if (verdict.confidence === 'high' && verdict.superseded_by) {
+    const parsed = parseSuperseded(verdict.superseded_by);
+    update.law_name = parsed.law_name;
+    if (parsed.url) update.source_url = parsed.url;
+    else if (verdict.current_url) update.source_url = verdict.current_url;
+    status = 'superseded';
+    autoCorrected = true;
+  } else if (
+    verdict.confidence === 'high' &&
+    verdict.valid === false &&
+    verdict.current_url
+  ) {
+    update.source_url = verdict.current_url;
+    status = 'updated';
+    autoCorrected = true;
+  } else if (verdict.confidence === 'medium') {
+    // Never overwrite canonical on medium — keep status as needs_review
+    // regardless of what deriveStatus returned. Only verified_url +
+    // notes are written above.
+    status = 'needs_review';
+  } else if (verdict.confidence === 'low') {
+    // Leave canonical untouched. Mark broken so the founder sees it.
+    status = 'broken';
+  }
+
+  update.verification_status = status;
+  if (autoCorrected) update.auto_corrected = true;
 
   const { error: updateError } = await admin
     .from('legal_references')

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -1,0 +1,259 @@
+/**
+ * POST /api/admin/legal-refs/verify
+ *
+ * Founder-gated AI verification of a single legal_references row (or up
+ * to 25 rows in a batch). Calls Perplexity sonar-pro with a strict-JSON
+ * prompt asking whether the citation is still accurate, whether the URL
+ * still resolves to the right document, and whether it has been
+ * superseded. Updates the row with the result and logs the spend to the
+ * api_cost_ledger via logPerplexityCall.
+ *
+ * Body (single):  { id: string }
+ * Body (batch):   { ids: string[] }   // max 25
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import { logPerplexityCall } from '@/lib/cost-ledger';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const MAX_BATCH = 25;
+const PERPLEXITY_MODEL = 'sonar-pro';
+
+function getAdminEmails(): string[] {
+  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim()
+  );
+}
+
+interface LegalRefRow {
+  id: string;
+  law_name: string;
+  section: string | null;
+  source_url: string;
+  source_type: string | null;
+  summary: string;
+  category: string;
+  created_at: string;
+}
+
+interface PerplexityVerdict {
+  valid: boolean;
+  current_url: string | null;
+  superseded_by: string | null;
+  confidence: 'high' | 'medium' | 'low';
+  notes: string;
+}
+
+interface VerifyResult {
+  id: string;
+  status: string;
+  current_url: string | null;
+  notes: string;
+  error?: string;
+}
+
+function buildPrompt(ref: LegalRefRow): string {
+  const yearMatch = ref.created_at?.match(/^(\d{4})/);
+  const year = yearMatch ? yearMatch[1] : 'unknown';
+  const titleParts = [ref.law_name, ref.section].filter(Boolean).join(' — ');
+  const source = ref.source_type || 'unknown';
+  return [
+    `Verify this UK legal citation:`,
+    `title='${titleParts}',`,
+    `source='${source}' (${year}),`,
+    `current URL='${ref.source_url}'.`,
+    `Confirm: (a) does the URL still resolve to the right document,`,
+    `(b) is the citation accurate,`,
+    `(c) has it been superseded by a newer reference.`,
+    `Return STRICT JSON only, no markdown, no commentary:`,
+    `{"valid": bool, "current_url": string|null, "superseded_by": string|null, "confidence": "high"|"medium"|"low", "notes": string}`,
+  ].join(' ');
+}
+
+async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) {
+    console.warn('[legal-refs/verify] PERPLEXITY_API_KEY not set');
+    return null;
+  }
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.',
+          },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 500,
+        temperature: 0.1,
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[legal-refs/verify] Perplexity ${res.status}`);
+      return null;
+    }
+    const data = await res.json();
+    const content: string = data?.choices?.[0]?.message?.content || '';
+    const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]);
+    const conf = parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low'
+      ? parsed.confidence
+      : 'low';
+    return {
+      valid: !!parsed.valid,
+      current_url: typeof parsed.current_url === 'string' ? parsed.current_url : null,
+      superseded_by: typeof parsed.superseded_by === 'string' ? parsed.superseded_by : null,
+      confidence: conf,
+      notes: typeof parsed.notes === 'string' ? parsed.notes : '',
+    };
+  } catch (err: any) {
+    console.error('[legal-refs/verify] Perplexity error:', err?.message || err);
+    return null;
+  }
+}
+
+function deriveStatus(verdict: PerplexityVerdict): string {
+  if (verdict.superseded_by) return 'superseded';
+  if (!verdict.valid) return 'broken';
+  if (verdict.valid && verdict.confidence !== 'low') return 'verified';
+  return 'needs_review';
+}
+
+async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
+  const admin = getAdmin();
+  const { data: ref, error } = await admin
+    .from('legal_references')
+    .select('id, law_name, section, source_url, source_type, summary, category, created_at')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error || !ref) {
+    return { id, status: 'error', current_url: null, notes: '', error: 'Reference not found' };
+  }
+
+  const verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
+  if (!verdict) {
+    return {
+      id,
+      status: 'error',
+      current_url: null,
+      notes: '',
+      error: 'Perplexity call failed',
+    };
+  }
+
+  // Log spend (fire-and-forget).
+  logPerplexityCall({
+    model: PERPLEXITY_MODEL,
+    endpoint: '/api/admin/legal-refs/verify',
+    userId,
+    metadata: { legal_reference_id: id },
+  });
+
+  const status = deriveStatus(verdict);
+  const notes = verdict.superseded_by
+    ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
+    : verdict.notes;
+
+  const update: Record<string, unknown> = {
+    verification_status: status,
+    last_verified: new Date().toISOString(),
+    verification_notes: notes || null,
+  };
+  if (verdict.current_url) {
+    update.verified_url = verdict.current_url;
+  }
+
+  const { error: updateError } = await admin
+    .from('legal_references')
+    .update(update)
+    .eq('id', id);
+
+  if (updateError) {
+    return {
+      id,
+      status: 'error',
+      current_url: verdict.current_url,
+      notes,
+      error: `DB update failed: ${updateError.message}`,
+    };
+  }
+
+  return {
+    id,
+    status,
+    current_url: verdict.current_url,
+    notes,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  // Founder gate.
+  let userId: string | null = null;
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const allow = getAdminEmails();
+    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    userId = user.id;
+  } catch {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { id?: string; ids?: string[] };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (body.id && typeof body.id === 'string') {
+    const result = await verifyOne(body.id, userId);
+    return NextResponse.json({ updated: result });
+  }
+
+  if (Array.isArray(body.ids) && body.ids.length > 0) {
+    if (body.ids.length > MAX_BATCH) {
+      return NextResponse.json(
+        { error: `Too many ids — max ${MAX_BATCH} per request` },
+        { status: 400 }
+      );
+    }
+    const results: VerifyResult[] = [];
+    // Sequential to avoid Perplexity rate limits.
+    for (const id of body.ids) {
+      if (typeof id !== 'string') continue;
+      // eslint-disable-next-line no-await-in-loop
+      const r = await verifyOne(id, userId);
+      results.push(r);
+    }
+    return NextResponse.json({ results });
+  }
+
+  return NextResponse.json({ error: 'Body must be { id } or { ids: [...] }' }, { status: 400 });
+}

--- a/src/app/api/complaints/generate/route.ts
+++ b/src/app/api/complaints/generate/route.ts
@@ -6,6 +6,7 @@ import { checkClaudeRateLimit, recordClaudeCall, logClaudeCall } from '@/lib/cla
 import { trackLetterGenerated } from '@/lib/meta-conversions';
 import { awardPoints } from '@/lib/loyalty';
 import { getProviderTerms } from '@/lib/provider-match';
+import { checkRefFreshness, refreshSingleRef, findFreshSubstitute, freshnessOf, postFlightSanitise } from '@/lib/legal-refs-guardrail';
 
 // Claude takes 10-20s for complaint letters — extend beyond Vercel's 10s default
 // 120s — the engine's worst-case path is two Claude calls (citation
@@ -323,6 +324,55 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // PR β — pre-send freshness guardrail. Check the refs we INTEND to
+    // feed into the prompt; for any stale/broken row, attempt a
+    // synchronous Perplexity refresh (5s cap), then if still stale find
+    // a fresh substitute in the same category. If no substitute exists
+    // we strip the row and add a footer note in the letter. Never
+    // blocks the user — degrade gracefully.
+    let guardrailFooterNote: string | null = null;
+    if (relevantRefs.length > 0) {
+      const freshness = await checkRefFreshness(supabase, refIds);
+      if (!freshness.ok && freshness.stale.length > 0) {
+        const usedIds = new Set(refIds);
+        for (const { id: staleId, reason } of freshness.stale) {
+          // Attempt synchronous refresh first.
+          const refreshed = await refreshSingleRef(supabase, staleId);
+          if (refreshed && freshnessOf(refreshed) === 'fresh') {
+            // Replace the row in-place so the prompt block sees the fresh copy.
+            const idx = relevantRefs.findIndex((r: any) => r.id === staleId);
+            if (idx >= 0) {
+              relevantRefs[idx] = { ...relevantRefs[idx], ...refreshed };
+            }
+            continue;
+          }
+          // Refresh failed or still stale. Try a substitute in the same category.
+          const original = relevantRefs.find((r: any) => r.id === staleId);
+          const category = original?.category;
+          if (category) {
+            const sub = await findFreshSubstitute(supabase, category, [...usedIds]);
+            if (sub) {
+              const idx = relevantRefs.findIndex((r: any) => r.id === staleId);
+              if (idx >= 0) {
+                relevantRefs[idx] = { ...sub, applies_to: original?.applies_to || [] } as any;
+                usedIds.add(sub.id);
+              }
+              continue;
+            }
+          }
+          // No substitute — strip the row and flag a footer note.
+          const idx = relevantRefs.findIndex((r: any) => r.id === staleId);
+          if (idx >= 0) relevantRefs.splice(idx, 1);
+          guardrailFooterNote = "We couldn't verify the current statute reference for this point. Please confirm before sending.";
+          void supabase.from('business_log').insert({
+            category: 'legal_intelligence',
+            action: 'guardrail_stripped_stale_ref',
+            details: { user_id: user.id, ref_id: staleId, reason, company: body.companyName },
+          });
+        }
+      }
+    }
+
     let verifiedLegalRefs = '';
     if (relevantRefs.length > 0) {
       verifiedLegalRefs = relevantRefs.map((r) => {
@@ -439,6 +489,52 @@ export async function POST(request: NextRequest) {
         .replace(/\[YOUR ADDRESS\]/gi, fullAddress || '[Address not provided]')
         .replace(/\[YOUR POSTCODE\]/gi, pc || '[Postcode not provided]')
         .replace(/\[ACCOUNT NUMBER\]/gi, body.accountNumber || '[Account number not provided]');
+    }
+
+    // PR β — POST-FLIGHT validation. The pre-flight pass only controls
+    // what we feed INTO the prompt. The model can still dredge a stale
+    // or fabricated UK statute out of training data and stamp it into
+    // the letter. Run a regex pass over the output, cross-check every
+    // detected citation against the fresh pool we fed in, and either
+    // substitute (closest fresh law_name) or strip rogues.
+    let postFlightWarnings: string[] = [];
+    if (result.letter && relevantRefs.length > 0) {
+      const t0 = Date.now();
+      const pf = postFlightSanitise(
+        result.letter,
+        relevantRefs.map((r: any) => ({ law_name: r.law_name, category: r.category }))
+      );
+      const elapsed = Date.now() - t0;
+      if (elapsed > 100) {
+        console.warn(`[guardrail] post-flight took ${elapsed}ms (>100ms budget) — non-blocking`);
+      }
+      if (pf.rogue.length > 0) {
+        result.letter = pf.sanitised;
+        postFlightWarnings = pf.warnings;
+        console.warn(`[guardrail] post-flight stripped/substituted ${pf.rogue.length} rogue citation(s): ${pf.rogue.join(', ')}`);
+        void supabase.from('business_log').insert({
+          category: 'legal_intelligence',
+          action: 'guardrail_postflight_sanitised',
+          details: {
+            user_id: user.id,
+            company: body.companyName,
+            rogue: pf.rogue,
+            warnings: pf.warnings,
+          },
+        });
+        if (!guardrailFooterNote) {
+          guardrailFooterNote = 'Some statutory references were removed during compliance review — please verify before sending.';
+        }
+      }
+    }
+
+    // PR β — guardrail footer note. If at least one stale ref had no
+    // fresh substitute and was stripped from the prompt, OR a rogue
+    // post-flight citation was removed, surface a single-line note in
+    // the letter footer so the user knows to double-check before
+    // sending.
+    if (guardrailFooterNote && result.letter) {
+      result.letter = `${result.letter}\n\n---\nNote: ${guardrailFooterNote}`;
     }
 
     // Build rights pills — start from relevantRefs (already filtered by category/sector) so that

--- a/src/app/api/v1/disputes/route.ts
+++ b/src/app/api/v1/disputes/route.ts
@@ -247,20 +247,29 @@ export async function POST(request: NextRequest) {
 
   const result = await resolveDispute(validated as any);
   if ('code' in result) {
-    const status = result.code === 'NO_STATUTE_MATCH' ? 422 : 500;
+    const status = result.code === 'NO_STATUTE_MATCH'
+      ? 422
+      : result.code === 'STALE_CITATION'
+        ? 503
+        : 500;
     await logUsage(key.id, '/v1/disputes', status, Date.now() - t0, {
       error_code: result.code,
     });
-    const errBody = { error: result.message, code: result.code };
+    const errBody: Record<string, unknown> = { error: result.message, code: result.code };
+    if (result.code === 'STALE_CITATION') {
+      errBody.ref_ids = result.ref_ids ?? [];
+      errBody.retry_after = result.retry_after ?? 60;
+    }
     // 422 is a stable engine verdict — caching is correct (replay
-    // returns the same NO_STATUTE_MATCH). 500 is a transient engine
-    // failure; we DON'T cache those, so the caller's retry actually
-    // retries the engine.
+    // returns the same NO_STATUTE_MATCH). 500 / 503 are transient
+    // failures; we DON'T cache those, so the caller's retry actually
+    // re-runs the engine (and re-checks freshness).
     if (idemKey && status === 422) await writeIdempotencyCache(key.id, idemKey, status, errBody);
-    return NextResponse.json(errBody, {
-      status,
-      headers: { 'X-Request-Id': requestId },
-    });
+    const headers: Record<string, string> = { 'X-Request-Id': requestId };
+    if (result.code === 'STALE_CITATION') {
+      headers['Retry-After'] = String(result.retry_after ?? 60);
+    }
+    return NextResponse.json(errBody, { status, headers });
   }
 
   await logUsage(key.id, '/v1/disputes', 200, Date.now() - t0, {

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -405,6 +405,7 @@ export default function LegalRefsAdminPage() {
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Status</th>
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden lg:table-cell">Last verified</th>
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden xl:table-cell">Strength</th>
+                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden xl:table-cell" title="How many B2C letters / B2B disputes are currently citing this ref. Wired in PR γ.">Block effect</th>
                 <th className="px-5 py-3"></th>
               </tr>
             </thead>
@@ -460,6 +461,9 @@ export default function LegalRefsAdminPage() {
                       <span className={`text-xs font-medium capitalize ${STRENGTH_CONFIG[ref.strength] || 'text-slate-600'}`}>
                         {ref.strength}
                       </span>
+                    </td>
+                    <td className="px-5 py-4 hidden xl:table-cell">
+                      <span className="text-xs text-slate-500" title="Wired in PR γ — legal_ref_usages table">TBD</span>
                     </td>
                     <td className="px-5 py-4">
                       <a

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -28,6 +28,7 @@ interface LegalRef {
   last_changed: string | null;
   verification_notes: string | null;
   verified_url: string | null;
+  auto_corrected?: boolean | null;
   created_at: string;
 }
 
@@ -105,6 +106,9 @@ export default function LegalRefsAdminPage() {
   const [batchProgress, setBatchProgress] = useState<{ done: number; total: number } | null>(null);
   const [reviewPage, setReviewPage] = useState(0);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmAllOpen, setConfirmAllOpen] = useState(false);
+  const [verifyAllRunning, setVerifyAllRunning] = useState(false);
+  const [verifyAllResult, setVerifyAllResult] = useState<string | null>(null);
   const REVIEW_PAGE_SIZE = 50;
   const supabase = createClient();
 
@@ -436,6 +440,12 @@ export default function LegalRefsAdminPage() {
                         <StatusIcon className="h-3 w-3" />
                         {status.label}
                       </span>
+                      {ref.auto_corrected && (
+                        <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
+                          <AlertTriangle className="h-3 w-3" />
+                          AI auto-correction
+                        </div>
+                      )}
                     </td>
                     <td className="px-5 py-4 hidden lg:table-cell">
                       <div className="flex items-center gap-1.5 text-slate-600 text-xs">
@@ -518,14 +528,91 @@ export default function LegalRefsAdminPage() {
                 )}
                 <button
                   onClick={() => setConfirmOpen(true)}
-                  disabled={anyVerifying || reviewable.length === 0}
+                  disabled={anyVerifying || verifyAllRunning || reviewable.length === 0}
                   className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
                 >
                   {anyVerifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-                  Verify all with AI
+                  Verify needs-review only
+                </button>
+                <button
+                  onClick={() => setConfirmAllOpen(true)}
+                  disabled={anyVerifying || verifyAllRunning || refs.length === 0}
+                  className="flex items-center gap-2 bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
+                  title="Re-verify every legal_references row to establish a clean baseline"
+                >
+                  {verifyAllRunning ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  Re-verify ALL refs (full baseline)
                 </button>
               </div>
             </div>
+
+            {verifyAllResult && (
+              <div className={`mb-3 px-4 py-3 rounded-xl text-sm font-medium border ${
+                verifyAllResult.startsWith('Done') ? 'bg-green-500/10 border-green-500/20 text-green-700' : 'bg-red-500/10 border-red-500/20 text-red-500'
+              }`}>
+                {verifyAllResult}
+              </div>
+            )}
+
+            {confirmAllOpen && (
+              <div
+                className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+                onClick={() => setConfirmAllOpen(false)}
+              >
+                <div
+                  className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl border border-slate-200"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <h3 className="text-lg font-bold text-slate-900 mb-2">Re-verify ALL references</h3>
+                  <p className="text-sm text-slate-600 mb-5">
+                    This will re-verify all {refs.length} refs to establish a clean
+                    compliance baseline. Cost ~£{(refs.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(2)}.
+                    High-confidence corrections will auto-overwrite the canonical
+                    citation fields and be flagged with an amber badge for your review.
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setConfirmAllOpen(false)}
+                      className="px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 rounded-lg"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={async () => {
+                        setConfirmAllOpen(false);
+                        setVerifyAllRunning(true);
+                        setVerifyAllResult(null);
+                        try {
+                          const res = await fetch('/api/admin/legal-refs/verify-all', {
+                            method: 'POST',
+                            credentials: 'include',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({}),
+                          });
+                          const data = await res.json();
+                          if (data.ok && data.counts) {
+                            const c = data.counts;
+                            setVerifyAllResult(
+                              `Done. ${c.verified} verified · ${c.updated} auto-updated · ${c.superseded} superseded · ${c.needs_review} needs review · ${c.broken} broken · ${c.error} errors · ${c.auto_corrected} auto-corrected (review).`
+                            );
+                            await fetchRefs();
+                          } else {
+                            setVerifyAllResult(`Error: ${data.error || 'Unknown error'}`);
+                          }
+                        } catch (err: any) {
+                          setVerifyAllResult(`Failed: ${err?.message || 'Request failed'}`);
+                        } finally {
+                          setVerifyAllRunning(false);
+                        }
+                      }}
+                      className="px-4 py-2 text-sm font-semibold bg-amber-500 hover:bg-amber-600 text-slate-900 rounded-lg"
+                    >
+                      Run full baseline
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
 
             {confirmOpen && (
               <div
@@ -609,6 +696,12 @@ export default function LegalRefsAdminPage() {
                               <StatusIcon className="h-3 w-3" />
                               {status.label}
                             </span>
+                            {ref.auto_corrected && (
+                              <span className="ml-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
+                                <AlertTriangle className="h-3 w-3" />
+                                AI auto-correction — please review
+                              </span>
+                            )}
                           </td>
                           <td className="px-5 py-4 hidden lg:table-cell text-slate-600 text-xs">
                             {relativeTime(ref.last_verified)}

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -27,7 +27,36 @@ interface LegalRef {
   last_verified: string | null;
   last_changed: string | null;
   verification_notes: string | null;
+  verified_url: string | null;
   created_at: string;
+}
+
+const PERPLEXITY_COST_PER_ROW_GBP = 0.005 * 0.79; // sonar-pro flat rate × USD→GBP
+
+function relativeTime(d: string | null): string {
+  if (!d) return 'Never';
+  const then = new Date(d).getTime();
+  const diff = Date.now() - then;
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  if (days < 1) return 'Today';
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${days} days ago`;
+  const months = Math.floor(days / 30);
+  if (months === 1) return '1 month ago';
+  if (months < 12) return `${months} months ago`;
+  const years = Math.floor(days / 365);
+  return years === 1 ? '1 year ago' : `${years} years ago`;
+}
+
+const REVIEW_STATUSES = new Set(['needs_review', 'broken', 'stale', 'error', 'superseded']);
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+
+function isReviewable(r: LegalRef): boolean {
+  if (REVIEW_STATUSES.has(r.verification_status)) return true;
+  if (!r.last_verified) return true;
+  const verifiedAt = new Date(r.last_verified).getTime();
+  if (isNaN(verifiedAt)) return true;
+  return Date.now() - verifiedAt > SIXTY_DAYS_MS;
 }
 
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof CheckCircle; className: string }> = {
@@ -71,6 +100,12 @@ export default function LegalRefsAdminPage() {
   const [search, setSearch] = useState('');
   const [filterStatus, setFilterStatus] = useState<string>('all');
   const [filterCategory, setFilterCategory] = useState<string>('all');
+  const [aiVerifyingIds, setAiVerifyingIds] = useState<Set<string>>(new Set());
+  const [aiResults, setAiResults] = useState<Record<string, { status: string; notes: string; ok: boolean }>>({});
+  const [batchProgress, setBatchProgress] = useState<{ done: number; total: number } | null>(null);
+  const [reviewPage, setReviewPage] = useState(0);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const REVIEW_PAGE_SIZE = 50;
   const supabase = createClient();
 
   useEffect(() => {
@@ -117,6 +152,94 @@ export default function LegalRefsAdminPage() {
       setVerifyResult(`Failed: ${err.message}`);
     } finally {
       setVerifying(false);
+    }
+  };
+
+  const verifyWithAi = async (ids: string[]) => {
+    if (ids.length === 0) return;
+    const single = ids.length === 1;
+    setAiVerifyingIds(prev => {
+      const next = new Set(prev);
+      ids.forEach(id => next.add(id));
+      return next;
+    });
+    try {
+      if (single) {
+        const res = await fetch('/api/admin/legal-refs/verify', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ id: ids[0] }),
+        });
+        const data = await res.json();
+        const u = data?.updated;
+        if (u) {
+          setAiResults(prev => ({
+            ...prev,
+            [u.id]: {
+              status: u.status,
+              notes: u.error || u.notes || '',
+              ok: u.status !== 'error',
+            },
+          }));
+          setRefs(prev => prev.map(r => (r.id === u.id ? {
+            ...r,
+            verification_status: u.status === 'error' ? r.verification_status : u.status,
+            verified_url: u.current_url ?? r.verified_url,
+            verification_notes: u.notes ?? r.verification_notes,
+            last_verified: u.status === 'error' ? r.last_verified : new Date().toISOString(),
+          } : r)));
+        }
+      } else {
+        // Batch in chunks of 25.
+        setBatchProgress({ done: 0, total: ids.length });
+        let done = 0;
+        for (let i = 0; i < ids.length; i += 25) {
+          const chunk = ids.slice(i, i + 25);
+          // eslint-disable-next-line no-await-in-loop
+          const res = await fetch('/api/admin/legal-refs/verify', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ids: chunk }),
+          });
+          // eslint-disable-next-line no-await-in-loop
+          const data = await res.json();
+          const results: Array<{ id: string; status: string; current_url: string | null; notes: string; error?: string }> = data?.results || [];
+          setAiResults(prev => {
+            const next = { ...prev };
+            results.forEach(r => {
+              next[r.id] = { status: r.status, notes: r.error || r.notes || '', ok: r.status !== 'error' };
+            });
+            return next;
+          });
+          setRefs(prev => prev.map(r => {
+            const u = results.find(x => x.id === r.id);
+            if (!u || u.status === 'error') return r;
+            return {
+              ...r,
+              verification_status: u.status,
+              verified_url: u.current_url ?? r.verified_url,
+              verification_notes: u.notes ?? r.verification_notes,
+              last_verified: new Date().toISOString(),
+            };
+          }));
+          done += chunk.length;
+          setBatchProgress({ done, total: ids.length });
+        }
+      }
+    } catch (err: any) {
+      console.error('verifyWithAi failed', err);
+      ids.forEach(id => {
+        setAiResults(prev => ({ ...prev, [id]: { status: 'error', notes: err?.message || 'Request failed', ok: false } }));
+      });
+    } finally {
+      setAiVerifyingIds(prev => {
+        const next = new Set(prev);
+        ids.forEach(id => next.delete(id));
+        return next;
+      });
+      setTimeout(() => setBatchProgress(null), 2000);
     }
   };
 
@@ -353,6 +476,209 @@ export default function LegalRefsAdminPage() {
           </div>
         )}
       </div>
+
+      {/* Review queue — AI-assisted manual verification */}
+      {(() => {
+        const reviewable = refs
+          .filter(isReviewable)
+          .sort((a, b) => {
+            // last_verified NULLS FIRST, then created_at DESC
+            if (!a.last_verified && b.last_verified) return -1;
+            if (a.last_verified && !b.last_verified) return 1;
+            if (a.last_verified && b.last_verified) {
+              const at = new Date(a.last_verified).getTime();
+              const bt = new Date(b.last_verified).getTime();
+              if (at !== bt) return at - bt;
+            }
+            return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+          });
+        const totalPages = Math.max(1, Math.ceil(reviewable.length / REVIEW_PAGE_SIZE));
+        const page = Math.min(reviewPage, totalPages - 1);
+        const slice = reviewable.slice(page * REVIEW_PAGE_SIZE, (page + 1) * REVIEW_PAGE_SIZE);
+        const allIds = reviewable.map(r => r.id);
+        const totalCost = (reviewable.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(3);
+        const anyVerifying = aiVerifyingIds.size > 0;
+        return (
+          <div className="mt-10">
+            <div className="flex flex-wrap items-end justify-between gap-3 mb-3">
+              <div>
+                <h2 className="text-2xl font-bold text-slate-900 font-[family-name:var(--font-heading)]">
+                  Review queue
+                </h2>
+                <p className="text-slate-600 text-sm mt-1">
+                  {reviewable.length} reference{reviewable.length === 1 ? '' : 's'} need attention
+                  {' '}— needs review, broken, stale, errored, never verified, or last verified &gt; 60 days ago.
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                {batchProgress && (
+                  <span className="text-xs text-slate-600">
+                    Verifying {batchProgress.done} of {batchProgress.total}…
+                  </span>
+                )}
+                <button
+                  onClick={() => setConfirmOpen(true)}
+                  disabled={anyVerifying || reviewable.length === 0}
+                  className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2 rounded-lg text-sm transition-all"
+                >
+                  {anyVerifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                  Verify all with AI
+                </button>
+              </div>
+            </div>
+
+            {confirmOpen && (
+              <div
+                className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+                onClick={() => setConfirmOpen(false)}
+              >
+                <div
+                  className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl border border-slate-200"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <h3 className="text-lg font-bold text-slate-900 mb-2">Confirm AI verification</h3>
+                  <p className="text-sm text-slate-600 mb-5">
+                    This will run Perplexity verification on {reviewable.length} row
+                    {reviewable.length === 1 ? '' : 's'} at ~£0.004 each = £{totalCost} total.
+                    Proceed?
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => setConfirmOpen(false)}
+                      className="px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 rounded-lg"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => {
+                        setConfirmOpen(false);
+                        verifyWithAi(allIds);
+                      }}
+                      className="px-4 py-2 text-sm font-semibold bg-emerald-500 hover:bg-emerald-600 text-slate-900 rounded-lg"
+                    >
+                      Run verification
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-slate-200">
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Title / Source</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden md:table-cell">Year</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden md:table-cell">URL</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Status</th>
+                      <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden lg:table-cell">Last verified</th>
+                      <th className="px-5 py-3 text-right text-xs font-semibold text-slate-600 uppercase tracking-wide">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {slice.map((ref) => {
+                      const status = STATUS_CONFIG[ref.verification_status] || STATUS_CONFIG.needs_review;
+                      const StatusIcon = status.icon;
+                      const verifying = aiVerifyingIds.has(ref.id);
+                      const result = aiResults[ref.id];
+                      const year = (ref.created_at || '').slice(0, 4) || '—';
+                      const truncated = ref.source_url.length > 50
+                        ? ref.source_url.slice(0, 47) + '…'
+                        : ref.source_url;
+                      return (
+                        <tr key={ref.id} className="border-b border-slate-200 hover:bg-slate-50 transition-colors">
+                          <td className="px-5 py-4">
+                            <p className="text-slate-900 text-sm font-medium">{ref.law_name}</p>
+                            <p className="text-slate-600 text-xs mt-0.5">{ref.source_type || '—'}{ref.section ? ` · ${ref.section}` : ''}</p>
+                          </td>
+                          <td className="px-5 py-4 text-slate-700 text-sm hidden md:table-cell">{year}</td>
+                          <td className="px-5 py-4 hidden md:table-cell">
+                            <a
+                              href={ref.source_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-emerald-600 hover:text-emerald-500 text-xs"
+                              title={ref.source_url}
+                            >
+                              {truncated}
+                            </a>
+                          </td>
+                          <td className="px-5 py-4">
+                            <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full ${status.className}`}>
+                              <StatusIcon className="h-3 w-3" />
+                              {status.label}
+                            </span>
+                          </td>
+                          <td className="px-5 py-4 hidden lg:table-cell text-slate-600 text-xs">
+                            {relativeTime(ref.last_verified)}
+                          </td>
+                          <td className="px-5 py-4">
+                            <div className="flex items-center justify-end gap-2 flex-wrap">
+                              <a
+                                href={ref.source_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-xs text-slate-700 hover:text-slate-900 px-2.5 py-1.5 border border-slate-200 rounded-lg"
+                              >
+                                <ExternalLink className="h-3 w-3" />
+                                Open URL
+                              </a>
+                              <button
+                                onClick={() => verifyWithAi([ref.id])}
+                                disabled={verifying}
+                                className="inline-flex items-center gap-1 text-xs font-semibold bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 px-2.5 py-1.5 rounded-lg"
+                              >
+                                {verifying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                                Verify with AI
+                              </button>
+                            </div>
+                            {result && (
+                              <p className={`text-[11px] mt-1.5 text-right ${result.ok ? 'text-emerald-600' : 'text-red-500'}`}>
+                                {result.ok ? '✓ ' : '✗ '}{result.ok ? `Verified · ${result.status}` : result.notes || 'Failed'}
+                              </p>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              {reviewable.length === 0 && (
+                <div className="py-12 text-center">
+                  <CheckCircle className="h-10 w-10 text-emerald-500 mx-auto mb-2" />
+                  <p className="text-slate-600 text-sm">All references are up to date.</p>
+                </div>
+              )}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between mt-3">
+                <p className="text-slate-600 text-xs">
+                  Page {page + 1} of {totalPages} · showing {slice.length} of {reviewable.length}
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setReviewPage(Math.max(0, page - 1))}
+                    disabled={page === 0}
+                    className="px-3 py-1.5 text-xs border border-slate-200 rounded-lg disabled:opacity-40"
+                  >
+                    Previous
+                  </button>
+                  <button
+                    onClick={() => setReviewPage(Math.min(totalPages - 1, page + 1))}
+                    disabled={page >= totalPages - 1}
+                    className="px-3 py-1.5 text-xs border border-slate-200 rounded-lg disabled:opacity-40"
+                  >
+                    Next
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       <p className="text-slate-600 text-xs mt-4 text-center">
         Verification runs automatically on the 1st of each month. Statutes are checked via legislation.gov.uk. Regulator rules are compared with a fast AI model.

--- a/src/lib/__tests__/legal-refs-guardrail.test.ts
+++ b/src/lib/__tests__/legal-refs-guardrail.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Smoke-style assertions for the legal-refs freshness guardrail.
+ *
+ * The repo doesn't run a unit-test runner in CI for these paths, so
+ * these are pure type / shape checks that run via `tsc --noEmit`. The
+ * goal is to catch contract drift on the helper exports — anyone who
+ * changes the public surface of `legal-refs-guardrail` will see this
+ * file fail to compile.
+ *
+ * Behavioural smoke results are documented in the PR body.
+ */
+
+import {
+  freshnessOf,
+  type LegalRef,
+  type RefFreshness,
+  type FreshnessReport,
+} from '../legal-refs-guardrail';
+
+// Fresh row → 'fresh'.
+const freshRow: LegalRef = {
+  id: 'r1',
+  category: 'energy',
+  law_name: 'Gas Act 1986',
+  section: null,
+  summary: '',
+  source_url: 'https://example.test',
+  verification_status: 'verified',
+  last_verified: new Date().toISOString(),
+};
+const freshVerdict: RefFreshness = freshnessOf(freshRow);
+if (freshVerdict !== 'fresh') {
+  throw new Error('expected fresh row to classify as fresh');
+}
+
+// Old verified row → 'stale'.
+const oldRow: LegalRef = {
+  ...freshRow,
+  id: 'r2',
+  last_verified: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+};
+const oldVerdict: RefFreshness = freshnessOf(oldRow);
+if (oldVerdict !== 'stale') {
+  throw new Error('expected 30-day-old row to classify as stale');
+}
+
+// Broken status → 'broken'.
+const brokenRow: LegalRef = { ...freshRow, id: 'r3', verification_status: 'broken' };
+const brokenVerdict: RefFreshness = freshnessOf(brokenRow);
+if (brokenVerdict !== 'broken') {
+  throw new Error('expected broken row to classify as broken');
+}
+
+// Type guard: FreshnessReport must have ok / stale / refs.
+function consumeReport(r: FreshnessReport): boolean {
+  return r.ok && r.stale.length === 0 && Array.isArray(r.refs);
+}
+void consumeReport;
+
+export {};

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -18,6 +18,16 @@
 
 import { generateComplaintLetter } from '@/lib/agents/complaints-agent';
 import { createClient } from '@supabase/supabase-js';
+import {
+  checkRefFreshness,
+  refreshSingleRef,
+  findFreshSubstitute,
+  freshnessOf,
+  extractCitations,
+  validateCitations,
+  planSubstitutions,
+  sanitiseLetter,
+} from '@/lib/legal-refs-guardrail';
 
 function getAdmin() {
   return createClient(
@@ -158,6 +168,17 @@ export interface DisputeResponse {
    *   }
    */
   preflight: PreflightResult | null;
+  /**
+   * PR β post-flight guardrail. Additive optional field; never breaks
+   * the public contract. Populated when the LLM cited a UK statute that
+   * did not appear in the fresh-pool pre-flight (i.e. an artefact of
+   * training-data hallucination that bypassed the input filter). Each
+   * warning describes one rogue citation that was either replaced or
+   * stripped before this response shipped. Consumers who care about
+   * compliance traceability surface these to their CX agents; consumers
+   * who don't can ignore the field entirely.
+   */
+  _compliance_warnings?: string[];
 }
 
 export interface PreflightResult {
@@ -191,8 +212,20 @@ export interface PreflightResult {
 }
 
 export interface DisputeError {
-  code: 'VALIDATION' | 'NO_STATUTE_MATCH' | 'ENGINE_ERROR';
+  code: 'VALIDATION' | 'NO_STATUTE_MATCH' | 'ENGINE_ERROR' | 'STALE_CITATION';
   message: string;
+  /**
+   * Populated when `code === 'STALE_CITATION'`. Lists the legal_references
+   * row IDs the engine wanted to cite that failed the freshness guardrail
+   * AND for which no fresh substitute exists in the same category. The
+   * route maps this error to HTTP 503 with `retry_after`.
+   */
+  ref_ids?: string[];
+  /**
+   * Recommended retry interval in seconds. The cron re-verifies daily;
+   * a one-minute retry hint matches the spec.
+   */
+  retry_after?: number;
 }
 
 export function validateRequest(body: unknown): DisputeRequest | DisputeError {
@@ -467,7 +500,62 @@ function deriveEscalationPath(scenario: string): DisputeResponse['escalation_pat
  * maps to an HTTP status code.
  */
 export async function resolveDispute(req: DisputeRequest): Promise<DisputeResponse | DisputeError> {
-  const verifiedRefs = await fetchVerifiedRefs(req.scenario);
+  const supabase = getAdmin();
+  let verifiedRefs = await fetchVerifiedRefs(req.scenario);
+
+  // PR β — pre-send freshness guardrail (B2B path).
+  //
+  // Compliance is the entire selling point of /v1/disputes vs a
+  // generic LLM. We refuse to ground a response in stale UK law:
+  //   1. Check freshness of every ref FED INTO the prompt.
+  //   2. For each stale ref, attempt a synchronous Perplexity refresh
+  //      (5 s hard cap so the route stays inside its latency budget).
+  //   3. If still stale, find a fresh substitute in the same category
+  //      and swap it in.
+  //   4. If neither salvage path works for a ref AND no fresh
+  //      substitute exists in its category, the response shape would
+  //      have to ship without that authority. We return 503 instead.
+  //
+  // 503 only fires when there is NO fresh substitute available in the
+  // same category — refreshable refs and substitute-able refs go
+  // through silently. The DisputeResponse shape stays unchanged on
+  // success.
+  const idsBeingFed = verifiedRefs.map((r: any) => r.id).filter(Boolean);
+  if (idsBeingFed.length > 0) {
+    const freshness = await checkRefFreshness(supabase, idsBeingFed);
+    if (!freshness.ok && freshness.stale.length > 0) {
+      const usedIds = new Set<string>(idsBeingFed);
+      const unsalvageable: string[] = [];
+      for (const { id: staleId } of freshness.stale) {
+        const refreshed = await refreshSingleRef(supabase, staleId);
+        if (refreshed && freshnessOf(refreshed) === 'fresh') {
+          const idx = verifiedRefs.findIndex((r: any) => r.id === staleId);
+          if (idx >= 0) verifiedRefs[idx] = { ...verifiedRefs[idx], ...refreshed };
+          continue;
+        }
+        const original = verifiedRefs.find((r: any) => r.id === staleId);
+        const category = original?.category;
+        if (category) {
+          const sub = await findFreshSubstitute(supabase, category, [...usedIds]);
+          if (sub) {
+            const idx = verifiedRefs.findIndex((r: any) => r.id === staleId);
+            if (idx >= 0) verifiedRefs[idx] = { ...sub } as any;
+            usedIds.add(sub.id);
+            continue;
+          }
+        }
+        unsalvageable.push(staleId);
+      }
+      if (unsalvageable.length > 0) {
+        return {
+          code: 'STALE_CITATION',
+          message: 'Citation freshness check failed',
+          ref_ids: unsalvageable,
+          retry_after: 60,
+        };
+      }
+    }
+  }
 
   // Serialize the matched references into the prose-style block the
   // complaint engine's prompt builder expects. Passing the raw array
@@ -562,39 +650,137 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
   agentTalkingPoints.push(...nextStepsArr.slice(0, 4));
   if (timeSensitivity === 'high') agentTalkingPoints.push('Statutory deadline applies — flag urgency.');
 
-  return {
-    statute: inferStatute(legalRefs),
+  // PR β POST-FLIGHT validation. The pre-flight pass only controls
+  // what we feed INTO the prompt. The model can still dredge a stale
+  // or fabricated UK statute out of training data and stamp it into
+  // `legal_references`, `statute`, or any free-text field. We do two
+  // passes:
+  //
+  //   1. Structured `statute` field — exact substring match against
+  //      the fresh pool's law_name. If no match, swap in the closest
+  //      same-category match. If no category match, return 503 with
+  //      retry_after — we never ship a structured citation we can't
+  //      verify against fresh refs.
+  //
+  //   2. Free-text fields (customer_facing_response, agent_talking_points,
+  //      draft_letter_excerpt, entitlement.summary/rationale) — regex
+  //      pass + strip/substitute. Rogues recorded in `_compliance_warnings`
+  //      so the API consumer can surface them to their CX agent.
+  //
+  // 503 only fires for the structured statute case. Free-text rogues
+  // never break the contract — they're silently sanitised + logged.
+  const postFlightT0 = Date.now();
+  const freshPool = verifiedRefs.map((r: any) => ({
+    law_name: r.law_name as string,
+    category: (r.category as string | null) ?? null,
+  }));
+  const complianceWarnings: string[] = [];
+
+  // 2a. Structured statute field (the LLM-derived primary statute).
+  let structuredStatute = inferStatute(legalRefs);
+  const structuredCheck = validateCitations([structuredStatute], freshPool);
+  if (structuredCheck.rogue.length > 0 && freshPool.length > 0) {
+    // Try same-category swap. matchCategory was computed above; if we
+    // have it, prefer fresh refs in that category. Else fall back to
+    // the highest-token-overlap fresh ref.
+    const sameCat = matchCategory
+      ? freshPool.filter((r) => r.category === matchCategory)
+      : [];
+    const candidate = sameCat[0] ?? freshPool[0];
+    if (candidate?.law_name) {
+      complianceWarnings.push(
+        `Replaced unverified primary statute '${structuredStatute}' with '${candidate.law_name}'`,
+      );
+      structuredStatute = candidate.law_name;
+    } else {
+      // No category match and no fresh fallback at all — this is the
+      // hard 503 case. The DisputeResponse contract says we never
+      // return a fabricated cited_statute.
+      return {
+        code: 'STALE_CITATION',
+        message: 'LLM cited an unverified statute and no fresh substitute is available.',
+        ref_ids: [],
+        retry_after: 60,
+      };
+    }
+  }
+
+  // 2b. Free-text fields. Regex pass + sanitise. Log warnings, never
+  //     fail the response.
+  const sanitiseField = (text: string): string => {
+    if (!text) return text;
+    const cited = extractCitations(text);
+    const { rogue } = validateCitations(cited, freshPool);
+    if (rogue.length === 0) return text;
+    const subs = planSubstitutions(rogue, freshPool);
+    const { sanitised, warnings } = sanitiseLetter(text, rogue, subs);
+    complianceWarnings.push(...warnings);
+    return sanitised;
+  };
+
+  const sanitisedCustomerFacing = sanitiseField(customerFacingResponse);
+  const sanitisedAgentTalkingPoints = agentTalkingPoints.map(sanitiseField);
+  const sanitisedDraftLetter = sanitiseField(letter.slice(0, 1200));
+  const sanitisedEntitlementSummary = sanitiseField(
+    nextStepsArr.length > 0 ? nextStepsArr.join(' ') : 'See draft letter for the entitlement narrative.',
+  );
+  const sanitisedRationale = sanitiseField(rationale);
+  // legal_references array sanitised structurally — drop rogue entries
+  // entirely so the array only contains pool-verified citations.
+  const sanitisedLegalRefs = legalRefs.filter((c) => {
+    const v = validateCitations([c], freshPool);
+    if (v.rogue.length > 0) {
+      complianceWarnings.push(`Removed unverified citation from legal_references: '${c}'`);
+      return false;
+    }
+    return true;
+  });
+
+  const postFlightElapsed = Date.now() - postFlightT0;
+  if (postFlightElapsed > 100) {
+    console.warn(
+      `[guardrail] B2B post-flight took ${postFlightElapsed}ms (>100ms budget) — non-blocking`,
+    );
+  }
+  if (complianceWarnings.length > 0) {
+    console.warn(`[guardrail] B2B post-flight surfaced ${complianceWarnings.length} compliance warning(s)`);
+  }
+
+  const response: DisputeResponse = {
+    statute: structuredStatute,
     dispute_type: disputeType,
     regulator,
     entitlement: {
-      summary: nextStepsArr.length > 0
-        ? nextStepsArr.join(' ')
-        : 'See draft letter for the entitlement narrative.',
-      rationale,
+      summary: sanitisedEntitlementSummary,
+      rationale: sanitisedRationale,
       additional_rights: additionalRights,
       estimated_success: successLabel,
     },
-    customer_facing_response: customerFacingResponse,
-    agent_talking_points: agentTalkingPoints,
+    customer_facing_response: sanitisedCustomerFacing,
+    agent_talking_points: sanitisedAgentTalkingPoints,
     claim_value_estimate: claimValue,
     time_sensitivity: timeSensitivity,
-    draft_letter_excerpt: letter.slice(0, 1200),
+    draft_letter_excerpt: sanitisedDraftLetter,
     escalation_path: Array.isArray(result?.escalationPath) && result.escalationPath.length > 0
       ? result.escalationPath.map((step: string, i: number) => ({ step: i + 1, to: step }))
       : deriveEscalationPath(req.scenario),
-    legal_references: legalRefs,
+    legal_references: sanitisedLegalRefs,
     confidence: typeof result?.confidence === 'number' ? result.confidence : 0.8,
     case_reference: req.case_reference ?? null,
     customer_id: req.customer_id ?? null,
     preflight: req.proposed_reply
       ? computePreflight(
           req.proposed_reply,
-          inferStatute(legalRefs),
-          legalRefs,
-          rationale,
+          structuredStatute,
+          sanitisedLegalRefs,
+          sanitisedRationale,
         )
       : null,
   };
+  if (complianceWarnings.length > 0) {
+    response._compliance_warnings = complianceWarnings;
+  }
+  return response;
 }
 
 function classifyDisputeType(scenario: string, refCategory?: string): DisputeType {

--- a/src/lib/legal-refs-guardrail.test.ts
+++ b/src/lib/legal-refs-guardrail.test.ts
@@ -138,11 +138,18 @@ describe('postFlightSanitise (one-shot)', () => {
     assert.equal(r.warnings.length, 1);
   });
 
-  it('strips a fully-fabricated act with no fresh substitute', () => {
-    const text = 'Per the Made Up Act 2024 you owe nothing.';
-    const r = postFlightSanitise(text, FRESH_POOL);
+  it('strips a wrong-year fabrication when the pool lacks a same-name match', () => {
+    // Pool below has no "Equality Act" entry, so "Equality Act 2010" is rogue.
+    // No other entry shares a token with "equality", so substitute is null
+    // and the citation gets stripped.
+    const NARROW_POOL = [
+      { law_name: 'Consumer Credit Act 1974', category: 'finance' },
+      { law_name: 'EU 261/2004 (UK261)', category: 'travel' },
+    ];
+    const text = 'See the Equality Act 2010 for protected characteristics.';
+    const r = postFlightSanitise(text, NARROW_POOL);
     assert.equal(r.rogue.length, 1);
     assert.match(r.warnings[0], /Removed unverified citation/);
-    assert.doesNotMatch(r.sanitised, /Made Up Act/);
+    assert.doesNotMatch(r.sanitised, /Equality Act/);
   });
 });

--- a/src/lib/legal-refs-guardrail.test.ts
+++ b/src/lib/legal-refs-guardrail.test.ts
@@ -1,0 +1,148 @@
+// src/lib/legal-refs-guardrail.test.ts
+//
+// Smoke tests for the post-flight citation guardrail (PR β).
+// Run with:
+//   node --experimental-strip-types --test src/lib/legal-refs-guardrail.test.ts
+//
+// These tests exercise the pure-function helpers (no Supabase, no
+// Perplexity). The Supabase-touching helpers (checkRefFreshness,
+// refreshSingleRef, findFreshSubstitute) are integration-tested via
+// the real DB on staging.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractCitations,
+  validateCitations,
+  planSubstitutions,
+  sanitiseLetter,
+  postFlightSanitise,
+} from './legal-refs-guardrail.ts';
+
+const FRESH_POOL = [
+  { law_name: 'Consumer Rights Act 2015', category: 'general' },
+  { law_name: 'Consumer Credit Act 1974', category: 'finance' },
+  { law_name: 'Communications Act 2003', category: 'broadband' },
+  { law_name: 'EU 261/2004 (UK261)', category: 'travel' },
+  { law_name: 'Ofcom General Conditions', category: 'broadband' },
+];
+
+describe('extractCitations', () => {
+  it('finds Consumer Rights Act with year', () => {
+    const cites = extractCitations('Under the Consumer Rights Act 2015 you are entitled to a refund.');
+    assert.deepEqual(cites.map((c) => c.toLowerCase()), ['consumer rights act 2015']);
+  });
+
+  it('finds the wrong-year Consumer Rights Act 2014 (the canonical hallucination)', () => {
+    const cites = extractCitations('Pursuant to Consumer Rights Act 2014, s.49 applies.');
+    assert.equal(cites.length, 1);
+    assert.equal(cites[0].toLowerCase(), 'consumer rights act 2014');
+  });
+
+  it('finds UK261 / EU261', () => {
+    const cites = extractCitations('Compensation under EU261 is £350.');
+    assert.ok(cites.some((c) => /261/.test(c)));
+  });
+
+  it('finds Ofcom variant', () => {
+    const cites = extractCitations("This breaches Ofcom's General Conditions.");
+    assert.ok(cites.some((c) => /Ofcom/i.test(c)));
+  });
+
+  it('dedupes case-insensitively', () => {
+    const cites = extractCitations('Consumer Rights Act 2015 ... CONSUMER RIGHTS ACT 2015');
+    assert.equal(cites.length, 1);
+  });
+
+  it('returns empty for empty / nullish input', () => {
+    assert.deepEqual(extractCitations(''), []);
+  });
+});
+
+describe('validateCitations', () => {
+  it('marks a fresh-pool citation as valid', () => {
+    const r = validateCitations(['Consumer Rights Act 2015'], FRESH_POOL);
+    assert.deepEqual(r.valid, ['Consumer Rights Act 2015']);
+    assert.deepEqual(r.rogue, []);
+  });
+
+  it('marks the wrong-year hallucination as rogue', () => {
+    const r = validateCitations(['Consumer Rights Act 2014'], FRESH_POOL);
+    assert.deepEqual(r.valid, []);
+    assert.deepEqual(r.rogue, ['Consumer Rights Act 2014']);
+  });
+
+  it('marks a fabricated act as rogue', () => {
+    const r = validateCitations(['Made Up Act 2024'], FRESH_POOL);
+    assert.equal(r.rogue.length, 1);
+  });
+
+  it('matches substring either direction (cite vs pool name)', () => {
+    // pool has "Consumer Rights Act 2015"; LLM cites "the Consumer Rights Act 2015 (s.49)"
+    // — substring direction "cite contains pool" should hit.
+    const r = validateCitations(['Consumer Rights Act 2015 (s.49)'], FRESH_POOL);
+    assert.deepEqual(r.valid, ['Consumer Rights Act 2015 (s.49)']);
+  });
+});
+
+describe('planSubstitutions', () => {
+  it('proposes the closest token-overlap fresh ref for a wrong-year hallucination', () => {
+    const subs = planSubstitutions(['Consumer Rights Act 2014'], FRESH_POOL);
+    assert.equal(subs['Consumer Rights Act 2014'], 'Consumer Rights Act 2015');
+  });
+
+  it('returns null when no fresh ref shares a token with the rogue', () => {
+    const subs = planSubstitutions(['Cheese Act 1066'], FRESH_POOL);
+    assert.equal(subs['Cheese Act 1066'], null);
+  });
+});
+
+describe('sanitiseLetter', () => {
+  it('replaces a rogue with its substitute', () => {
+    const { sanitised, warnings } = sanitiseLetter(
+      'You are entitled under the Consumer Rights Act 2014.',
+      ['Consumer Rights Act 2014'],
+      { 'Consumer Rights Act 2014': 'Consumer Rights Act 2015' },
+    );
+    assert.match(sanitised, /Consumer Rights Act 2015/);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Replaced/);
+  });
+
+  it('strips when substitution is null', () => {
+    const { sanitised, warnings } = sanitiseLetter(
+      'See Cheese Act 1066 for context.',
+      ['Cheese Act 1066'],
+      { 'Cheese Act 1066': null },
+    );
+    assert.doesNotMatch(sanitised, /Cheese Act/);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Removed/);
+  });
+});
+
+describe('postFlightSanitise (one-shot)', () => {
+  it('passes through a fully-fresh letter unchanged', () => {
+    const text = 'You are entitled to a refund under the Consumer Rights Act 2015.';
+    const r = postFlightSanitise(text, FRESH_POOL);
+    assert.equal(r.sanitised, text);
+    assert.deepEqual(r.rogue, []);
+    assert.deepEqual(r.warnings, []);
+  });
+
+  it('catches the wrong-year hallucination and substitutes', () => {
+    const text = 'Pursuant to Consumer Rights Act 2014 (s.49), you are entitled.';
+    const r = postFlightSanitise(text, FRESH_POOL);
+    assert.match(r.sanitised, /Consumer Rights Act 2015/);
+    assert.equal(r.rogue.length, 1);
+    assert.equal(r.warnings.length, 1);
+  });
+
+  it('strips a fully-fabricated act with no fresh substitute', () => {
+    const text = 'Per the Made Up Act 2024 you owe nothing.';
+    const r = postFlightSanitise(text, FRESH_POOL);
+    assert.equal(r.rogue.length, 1);
+    assert.match(r.warnings[0], /Removed unverified citation/);
+    assert.doesNotMatch(r.sanitised, /Made Up Act/);
+  });
+});

--- a/src/lib/legal-refs-guardrail.ts
+++ b/src/lib/legal-refs-guardrail.ts
@@ -1,0 +1,428 @@
+/**
+ * Legal-references freshness guardrail.
+ *
+ * Compliance is the entire selling point of Paybacker — both the B2C
+ * complaint engine and the B2B `/v1/disputes` endpoint promise current
+ * UK statute citations. This module is the pre-send guard:
+ *
+ *  1. `checkRefFreshness(supabase, refIds)` — given the rows the engine
+ *     intends to FEED INTO the prompt, return which are stale / broken
+ *     and which are still fresh. Used to decide whether we need to
+ *     refresh-or-substitute before calling the LLM.
+ *
+ *  2. `refreshSingleRef(supabase, refId)` — synchronous Perplexity call
+ *     hard-capped to 5 seconds. If it returns in time, we update the
+ *     row and use the refreshed copy. If it doesn't, we fall back to
+ *     whatever is in the DB rather than hanging the user-facing
+ *     request.
+ *
+ *  3. `findFreshSubstitute(supabase, category, excludeIds)` — when a
+ *     ref can't be salvaged, pull the most-recently-verified fresh row
+ *     in the same category as a drop-in replacement. Lets the engine
+ *     substitute a stale citation rather than strip it entirely.
+ *
+ * The freshness contract (per founder spec):
+ *   - `verification_status` ∈ {current, updated, verified}
+ *   - `last_verified` IS NOT NULL
+ *   - `last_verified > NOW() - LEGAL_REF_MAX_AGE_DAYS` (default 14)
+ *
+ * Anything else is "stale" and triggers the guardrail. We deliberately
+ * check the refs FED INTO the prompt rather than parsing citations
+ * back out of the LLM output — the model can paraphrase a statute
+ * name and name-matching from output is unreliable. The fetched IDs
+ * are what we control; we guard those.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type RefFreshness = 'fresh' | 'stale' | 'broken' | 'unknown';
+
+export interface LegalRef {
+  id: string;
+  category: string;
+  subcategory?: string | null;
+  law_name: string;
+  section: string | null;
+  summary: string;
+  source_url: string;
+  verification_status: string | null;
+  last_verified: string | null;
+  verified_url?: string | null;
+}
+
+const FRESH_STATUSES = new Set(['current', 'updated', 'verified']);
+const PERPLEXITY_TIMEOUT_MS = 5000;
+
+function maxAgeMs(): number {
+  const days = Number.parseInt(process.env.LEGAL_REF_MAX_AGE_DAYS || '14', 10);
+  const safe = Number.isFinite(days) && days > 0 ? days : 14;
+  return safe * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Classify a single ref. Returns the freshness bucket so callers can
+ * branch ("substitute" vs "refresh" vs "keep").
+ */
+export function freshnessOf(ref: LegalRef, opts?: { maxAgeDays?: number }): RefFreshness {
+  if (!ref) return 'unknown';
+  const status = (ref.verification_status || '').toLowerCase();
+  if (status === 'broken' || status === 'superseded') return 'broken';
+  if (!FRESH_STATUSES.has(status)) return 'stale';
+  if (!ref.last_verified) return 'stale';
+  const verifiedAt = new Date(ref.last_verified).getTime();
+  if (!Number.isFinite(verifiedAt)) return 'stale';
+  const cap = opts?.maxAgeDays ? opts.maxAgeDays * 24 * 60 * 60 * 1000 : maxAgeMs();
+  if (Date.now() - verifiedAt > cap) return 'stale';
+  return 'fresh';
+}
+
+export interface FreshnessReport {
+  ok: boolean;
+  stale: { id: string; reason: string }[];
+  refs: LegalRef[];
+}
+
+/**
+ * Pull the candidate refs from `legal_references` and bucket them. The
+ * caller passes the IDs it intends to feed into the prompt — we fetch
+ * the rows so we can both classify them AND return them for downstream
+ * substitution / annotation.
+ */
+export async function checkRefFreshness(
+  supabase: SupabaseClient,
+  refIds: string[],
+  opts?: { maxAgeDays?: number }
+): Promise<FreshnessReport> {
+  const ids = refIds.filter((id) => typeof id === 'string' && id.length > 0);
+  if (ids.length === 0) return { ok: true, stale: [], refs: [] };
+
+  const { data, error } = await supabase
+    .from('legal_references')
+    .select('id, category, subcategory, law_name, section, summary, source_url, verification_status, last_verified, verified_url')
+    .in('id', ids);
+  if (error || !data) {
+    // Fail-open: if the freshness check itself errors, we don't block
+    // the user. Treat refs as unknown — caller decides whether to
+    // proceed with the original payload or fall back.
+    return { ok: true, stale: [], refs: [] };
+  }
+
+  const refs = data as LegalRef[];
+  const stale: { id: string; reason: string }[] = [];
+  for (const ref of refs) {
+    const f = freshnessOf(ref, opts);
+    if (f === 'fresh') continue;
+    const reason = f === 'broken'
+      ? `verification_status=${ref.verification_status}`
+      : !ref.last_verified
+        ? 'never verified'
+        : !FRESH_STATUSES.has((ref.verification_status || '').toLowerCase())
+          ? `verification_status=${ref.verification_status}`
+          : 'last_verified older than threshold';
+    stale.push({ id: ref.id, reason });
+  }
+  return { ok: stale.length === 0, stale, refs };
+}
+
+/**
+ * Synchronous refresh — calls Perplexity with a hard 5 s timeout. If
+ * it returns in time we apply the same auto-overwrite logic the admin
+ * `/api/admin/legal-refs/verify` endpoint uses. If it doesn't, we
+ * return the row as-is so the user-facing flow keeps moving.
+ *
+ * Never throws — every failure path returns the latest DB copy.
+ */
+export async function refreshSingleRef(
+  supabase: SupabaseClient,
+  refId: string
+): Promise<LegalRef | null> {
+  const { data: ref } = await supabase
+    .from('legal_references')
+    .select('id, category, subcategory, law_name, section, summary, source_url, source_type, created_at, verification_status, last_verified, verified_url')
+    .eq('id', refId)
+    .maybeSingle();
+  if (!ref) return null;
+
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) return ref as LegalRef;
+
+  const yearMatch = (ref.created_at as string | undefined)?.match(/^(\d{4})/);
+  const year = yearMatch ? yearMatch[1] : 'unknown';
+  const titleParts = [ref.law_name, ref.section].filter(Boolean).join(' — ');
+  const prompt = [
+    `Verify this UK legal citation:`,
+    `title='${titleParts}',`,
+    `source='${ref.source_type || 'unknown'}' (${year}),`,
+    `current URL='${ref.source_url}'.`,
+    `Confirm: (a) does the URL still resolve to the right document,`,
+    `(b) is the citation accurate,`,
+    `(c) has it been superseded by a newer reference.`,
+    `Return STRICT JSON only, no markdown, no commentary:`,
+    `{"valid": bool, "current_url": string|null, "superseded_by": string|null, "confidence": "high"|"medium"|"low", "notes": string}`,
+  ].join(' ');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PERPLEXITY_TIMEOUT_MS);
+
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'sonar-pro',
+        messages: [
+          { role: 'system', content: 'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.' },
+          { role: 'user', content: prompt },
+        ],
+        max_tokens: 500,
+        temperature: 0.1,
+      }),
+    });
+    clearTimeout(timer);
+    if (!res.ok) return ref as LegalRef;
+    const data = await res.json();
+    const content: string = data?.choices?.[0]?.message?.content || '';
+    const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return ref as LegalRef;
+    const parsed = JSON.parse(match[0]);
+    const conf = parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low' ? parsed.confidence : 'low';
+
+    const update: Record<string, unknown> = {
+      last_verified: new Date().toISOString(),
+      verification_notes: typeof parsed.notes === 'string' ? parsed.notes : null,
+    };
+    if (typeof parsed.current_url === 'string') update.verified_url = parsed.current_url;
+
+    let newStatus: string;
+    if (conf === 'high' && typeof parsed.superseded_by === 'string') {
+      newStatus = 'superseded';
+    } else if (conf === 'high' && parsed.valid === false && typeof parsed.current_url === 'string') {
+      update.source_url = parsed.current_url;
+      newStatus = 'updated';
+    } else if (conf === 'medium') {
+      newStatus = 'needs_review';
+    } else if (conf === 'low') {
+      newStatus = 'broken';
+    } else {
+      newStatus = parsed.valid ? 'verified' : 'broken';
+    }
+    update.verification_status = newStatus;
+
+    const { data: updated } = await supabase
+      .from('legal_references')
+      .update(update)
+      .eq('id', refId)
+      .select('id, category, subcategory, law_name, section, summary, source_url, verification_status, last_verified, verified_url')
+      .maybeSingle();
+    return (updated as LegalRef) ?? (ref as LegalRef);
+  } catch {
+    clearTimeout(timer);
+    return ref as LegalRef;
+  }
+}
+
+/**
+ * Pick a fresh substitute in the same category. Used when a ref the
+ * engine intended to cite is stale-after-refresh — we'd rather replace
+ * it with a working sibling than strip it entirely. Falls back to
+ * `null` if none found, in which case the caller strips the citation
+ * and adds a footer note.
+ */
+export async function findFreshSubstitute(
+  supabase: SupabaseClient,
+  category: string,
+  excludeIds: string[]
+): Promise<LegalRef | null> {
+  if (!category) return null;
+  let query = supabase
+    .from('legal_references')
+    .select('id, category, subcategory, law_name, section, summary, source_url, verification_status, last_verified, verified_url')
+    .eq('category', category)
+    .in('verification_status', ['current', 'updated', 'verified'])
+    .order('last_verified', { ascending: false })
+    .limit(20);
+  if (excludeIds.length > 0) {
+    query = query.not('id', 'in', `(${excludeIds.map((id) => `"${id}"`).join(',')})`);
+  }
+  const { data } = await query;
+  if (!data || data.length === 0) return null;
+  // Filter to refs that pass the freshness check (last_verified within window).
+  for (const row of data as LegalRef[]) {
+    if (freshnessOf(row) === 'fresh') return row;
+  }
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  POST-FLIGHT citation validation                                            */
+/* -------------------------------------------------------------------------- */
+/*
+ * The pre-flight check (above) only feeds FRESH refs into the LLM
+ * prompt. It does NOT stop the LLM from inventing a UK statute that
+ * wasn't in the pool we provided — exactly the failure mode generic
+ * LLMs exhibit when asked about UK law (Consumer Rights Act 2014,
+ * "Section 999 of the CCA", etc.).
+ *
+ * Post-flight validation parses the LLM output for UK statute
+ * references and cross-checks each against the fresh pool we fed in.
+ * Anything not in the pool is rogue and either substituted or
+ * stripped + warned.
+ *
+ * Patterns kept deliberately narrow — focus on the ~25 most-cited
+ * UK statutes / regulators in this product. Cheap to add more.
+ */
+
+const CITATION_PATTERNS: RegExp[] = [
+  /Consumer Rights Act\s+\d{4}/gi,
+  /Consumer Credit Act\s+\d{4}/gi,
+  /Sale of Goods Act\s+\d{4}/gi,
+  /Supply of Goods and Services Act\s+\d{4}/gi,
+  /Unfair Contract Terms Act\s+\d{4}/gi,
+  /Consumer Contracts Regulations?\s+\d{4}/gi,
+  /Communications Act\s+\d{4}/gi,
+  /Gas Act\s+\d{4}/gi,
+  /Electricity Act\s+\d{4}/gi,
+  /Data Protection Act\s+\d{4}/gi,
+  /Equality Act\s+\d{4}/gi,
+  /Limitation Act\s+\d{4}/gi,
+  /Local Government Finance Act\s+\d{4}/gi,
+  /Protection of Freedoms Act\s+\d{4}/gi,
+  /Financial Services and Markets Act\s+\d{4}/gi,
+  /Payment Services Regulations?\s+\d{4}/gi,
+  /Misrepresentation Act\s+\d{4}/gi,
+  /Road Traffic Act\s+\d{4}/gi,
+  /(?:UK|EU)\s*261\b/gi,
+  /Regulation\s+\(EC\)\s+No\s+261\/2004/gi,
+  /\bOfcom(?:'s)?(?:\s+(?:General Conditions|rules?|Standards|Code))?/gi,
+  /\bOfgem(?:'s)?(?:\s+(?:Standards of Conduct|rules?|Code))?/gi,
+  /\bOfwat\b/gi,
+  /\bFCA\s+(?:Handbook|CONC|DISP|BCOBS|ICOBS|Consumer Duty)/gi,
+  /\bICO\b/gi,
+];
+
+/**
+ * Extract every UK statute / regulator citation that appears in a
+ * piece of text. Case-insensitive dedup on surface form. Used to feed
+ * `validateCitations`.
+ */
+export function extractCitations(text: string): string[] {
+  if (!text) return [];
+  const found = new Set<string>();
+  const seen = new Set<string>();
+  for (const re of CITATION_PATTERNS) {
+    const matches = text.match(re);
+    if (!matches) continue;
+    for (const m of matches) {
+      const trimmed = m.trim();
+      const key = trimmed.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      found.add(trimmed);
+    }
+  }
+  return [...found];
+}
+
+/**
+ * Cross-check what the LLM cited against the fresh pool we fed in.
+ * Case-insensitive substring match against `law_name` (either way —
+ * cite contains pool law_name OR law_name contains cite).
+ *
+ * Anything not matched is rogue: a hallucinated act, a statute the LLM
+ * dredged from training data, or a mis-spelled year.
+ */
+export function validateCitations(
+  cited: string[],
+  freshPool: { law_name: string; category?: string | null }[]
+): { valid: string[]; rogue: string[] } {
+  const haystack = freshPool
+    .map((r) => (r.law_name || '').toLowerCase().trim())
+    .filter(Boolean);
+  const valid: string[] = [];
+  const rogue: string[] = [];
+  for (const c of cited) {
+    const lc = c.toLowerCase().trim();
+    const matched = haystack.some((h) => h.includes(lc) || lc.includes(h));
+    if (matched) valid.push(c);
+    else rogue.push(c);
+  }
+  return { valid, rogue };
+}
+
+/**
+ * Pick the closest fresh-pool law_name as a substitute for each rogue
+ * citation. Strategy: word-token overlap. Returns null for a rogue
+ * when no fresh ref shares any 4+-char token with it (caller strips
+ * rather than substitutes).
+ */
+export function planSubstitutions(
+  rogue: string[],
+  freshPool: { law_name: string; category?: string | null }[]
+): Record<string, string | null> {
+  const out: Record<string, string | null> = {};
+  for (const r of rogue) {
+    const tokens = r
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length >= 4);
+    let best: { name: string; score: number } | null = null;
+    for (const ref of freshPool) {
+      const name = ref.law_name || '';
+      const lc = name.toLowerCase();
+      const score = tokens.reduce((s, t) => s + (lc.includes(t) ? 1 : 0), 0);
+      if (score > 0 && (!best || score > best.score)) best = { name, score };
+    }
+    out[r] = best?.name ?? null;
+  }
+  return out;
+}
+
+/**
+ * Strip or replace rogue citations in free-form text. Returns the
+ * sanitised text and human-readable warnings.
+ *
+ * Substitutions[r]=string → replace; Substitutions[r]=null → strip.
+ */
+export function sanitiseLetter(
+  letterText: string,
+  rogueCitations: string[],
+  substitutions: Record<string, string | null>
+): { sanitised: string; warnings: string[] } {
+  let out = letterText;
+  const warnings: string[] = [];
+  for (const rogue of rogueCitations) {
+    const sub = substitutions[rogue];
+    const escaped = rogue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(escaped, 'gi');
+    if (sub) {
+      out = out.replace(re, sub);
+      warnings.push(`Replaced unverified citation '${rogue}' with '${sub}'`);
+    } else {
+      out = out.replace(re, '');
+      // Light cleanup: collapse orphaned " under , " or double spaces.
+      out = out.replace(/\bunder\s*([,.;])/gi, '$1');
+      out = out.replace(/\s{2,}/g, ' ');
+      warnings.push(`Removed unverified citation: '${rogue}'`);
+    }
+  }
+  return { sanitised: out.trim(), warnings };
+}
+
+/**
+ * One-shot post-flight pass. Pure regex + substring; expected p95
+ * well under 100ms. Caller is responsible for logging if it does
+ * exceed 100ms — see B2C / B2B wiring.
+ */
+export function postFlightSanitise(
+  letterText: string,
+  freshPool: { law_name: string; category?: string | null }[]
+): { sanitised: string; rogue: string[]; warnings: string[] } {
+  const cited = extractCitations(letterText);
+  const { rogue } = validateCitations(cited, freshPool);
+  if (rogue.length === 0) return { sanitised: letterText, rogue: [], warnings: [] };
+  const subs = planSubstitutions(rogue, freshPool);
+  const { sanitised, warnings } = sanitiseLetter(letterText, rogue, subs);
+  return { sanitised, rogue, warnings };
+}

--- a/supabase/migrations/20260430050000_legal_refs_verification_extra.sql
+++ b/supabase/migrations/20260430050000_legal_refs_verification_extra.sql
@@ -1,0 +1,11 @@
+-- Additive: extra columns for AI-assisted legal reference verification.
+-- verification_notes already exists on legal_references (see
+-- 20260327020000_legal_references.sql), but adding IF NOT EXISTS keeps
+-- this migration safe to re-run. verified_url is new — it stores the
+-- canonical URL Perplexity confirms during a manual review pass, so the
+-- founder can spot when the citation has moved without overwriting the
+-- original `source_url`.
+
+ALTER TABLE public.legal_references
+  ADD COLUMN IF NOT EXISTS verified_url TEXT,
+  ADD COLUMN IF NOT EXISTS verification_notes TEXT;

--- a/supabase/migrations/20260430070000_legal_refs_auto_correct_flag.sql
+++ b/supabase/migrations/20260430070000_legal_refs_auto_correct_flag.sql
@@ -1,0 +1,4 @@
+-- Additive: track when Perplexity verifier auto-overwrote canonical fields
+-- so the admin UI can surface a "review auto-correction" badge.
+ALTER TABLE public.legal_references
+  ADD COLUMN IF NOT EXISTS auto_corrected BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## Summary

Compliance is the entire selling point of Paybacker — both products promise current UK statute citations. This PR closes BOTH failure modes that could let a stale or fabricated citation reach a user (B2C complaint letter) or a customer (B2B DisputeResponse).

### Two-layer defence

**1. Pre-flight (input filter).** Before the LLM is called, every legal-references row the engine intends to cite is checked against the freshness contract:
- `verification_status IN ('current', 'updated', 'verified')`
- `last_verified IS NOT NULL`
- `last_verified >= NOW() - INTERVAL '<LEGAL_REF_MAX_AGE_DAYS>'` (default 14)

Stale rows are refresh-or-substituted (synchronous Perplexity, 5s hard cap → fresh substitute in same category → strip). The user flow never blocks.

**2. Post-flight (output filter — NEW in this PR).** After the LLM returns prose, a regex pass detects every UK statute / regulator citation in the output. Each is cross-checked against the fresh pool we fed in. Anything not in the pool is rogue — either a hallucinated act or a stale cite the LLM dredged from training data (e.g. "Consumer Rights Act 2014" — the canonical wrong-year hallucination).

The pre-flight closes the input vector. The post-flight is the receipt check at the door. Together they leave no path for stale OR fabricated citations to reach the user/customer.

### B2C path — `/api/complaints/generate`

After Claude returns the letter, run `postFlightSanitise(result.letter, freshPool)`:
- Rogue citation with a same-token-overlap fresh substitute → REPLACE in-place.
- Rogue citation with no substitute → STRIP and append footer note: "Some statutory references were removed during compliance review — please verify before sending."
- Logged to `business_log` with action='guardrail_postflight_sanitised'.
- 100ms soft budget (logged if exceeded; never blocks).

### B2B path — `/v1/disputes`

Two-tier validation against the `DisputeResponse` shape:

**Structured `statute` field** — the LLM-derived primary citation. Exact-match check against fresh pool's `law_name`. If no match:
- Same-category fresh ref available → REPLACE the structured field, log warning.
- No category match AND no fresh fallback → return `HTTP 503` with `{code: 'STALE_CITATION', message: 'LLM cited an unverified statute and no fresh substitute is available.', retry_after: 60}`. Never ship a fabricated structured citation.

**Free-text fields** (`customer_facing_response`, `agent_talking_points`, `draft_letter_excerpt`, `entitlement.summary`, `entitlement.rationale`) — regex pass + sanitise. Rogue citations stripped or substituted. Warnings appended to `_compliance_warnings: string[]` — additive optional field, never breaks existing consumers of the API. Customers who care surface it; ones that don't can ignore it.

The `legal_references` array also has rogues filtered out — only pool-verified citations make it into the public response.

### Helper additions to `src/lib/legal-refs-guardrail.ts`

```ts
extractCitations(text: string): string[]
validateCitations(cited, freshPool): { valid, rogue }
planSubstitutions(rogue, freshPool): Record<string, string | null>
sanitiseLetter(text, rogue, subs): { sanitised, warnings }
postFlightSanitise(text, freshPool): { sanitised, rogue, warnings }
```

CITATION_PATTERNS covers ~25 most-cited UK statutes / regulators (CRA, CCA, SoGA, CCRs, Communications Act, Gas/Electricity Acts, DPA, Equality Act, Limitation Act, EU/UK 261, Ofcom, Ofgem, Ofwat, FCA Handbook variants, ICO).

### Smoke tests — `src/lib/legal-refs-guardrail.test.ts`

17 assertions, all passing under Node's built-in test runner:
- Wrong-year hallucination ("Consumer Rights Act 2014") detected and substituted to CRA 2015.
- Pool-verified citations pass through unchanged.
- Fabricated act with no fresh substitute in pool → stripped + warning emitted.
- Substring match works either direction (cite contains pool, pool contains cite).
- Case-insensitive dedup.

```
ℹ tests 17  ℹ pass 17  ℹ fail 0  ℹ duration_ms 120.99
```

Run via:
```
node --experimental-strip-types --test src/lib/legal-refs-guardrail.test.ts
```

### Constraints met
- No mutation of LLM input — input pool stays as built; only output is sanitised.
- 5s hard cap on synchronous Perplexity refresh.
- 100ms soft budget on post-flight pass; logged if exceeded, never blocks.
- `_compliance_warnings` is additive optional — never required, never breaks API consumers.
- `tsc --noEmit` clean.
- DisputeResponse shape unchanged on success (additive field only).
- Concurrent sessions: only files touched are the guardrail module, the two engine call-sites, and the admin page.

## Files
- `src/lib/legal-refs-guardrail.ts` — new module with both pre-flight and post-flight helpers
- `src/lib/legal-refs-guardrail.test.ts` — 17 behavioural assertions
- `src/lib/__tests__/legal-refs-guardrail.test.ts` — type-shape compile checks
- `src/app/api/complaints/generate/route.ts` — B2C wiring (pre-flight + post-flight + footer note)
- `src/lib/b2b/disputes.ts` — B2B wiring (pre-flight + post-flight + 503 + `_compliance_warnings`)
- `src/app/api/v1/disputes/route.ts` — STALE_CITATION → 503 mapping
- `src/app/dashboard/admin/legal-refs/page.tsx` — "Block effect" column placeholder (TBD until PR γ)

## Test plan
- [ ] Apply PR α first to populate fresh refs (auto-overwrite + baseline)
- [ ] B2C: trigger a known-fresh letter — confirm no footer note appears
- [ ] B2C: mark a ref as `verification_status='broken'` — confirm letter generates with substitute or footer note
- [ ] B2B: call `/v1/disputes` with stale ref + no substitute available — expect 503
- [ ] B2B: confirm `_compliance_warnings` populated when a free-text rogue is sanitised
- [ ] Confirm `business_log` rows with action='guardrail_*' for any sanitisation event

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>