### PR TITLE
fix(legal-refs): add 'verified' to readers' status allowlist (P1 from #373/#375)

### DIFF
--- a/src/app/api/complaints/generate/route.ts
+++ b/src/app/api/complaints/generate/route.ts
@@ -6,6 +6,7 @@ import { checkClaudeRateLimit, recordClaudeCall, logClaudeCall } from '@/lib/cla
 import { trackLetterGenerated } from '@/lib/meta-conversions';
 import { awardPoints } from '@/lib/loyalty';
 import { getProviderTerms } from '@/lib/provider-match';
+import { CITATION_PERMISSIVE_STATUSES } from '@/lib/legal-refs-statuses';
 
 // Claude takes 10-20s for complaint letters — extend beyond Vercel's 10s default
 // 120s — the engine's worst-case path is two Claude calls (citation
@@ -283,7 +284,7 @@ export async function POST(request: NextRequest) {
       .from('legal_references')
       .select('id, category, law_name, section, summary, source_url, escalation_body, strength, applies_to, verification_status')
       .in('category', categories)
-      .in('verification_status', ['current', 'updated', 'needs_review']);
+      .in('verification_status', CITATION_PERMISSIVE_STATUSES as unknown as string[]);
 
     // Filter out 'general' refs that have a sector-specific applies_to array which doesn't
     // overlap with the current dispute's categories. This prevents gym/fitness legal refs

--- a/src/app/api/cron/citation-canary/route.ts
+++ b/src/app/api/cron/citation-canary/route.ts
@@ -56,6 +56,7 @@ import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
 import { generateComplaintLetter } from '@/lib/agents/complaints-agent';
+import { CITATION_PERMISSIVE_STATUSES } from '@/lib/legal-refs-statuses';
 
 export const runtime = 'nodejs';
 export const maxDuration = 300;
@@ -181,7 +182,7 @@ export async function GET(request: NextRequest) {
   const { data: allRefs } = await sb
     .from('legal_references')
     .select('category, law_name, section, summary, verification_status')
-    .in('verification_status', ['current', 'updated', 'needs_review']);
+    .in('verification_status', CITATION_PERMISSIVE_STATUSES as unknown as string[]);
 
   if (!allRefs || allRefs.length === 0) {
     return NextResponse.json({ ok: false, error: 'No refs in legal_references' }, { status: 500 });

--- a/src/app/api/cron/legal-coverage-alert/route.ts
+++ b/src/app/api/cron/legal-coverage-alert/route.ts
@@ -41,6 +41,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { CITATION_ELIGIBLE_STATUSES } from '@/lib/legal-refs-statuses';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
@@ -126,7 +127,7 @@ export async function GET(request: NextRequest) {
   const { data: allActive } = await sb
     .from('legal_references')
     .select('id, law_name, section, last_verified, last_check_attempt_at, confidence_score')
-    .in('verification_status', ['current', 'updated']);
+    .in('verification_status', CITATION_ELIGIBLE_STATUSES as unknown as string[]);
   const total = allActive?.length ?? 0;
   const stale = (allActive ?? []).filter((r) => {
     const checked = r.last_check_attempt_at ?? r.last_verified;
@@ -152,7 +153,7 @@ export async function GET(request: NextRequest) {
   const { data: sourceRows } = await sb
     .from('legal_references')
     .select('source_url')
-    .in('verification_status', ['current', 'updated'])
+    .in('verification_status', CITATION_ELIGIBLE_STATUSES as unknown as string[])
     .not('source_url', 'is', null);
   const sourceCounts = new Map<string, number>();
   for (const r of sourceRows ?? []) {
@@ -182,7 +183,7 @@ export async function GET(request: NextRequest) {
   const { data: byCat } = await sb
     .from('legal_references')
     .select('category')
-    .in('verification_status', ['current', 'updated']);
+    .in('verification_status', CITATION_ELIGIBLE_STATUSES as unknown as string[]);
   const present = new Set<string>();
   for (const r of byCat ?? []) present.add((r.category as string) ?? 'general');
   const missingCategories = REQUIRED_CATEGORIES.filter((c) => !present.has(c));
@@ -192,7 +193,7 @@ export async function GET(request: NextRequest) {
     const { count } = await sb
       .from('legal_references')
       .select('id', { count: 'exact', head: true })
-      .in('verification_status', ['current', 'updated'])
+      .in('verification_status', CITATION_ELIGIBLE_STATUSES as unknown as string[])
       .ilike('law_name', `%${probe.keyword}%`);
     if (!count || count === 0) missingNamedStatutes.push(probe);
   }

--- a/src/app/api/cron/legal-updates/route.ts
+++ b/src/app/api/cron/legal-updates/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { CITATION_ELIGIBLE_STATUSES } from '@/lib/legal-refs-statuses';
 
 export const maxDuration = 300;
 
@@ -166,7 +167,7 @@ export async function GET(request: NextRequest) {
   const { data: allRefs } = await supabase
     .from('legal_references')
     .select('id, law_name, section, summary, source_url, source_type, category, content_hash')
-    .in('verification_status', ['current', 'updated']);
+    .in('verification_status', CITATION_ELIGIBLE_STATUSES as unknown as string[]);
 
   const refs: LegalRef[] = allRefs || [];
 

--- a/src/app/for-business/coverage/page.tsx
+++ b/src/app/for-business/coverage/page.tsx
@@ -12,6 +12,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { createClient } from '@supabase/supabase-js';
+import { CITATION_ELIGIBLE_STATUSES } from '@/lib/legal-refs-statuses';
 
 export const dynamic = 'force-dynamic';
 
@@ -173,7 +174,7 @@ async function fetchCoverage(): Promise<Ref[]> {
     const { data } = await supabase
       .from('legal_references')
       .select('law_name, section, summary, category')
-      .in('verification_status', ['current', 'updated'])
+      .in('verification_status', CITATION_ELIGIBLE_STATUSES as unknown as string[])
       .order('law_name');
     return (data ?? []) as Ref[];
   } catch {

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -18,6 +18,7 @@
 
 import { generateComplaintLetter } from '@/lib/agents/complaints-agent';
 import { createClient } from '@supabase/supabase-js';
+import { CITATION_ELIGIBLE_STATUSES } from '@/lib/legal-refs-statuses';
 
 function getAdmin() {
   return createClient(
@@ -390,7 +391,7 @@ async function fetchVerifiedRefs(scenario: string): Promise<any[]> {
   const { data } = await supabase
     .from('legal_references')
     .select('law_name, section, summary, full_text, source_url, category')
-    .in('verification_status', ['current', 'updated'])
+    .in('verification_status', CITATION_ELIGIBLE_STATUSES as unknown as string[])
     .limit(500);
   if (!data || data.length === 0) return [];
 

--- a/src/lib/legal-refs-statuses.ts
+++ b/src/lib/legal-refs-statuses.ts
@@ -1,0 +1,37 @@
+/**
+ * Canonical sets of `legal_references.verification_status` values.
+ *
+ * Single source of truth so that adding a new status (e.g. when a future
+ * verifier introduces something like 'auto_verified') doesn't silently
+ * exclude refs from product behaviour. PR #373/#375 introduced 'verified',
+ * 'superseded', and 'broken' — readers that filtered to ['current','updated']
+ * suddenly stopped seeing successfully-verified refs until this constant
+ * was wired everywhere.
+ *
+ * Rule of thumb when adding a status:
+ *   - Should the engine cite this ref? → put it in ACTIVE_REF_STATUSES.
+ *   - Should the founder review this ref? → put it in REVIEW_REF_STATUSES.
+ *   - Should we never cite or surface this ref? → put it nowhere. The
+ *     readers below will exclude it by omission.
+ */
+
+export const ACTIVE_REF_STATUSES = ['current', 'updated', 'verified'] as const;
+
+export const REVIEW_REF_STATUSES = [
+  'needs_review',
+  'broken',
+  'stale',
+  'error',
+  'outdated',
+  'url_dead',
+] as const;
+
+// Engines that ground complaints/disputes only — be strict.
+export const CITATION_ELIGIBLE_STATUSES = ACTIVE_REF_STATUSES;
+
+// Citation-canary + complaints generation are permissive: they include
+// needs_review so refs awaiting verification still surface (with a flag).
+export const CITATION_PERMISSIVE_STATUSES = [
+  ...ACTIVE_REF_STATUSES,
+  'needs_review',
+] as const;


### PR DESCRIPTION
## Why
Codex P1 on PRs #373 and #375 — the new verifier in those PRs writes \`verification_status='verified'\` for successfully-checked refs, but six readers still filter to \`['current','updated']\` (or with \`needs_review\` added). After any successful machine verification, those refs silently vanish from product behaviour for both B2C letters and B2B disputes.

## What
- New \`src/lib/legal-refs-statuses.ts\` — single source of truth for which statuses count as cite-eligible:
  - \`CITATION_ELIGIBLE_STATUSES = ['current','updated','verified']\` — strict
  - \`CITATION_PERMISSIVE_STATUSES\` — adds \`'needs_review'\` for readers that were already permissive
- Six readers updated to consume the constants:
  - \`/api/complaints/generate\` (B2C letter grounding)
  - \`/api/cron/citation-canary\` (proactive canary)
  - \`/api/cron/legal-coverage-alert\` (4 spots)
  - \`/api/cron/legal-updates\`
  - \`/for-business/coverage\` (public coverage page)
  - \`/lib/b2b/disputes\` (B2B engine grounding)

## What it deliberately doesn't do
- \`'superseded'\` and \`'broken'\` are NOT in the eligible set — those refs should never be cited.
- The β guardrail's freshness check (PR #378) still applies on top — \`verified\` only matters if \`last_verified\` is recent enough.

## Verification
- \`tsc --noEmit\` clean.
- Mechanical change; six call-sites updated identically.

## Suggested merge order
This PR can land before or alongside #373/#375. Once it does, the new statuses introduced by those PRs no longer cause refs to disappear from product behaviour.