### PR TITLE
feat(compliance): fix stats counters + active legal-ref discovery pipeline (PR δ)

### DIFF
--- a/src/app/api/admin/legal-ref-candidates/[id]/decision/route.ts
+++ b/src/app/api/admin/legal-ref-candidates/[id]/decision/route.ts
@@ -1,0 +1,135 @@
+/**
+ * POST /api/admin/legal-ref-candidates/:id/decision
+ *
+ * Founder review action for a discovered legal-reference candidate.
+ *
+ * Body:
+ *   { action: 'approve' | 'reject' | 'duplicate', notes?: string, duplicate_of?: uuid }
+ *
+ * Behaviour:
+ *   - approve   : insert a new row into legal_references (discovery_source
+ *                 set to 'perplexity_discovery'), mark candidate approved.
+ *                 Never overwrites an existing ref.
+ *   - reject    : mark candidate rejected with optional notes.
+ *   - duplicate : mark candidate duplicate, store reference to the
+ *                 existing legal_references.id in notes/duplicate_of.
+ *
+ * Auth: founder admin session (CRON_SECRET path also accepted via
+ * authorizeAdminOrCron, mainly for tooling).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron, ADMIN_EMAIL } from '@/lib/admin-auth';
+
+export const runtime = 'nodejs';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+interface DecisionBody {
+  action: 'approve' | 'reject' | 'duplicate';
+  notes?: string;
+  duplicate_of?: string;
+}
+
+export async function POST(request: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+
+  const { id } = await ctx.params;
+  if (!id || typeof id !== 'string') {
+    return NextResponse.json({ error: 'missing id' }, { status: 400 });
+  }
+
+  let body: DecisionBody;
+  try {
+    body = (await request.json()) as DecisionBody;
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  if (!body.action || !['approve', 'reject', 'duplicate'].includes(body.action)) {
+    return NextResponse.json({ error: 'invalid action' }, { status: 400 });
+  }
+
+  const admin = getAdmin();
+
+  const { data: cand, error: candErr } = await admin
+    .from('legal_ref_candidates')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (candErr || !cand) {
+    return NextResponse.json({ error: 'candidate not found' }, { status: 404 });
+  }
+  if (cand.status !== 'pending') {
+    return NextResponse.json({ error: `candidate already ${cand.status}` }, { status: 409 });
+  }
+
+  const reviewer = ADMIN_EMAIL;
+  const reviewedAt = new Date().toISOString();
+
+  if (body.action === 'approve') {
+    // Insert into legal_references. Use a defensive payload — only
+    // columns that we know are safe across the shared B2C/B2B schema.
+    // Other columns (escalation_body, strength, etc.) default to null /
+    // their column defaults. The founder can edit further once it lands.
+    const { error: insErr } = await admin.from('legal_references').insert({
+      law_name: cand.title,
+      summary: cand.summary || cand.title,
+      source_url: cand.source_url,
+      source_type: cand.source_type || 'guidance',
+      category: cand.category || 'general',
+      verification_status: 'needs_review', // founder-approved but unverified
+      discovery_source: 'perplexity_discovery',
+      pending_review: false,
+    });
+    if (insErr) {
+      return NextResponse.json({ error: `legal_references insert failed: ${insErr.message}` }, { status: 500 });
+    }
+    await admin
+      .from('legal_ref_candidates')
+      .update({
+        status: 'approved',
+        reviewed_at: reviewedAt,
+        reviewed_by: reviewer,
+        notes: body.notes ?? null,
+      })
+      .eq('id', id);
+    return NextResponse.json({ ok: true, action: 'approve' });
+  }
+
+  if (body.action === 'reject') {
+    await admin
+      .from('legal_ref_candidates')
+      .update({
+        status: 'rejected',
+        reviewed_at: reviewedAt,
+        reviewed_by: reviewer,
+        notes: body.notes ?? null,
+      })
+      .eq('id', id);
+    return NextResponse.json({ ok: true, action: 'reject' });
+  }
+
+  // duplicate
+  await admin
+    .from('legal_ref_candidates')
+    .update({
+      status: 'duplicate',
+      reviewed_at: reviewedAt,
+      reviewed_by: reviewer,
+      duplicate_of: body.duplicate_of ?? null,
+      notes: body.notes ?? (body.duplicate_of ? `duplicate of ${body.duplicate_of}` : null),
+    })
+    .eq('id', id);
+  return NextResponse.json({ ok: true, action: 'duplicate' });
+}

--- a/src/app/api/cron/discover-legal-refs/route.ts
+++ b/src/app/api/cron/discover-legal-refs/route.ts
@@ -1,0 +1,344 @@
+/**
+ * GET /api/cron/discover-legal-refs?leg=recent|category
+ *
+ * Active legal-reference discovery pipeline. Per founder strategic note:
+ *   "We need to always be ADDING to the laws in the compliance centre to
+ *    ensure Paybacker always has every source of law that can be cited."
+ *
+ * Two legs:
+ *   - leg=recent  : weekly broad sweep of UK consumer-law changes in the
+ *                   last 30 days (Acts, SIs, Ofcom/Ofgem/FCA rulings,
+ *                   FOS decisions, CAA, HMRC/DVLA, court rulings).
+ *   - leg=category: daily per-category coverage check, rotating through
+ *                   the distinct categories so each is touched ~bi-weekly.
+ *
+ * Output flow (NEVER auto-applies):
+ *   1. Ask Perplexity sonar-pro.
+ *   2. For each returned item, dedupe against legal_references and
+ *      legal_ref_candidates (by source_url or title substring match).
+ *   3. Insert survivors into legal_ref_candidates with status='pending'.
+ *   4. Log run summary into legal_ref_discovery_runs.
+ *
+ * Cost control:
+ *   - Hard cap: max 60 Perplexity calls per run (£0.30 ish).
+ *   - If pending candidate queue > 100, skip with a 'queue full' note.
+ *   - Every Perplexity call goes through logPerplexityCall.
+ *
+ * Per CLAUDE.md rule #3 — Perplexity only for real-time web research.
+ *
+ * Auth: Bearer CRON_SECRET (Vercel cron) OR logged-in admin (founder
+ * "Discover now" button).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { logPerplexityCall } from '@/lib/cost-ledger';
+
+export const runtime = 'nodejs';
+export const maxDuration = 120;
+
+const PERPLEXITY_USD_PER_CALL = 0.005; // sonar-pro flat rate per cost-ledger.ts
+const USD_TO_GBP = 0.79;
+const HARD_CAP_GBP = 0.30;
+const MAX_CALLS_PER_RUN = Math.floor(HARD_CAP_GBP / (PERPLEXITY_USD_PER_CALL * USD_TO_GBP)); // ~75
+const MAX_PENDING_QUEUE = 100;
+
+// Default category list — used if the legal_references table is empty
+// (shouldn't happen in prod) or if a brand-new category is requested.
+const DEFAULT_CATEGORIES = [
+  'energy', 'broadband', 'mobile', 'water', 'insurance', 'fitness',
+  'software', 'finance', 'food', 'transport', 'statutory', 'streaming',
+  'banking', 'debt-recovery',
+];
+
+interface PerplexityCandidate {
+  title: string;
+  source_url?: string | null;
+  source_type?: string | null;
+  summary?: string | null;
+  category?: string | null;
+  jurisdiction?: string | null;
+  published_at?: string | null;
+  citation?: string | null;
+  confidence?: string | null;
+}
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+function normaliseTitle(s: string): string {
+  return s.toLowerCase().replace(/[^\w\s]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+async function callPerplexity(prompt: string): Promise<{ items: PerplexityCandidate[]; raw: unknown }> {
+  const key = process.env.PERPLEXITY_API_KEY;
+  if (!key) throw new Error('PERPLEXITY_API_KEY not set');
+  const res = await fetch('https://api.perplexity.ai/chat/completions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: 'sonar-pro',
+      messages: [{ role: 'user', content: prompt }],
+      return_citations: true,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Perplexity HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  const data = await res.json();
+  logPerplexityCall({ model: 'sonar-pro', endpoint: '/api/cron/discover-legal-refs' });
+  const content: string = data.choices?.[0]?.message?.content ?? '';
+  const match = content.match(/\[[\s\S]*\]/);
+  if (!match) return { items: [], raw: data };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[0]);
+  } catch {
+    return { items: [], raw: data };
+  }
+  if (!Array.isArray(parsed)) return { items: [], raw: data };
+  const items = parsed.filter(
+    (u): u is PerplexityCandidate =>
+      !!u && typeof u === 'object' && typeof (u as PerplexityCandidate).title === 'string',
+  );
+  return { items, raw: data };
+}
+
+function recentPrompt(): string {
+  return `List UK consumer law changes published in the last 30 days — Acts, statutory instruments, Ofcom/Ofgem/FCA rulings, FOS decisions, Civil Aviation Authority updates, HMRC/DVLA guidance changes, court rulings on consumer rights. Return ONLY a JSON array (no preamble, no markdown fences) with objects shaped:
+[{"title": "...", "source_url": "...", "source_type": "statute|regulator_rule|case_law|guidance|fos_decision", "summary": "...", "jurisdiction": "UK", "published_at": "yyyy-mm-dd", "category": "energy|broadband|mobile|water|insurance|finance|transport|banking|statutory|streaming|software|fitness|food|debt-recovery", "confidence": "high|medium|low"}]
+Only items genuinely material for consumer disputes. Maximum 15 items.`;
+}
+
+function categoryPrompt(category: string): string {
+  return `For UK ${category} consumer disputes, list all currently-cited primary statutes, statutory instruments, regulator rules, ombudsman decisions and binding case law. Return ONLY a JSON array (no preamble, no markdown fences) with objects:
+[{"title": "...", "source_url": "...", "source_type": "statute|regulator_rule|case_law|guidance|fos_decision", "citation": "...", "summary": "...", "category": "${category}", "jurisdiction": "UK", "confidence": "high|medium|low"}]
+Include items that are commonly cited even if not the freshest. Maximum 15 items.`;
+}
+
+async function loadCategoriesFromDb(): Promise<string[]> {
+  const admin = getAdmin();
+  const { data } = await admin
+    .from('legal_references')
+    .select('category')
+    .not('category', 'is', null)
+    .limit(2000);
+  if (!data) return DEFAULT_CATEGORIES;
+  const set = new Set<string>();
+  for (const row of data as Array<{ category: string | null }>) {
+    if (row.category) set.add(row.category);
+  }
+  const list = Array.from(set);
+  return list.length > 0 ? list.sort() : DEFAULT_CATEGORIES;
+}
+
+/**
+ * Best-effort dedupe. Two checks:
+ *   - exact source_url match against legal_references
+ *   - normalised title substring match against legal_references.law_name
+ *   - same checks against legal_ref_candidates with status in pending/rejected
+ *     (avoid resurrecting a previously-rejected suggestion)
+ */
+async function isDuplicate(
+  cand: PerplexityCandidate,
+): Promise<boolean> {
+  const admin = getAdmin();
+  const url = cand.source_url?.trim() || null;
+  const norm = normaliseTitle(cand.title);
+  if (url) {
+    const { data: byUrl } = await admin
+      .from('legal_references')
+      .select('id')
+      .eq('source_url', url)
+      .limit(1);
+    if (byUrl && byUrl.length > 0) return true;
+    const { data: candByUrl } = await admin
+      .from('legal_ref_candidates')
+      .select('id')
+      .eq('source_url', url)
+      .in('status', ['pending', 'rejected', 'approved'])
+      .limit(1);
+    if (candByUrl && candByUrl.length > 0) return true;
+  }
+  if (norm.length > 5) {
+    // ilike substring on first 30 chars of normalised title
+    const probe = norm.slice(0, 30);
+    const { data: byTitle } = await admin
+      .from('legal_references')
+      .select('id')
+      .ilike('law_name', `%${probe}%`)
+      .limit(1);
+    if (byTitle && byTitle.length > 0) return true;
+  }
+  return false;
+}
+
+async function pendingQueueSize(): Promise<number> {
+  const admin = getAdmin();
+  const { count } = await admin
+    .from('legal_ref_candidates')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', 'pending');
+  return count ?? 0;
+}
+
+async function logRun(args: {
+  leg: 'recent_updates' | 'category_coverage';
+  category?: string | null;
+  found: number;
+  added: number;
+  skipped: number;
+  costGbp: number;
+  raw?: unknown;
+  notes?: string | null;
+}): Promise<number | null> {
+  const admin = getAdmin();
+  const { data, error } = await admin
+    .from('legal_ref_discovery_runs')
+    .insert({
+      leg: args.leg,
+      category: args.category ?? null,
+      candidates_found: args.found,
+      candidates_added: args.added,
+      candidates_skipped_duplicate: args.skipped,
+      cost_gbp: args.costGbp,
+      perplexity_response: args.raw ?? null,
+      notes: args.notes ?? null,
+    })
+    .select('id')
+    .single();
+  if (error) {
+    console.warn('[discover-legal-refs] run log insert failed:', error.message);
+    return null;
+  }
+  return (data as { id: number } | null)?.id ?? null;
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+
+  const url = new URL(request.url);
+  const legParam = (url.searchParams.get('leg') || 'recent').toLowerCase();
+  const leg: 'recent_updates' | 'category_coverage' =
+    legParam === 'category' || legParam === 'category_coverage'
+      ? 'category_coverage'
+      : 'recent_updates';
+
+  const queueSize = await pendingQueueSize();
+  if (queueSize > MAX_PENDING_QUEUE) {
+    const notes = `queue full — review pending first (${queueSize} pending)`;
+    await logRun({ leg, found: 0, added: 0, skipped: 0, costGbp: 0, notes });
+    return NextResponse.json({ ok: true, skipped: true, notes, candidates_found: 0, candidates_added: 0, candidates_skipped_duplicate: 0 });
+  }
+
+  // Resolve target category for leg B — rotate through categories using
+  // day-of-year mod N so each fires every ~14 days.
+  let targetCategory: string | null = null;
+  if (leg === 'category_coverage') {
+    const categories = await loadCategoriesFromDb();
+    const explicit = url.searchParams.get('category');
+    if (explicit && categories.includes(explicit)) {
+      targetCategory = explicit;
+    } else {
+      const start = new Date(Date.UTC(new Date().getUTCFullYear(), 0, 0));
+      const dayOfYear = Math.floor((Date.now() - start.getTime()) / (1000 * 60 * 60 * 24));
+      targetCategory = categories[dayOfYear % categories.length];
+    }
+  }
+
+  const prompt = leg === 'recent_updates' ? recentPrompt() : categoryPrompt(targetCategory!);
+
+  let perplexityResult: { items: PerplexityCandidate[]; raw: unknown } = { items: [], raw: null };
+  let costGbp = 0;
+  try {
+    perplexityResult = await callPerplexity(prompt);
+    costGbp = PERPLEXITY_USD_PER_CALL * USD_TO_GBP;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await logRun({ leg, category: targetCategory, found: 0, added: 0, skipped: 0, costGbp: 0, notes: `perplexity error: ${msg}` });
+    return NextResponse.json({ ok: false, error: msg }, { status: 502 });
+  }
+
+  // Cap on calls — current implementation is single-call per run, but
+  // guard anyway so a future fan-out can't exceed the budget silently.
+  if (costGbp > HARD_CAP_GBP) {
+    await logRun({ leg, category: targetCategory, found: 0, added: 0, skipped: 0, costGbp, notes: 'cost cap exceeded — aborted' });
+    return NextResponse.json({ ok: false, error: 'cost cap exceeded' }, { status: 429 });
+  }
+
+  const items = perplexityResult.items.slice(0, MAX_CALLS_PER_RUN); // safety bound
+  let added = 0;
+  let skipped = 0;
+  const admin = getAdmin();
+
+  // Insert run row first so candidates can reference it.
+  const runId = await logRun({
+    leg,
+    category: targetCategory,
+    found: items.length,
+    added: 0,
+    skipped: 0,
+    costGbp,
+    raw: perplexityResult.raw,
+    notes: targetCategory ? `category: ${targetCategory}` : null,
+  });
+
+  for (const item of items) {
+    if (!item.title || typeof item.title !== 'string') {
+      skipped++;
+      continue;
+    }
+    if (await isDuplicate(item)) {
+      skipped++;
+      continue;
+    }
+    const { error } = await admin.from('legal_ref_candidates').insert({
+      title: item.title.slice(0, 500),
+      source_url: item.source_url?.toString().slice(0, 1000) || null,
+      source_type: item.source_type?.toString().slice(0, 80) || null,
+      summary: item.summary?.toString().slice(0, 4000) || null,
+      category: (item.category || targetCategory || null)?.toString().slice(0, 80) || null,
+      jurisdiction: item.jurisdiction || 'UK',
+      confidence: item.confidence?.toString().slice(0, 20) || null,
+      status: 'pending',
+      discovery_run_id: runId,
+    });
+    if (error) {
+      console.warn('[discover-legal-refs] candidate insert failed:', error.message);
+      skipped++;
+      continue;
+    }
+    added++;
+  }
+
+  // Update run row with final tallies (best-effort).
+  if (runId !== null) {
+    await admin
+      .from('legal_ref_discovery_runs')
+      .update({ candidates_added: added, candidates_skipped_duplicate: skipped })
+      .eq('id', runId);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    leg,
+    category: targetCategory,
+    candidates_found: items.length,
+    candidates_added: added,
+    candidates_skipped_duplicate: skipped,
+    cost_gbp: Number(costGbp.toFixed(6)),
+  });
+}
+
+export async function POST(request: NextRequest) {
+  // Mirror GET so the founder "Discover now" admin button can POST.
+  return GET(request);
+}

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -32,10 +32,28 @@ interface LegalRef {
 
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof CheckCircle; className: string }> = {
   current: { label: 'Current', icon: CheckCircle, className: 'text-green-400 bg-green-500/10' },
+  verified: { label: 'Verified', icon: CheckCircle, className: 'text-green-500 bg-green-500/10' },
   updated: { label: 'Auto-updated', icon: RefreshCw, className: 'text-emerald-600 bg-emerald-500/10' },
   needs_review: { label: 'Needs review', icon: AlertTriangle, className: 'text-amber-600 bg-amber-100' },
   outdated: { label: 'Outdated', icon: AlertTriangle, className: 'text-red-400 bg-red-500/10' },
+  broken: { label: 'Broken', icon: AlertTriangle, className: 'text-red-500 bg-red-500/10' },
+  stale: { label: 'Stale', icon: Clock, className: 'text-amber-500 bg-amber-500/10' },
+  error: { label: 'Error', icon: AlertTriangle, className: 'text-red-400 bg-red-500/10' },
+  superseded: { label: 'Superseded', icon: RefreshCw, className: 'text-slate-500 bg-slate-100' },
+  url_dead: { label: 'URL dead', icon: AlertTriangle, className: 'text-red-500 bg-red-500/10' },
 };
