### PR TITLE
feat(compliance): email alerts + assistant tool + dev-agent enrichment (PR ζ)

### DIFF
--- a/src/app/api/admin/compliance-alert/route.ts
+++ b/src/app/api/admin/compliance-alert/route.ts
@@ -1,0 +1,177 @@
+/**
+ * Immediate compliance alert endpoint (PR ζ).
+ *
+ * Internal endpoint, called by the verifier or other compliance tooling
+ * when something needs the founder's attention before the daily digest:
+ *   - A ref used in the last 7 days transitioned to broken
+ *   - >3 corrections accumulated for the same ref_id (systemic issue)
+ *   - A discovery candidate landed for a heavy-traffic category
+ *
+ * Cost guards:
+ *   - Idempotent via compliance_alerts_sent.alert_key UNIQUE
+ *   - Hard cap of 5 urgent alerts per UTC day
+ *
+ * This endpoint NEVER auto-resolves anything. It only emails.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { resend, FROM_EMAIL } from '@/lib/resend';
+
+export const maxDuration = 30;
+
+const ALERT_TO = 'hello@paybacker.co.uk';
+const ADMIN_BASE = process.env.NEXT_PUBLIC_SITE_URL || 'https://paybacker.co.uk';
+const DAILY_URGENT_CAP = 5;
+
+type Reason =
+  | 'ref_broke_high_traffic'
+  | 'correction_flood'
+  | 'heavy_traffic_candidate';
+
+interface AlertRequest {
+  reason: Reason;
+  ref_id?: string;
+  ref_title?: string;
+  category?: string;
+  used_count_7d?: number;
+  correction_count?: number;
+  candidate_id?: string;
+  details?: string;
+}
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function alertKeyFor(body: AlertRequest): string {
+  const today = new Date().toISOString().slice(0, 10);
+  switch (body.reason) {
+    case 'ref_broke_high_traffic':
+      return `ref-broke:${body.ref_id || 'unknown'}`;
+    case 'correction_flood':
+      return `correction-flood:${body.ref_id || 'unknown'}:${today}`;
+    case 'heavy_traffic_candidate':
+      return `category-flood:${body.category || 'unknown'}:${today}`;
+  }
+}
+
+function subjectFor(body: AlertRequest): string {
+  switch (body.reason) {
+    case 'ref_broke_high_traffic':
+      return `[Compliance · URGENT] Ref "${body.ref_title || body.ref_id}" broke — used ${body.used_count_7d ?? '?'} times in last 7d`;
+    case 'correction_flood':
+      return `[Compliance · URGENT] ${body.correction_count ?? '?'} corrections on "${body.ref_title || body.ref_id}" — possible systemic issue`;
+    case 'heavy_traffic_candidate':
+      return `[Compliance · URGENT] New ${body.category || 'unknown'} reference candidate — review needed`;
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+
+  let body: AlertRequest;
+  try {
+    body = (await request.json()) as AlertRequest;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!body || !body.reason) {
+    return NextResponse.json({ error: 'reason is required' }, { status: 400 });
+  }
+
+  const supabase = getAdmin();
+  const alertKey = alertKeyFor(body);
+
+  // Idempotency: try to claim the alert_key. If it already exists, skip.
+  try {
+    const { error: insertErr } = await supabase
+      .from('compliance_alerts_sent')
+      .insert({
+        alert_key: alertKey,
+        channel: 'email',
+        metadata: body as unknown as Record<string, unknown>,
+      });
+    if (insertErr) {
+      // Most likely UNIQUE violation — already sent
+      return NextResponse.json({ ok: true, skipped: 'already_sent', alert_key: alertKey });
+    }
+  } catch {
+    return NextResponse.json({ ok: true, skipped: 'dedup_table_unavailable', alert_key: alertKey });
+  }
+
+  // Daily cap check (5/day) — count rows sent today
+  try {
+    const since = new Date();
+    since.setUTCHours(0, 0, 0, 0);
+    const { count } = await supabase
+      .from('compliance_alerts_sent')
+      .select('id', { count: 'exact', head: true })
+      .gte('sent_at', since.toISOString());
+    if ((count ?? 0) > DAILY_URGENT_CAP) {
+      return NextResponse.json({
+        ok: true,
+        skipped: 'daily_cap_reached',
+        cap: DAILY_URGENT_CAP,
+        alert_key: alertKey,
+      });
+    }
+  } catch {
+    // soldier on
+  }
+
+  const subject = subjectFor(body);
+  const reviewLink = `${ADMIN_BASE}/dashboard/admin/legal-refs`;
+  const detailsBlock = body.details ? `<p style="color: #94a3b8;">${escapeHtml(body.details)}</p>` : '';
+
+  const html = `
+    <div style="font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 0 auto; background: #0f172a; color: #e2e8f0; padding: 32px; border-radius: 12px;">
+      <div style="background: #7f1d1d; color: #fee2e2; padding: 6px 12px; border-radius: 4px; display: inline-block; font-size: 12px; font-weight: 700; letter-spacing: 0.5px;">URGENT</div>
+      <h2 style="color: #f87171; margin: 12px 0 8px;">${escapeHtml(subject.replace(/^\[Compliance · URGENT\]\s*/, ''))}</h2>
+      <table style="width: 100%; margin-top: 16px; color: #e2e8f0; font-size: 13px;">
+        ${body.ref_id ? `<tr><td style="color: #94a3b8; padding: 4px 8px 4px 0;">Ref ID</td><td><code>${escapeHtml(body.ref_id)}</code></td></tr>` : ''}
+        ${body.category ? `<tr><td style="color: #94a3b8; padding: 4px 8px 4px 0;">Category</td><td>${escapeHtml(body.category)}</td></tr>` : ''}
+        ${body.used_count_7d !== undefined ? `<tr><td style="color: #94a3b8; padding: 4px 8px 4px 0;">Uses (7d)</td><td>${body.used_count_7d}</td></tr>` : ''}
+        ${body.correction_count !== undefined ? `<tr><td style="color: #94a3b8; padding: 4px 8px 4px 0;">Corrections</td><td>${body.correction_count}</td></tr>` : ''}
+      </table>
+      ${detailsBlock}
+      <p style="margin-top: 24px;">
+        <a href="${reviewLink}" style="display: inline-block; background: #f59e0b; color: #0f172a; padding: 10px 20px; border-radius: 6px; text-decoration: none; font-weight: 600;">Open review centre</a>
+      </p>
+      <p style="color: #64748b; font-size: 12px; margin-top: 16px;">— Paybacker Compliance Centre. Observational alert only — nothing has been auto-applied.</p>
+    </div>
+  `;
+
+  try {
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: ALERT_TO,
+      subject,
+      html,
+    });
+  } catch (err) {
+    console.error('[compliance-alert] Resend send failed:', err);
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, alert_key: alertKey, subject });
+}

--- a/src/app/api/cron/compliance-digest/route.ts
+++ b/src/app/api/cron/compliance-digest/route.ts
@@ -1,0 +1,233 @@
+/**
+ * Daily compliance digest (PR ζ).
+ *
+ * Schedule: 09:00 UTC daily — wired in vercel.json.
+ * Sends ONE email per day to hello@paybacker.co.uk summarising pending
+ * compliance review queues and stale references.
+ *
+ * Cost: 1 Resend send/day (well under free tier).
+ *
+ * This cron is observational only. It NEVER auto-applies a correction
+ * or auto-resolves anything. Per CLAUDE.md compliance principle: no
+ * canonical legal_references write without an approved correction +
+ * a deliberate founder click.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { resend, FROM_EMAIL } from '@/lib/resend';
+import {
+  pendingCorrectionsCount,
+  pendingCandidatesCount,
+  staleRefsCount,
+  brokenRefsCount,
+  topPendingCorrections,
+  topStaleRefsCitedRecently,
+} from '@/lib/compliance-queries';
+
+export const maxDuration = 60;
+
+const ALERT_TO = 'hello@paybacker.co.uk';
+const ADMIN_BASE = process.env.NEXT_PUBLIC_SITE_URL || 'https://paybacker.co.uk';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function fmtDate(iso?: string | null): string {
+  if (!iso) return 'never';
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+
+  const supabase = getAdmin();
+  const today = new Date().toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+
+  const [pendingCorr, pendingCand, stale, broken, topCorr, topStale] = await Promise.all([
+    pendingCorrectionsCount(supabase),
+    pendingCandidatesCount(supabase),
+    staleRefsCount(supabase),
+    brokenRefsCount(supabase),
+    topPendingCorrections(supabase, 5),
+    topStaleRefsCitedRecently(supabase, 5),
+  ]);
+
+  // Treat null (table missing) as 0 for the headline but flag it in metadata
+  const pc = pendingCorr ?? 0;
+  const pcand = pendingCand ?? 0;
+  const st = stale ?? 0;
+  const br = broken ?? 0;
+  const total = pc + pcand;
+
+  const subject =
+    total === 0 && st === 0 && br === 0
+      ? `[Compliance] All queues clear — ${today}`
+      : `[Compliance] ${total} pending reviews, ${st} stale refs — ${today}`;
+
+  const allClear = total === 0 && st === 0 && br === 0;
+
+  const reviewLink = `${ADMIN_BASE}/dashboard/admin/legal-refs`;
+
+  let html: string;
+  if (allClear) {
+    html = `
+      <div style="font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 0 auto; background: #0f172a; color: #e2e8f0; padding: 32px; border-radius: 12px;">
+        <h2 style="color: #34d399; margin: 0 0 8px;">All compliance queues clear ✓</h2>
+        <p style="color: #94a3b8; margin: 0;">No pending corrections, candidates, or stale references as of ${escapeHtml(today)}.</p>
+        <p style="color: #64748b; font-size: 13px; margin-top: 24px;">— Paybacker Compliance Centre</p>
+      </div>
+    `;
+  } else {
+    const corrRows =
+      topCorr && topCorr.length > 0
+        ? topCorr
+            .map((c) => {
+              const before = c.before_value ? escapeHtml(String(c.before_value).slice(0, 120)) : '<em>(empty)</em>';
+              const after = c.after_value ? escapeHtml(String(c.after_value).slice(0, 120)) : '<em>(empty)</em>';
+              return `
+                <tr>
+                  <td style="padding: 8px 12px; border-bottom: 1px solid #1e293b; color: #e2e8f0; font-size: 13px;">
+                    <div><strong>${escapeHtml(c.id.slice(0, 8))}</strong> · ${escapeHtml(fmtDate(c.created_at))}</div>
+                    <div style="color: #94a3b8; margin-top: 4px;">Before: ${before}</div>
+                    <div style="color: #34d399; margin-top: 2px;">After: ${after}</div>
+                    <a href="${reviewLink}" style="color: #60a5fa; font-size: 12px;">Review →</a>
+                  </td>
+                </tr>`;
+            })
+            .join('')
+        : `<tr><td style="padding: 12px; color: #64748b; font-size: 13px;">No pending corrections to display.</td></tr>`;
+
+    const staleRows =
+      topStale && topStale.length > 0
+        ? topStale
+            .map((r) => {
+              return `
+                <tr>
+                  <td style="padding: 8px 12px; border-bottom: 1px solid #1e293b; color: #e2e8f0; font-size: 13px;">
+                    <div><strong>${escapeHtml(r.law_name)}</strong>${r.section ? ' ' + escapeHtml(r.section) : ''}</div>
+                    <div style="color: #94a3b8; margin-top: 4px;">Status: ${escapeHtml(r.verification_status || 'unknown')} · Last verified: ${escapeHtml(fmtDate(r.last_verified))} · Used ${r.uses_30d}× in last 30d</div>
+                    <a href="${reviewLink}" style="color: #60a5fa; font-size: 12px;">Review →</a>
+                  </td>
+                </tr>`;
+            })
+            .join('')
+        : `<tr><td style="padding: 12px; color: #64748b; font-size: 13px;">No stale references cited recently.</td></tr>`;
+
+    html = `
+      <div style="font-family: -apple-system, system-ui, sans-serif; max-width: 640px; margin: 0 auto; background: #0f172a; color: #e2e8f0; padding: 32px; border-radius: 12px;">
+        <h2 style="color: #f59e0b; margin: 0 0 16px;">Compliance digest — ${escapeHtml(today)}</h2>
+
+        <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
+          <tr>
+            <td style="padding: 12px; background: #1e293b; border-radius: 8px; width: 50%;">
+              <div style="color: #94a3b8; font-size: 12px;">Pending corrections</div>
+              <div style="color: #f59e0b; font-size: 28px; font-weight: 700;">${pc}</div>
+            </td>
+            <td style="width: 8px;"></td>
+            <td style="padding: 12px; background: #1e293b; border-radius: 8px; width: 50%;">
+              <div style="color: #94a3b8; font-size: 12px;">Pending candidates</div>
+              <div style="color: #f59e0b; font-size: 28px; font-weight: 700;">${pcand}</div>
+            </td>
+          </tr>
+          <tr><td colspan="3" style="height: 8px;"></td></tr>
+          <tr>
+            <td style="padding: 12px; background: #1e293b; border-radius: 8px;">
+              <div style="color: #94a3b8; font-size: 12px;">Stale refs (&gt;30d)</div>
+              <div style="color: #fbbf24; font-size: 28px; font-weight: 700;">${st}</div>
+            </td>
+            <td></td>
+            <td style="padding: 12px; background: #1e293b; border-radius: 8px;">
+              <div style="color: #94a3b8; font-size: 12px;">Broken / flagged</div>
+              <div style="color: #f87171; font-size: 28px; font-weight: 700;">${br}</div>
+            </td>
+          </tr>
+        </table>
+
+        <h3 style="color: #e2e8f0; font-size: 16px; margin: 24px 0 8px;">Top 5 corrections to review</h3>
+        <table style="width: 100%; border-collapse: collapse; background: #0b1220; border-radius: 8px; overflow: hidden;">
+          ${corrRows}
+        </table>
+
+        <h3 style="color: #e2e8f0; font-size: 16px; margin: 24px 0 8px;">Top 5 stale refs cited recently</h3>
+        <table style="width: 100%; border-collapse: collapse; background: #0b1220; border-radius: 8px; overflow: hidden;">
+          ${staleRows}
+        </table>
+
+        <p style="margin-top: 24px;">
+          <a href="${reviewLink}" style="display: inline-block; background: #f59e0b; color: #0f172a; padding: 10px 20px; border-radius: 6px; text-decoration: none; font-weight: 600;">Open review centre</a>
+        </p>
+
+        <p style="color: #64748b; font-size: 12px; margin-top: 24px; line-height: 1.5;">
+          — Paybacker Compliance Centre. Every change requires a deliberate founder click; nothing in this email auto-applies.
+        </p>
+      </div>
+    `;
+  }
+
+  const tablesMissing = {
+    legal_ref_corrections: pendingCorr === null,
+    legal_ref_candidates: pendingCand === null,
+    legal_ref_usages: topStale === null,
+  };
+
+  try {
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: ALERT_TO,
+      subject,
+      html,
+    });
+  } catch (err) {
+    console.error('[compliance-digest] Resend send failed:', err);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        counts: { pendingCorr: pc, pendingCand: pcand, stale: st, broken: br },
+        tables_missing: tablesMissing,
+      },
+      { status: 500 },
+    );
+  }
+
+  // Best-effort log
+  try {
+    await supabase.from('business_log').insert({
+      category: 'compliance',
+      action: 'daily_digest_sent',
+      details: {
+        counts: { pendingCorr: pc, pendingCand: pcand, stale: st, broken: br },
+        tables_missing: tablesMissing,
+        all_clear: allClear,
+      },
+    });
+  } catch {
+    // business_log is optional
+  }
+
+  return NextResponse.json({
+    ok: true,
+    sent_to: ALERT_TO,
+    subject,
+    counts: { pendingCorr: pc, pendingCand: pcand, stale: st, broken: br },
+    tables_missing: tablesMissing,
+  });
+}

--- a/src/app/api/cron/enrich-compliance-pending/route.ts
+++ b/src/app/api/cron/enrich-compliance-pending/route.ts
@@ -1,0 +1,416 @@
+/**
+ * Compliance enrichment cron (PR ζ).
+ *
+ * Schedule: 04:00 UTC daily — wired in vercel.json.
+ *
+ * Purpose: when a correction or candidate lands in the queue, do the
+ * legwork BEFORE the founder reviews — fetch source URL, extract relevant
+ * text, diff URL/title, risk-score the change, optionally summarise via
+ * Perplexity. Founder then sees a fully-prepped diff with evidence
+ * instead of a one-line "Perplexity says try this".
+ *
+ * Hard rules:
+ *   - NEVER auto-applies a correction. Only writes enrichment_data
+ *     onto the pending row.
+ *   - Hard cap: 50 items/day total (corrections + candidates combined).
+ *   - Per-item cost ≈ £0.01 (Perplexity AI summary + free HTTP fetch).
+ *     Daily worst-case ~£0.50.
+ *   - Skips items that already have enriched_at set.
+ *   - Gracefully no-ops if legal_ref_corrections / legal_ref_candidates
+ *     don't exist yet (sibling PRs δ, ε not merged).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+
+export const maxDuration = 300;
+
+const DAILY_CAP = 50;
+const FETCH_TIMEOUT_MS = 5000;
+const MAX_BODY_BYTES = 1_000_000; // 1MB
+
+type RiskScore = 'low' | 'medium' | 'high';
+
+interface EnrichmentData {
+  fetched_at: string;
+  fetched_status: number | null;
+  fetched_redirect_chain: string[];
+  extracted_text: string;
+  url_diff: { from: string | null; to: string | null; redirected_to: string | null };
+  title_diff: { from: string | null; to: string | null };
+  risk_score: RiskScore;
+  risk_reasons: string[];
+  ai_summary: string | null;
+  error?: string;
+}
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+async function safeFetch(url: string): Promise<{
+  status: number | null;
+  body: string;
+  finalUrl: string | null;
+  redirectChain: string[];
+  error?: string;
+}> {
+  const redirectChain: string[] = [];
+  try {
+    const res = await fetch(url, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: {
+        'User-Agent': 'Paybacker-ComplianceEnricher/1.0 (hello@paybacker.co.uk)',
+      },
+    });
+    if (res.url && res.url !== url) redirectChain.push(res.url);
+
+    // Cap body size
+    const reader = res.body?.getReader();
+    let received = 0;
+    const chunks: Uint8Array[] = [];
+    if (reader) {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        received += value.length;
+        if (received > MAX_BODY_BYTES) {
+          chunks.push(value.slice(0, Math.max(0, MAX_BODY_BYTES - (received - value.length))));
+          break;
+        }
+        chunks.push(value);
+      }
+    }
+    const buf = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    const body = buf.toString('utf-8');
+    return { status: res.status, body, finalUrl: res.url || url, redirectChain };
+  } catch (err) {
+    return {
+      status: null,
+      body: '',
+      finalUrl: null,
+      redirectChain,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function extractRelevantText(html: string, url: string): string {
+  // legislation.gov.uk: try to find h1/h2 + paragraph text near the section
+  // For other sources: strip tags, take first 2KB
+  const stripped = html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (url.includes('legislation.gov.uk')) {
+    // Try to find a section heading and the body following it
+    const headingMatch = stripped.match(/(\d+\s+[A-Z][^.]+\.[^.]*\.)/);
+    if (headingMatch) {
+      return stripped.slice(stripped.indexOf(headingMatch[0]), stripped.indexOf(headingMatch[0]) + 2000);
+    }
+  }
+  return stripped.slice(0, 2000);
+}
+
+function extractTitle(html: string): string | null {
+  const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  return m ? m[1].trim().replace(/\s+/g, ' ') : null;
+}
+
+function scoreRisk(opts: {
+  urlFrom: string | null;
+  urlTo: string | null;
+  finalUrl: string | null;
+  titleFrom: string | null;
+  titleTo: string | null;
+  beforeValue: string | null;
+  afterValue: string | null;
+}): { score: RiskScore; reasons: string[] } {
+  const reasons: string[] = [];
+  let level: RiskScore = 'low';
+
+  const promote = (target: RiskScore) => {
+    const order: Record<RiskScore, number> = { low: 0, medium: 1, high: 2 };
+    if (order[target] > order[level]) level = target;
+  };
+
+  const { urlFrom, urlTo, finalUrl, titleFrom, titleTo, beforeValue, afterValue } = opts;
+
+  if (urlFrom && urlTo && urlFrom !== urlTo) {
+    try {
+      const a = new URL(urlFrom);
+      const b = new URL(urlTo);
+      if (a.host !== b.host) {
+        reasons.push(`host changed: ${a.host} → ${b.host}`);
+        promote('high');
+      } else if (a.pathname !== b.pathname) {
+        reasons.push(`path changed: ${a.pathname} → ${b.pathname}`);
+        promote('medium');
+      } else {
+        reasons.push('URL slug differs');
+        promote('low');
+      }
+    } catch {
+      reasons.push('URL parse failed — treating as medium');
+      promote('medium');
+    }
+  }
+
+  if (urlTo && finalUrl && urlTo !== finalUrl) {
+    reasons.push(`source redirected: ${urlTo} → ${finalUrl}`);
+    promote('low');
+  }
+
+  if (titleFrom && titleTo && titleFrom !== titleTo) {
+    const a = titleFrom.toLowerCase();
+    const b = titleTo.toLowerCase();
+    if (a === b) {
+      reasons.push('title case/punctuation only');
+      promote('low');
+    } else {
+      reasons.push(`title changed: "${titleFrom.slice(0, 60)}" → "${titleTo.slice(0, 60)}"`);
+      promote('medium');
+    }
+  }
+
+  if (beforeValue && afterValue) {
+    const sectionRe = /\bsection\s+(\d+)/i;
+    const a = beforeValue.match(sectionRe);
+    const b = afterValue.match(sectionRe);
+    if (a && b && a[1] !== b[1]) {
+      reasons.push(`section number changed: ${a[1]} → ${b[1]}`);
+      promote('medium');
+    }
+    // Act-name change heuristic: any 4-digit year change
+    const yearA = beforeValue.match(/\b(19|20)\d{2}\b/);
+    const yearB = afterValue.match(/\b(19|20)\d{2}\b/);
+    if (yearA && yearB && yearA[0] !== yearB[0]) {
+      reasons.push(`year edition changed: ${yearA[0]} → ${yearB[0]}`);
+      promote('medium');
+    }
+    // Crude act-name check
+    const actA = beforeValue.match(/([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\s+Act)/);
+    const actB = afterValue.match(/([A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\s+Act)/);
+    if (actA && actB && actA[1] !== actB[1]) {
+      reasons.push(`act name changed: ${actA[1]} → ${actB[1]}`);
+      promote('high');
+    }
+  }
+
+  if (reasons.length === 0) reasons.push('no material change detected — punctuation/whitespace only');
+  return { score: level, reasons };
+}
+
+async function perplexitySummary(prompt: string): Promise<string | null> {
+  const key = process.env.PERPLEXITY_API_KEY;
+  if (!key) return null;
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${key}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'sonar',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are an evidence-led UK legal-reference reviewer. Answer in 1-2 sentences. NEVER invent law. If unsure, say so.',
+          },
+          { role: 'user', content: prompt },
+        ],
+      }),
+      signal: AbortSignal.timeout(20000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    return data.choices?.[0]?.message?.content?.trim() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function enrichRow(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  table: 'legal_ref_corrections' | 'legal_ref_candidates',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  row: any,
+): Promise<{ ok: boolean; risk?: RiskScore; error?: string }> {
+  const sourceUrl: string | null =
+    row.source_url ||
+    row.proposed_url ||
+    row.after_url ||
+    row.url ||
+    null;
+
+  let fetched: Awaited<ReturnType<typeof safeFetch>> = {
+    status: null,
+    body: '',
+    finalUrl: null,
+    redirectChain: [],
+  };
+  if (sourceUrl) {
+    fetched = await safeFetch(sourceUrl);
+  }
+
+  const extractedText = fetched.body
+    ? extractRelevantText(fetched.body, sourceUrl || '')
+    : '';
+  const fetchedTitle = fetched.body ? extractTitle(fetched.body) : null;
+
+  const titleFrom: string | null = row.before_title || row.canonical_title || null;
+  const titleTo: string | null = row.after_title || row.proposed_title || fetchedTitle;
+
+  const urlFrom: string | null = row.before_url || row.canonical_url || null;
+  const urlTo: string | null = sourceUrl;
+
+  const { score, reasons } = scoreRisk({
+    urlFrom,
+    urlTo,
+    finalUrl: fetched.finalUrl,
+    titleFrom,
+    titleTo,
+    beforeValue: row.before_value || null,
+    afterValue: row.after_value || null,
+  });
+
+  let aiSummary: string | null = null;
+  if (extractedText && (titleTo || urlTo)) {
+    const prompt = `Compare this proposed UK legal reference change. Is it likely a primary source still in force? Risk: ${score}. URL: ${urlTo}. Title: ${titleTo}. Excerpt: ${extractedText.slice(0, 800)}`;
+    aiSummary = await perplexitySummary(prompt);
+  }
+
+  const enrichment: EnrichmentData = {
+    fetched_at: new Date().toISOString(),
+    fetched_status: fetched.status,
+    fetched_redirect_chain: fetched.redirectChain,
+    extracted_text: extractedText.slice(0, 2000),
+    url_diff: { from: urlFrom, to: urlTo, redirected_to: fetched.finalUrl },
+    title_diff: { from: titleFrom, to: titleTo },
+    risk_score: score,
+    risk_reasons: reasons,
+    ai_summary: aiSummary,
+    ...(fetched.error ? { error: fetched.error } : {}),
+  };
+
+  try {
+    const { error } = await supabase
+      .from(table)
+      .update({
+        enrichment_data: enrichment,
+        enriched_at: new Date().toISOString(),
+      })
+      .eq('id', row.id);
+    if (error) return { ok: false, error: error.message };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  return { ok: true, risk: score };
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+
+  const supabase = getAdmin();
+  const results = {
+    processed_corrections: 0,
+    processed_candidates: 0,
+    risk_low: 0,
+    risk_medium: 0,
+    risk_high: 0,
+    errors: 0,
+    cap: DAILY_CAP,
+    tables_missing: { legal_ref_corrections: false, legal_ref_candidates: false },
+  };
+
+  let budget = DAILY_CAP;
+
+  // Corrections first
+  try {
+    const { data: corrections, error } = await supabase
+      .from('legal_ref_corrections')
+      .select('*')
+      .eq('status', 'pending')
+      .is('enriched_at', null)
+      .order('created_at', { ascending: true })
+      .limit(budget);
+    if (error) {
+      // Likely missing table or missing enriched_at column — skip silently
+      results.tables_missing.legal_ref_corrections = true;
+    } else if (corrections) {
+      for (const row of corrections) {
+        if (budget <= 0) break;
+        const out = await enrichRow(supabase, 'legal_ref_corrections', row);
+        budget--;
+        if (out.ok) {
+          results.processed_corrections++;
+          if (out.risk === 'low') results.risk_low++;
+          else if (out.risk === 'medium') results.risk_medium++;
+          else if (out.risk === 'high') results.risk_high++;
+        } else {
+          results.errors++;
+        }
+      }
+    }
+  } catch {
+    results.tables_missing.legal_ref_corrections = true;
+  }
+
+  // Candidates
+  try {
+    const { data: candidates, error } = await supabase
+      .from('legal_ref_candidates')
+      .select('*')
+      .eq('status', 'pending')
+      .is('enriched_at', null)
+      .order('created_at', { ascending: true })
+      .limit(budget);
+    if (error) {
+      results.tables_missing.legal_ref_candidates = true;
+    } else if (candidates) {
+      for (const row of candidates) {
+        if (budget <= 0) break;
+        const out = await enrichRow(supabase, 'legal_ref_candidates', row);
+        budget--;
+        if (out.ok) {
+          results.processed_candidates++;
+          if (out.risk === 'low') results.risk_low++;
+          else if (out.risk === 'medium') results.risk_medium++;
+          else if (out.risk === 'high') results.risk_high++;
+        } else {
+          results.errors++;
+        }
+      }
+    }
+  } catch {
+    results.tables_missing.legal_ref_candidates = true;
+  }
+
+  // Best-effort log
+  try {
+    await supabase.from('business_log').insert({
+      category: 'compliance',
+      action: 'enrichment_cron',
+      details: results,
+    });
+  } catch {
+    // optional
+  }
+
+  return NextResponse.json({ ok: true, ...results });
+}

--- a/src/app/api/mcp/compliance-status/route.ts
+++ b/src/app/api/mcp/compliance-status/route.ts
@@ -1,0 +1,111 @@
+/**
+ * Paybacker Assistant compliance status endpoint (PR ζ).
+ *
+ * Read-only. Surfaces the same counts + top items the daily digest
+ * email contains, plus a markdown summary suitable for chat display.
+ *
+ * Wired from the MCP server via a simple HTTP fetch — keeps this PR
+ * additive and avoids touching the 1200-line MCP tool registry. The
+ * MCP wiring (registering a `compliance_status` tool that calls this
+ * endpoint) is a follow-up.
+ *
+ * Auth: cron secret OR admin session — same guard as the other
+ * compliance endpoints.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import {
+  pendingCorrectionsCount,
+  pendingCandidatesCount,
+  staleRefsCount,
+  brokenRefsCount,
+  topPendingCorrections,
+  topStaleRefsCitedRecently,
+} from '@/lib/compliance-queries';
+
+export const maxDuration = 30;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+
+  const url = new URL(request.url);
+  const category = url.searchParams.get('category');
+
+  const supabase = getAdmin();
+
+  const [pc, pcand, st, br, topCorr, topStale] = await Promise.all([
+    pendingCorrectionsCount(supabase),
+    pendingCandidatesCount(supabase),
+    staleRefsCount(supabase),
+    brokenRefsCount(supabase),
+    topPendingCorrections(supabase, 5),
+    topStaleRefsCitedRecently(supabase, 5),
+  ]);
+
+  const filteredStale =
+    category && topStale ? topStale.filter((r) => r.category === category) : topStale;
+
+  const counts = {
+    pending_corrections: pc,
+    pending_candidates: pcand,
+    stale_refs: st,
+    broken_refs: br,
+  };
+
+  const tablesMissing = {
+    legal_ref_corrections: pc === null,
+    legal_ref_candidates: pcand === null,
+    legal_ref_usages: topStale === null,
+  };
+
+  // Build a markdown summary suitable for chat
+  const lines: string[] = [];
+  lines.push('### Paybacker compliance status');
+  lines.push('');
+  lines.push(`- **Pending corrections:** ${pc ?? 'n/a'}`);
+  lines.push(`- **Pending candidates:** ${pcand ?? 'n/a'}`);
+  lines.push(`- **Stale references (>30d):** ${st ?? 'n/a'}`);
+  lines.push(`- **Broken / flagged references:** ${br ?? 'n/a'}`);
+  lines.push('');
+  if (topCorr && topCorr.length > 0) {
+    lines.push('**Top pending corrections:**');
+    for (const c of topCorr) {
+      const before = (c.before_value || '').toString().slice(0, 80);
+      const after = (c.after_value || '').toString().slice(0, 80);
+      lines.push(`- \`${c.id.slice(0, 8)}\` · ${before} → ${after}`);
+    }
+    lines.push('');
+  }
+  if (filteredStale && filteredStale.length > 0) {
+    lines.push('**Top stale references cited recently:**');
+    for (const r of filteredStale) {
+      lines.push(
+        `- ${r.law_name}${r.section ? ' ' + r.section : ''} (${r.verification_status || 'unknown'}, used ${r.uses_30d}× in 30d)`,
+      );
+    }
+    lines.push('');
+  }
+  lines.push('_Read-only snapshot. Every change still requires a deliberate founder click._');
+
+  return NextResponse.json({
+    ok: true,
+    counts,
+    top_pending_corrections: topCorr ?? [],
+    top_stale_refs: filteredStale ?? [],
+    tables_missing: tablesMissing,
+    markdown: lines.join('\n'),
+    generated_at: new Date().toISOString(),
+  });
+}