+
+// A row "needs review" if its verification_status is in this set OR last_verified
+// is null OR older than 60 days. Mirrors PR #373's review-list predicate so the
+// summary stats and the list view always agree.
+const NEEDS_REVIEW_STATUSES = new Set(['needs_review', 'broken', 'stale', 'error', 'outdated', 'url_dead']);
+const STALE_AFTER_DAYS = 60;
+function needsReview(ref: LegalRef): boolean {
+  if (NEEDS_REVIEW_STATUSES.has(ref.verification_status)) return true;
+  if (!ref.last_verified) return true;
+  const ageMs = Date.now() - new Date(ref.last_verified).getTime();
+  return ageMs > STALE_AFTER_DAYS * 24 * 60 * 60 * 1000;
+}
 
 const STRENGTH_CONFIG: Record<string, string> = {
   strong: 'text-green-400',
@@ -62,9 +80,28 @@ function formatDate(d: string | null) {
   return new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
+interface Candidate {
+  id: string;
+  title: string;
+  source_url: string | null;
+  source_type: string | null;
+  summary: string | null;
+  category: string | null;
+  jurisdiction: string | null;
+  confidence: string | null;
+  status: 'pending' | 'approved' | 'rejected' | 'duplicate';
+  discovered_at: string;
+  notes: string | null;
+}
+
 export default function LegalRefsAdminPage() {
   const [authorized, setAuthorized] = useState<boolean | null>(null);
   const [refs, setRefs] = useState<LegalRef[]>([]);
+  const [dbTotal, setDbTotal] = useState<number | null>(null);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [pendingCandCount, setPendingCandCount] = useState(0);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverResult, setDiscoverResult] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [verifying, setVerifying] = useState(false);
   const [verifyResult, setVerifyResult] = useState<string | null>(null);
@@ -82,21 +119,93 @@ export default function LegalRefsAdminPage() {
         return;
       }
       setAuthorized(true);
-      await fetchRefs();
+      await Promise.all([fetchRefs(), fetchCandidates()]);
     };
     load();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const fetchRefs = async () => {
-    const { data, error } = await supabase
+    // Page rows in batches of 1000 — PostgREST default range cap is 1000 and
+    // the founder reported the count widget showed 78 / 112. We need every
+    // row regardless of status to surface the true table size.
+    const PAGE = 1000;
+    const all: LegalRef[] = [];
+    let from = 0;
+    // Best-effort exact count — separate head:true query so we can compare
+    // .length vs server count and detect range truncation.
+    const { count } = await supabase
       .from('legal_references')
-      .select('*')
-      .order('category')
-      .order('law_name');
-
-    if (!error && data) setRefs(data);
+      .select('*', { count: 'exact', head: true });
+    setDbTotal(typeof count === 'number' ? count : null);
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { data, error } = await supabase
+        .from('legal_references')
+        .select('*')
+        .order('category')
+        .order('law_name')
+        .range(from, from + PAGE - 1);
+      if (error || !data || data.length === 0) break;
+      all.push(...(data as LegalRef[]));
+      if (data.length < PAGE) break;
+      from += PAGE;
+    }
+    setRefs(all);
     setLoading(false);
+  };
+
+  const fetchCandidates = async () => {
+    const { data: pendingData } = await supabase
+      .from('legal_ref_candidates')
+      .select('*')
+      .eq('status', 'pending')
+      .order('discovered_at', { ascending: false })
+      .limit(200);
+    const list = (pendingData as Candidate[] | null) ?? [];
+    setCandidates(list);
+    setPendingCandCount(list.length);
+  };
+
+  const decideCandidate = async (
+    id: string,
+    action: 'approve' | 'reject' | 'duplicate',
+    notes?: string,
+    duplicate_of?: string,
+  ) => {
+    const res = await fetch(`/api/admin/legal-ref-candidates/${id}/decision`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ action, notes, duplicate_of }),
+    });
+    if (res.ok) {
+      await Promise.all([fetchRefs(), fetchCandidates()]);
+    } else {
+      const err = await res.json().catch(() => ({}));
+      alert(`Decision failed: ${err.error ?? res.status}`);
+    }
+  };
+
+  const triggerDiscovery = async (leg: 'recent' | 'category') => {
+    setDiscovering(true);
+    setDiscoverResult(null);
+    try {
+      const res = await fetch(`/api/cron/discover-legal-refs?leg=${leg}`, { credentials: 'include' });
+      const data = await res.json();
+      if (data.ok) {
+        setDiscoverResult(
+          `Done. ${data.candidates_found ?? 0} found, ${data.candidates_added ?? 0} new, ${data.candidates_skipped_duplicate ?? 0} duplicates.${data.notes ? ' ' + data.notes : ''}`,
+        );
+        await fetchCandidates();
+      } else {
+        setDiscoverResult(`Error: ${data.error || 'Unknown error'}`);
+      }
+    } catch (err) {
+      setDiscoverResult(`Failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setDiscovering(false);
+    }
   };
 
   const runVerification = async () => {
@@ -121,7 +230,9 @@ export default function LegalRefsAdminPage() {
   };
 
   const filtered = refs.filter(r => {
-    if (filterStatus !== 'all' && r.verification_status !== filterStatus) return false;
+    if (filterStatus === 'needs_review_any') {
+      if (!needsReview(r)) return false;
+    } else if (filterStatus !== 'all' && r.verification_status !== filterStatus) return false;
     if (filterCategory !== 'all' && r.category !== filterCategory) return false;
     if (search) {
       const q = search.toLowerCase();
@@ -136,12 +247,18 @@ export default function LegalRefsAdminPage() {
   });
 
   const categories = [...new Set(refs.map(r => r.category))].sort();
+  // Stats now share the same predicate as the review list (PR #373) so the
+  // "Needs review" count equals the rows the founder actually sees.
+  const reviewList = refs.filter(needsReview);
+  const staleAfter = Date.now() - STALE_AFTER_DAYS * 24 * 60 * 60 * 1000;
   const counts = {
     total: refs.length,
-    current: refs.filter(r => r.verification_status === 'current').length,
+    dbTotal: dbTotal ?? refs.length,
+    current: refs.filter(r => r.verification_status === 'current' || r.verification_status === 'verified').length,
     updated: refs.filter(r => r.verification_status === 'updated').length,
-    needs_review: refs.filter(r => r.verification_status === 'needs_review').length,
-    outdated: refs.filter(r => r.verification_status === 'outdated').length,
+    needs_review: reviewList.length,
+    stale: refs.filter(r => r.last_verified && new Date(r.last_verified).getTime() < staleAfter).length,
+    outdated: refs.filter(r => r.verification_status === 'outdated' || r.verification_status === 'broken' || r.verification_status === 'url_dead').length,
   };
 
   if (loading) {
@@ -181,16 +298,32 @@ export default function LegalRefsAdminPage() {
               <Shield className="h-9 w-9 text-emerald-600" />
               Legal References
             </h1>
-            <p className="text-slate-600">{counts.total} references across {categories.length} categories</p>
+            <p className="text-slate-600">
+              {counts.dbTotal} references across {categories.length} categories
+              {counts.dbTotal !== counts.total && (
+                <span className="text-amber-600"> · {counts.total} loaded</span>
+              )}
+            </p>
           </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={() => triggerDiscovery('recent')}
+              disabled={discovering}
+              className="flex items-center gap-2 bg-white border border-slate-200 hover:border-emerald-500 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2.5 rounded-lg transition-all text-sm"
+              title="Run Perplexity discovery for recent UK consumer-law updates"
+            >
+              {discovering ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+              Discover now
+            </button>
           <button
             onClick={runVerification}
             disabled={verifying}
-            className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm shrink-0"
+            className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm"
           >
             {verifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
             {verifying ? 'Verifying...' : 'Run Verification'}
           </button>
+          </div>
         </div>
       </div>
 
@@ -202,18 +335,104 @@ export default function LegalRefsAdminPage() {
           {verifyResult}
         </div>
       )}
+      {discoverResult && (
+        <div className={`mb-4 px-4 py-3 rounded-xl text-sm font-medium border ${
+          discoverResult.startsWith('Done') ? 'bg-emerald-500/10 border-emerald-500/20 text-emerald-700' : 'bg-red-500/10 border-red-500/20 text-red-400'
+        }`}>
+          {discoverResult}
+        </div>
+      )}
+
+      {/* Discovery candidates queue */}
+      {pendingCandCount > 0 && (
+        <div className="mb-6 bg-white border border-emerald-200 rounded-2xl overflow-hidden">
+          <div className="px-5 py-3 bg-emerald-50 border-b border-emerald-200 flex items-center justify-between">
+            <p className="font-semibold text-emerald-800 text-sm">
+              Discovery candidates ({pendingCandCount} pending)
+            </p>
+            <p className="text-xs text-emerald-700">Founder review only — never auto-approved.</p>
+          </div>
+          <div className="divide-y divide-slate-200">
+            {candidates.map(c => (
+              <div key={c.id} className="p-4 flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="font-semibold text-slate-900 text-sm">{c.title}</p>
+                    {c.category && (
+                      <span className="text-xs bg-slate-100 text-slate-700 px-2 py-0.5 rounded-full">
+                        {CATEGORY_LABELS[c.category] || c.category}
+                      </span>
+                    )}
+                    {c.source_type && (
+                      <span className="text-xs text-slate-500">{c.source_type}</span>
+                    )}
+                  </div>
+                  {c.summary && <p className="text-xs text-slate-600 mt-1 line-clamp-2">{c.summary}</p>}
+                  <div className="flex items-center gap-3 mt-1.5">
+                    {c.source_url && (
+                      <a
+                        href={c.source_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-xs text-emerald-600 hover:underline"
+                      >
+                        <ExternalLink className="h-3 w-3" /> source
+                      </a>
+                    )}
+                    <span className="text-[11px] text-slate-500">{formatDate(c.discovered_at)}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    onClick={() => decideCandidate(c.id, 'approve')}
+                    className="text-xs px-3 py-1.5 rounded-lg bg-emerald-500 hover:bg-emerald-600 text-white font-medium"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => {
+                      const notes = window.prompt('Notes (optional)') ?? undefined;
+                      void decideCandidate(c.id, 'reject', notes);
+                    }}
+                    className="text-xs px-3 py-1.5 rounded-lg bg-white border border-slate-200 hover:border-red-400 text-slate-700"
+                  >
+                    Reject
+                  </button>
+                  <button
+                    onClick={() => {
+                      const dup = window.prompt('Existing legal_references.id (UUID) this duplicates') ?? undefined;
+                      void decideCandidate(c.id, 'duplicate', undefined, dup);
+                    }}
+                    className="text-xs px-3 py-1.5 rounded-lg bg-white border border-slate-200 hover:border-amber-400 text-slate-700"
+                  >
+                    Duplicate
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Summary cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-6">
         {[
+          { label: 'Total in DB', count: counts.dbTotal, className: 'border-slate-200 bg-slate-50', textClass: 'text-slate-900' },
           { label: 'Current', count: counts.current, className: 'border-green-500/20 bg-green-500/5', textClass: 'text-green-400' },
           { label: 'Auto-updated', count: counts.updated, className: 'border-emerald-500/20 bg-emerald-500/5', textClass: 'text-emerald-600' },
           { label: 'Needs review', count: counts.needs_review, className: 'border-amber-200 bg-amber-50', textClass: 'text-amber-600' },
-          { label: 'Outdated', count: counts.outdated, className: 'border-red-500/20 bg-red-500/5', textClass: 'text-red-400' },
+          { label: 'Stale (>60d)', count: counts.stale, className: 'border-amber-300 bg-amber-50/50', textClass: 'text-amber-700' },
         ].map(card => (
           <button
             key={card.label}
-            onClick={() => setFilterStatus(filterStatus === card.label.toLowerCase().replace(' ', '_') ? 'all' : card.label.toLowerCase().replace(' ', '_'))}
+            onClick={() => {
+              const target = card.label === 'Needs review'
+                ? 'needs_review_any'
+                : card.label === 'Total in DB' || card.label === 'Stale (>60d)'
+                  ? 'all'
+                  : card.label.toLowerCase().replace(' ', '_').replace('auto-updated', 'updated');
+              setFilterStatus(filterStatus === target ? 'all' : target);
+            }}
             className={`border rounded-2xl p-5 text-left transition-all hover:opacity-80 ${card.className}`}
           >
             <p className={`text-3xl font-bold ${card.textClass}`}>{card.count}</p>
@@ -240,6 +459,7 @@ export default function LegalRefsAdminPage() {
           className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm focus:outline-none focus:border-emerald-500"
         >
           <option value="all">All statuses</option>
+          <option value="needs_review_any">Needs review (any)</option>
           <option value="current">Current</option>
           <option value="updated">Auto-updated</option>
           <option value="needs_review">Needs review</option>

--- a/supabase/migrations/20260430100000_legal_refs_discovery.sql
+++ b/supabase/migrations/20260430100000_legal_refs_discovery.sql
@@ -1,0 +1,63 @@
+-- Active legal-reference discovery pipeline (additive only).
+--
+-- Goal: turn the compliance centre from a closed seed of ~112 hand-picked
+-- refs into an actively-growing corpus, while never auto-mutating the
+-- shared `legal_references` table (B2C + B2B both consume it). Every
+-- candidate goes through founder review.
+--
+-- Three additions:
+--   1. legal_references gains discovery_source + pending_review for audit.
+--   2. legal_ref_discovery_runs logs every Perplexity discovery cron run.
+--   3. legal_ref_candidates is the founder review queue.
+--
+-- Strictly additive — no DROP, no DELETE, no constraint mutation.
+
+ALTER TABLE public.legal_references
+  ADD COLUMN IF NOT EXISTS discovery_source TEXT,
+  ADD COLUMN IF NOT EXISTS pending_review BOOLEAN DEFAULT FALSE;
+
+CREATE TABLE IF NOT EXISTS public.legal_ref_discovery_runs (
+  id BIGSERIAL PRIMARY KEY,
+  run_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  leg TEXT NOT NULL,                 -- 'recent_updates' | 'category_coverage'
+  category TEXT,                     -- only set for leg B
+  candidates_found INTEGER NOT NULL DEFAULT 0,
+  candidates_added INTEGER NOT NULL DEFAULT 0,
+  candidates_skipped_duplicate INTEGER NOT NULL DEFAULT 0,
+  cost_gbp NUMERIC(10,6),
+  perplexity_response JSONB,
+  notes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_ref_discovery_runs_at
+  ON public.legal_ref_discovery_runs(run_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.legal_ref_candidates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  discovered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  title TEXT NOT NULL,
+  source_url TEXT,
+  source_type TEXT,
+  summary TEXT,
+  category TEXT,
+  jurisdiction TEXT DEFAULT 'UK',
+  confidence TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','approved','rejected','duplicate')),
+  reviewed_at TIMESTAMPTZ,
+  reviewed_by TEXT,
+  notes TEXT,
+  duplicate_of UUID,
+  discovery_run_id BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_legal_ref_candidates_status
+  ON public.legal_ref_candidates(status, discovered_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_legal_ref_candidates_source_url
+  ON public.legal_ref_candidates(source_url);
+
+-- Enable RLS but leave it locked down — only service-role-keyed crons /
+-- the founder admin endpoints touch these tables. No user-facing access.
+ALTER TABLE public.legal_ref_discovery_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.legal_ref_candidates ENABLE ROW LEVEL SECURITY;

--- a/vercel.json
+++ b/vercel.json
@@ -46,6 +46,8 @@
     { "path": "/api/cron/support-chase",             "schedule": "0 9 * * *" },
     { "path": "/api/cron/builder-pickup",            "schedule": "*/30 * * * *" },
     { "path": "/api/cron/builder-verify",            "schedule": "*/5 * * * *" },
-    { "path": "/api/cron/refresh-cancellation-info", "schedule": "0 3 * * 1" }
+    { "path": "/api/cron/refresh-cancellation-info", "schedule": "0 3 * * 1" },
+    { "path": "/api/cron/discover-legal-refs?leg=recent",   "schedule": "0 3 * * 0" },
+    { "path": "/api/cron/discover-legal-refs?leg=category", "schedule": "30 4 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

Three fixes to the compliance centre flagged by the founder.

### Issue 1 — 112 → 78 legal-refs count gap (DIAGNOSIS)

The page used `select('*')` with no filter and reported `refs.length` as the total, so the displayed number IS the live row count. Investigation:

- No `DELETE`/`DROP`/`TRUNCATE` against `legal_references` in any `2026*` migration.
- `/api/cron/verify-legal-refs` does not delete rows — it only updates status / hashes.
- The new verifier statuses (`broken`, `stale`, `error`, `superseded`, `url_dead`) do not affect the unfiltered `select('*')`.

**Conclusion:** if the live total is genuinely 78, **34 rows are missing from the table with no audit trail of what they were**. The founder will need to reseed manually. This PR does not attempt to restore them.

**Defensive fix shipped:** the page now issues a separate `count: 'exact', head: true` query AND paginates rows in 1000-row batches, so the truth is visible even if PostgREST range-caps. A "Total in DB" stat surfaces the count loud and clear; if rows are loaded < DB total an amber "X loaded" caveat shows.

### Issue 2 — "1 / 0 needs review" stat mismatch

Stats and the review list disagreed because PR #373 widened the list predicate (`needs_review|broken|stale|error|null|>60d`) but the stat counter still asked `verification_status === 'needs_review'`. **Fix:** stats now use the same `needsReview()` predicate as the list, so the "Needs review" card always equals the rows the founder sees. Added "Stale (>60d)" and "Total in DB" cards. New "Needs review (any)" filter mirrors the same predicate.

### Issue 3 — Active Perplexity-powered discovery pipeline

- Migration `20260430100000_legal_refs_discovery.sql` (additive only): adds `discovery_source` + `pending_review` to `legal_references`, plus two new tables `legal_ref_discovery_runs` and `legal_ref_candidates` (RLS on, service-role only).
- `/api/cron/discover-legal-refs?leg=recent|category`. Recent leg = weekly broad sweep of UK consumer-law changes in last 30 days. Category leg = daily, rotates through distinct `legal_references.category` values via day-of-year mod N (each category fires ~every 14d).
- **Cost cap £0.30/run** (sonar-pro flat $0.005/call → ~75 calls max), `logPerplexityCall` on every call. Queue overflow guard: if pending candidates > 100, skip with notes `queue full — review pending first`.
- **Never auto-inserts into `legal_references`** — every candidate goes through founder review. Approval routes via `POST /api/admin/legal-ref-candidates/:id/decision` with action `approve|reject|duplicate`. Approve inserts a fresh `legal_references` row with `discovery_source='perplexity_discovery'`; existing seeded 112 rows are untouched.
- Admin UI: discovery candidates queue rendered above the existing review list on `/dashboard/admin/legal-refs`. Each row has Approve / Reject / Mark duplicate buttons. New "Discover now" button at the top triggers the cron route ad hoc with the founder session.
- Vercel cron: `leg=recent` Sunday 03:00 UTC; `leg=category` daily 04:30 UTC.
- **Volume:** ~1 recent run/week (≤15 candidates) + 7 category runs/week (≤15 each) → ≤120 raw candidates/week, materially fewer after dedupe.
- **Cost:** 8 Perplexity sonar-pro calls/week ≈ $0.04 ≈ **£0.13/month**, well under the cap.

### Constraints respected

- B2C and B2B both consume `legal_references` — no breaking schema changes (additive nullable columns only).
- `DisputeResponse` shape untouched.
- Migrations strictly additive; no DROP/DELETE.
- No `git add -A`.
- `tsc --noEmit` clean.
- Founder review only — never auto-approve a discovered ref.
- Existing 112-row seed untouched.

### Judgment calls

1. **Schema discovery for approve:** the existing `legal_references` table has columns we don't fully populate from a Perplexity candidate (`section`, `strength`, `escalation_body`, `subcategory`). Approve writes a minimal row with `verification_status='needs_review'` so the founder gets a row that's clearly flagged for follow-up enrichment. The verifier cron will pick it up on the next run.
2. **Default categories:** category list is read live from `legal_references.category` distinct values; falls back to a hardcoded UK consumer set if empty.
3. **POST mirror of GET:** the cron is `GET` for Vercel; `POST` is added so a future client-side button could call it without breaking the cron.

## Test plan

- [ ] Apply migration in staging, confirm new tables + columns exist.
- [ ] Visit `/dashboard/admin/legal-refs` as founder, confirm "Total in DB" matches a `SELECT COUNT(*) FROM legal_references` run directly.
- [ ] Confirm "Needs review" stat = number of rows visible when "Needs review (any)" filter is selected.
- [ ] Click "Discover now" → confirm a row in `legal_ref_discovery_runs`, candidates appear in queue.
- [ ] Approve a candidate, confirm new row in `legal_references` with `discovery_source='perplexity_discovery'`.
- [ ] Reject a candidate, confirm `status='rejected'` in `legal_ref_candidates`.
- [ ] Verify `api_cost_ledger` has a fresh row tagged `provider='perplexity', endpoint='/api/cron/discover-legal-refs'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)