--- a/src/lib/compliance-queries.ts
+++ b/src/lib/compliance-queries.ts
@@ -1,0 +1,185 @@
+/**
+ * Shared compliance-queue queries (PR ζ).
+ *
+ * Every cross-PR table read is wrapped in try/catch so this module
+ * gracefully no-ops if a sibling PR (γ/δ/ε) hasn't merged yet:
+ *   - legal_ref_corrections (ε)
+ *   - legal_ref_candidates  (δ)
+ *   - legal_ref_verifications (γ)
+ *   - legal_ref_usages       (γ)
+ *
+ * Returning null (not throwing) is the contract — callers branch on
+ * presence rather than catching.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Supa = any;
+
+export interface PendingCorrectionRow {
+  id: string;
+  ref_id: string | null;
+  proposed_change: unknown;
+  before_value: string | null;
+  after_value: string | null;
+  status: string | null;
+  created_at: string;
+  enrichment_data?: unknown;
+}
+
+export interface PendingCandidateRow {
+  id: string;
+  category: string | null;
+  proposed_law: string | null;
+  source_url: string | null;
+  status: string | null;
+  created_at: string;
+  enrichment_data?: unknown;
+}
+
+export interface StaleRefRow {
+  id: string;
+  law_name: string;
+  section: string | null;
+  category: string | null;
+  verification_status: string | null;
+  last_verified: string | null;
+  source_url: string | null;
+}
+
+export async function safeCount(supabase: Supa, table: string, filter?: (q: any) => any): Promise<number | null> {
+  try {
+    let query = supabase.from(table).select('id', { count: 'exact', head: true });
+    if (filter) query = filter(query);
+    const { count, error } = await query;
+    if (error) return null;
+    return count ?? 0;
+  } catch {
+    return null;
+  }
+}
+
+export async function pendingCorrectionsCount(supabase: Supa): Promise<number | null> {
+  return safeCount(supabase, 'legal_ref_corrections', (q) => q.eq('status', 'pending'));
+}
+
+export async function pendingCandidatesCount(supabase: Supa): Promise<number | null> {
+  return safeCount(supabase, 'legal_ref_candidates', (q) => q.eq('status', 'pending'));
+}
+
+export async function staleRefsCount(supabase: Supa): Promise<number | null> {
+  try {
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const { count, error } = await supabase
+      .from('legal_references')
+      .select('id', { count: 'exact', head: true })
+      .or(`last_verified.lt.${cutoff},last_verified.is.null`);
+    if (error) return null;
+    return count ?? 0;
+  } catch {
+    return null;
+  }
+}
+
+export async function brokenRefsCount(supabase: Supa): Promise<number | null> {
+  try {
+    const { count, error } = await supabase
+      .from('legal_references')
+      .select('id', { count: 'exact', head: true })
+      .in('verification_status', ['broken', 'stale', 'error', 'url_dead', 'needs_review']);
+    if (error) return null;
+    return count ?? 0;
+  } catch {
+    return null;
+  }
+}
+
+export async function topPendingCorrections(supabase: Supa, limit = 5): Promise<PendingCorrectionRow[] | null> {
+  try {
+    const { data, error } = await supabase
+      .from('legal_ref_corrections')
+      .select('id, ref_id, proposed_change, before_value, after_value, status, created_at, enrichment_data')
+      .eq('status', 'pending')
+      .order('created_at', { ascending: true })
+      .limit(limit);
+    if (error) return null;
+    return (data || []) as PendingCorrectionRow[];
+  } catch {
+    return null;
+  }
+}
+
+export async function topStaleRefsCitedRecently(
+  supabase: Supa,
+  limit = 5,
+): Promise<Array<StaleRefRow & { uses_30d: number }> | null> {
+  try {
+    // Pull stale refs first
+    const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const { data: refs, error } = await supabase
+      .from('legal_references')
+      .select('id, law_name, section, category, verification_status, last_verified, source_url')
+      .or(
+        `verification_status.in.(broken,stale,error,url_dead,needs_review),last_verified.lt.${cutoff}`,
+      )
+      .limit(50);
+    if (error || !refs) return null;
+
+    // Cross-ref usages in last 30 days
+    const usageCounts: Record<string, number> = {};
+    try {
+      const { data: usages } = await supabase
+        .from('legal_ref_usages')
+        .select('ref_id')
+        .gte('used_at', cutoff);
+      if (usages) {
+        for (const u of usages) {
+          const id = (u as { ref_id: string }).ref_id;
+          if (id) usageCounts[id] = (usageCounts[id] || 0) + 1;
+        }
+      }
+    } catch {
+      // legal_ref_usages doesn't exist yet — fall through with zero counts
+    }
+
+    const enriched = (refs as StaleRefRow[]).map((r) => ({
+      ...r,
+      uses_30d: usageCounts[r.id] || 0,
+    }));
+    enriched.sort((a, b) => b.uses_30d - a.uses_30d);
+    return enriched.slice(0, limit);
+  } catch {
+    return null;
+  }
+}
+
+export async function recentUsageCountForRef(
+  supabase: Supa,
+  refId: string,
+  days = 7,
+): Promise<number | null> {
+  try {
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+    const { count, error } = await supabase
+      .from('legal_ref_usages')
+      .select('id', { count: 'exact', head: true })
+      .eq('ref_id', refId)
+      .gte('used_at', cutoff);
+    if (error) return null;
+    return count ?? 0;
+  } catch {
+    return null;
+  }
+}
+
+export async function correctionCountForRef(supabase: Supa, refId: string): Promise<number | null> {
+  try {
+    const { count, error } = await supabase
+      .from('legal_ref_corrections')
+      .select('id', { count: 'exact', head: true })
+      .eq('ref_id', refId);
+    if (error) return null;
+    return count ?? 0;
+  } catch {
+    return null;
+  }
+}

--- a/supabase/migrations/20260430120000_compliance_alerts_sent.sql
+++ b/supabase/migrations/20260430120000_compliance_alerts_sent.sql
@@ -1,0 +1,18 @@
+-- Compliance alerts dedup table (PR ζ)
+-- Tracks which compliance email alerts have already been sent so the
+-- urgent-alert path is idempotent. Alert keys are deterministic strings
+-- like "ref-broke:<ref_id>" or "category-flood:energy:2026-04-30".
+--
+-- Additive only — never DROP. Daily digest does NOT use this table
+-- (digest sends one email per day unconditionally).
+
+CREATE TABLE IF NOT EXISTS public.compliance_alerts_sent (
+  id BIGSERIAL PRIMARY KEY,
+  alert_key TEXT NOT NULL UNIQUE,
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  channel TEXT NOT NULL DEFAULT 'email',
+  metadata JSONB
+);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_alerts_sent_sent_at
+  ON public.compliance_alerts_sent (sent_at DESC);

--- a/supabase/migrations/20260430130000_compliance_enrichment.sql
+++ b/supabase/migrations/20260430130000_compliance_enrichment.sql
@@ -1,0 +1,23 @@
+-- Compliance enrichment columns (PR ζ)
+-- Adds enrichment_data JSONB + enriched_at TIMESTAMPTZ to the pending
+-- review tables created by sibling PRs (δ, ε). If those tables don't
+-- exist yet in this environment, the DO blocks no-op and the migration
+-- still succeeds — keeps ζ deployable independently of its siblings.
+--
+-- Additive only. Never DROP.
+
+DO $$ BEGIN
+  ALTER TABLE public.legal_ref_corrections
+    ADD COLUMN IF NOT EXISTS enrichment_data JSONB,
+    ADD COLUMN IF NOT EXISTS enriched_at TIMESTAMPTZ;
+EXCEPTION WHEN undefined_table THEN
+  RAISE NOTICE 'legal_ref_corrections does not exist yet — skipping enrichment columns';
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE public.legal_ref_candidates
+    ADD COLUMN IF NOT EXISTS enrichment_data JSONB,
+    ADD COLUMN IF NOT EXISTS enriched_at TIMESTAMPTZ;
+EXCEPTION WHEN undefined_table THEN
+  RAISE NOTICE 'legal_ref_candidates does not exist yet — skipping enrichment columns';
+END $$;

--- a/vercel.json
+++ b/vercel.json
@@ -46,6 +46,8 @@
     { "path": "/api/cron/support-chase",             "schedule": "0 9 * * *" },
     { "path": "/api/cron/builder-pickup",            "schedule": "*/30 * * * *" },
     { "path": "/api/cron/builder-verify",            "schedule": "*/5 * * * *" },
-    { "path": "/api/cron/refresh-cancellation-info", "schedule": "0 3 * * 1" }
+    { "path": "/api/cron/refresh-cancellation-info", "schedule": "0 3 * * 1" },
+    { "path": "/api/cron/compliance-digest",         "schedule": "0 9 * * *" },
+    { "path": "/api/cron/enrich-compliance-pending", "schedule": "0 4 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

PR ζ adds **observability and decision-support** to the compliance pipeline. It does **NOT** add any auto-apply path — every change to `legal_references` still requires an approved correction plus a deliberate founder click. Per the user's standing rule: no law cited that isn't 100% correct, no canonical write without explicit approval.

This PR is additive and gracefully no-ops against tables created by sibling PRs (γ/δ/ε) that may not be merged yet.

## What's in here

### ζ1. Email alerting
- **`/api/cron/compliance-digest`** (09:00 UTC daily, wired in `vercel.json`) — single Resend email per day to `hello@paybacker.co.uk` with: counts grid (pending corrections, pending candidates, stale refs >30d, broken/flagged), top 5 pending corrections (newest-stale-first with before/after diff), top 5 stale refs cited recently (cross-referenced via `legal_ref_usages`). Sends a one-line "All compliance queues clear ✓" when everything is empty.
- **`/api/admin/compliance-alert`** (POST) — internal urgent-alert endpoint. Three reasons supported:
  - `ref_broke_high_traffic` (a ref used in last 7d transitioned to broken)
  - `correction_flood` (>3 corrections on the same ref_id)
  - `heavy_traffic_candidate` (new energy/broadband/mobile/finance candidate)
  Idempotent via `compliance_alerts_sent.alert_key UNIQUE`. Hard cap 5 urgent alerts/day.

### ζ2. Paybacker Assistant tool
- **`/api/mcp/compliance-status`** (GET, read-only) — same counts + top items as the digest, plus a chat-ready markdown summary. Optional `?category=` filter.
- **MCP wiring deferred** — the MCP server's tool registry is a 1200-line case statement and registering a new `compliance_status` tool was out of scope for this PR. This endpoint is the underlying contract; MCP follow-up will be a thin wrapper that fetches from this URL.

### ζ3. Developer-agent enrichment
- **`/api/cron/enrich-compliance-pending`** (04:00 UTC daily) — for each pending correction or candidate not yet enriched: fetches source URL (5s timeout, follows redirects, 1MB cap), extracts relevant text, computes URL diff, title diff, risk-scores the change (`low | medium | high`), optionally summarises via Perplexity, writes `enrichment_data JSONB` + `enriched_at` onto the row.
- **NEVER auto-applies** a correction. Only adds context to the pending review.
- **Hard cap 50 items/day** (~£0.50/day worst case).

### Migrations (additive only)
- `20260430120000_compliance_alerts_sent.sql` — new dedup table.
- `20260430130000_compliance_enrichment.sql` — adds `enrichment_data` + `enriched_at` to `legal_ref_corrections` and `legal_ref_candidates`. Both `ALTER` statements are wrapped in `DO $$ ... EXCEPTION WHEN undefined_table THEN ... END $$` so the migration succeeds even if the sibling PRs creating those tables haven't merged.

## Cross-PR safety

Every read against `legal_ref_corrections`, `legal_ref_candidates`, `legal_ref_usages`, `legal_ref_verifications` is wrapped in `try/catch` (in `src/lib/compliance-queries.ts`). When a table is missing, the query returns `null`, the digest treats the count as 0 but flags `tables_missing` in the response, and the urgent-alert endpoint treats dedup-table failures as "skip-and-soldier-on". ζ is observational glue and never breaks if a sibling PR isn't merged.

## Hard rules (per CLAUDE.md compliance principle)

- The enrichment cron NEVER auto-applies a correction. It only adds context.
- Email alerts are observational — they DON'T auto-resolve anything.
- The MCP tool / status endpoint is read-only.
- The "Approve" button still requires a human click for every change.
- No canonical field write without `legal_ref_corrections.status='approved'` AND a founder click.

## Cost control

- Daily digest: 1 Resend send/day = ~£0 (well under tier).
- Urgent alerts: max 5 per day hard cap; throttled via `compliance_alerts_sent`.
- Enrichment cron: 50 items/day × ~£0.01 (Perplexity AI summary + free HTTP fetch) = ~£0.50/day worst case.

## Things deferred or skipped

- **MCP wiring** (deferred to follow-up — endpoint is built, registry edit is a focused next PR).
- **WhatsApp Pro alert side-quest** (skipped — non-trivial to wire safely under time budget; observational email path already covers the founder).
- **Admin UI consumption of `enrichment_data`** (deferred — current `/dashboard/admin/legal-refs` page does not yet render the corrections/candidates queue on master; that's coming in sibling PRs δ/ε. UI enhancement should ride on whichever lands first).

## tsc

Clean for the new files. `npx tsc --noEmit` baseline on `master` had 4 pre-existing errors unrelated to this PR; this branch adds zero new errors.

## Test plan

- [ ] Hit `/api/cron/compliance-digest` with `Authorization: Bearer $CRON_SECRET` in a preview deploy and confirm a single email arrives at `hello@paybacker.co.uk`. Verify counts populate when sibling tables exist; verify "all clear" body when they don't.
- [ ] POST to `/api/admin/compliance-alert` with `{"reason":"ref_broke_high_traffic","ref_id":"test","ref_title":"Sample Act","used_count_7d":12}` and confirm the email arrives. POST again with the same payload and confirm the response says `skipped: already_sent`.
- [ ] Hit `/api/mcp/compliance-status` and confirm shape: `{counts, top_pending_corrections, top_stale_refs, tables_missing, markdown}`.
- [ ] Apply both migrations against staging — confirm `compliance_alerts_sent` is created and that the enrichment ALTERs are no-op when sibling tables are absent (no error).
- [ ] Hit `/api/cron/enrich-compliance-pending` once corrections/candidates exist; verify `enrichment_data` is populated with `risk_score`, `risk_reasons`, `url_diff`, `title_diff`.
- [ ] Confirm `vercel.json` cron entries land in the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)