### PR TITLE
feat(compliance): tiered freshness + category fallback + 503 alarm — make B2B 503 essentially never

### DIFF
--- a/src/app/api/complaints/generate/route.ts
+++ b/src/app/api/complaints/generate/route.ts
@@ -7,7 +7,17 @@ import { checkClaudeRateLimit, recordClaudeCall, logClaudeCall } from '@/lib/cla
 import { trackLetterGenerated } from '@/lib/meta-conversions';
 import { awardPoints } from '@/lib/loyalty';
 import { getProviderTerms } from '@/lib/provider-match';
-import { checkRefFreshness, refreshSingleRef, findFreshSubstitute, freshnessOf, postFlightSanitise } from '@/lib/legal-refs-guardrail';
+import {
+  checkRefFreshness,
+  refreshSingleRef,
+  findFreshSubstitute,
+  freshnessOf,
+  freshnessTier,
+  tierWarning,
+  findTieredSubstitute,
+  findChainSubstitute,
+  postFlightSanitise,
+} from '@/lib/legal-refs-guardrail';
 import { CITATION_PERMISSIVE_STATUSES } from '@/lib/legal-refs-statuses';
 
 // Claude takes 10-20s for complaint letters — extend beyond Vercel's 10s default
@@ -333,36 +343,64 @@ export async function POST(request: NextRequest) {
     // we strip the row and add a footer note in the letter. Never
     // blocks the user — degrade gracefully.
     let guardrailFooterNote: string | null = null;
+    // Tier 2-4 + chain fallback warnings collected here — appended to
+    // the letter footer at the end so the user sees the same "verified
+    // X days ago" caveat the B2B response surfaces in _compliance_warnings.
+    // B2C never blocks: even a tier-4 ref or chain fallback is preferable
+    // to stripping the citation entirely.
+    const guardrailTierWarnings: string[] = [];
     if (relevantRefs.length > 0) {
       const freshness = await checkRefFreshness(supabase, refIds);
       if (!freshness.ok && freshness.stale.length > 0) {
-        const usedIds = new Set(refIds);
+        const usedIds = new Set<string>((refIds as unknown[]).filter((x: unknown): x is string => typeof x === 'string'));
         for (const { id: staleId, reason } of freshness.stale) {
-          // Attempt synchronous refresh first.
+          // Attempt synchronous refresh first. Tier-aware: tier 1 → use
+          // silently; tier 2-4 → use + warning; null → fall through.
           const refreshed = await refreshSingleRef(supabase, staleId);
-          if (refreshed && freshnessOf(refreshed) === 'fresh') {
-            // Replace the row in-place so the prompt block sees the fresh copy.
-            const idx = relevantRefs.findIndex((r: any) => r.id === staleId);
-            if (idx >= 0) {
-              relevantRefs[idx] = { ...relevantRefs[idx], ...refreshed };
-            }
-            continue;
-          }
-          // Refresh failed or still stale. Try a substitute in the same category.
-          const original = relevantRefs.find((r: any) => r.id === staleId);
-          const category = original?.category;
-          if (category) {
-            const sub = await findFreshSubstitute(supabase, category, [...usedIds]);
-            if (sub) {
+          if (refreshed) {
+            const t = freshnessTier(refreshed);
+            if (t) {
               const idx = relevantRefs.findIndex((r: any) => r.id === staleId);
               if (idx >= 0) {
-                relevantRefs[idx] = { ...sub, applies_to: original?.applies_to || [] } as any;
-                usedIds.add(sub.id);
+                relevantRefs[idx] = { ...relevantRefs[idx], ...refreshed };
               }
+              const w = tierWarning(refreshed, t);
+              if (w) guardrailTierWarnings.push(w);
               continue;
             }
           }
-          // No substitute — strip the row and flag a footer note.
+          // Same-category tiered substitute (tier 1 → 4).
+          const original = relevantRefs.find((r: any) => r.id === staleId);
+          const category = original?.category;
+          if (category) {
+            const sub = await findTieredSubstitute(supabase, category, [...usedIds]);
+            if (sub) {
+              const idx = relevantRefs.findIndex((r: any) => r.id === staleId);
+              if (idx >= 0) {
+                relevantRefs[idx] = { ...sub.ref, applies_to: original?.applies_to || [] } as any;
+                usedIds.add(sub.ref.id);
+              }
+              const w = tierWarning(sub.ref, sub.tier);
+              if (w) guardrailTierWarnings.push(w);
+              continue;
+            }
+            // Category fallback chain (energy → utilities → general etc.).
+            const chained = await findChainSubstitute(supabase, category, [...usedIds]);
+            if (chained) {
+              const idx = relevantRefs.findIndex((r: any) => r.id === staleId);
+              if (idx >= 0) {
+                relevantRefs[idx] = { ...chained.ref, applies_to: original?.applies_to || [] } as any;
+                usedIds.add(chained.ref.id);
+              }
+              guardrailTierWarnings.push(
+                `No fresh ref for '${category}' — substituted with '${chained.fallbackCategory}' (${chained.ref.law_name})`,
+              );
+              const w = tierWarning(chained.ref, chained.tier);
+              if (w) guardrailTierWarnings.push(w);
+              continue;
+            }
+          }
+          // No substitute even via the chain — strip the row and flag a footer note.
           const idx = relevantRefs.findIndex((r: any) => r.id === staleId);
           if (idx >= 0) relevantRefs.splice(idx, 1);
           guardrailFooterNote = "We couldn't verify the current statute reference for this point. Please confirm before sending.";
@@ -373,6 +411,14 @@ export async function POST(request: NextRequest) {
           });
         }
       }
+    }
+    // Promote tier 2-4 warnings into the footer note. Multiple warnings
+    // are joined; if the strip-fallback note also fired we keep both.
+    if (guardrailTierWarnings.length > 0) {
+      const tierFooter = guardrailTierWarnings.join(' · ');
+      guardrailFooterNote = guardrailFooterNote
+        ? `${guardrailFooterNote} ${tierFooter}`
+        : tierFooter;
     }
 
     let verifiedLegalRefs = '';

--- a/src/app/api/v1/disputes/route.ts
+++ b/src/app/api/v1/disputes/route.ts
@@ -25,6 +25,7 @@ import { createClient } from '@supabase/supabase-js';
 import { authenticate, logUsage } from '@/lib/b2b/auth';
 import { validateRequest, resolveDispute } from '@/lib/b2b/disputes';
 import { publishUsageThreshold } from '@/lib/b2b/webhook-publisher';
+import { resend, FROM_EMAIL } from '@/lib/resend';
 
 export const runtime = 'nodejs';
 export const maxDuration = 30;
@@ -112,6 +113,115 @@ async function maybeFireThresholdWebhook(args: {
 
 function hashKey(plaintext: string): string {
   return createHash('sha256').update(plaintext).digest('base64');
+}
+
+/**
+ * 503 alarm — fires when the freshness cascade (tier 1-4 + chain
+ * fallback) couldn't salvage at least one ref AND the post-flight had
+ * no fresh substitute either. Should be vanishingly rare; when it fires
+ * the founder needs to know within seconds because the API is shipping
+ * 503s to a paying B2B customer.
+ *
+ * Idempotent per (category, UTC date) via `compliance_alerts_sent.alert_key`
+ * so a burst of 503s in the same category on the same day fires exactly
+ * one Telegram + one email. Both channels are fire-and-forget — failure
+ * never affects the API response.
+ */
+async function fireStaleCitation503Alarm(args: {
+  categories: string[];
+  refIds: string[];
+  scenario: string;
+  keyPrefix: string;
+  requestId: string;
+}): Promise<void> {
+  // Pick the primary category for the alert key. Multiple categories on
+  // a single 503 is rare; we dedupe on the first one and fold the rest
+  // into the body so the email still surfaces them all.
+  const primaryCategory = args.categories[0] || 'unknown';
+  const today = new Date().toISOString().slice(0, 10);
+  const alertKey = `b2b-503:${primaryCategory}:${today}`;
+  const sb = admin();
+
+  // Claim the alert key. Unique violation = already alerted today.
+  try {
+    const { error } = await sb.from('compliance_alerts_sent').insert({
+      alert_key: alertKey,
+      channel: 'multi',
+      metadata: {
+        categories: args.categories,
+        ref_ids: args.refIds,
+        request_id: args.requestId,
+        key_prefix: args.keyPrefix,
+      },
+    });
+    if (error) return; // already fired today
+  } catch {
+    // Dedup table unavailable — bail rather than risk a flood. Better to
+    // miss an alert than spam the founder during a Supabase incident.
+    return;
+  }
+
+  const truncatedScenario = args.scenario.length > 400
+    ? args.scenario.slice(0, 400) + '…'
+    : args.scenario;
+  const ts = new Date().toISOString();
+
+  // Telegram (founder chat) — fire-and-forget.
+  const tgToken = process.env.TELEGRAM_BOT_TOKEN;
+  const tgChat = process.env.TELEGRAM_FOUNDER_CHAT_ID;
+  if (tgToken && tgChat) {
+    void fetch(`https://api.telegram.org/bot${tgToken}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: Number(tgChat),
+        text: [
+          `🚨 *B2B 503 — STALE_CITATION*`,
+          ``,
+          `Category: \`${primaryCategory}\`${args.categories.length > 1 ? ` (+${args.categories.length - 1})` : ''}`,
+          `Refs: ${args.refIds.length}`,
+          `Key: \`${args.keyPrefix}\``,
+          `Request: \`${args.requestId}\``,
+          ``,
+          `Cascade exhausted (tier 1-4 + chain fallback). Re-verify the category urgently.`,
+        ].join('\n'),
+        parse_mode: 'Markdown',
+      }),
+    }).catch(() => undefined);
+  }
+
+  // Email to hello@paybacker.co.uk via Resend — fire-and-forget.
+  if (process.env.RESEND_API_KEY) {
+    void resend.emails.send({
+      from: FROM_EMAIL,
+      to: 'hello@paybacker.co.uk',
+      subject: `[B2B URGENT] STALE_CITATION 503 — ${primaryCategory} category exhausted`,
+      html: `<div style="font-family:-apple-system,system-ui,sans-serif;max-width:640px;margin:auto;color:#0f172a;">
+        <div style="background:#7f1d1d;color:#fee2e2;padding:8px 14px;border-radius:6px;display:inline-block;font-size:12px;font-weight:700;letter-spacing:0.5px;">B2B 503</div>
+        <h2 style="margin:14px 0 8px;">STALE_CITATION 503 — ${escapeHtml(primaryCategory)} exhausted</h2>
+        <p style="color:#475569;">The freshness cascade (tier 1 → 4 + category chain fallback) produced no usable ref. The /v1/disputes endpoint is currently returning 503 for matching scenarios in this category.</p>
+        <table style="width:100%;font-size:13px;color:#0f172a;border-collapse:collapse;margin-top:12px;">
+          <tr><td style="color:#64748b;padding:4px 12px 4px 0;">Categories</td><td>${escapeHtml(args.categories.join(', '))}</td></tr>
+          <tr><td style="color:#64748b;padding:4px 12px 4px 0;">Unsalvageable refs</td><td><code>${args.refIds.map(escapeHtml).join(', ') || '(none — post-flight rogue path)'}</code></td></tr>
+          <tr><td style="color:#64748b;padding:4px 12px 4px 0;">Timestamp</td><td>${escapeHtml(ts)}</td></tr>
+          <tr><td style="color:#64748b;padding:4px 12px 4px 0;">API key prefix</td><td><code>${escapeHtml(args.keyPrefix)}</code></td></tr>
+          <tr><td style="color:#64748b;padding:4px 12px 4px 0;">Request ID</td><td><code>${escapeHtml(args.requestId)}</code></td></tr>
+        </table>
+        <h3 style="margin-top:18px;font-size:14px;">Scenario (truncated)</h3>
+        <pre style="background:#f1f5f9;padding:12px;border-radius:6px;font-size:12px;white-space:pre-wrap;color:#0f172a;">${escapeHtml(truncatedScenario)}</pre>
+        <p style="margin-top:18px;"><a href="https://paybacker.co.uk/dashboard/admin/legal-refs" style="background:#0f172a;color:#fff;padding:10px 16px;border-radius:6px;text-decoration:none;display:inline-block;">Open legal-refs admin</a></p>
+        <p style="color:#64748b;font-size:12px;margin-top:14px;">Idempotent: one alert per (category, UTC date). Further 503s in '${escapeHtml(primaryCategory)}' today will be silenced.</p>
+      </div>`,
+    }).catch(() => undefined);
+  }
+}
+
+function escapeHtml(s: string): string {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
 }
 
 /**
@@ -268,6 +378,17 @@ export async function POST(request: NextRequest) {
     const headers: Record<string, string> = { 'X-Request-Id': requestId };
     if (result.code === 'STALE_CITATION') {
       headers['Retry-After'] = String(result.retry_after ?? 60);
+      // 503 alarm — fire-and-forget Telegram + email to founder so a
+      // production stale-citation outage is detected within seconds.
+      // Idempotent per (category, UTC date) so a burst doesn't spam.
+      const scenarioStr = (validated as { scenario?: unknown }).scenario;
+      void fireStaleCitation503Alarm({
+        categories: result.unsalvageable_categories ?? [],
+        refIds: result.ref_ids ?? [],
+        scenario: typeof scenarioStr === 'string' ? scenarioStr : '',
+        keyPrefix: key.keyPrefix,
+        requestId,
+      });
     }
     return NextResponse.json(errBody, { status, headers });
   }

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -23,6 +23,10 @@ import {
   refreshSingleRef,
   findFreshSubstitute,
   freshnessOf,
+  freshnessTier,
+  tierWarning,
+  findTieredSubstitute,
+  findChainSubstitute,
   extractCitations,
   validateCitations,
   planSubstitutions,
@@ -227,6 +231,13 @@ export interface DisputeError {
    * a one-minute retry hint matches the spec.
    */
   retry_after?: number;
+  /**
+   * Categories whose entire freshness cascade (tier 1-4 + chain
+   * fallback) produced no usable ref. Surfaced to the route handler so
+   * the 503 alarm can pinpoint which legal sectors need urgent
+   * re-verification.
+   */
+  unsalvageable_categories?: string[];
 }
 
 export function validateRequest(body: unknown): DisputeRequest | DisputeError {
@@ -504,6 +515,12 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
   const supabase = getAdmin();
   let verifiedRefs = await fetchVerifiedRefs(req.scenario);
 
+  // Accumulate compliance warnings from pre-flight (tier 2-4 usage,
+  // category-chain fallback) AND post-flight (rogue citation rewrites).
+  // Single buffer so the final response carries everything that fired
+  // during this call.
+  const complianceWarnings: string[] = [];
+
   // PR β — pre-send freshness guardrail (B2B path).
   //
   // Compliance is the entire selling point of /v1/disputes vs a
@@ -527,32 +544,67 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
     if (!freshness.ok && freshness.stale.length > 0) {
       const usedIds = new Set<string>(idsBeingFed);
       const unsalvageable: string[] = [];
+      const unsalvageableCategories = new Set<string>();
       for (const { id: staleId } of freshness.stale) {
+        // Step 1 — synchronous Perplexity refresh. If it returns a tier-1
+        // ref we use it silently; if it returns a tier 2-4 ref we keep it
+        // but emit a warning; if it doesn't qualify under any tier we fall
+        // through to the substitute logic.
         const refreshed = await refreshSingleRef(supabase, staleId);
-        if (refreshed && freshnessOf(refreshed) === 'fresh') {
-          const idx = verifiedRefs.findIndex((r: any) => r.id === staleId);
-          if (idx >= 0) verifiedRefs[idx] = { ...verifiedRefs[idx], ...refreshed };
-          continue;
+        if (refreshed) {
+          const t = freshnessTier(refreshed);
+          if (t) {
+            const idx = verifiedRefs.findIndex((r: any) => r.id === staleId);
+            if (idx >= 0) verifiedRefs[idx] = { ...verifiedRefs[idx], ...refreshed };
+            const w = tierWarning(refreshed, t);
+            if (w) complianceWarnings.push(w);
+            continue;
+          }
         }
+        // Step 2 — same-category tiered substitute. Walks tier 1 → 4.
         const original = verifiedRefs.find((r: any) => r.id === staleId);
         const category = original?.category;
         if (category) {
-          const sub = await findFreshSubstitute(supabase, category, [...usedIds]);
+          const sub = await findTieredSubstitute(supabase, category, [...usedIds]);
           if (sub) {
             const idx = verifiedRefs.findIndex((r: any) => r.id === staleId);
-            if (idx >= 0) verifiedRefs[idx] = { ...sub } as any;
-            usedIds.add(sub.id);
+            if (idx >= 0) verifiedRefs[idx] = { ...sub.ref } as any;
+            usedIds.add(sub.ref.id);
+            const w = tierWarning(sub.ref, sub.tier);
+            if (w) complianceWarnings.push(w);
             continue;
           }
+          // Step 3 — category fallback chain. Borrow from a legally-
+          // adjacent neighbour (energy → utilities → general etc.). Even
+          // a tier-4 hit here is preferable to a 503 because the chain
+          // entries are pan-sector statutes (CRA 2015, CCA 1974) that
+          // legitimately apply across categories.
+          const chained = await findChainSubstitute(supabase, category, [...usedIds]);
+          if (chained) {
+            const idx = verifiedRefs.findIndex((r: any) => r.id === staleId);
+            if (idx >= 0) verifiedRefs[idx] = { ...chained.ref } as any;
+            usedIds.add(chained.ref.id);
+            complianceWarnings.push(
+              `No fresh ref for '${category}' — substituted with '${chained.fallbackCategory}' (${chained.ref.law_name})`,
+            );
+            const w = tierWarning(chained.ref, chained.tier);
+            if (w) complianceWarnings.push(w);
+            continue;
+          }
+          unsalvageableCategories.add(category);
         }
         unsalvageable.push(staleId);
       }
       if (unsalvageable.length > 0) {
+        // 503 only fires when the entire cascade — refresh, tier 1-4
+        // substitute, AND category fallback chain — produced nothing for
+        // at least one ref. Should be vanishingly rare in normal operation.
         return {
           code: 'STALE_CITATION',
           message: 'Citation freshness check failed',
           ref_ids: unsalvageable,
           retry_after: 60,
+          unsalvageable_categories: [...unsalvageableCategories],
         };
       }
     }
@@ -675,7 +727,9 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
     law_name: r.law_name as string,
     category: (r.category as string | null) ?? null,
   }));
-  const complianceWarnings: string[] = [];
+  // complianceWarnings hoisted at top of function — pre-flight tier/chain
+  // warnings already accumulated, post-flight rogue-citation warnings
+  // appended below.
 
   // 2a. Structured statute field (the LLM-derived primary statute).
   let structuredStatute = inferStatute(legalRefs);

--- a/src/lib/legal-refs-guardrail.ts
+++ b/src/lib/legal-refs-guardrail.ts
@@ -53,10 +53,38 @@ export interface LegalRef {
 const FRESH_STATUSES = new Set(['current', 'updated', 'verified']);
 const PERPLEXITY_TIMEOUT_MS = 5000;
 
-function maxAgeMs(): number {
+/**
+ * Tiered freshness cascade (PR — 503-softening).
+ *
+ * Replaces the binary fresh/stale split with four bands. Tier 1 is the
+ * historical "fresh" window — citations in this band emit no warning.
+ * Tiers 2-4 are progressively older but still usable; the engine cites
+ * them and surfaces a `_compliance_warnings` entry so the API consumer
+ * can decide whether to surface to the agent. Beyond tier 4 (or with
+ * an ineligible verification_status) the ref is unusable and falls
+ * through to the substitute / category-chain logic.
+ *
+ * Tier 1 is governed by `LEGAL_REF_MAX_AGE_DAYS` so existing operator
+ * configuration still controls the "no-warning" window. Tiers 2-4 are
+ * fixed at 30/60/90 days because their semantics (warning copy) is
+ * baked into product UX.
+ */
+export const FRESHNESS_TIER_CAPS_DAYS = [14, 30, 60, 90] as const;
+
+export interface FreshnessTier {
+  /** 1-4. Tier 1 = no warning, tiers 2-4 emit progressively stronger warnings. */
+  tier: 1 | 2 | 3 | 4;
+  /** Age in whole days at the time of evaluation. */
+  ageDays: number;
+}
+
+function tier1MaxDays(): number {
   const days = Number.parseInt(process.env.LEGAL_REF_MAX_AGE_DAYS || '14', 10);
-  const safe = Number.isFinite(days) && days > 0 ? days : 14;
-  return safe * 24 * 60 * 60 * 1000;
+  return Number.isFinite(days) && days > 0 ? days : 14;
+}
+
+function maxAgeMs(): number {
+  return tier1MaxDays() * 24 * 60 * 60 * 1000;
 }
 
 /**
@@ -251,6 +279,169 @@ export async function findFreshSubstitute(
   // Filter to refs that pass the freshness check (last_verified within window).
   for (const row of data as LegalRef[]) {
     if (freshnessOf(row) === 'fresh') return row;
+  }
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  TIERED FRESHNESS + CATEGORY FALLBACK CHAIN                                 */
+/* -------------------------------------------------------------------------- */
+/*
+ * 503-softening (PR — make B2B 503 essentially never).
+ *
+ * The pre-flight guardrail above is binary: a ref either passes the 14-day
+ * window or it doesn't. In practice the founder's verification cron runs
+ * daily but third-party rate limits + Perplexity flakes occasionally
+ * leave a category with NO ref freshly verified in the last fortnight,
+ * which forces a 503 even though we have a perfectly serviceable copy
+ * verified 21 days ago.
+ *
+ * `freshnessTier` returns the freshest tier a ref qualifies under so
+ * the engine can decide:
+ *   - tier 1 (≤14d): use silently
+ *   - tier 2 (15-30d): use + emit "within acceptable bounds" warning
+ *   - tier 3 (31-60d): use + emit "stronger" warning
+ *   - tier 4 (61-90d): use + emit "critical" warning
+ *   - null: ineligible status, never verified, or older than 90d
+ *
+ * `findTieredSubstitute` walks tier 1 → 4 and returns the first fresh
+ * substitute it finds in the same category, plus the tier it qualified
+ * under (so the caller can emit the right warning).
+ *
+ * `CATEGORY_FALLBACK_CHAINS` lets a stale category borrow from a
+ * legally-adjacent neighbour. Energy + broadband + mobile all fall back
+ * to "general" (which holds CRA 2015, CCA 1974 — pan-sector statutes
+ * that apply regardless of vertical). Travel + rail share. Finance +
+ * insurance share. The chains were chosen so that every fallback is
+ * legally defensible: a CRA 2015 citation is correct on an energy
+ * dispute even when there's no fresh Gas Act ref.
+ */
+
+export const CATEGORY_FALLBACK_CHAINS: Record<string, string[]> = {
+  energy: ['utilities', 'general'],
+  utilities: ['general'],
+  broadband: ['telecoms', 'general'],
+  telecoms: ['general'],
+  mobile: ['telecoms', 'general'],
+  finance: ['banking', 'general'],
+  banking: ['finance', 'general'],
+  insurance: ['finance', 'general'],
+  travel: ['general'],
+  rail: ['travel', 'general'],
+  parking: ['general'],
+  council_tax: ['general'],
+  hmrc: ['general'],
+  dvla: ['general'],
+  nhs: ['general'],
+  gym: ['general'],
+  debt: ['finance', 'general'],
+  general: [],
+};
+
+/**
+ * Classify a ref by the freshest tier it qualifies under. Returns
+ * null when the ref is unusable (broken/superseded status, missing
+ * last_verified, ineligible verification_status, or older than the
+ * tier-4 cap of 90 days).
+ *
+ * Tier 1's cap is read from LEGAL_REF_MAX_AGE_DAYS (defaults to 14).
+ * Tiers 2-4 are fixed at 30/60/90 days.
+ */
+export function freshnessTier(ref: LegalRef, now: Date = new Date()): FreshnessTier | null {
+  if (!ref) return null;
+  const status = (ref.verification_status || '').toLowerCase();
+  if (status === 'broken' || status === 'superseded') return null;
+  if (!FRESH_STATUSES.has(status)) return null;
+  if (!ref.last_verified) return null;
+  const verifiedAt = new Date(ref.last_verified).getTime();
+  if (!Number.isFinite(verifiedAt)) return null;
+  const ageMs = now.getTime() - verifiedAt;
+  if (ageMs < 0) return { tier: 1, ageDays: 0 };
+  const ageDays = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+  const tier1Cap = tier1MaxDays();
+  // Tier 1 follows operator configuration; tiers 2-4 are product-fixed.
+  if (ageDays <= tier1Cap) return { tier: 1, ageDays };
+  if (ageDays <= 30) return { tier: 2, ageDays };
+  if (ageDays <= 60) return { tier: 3, ageDays };
+  if (ageDays <= 90) return { tier: 4, ageDays };
+  return null;
+}
+
+/**
+ * Build the human-readable `_compliance_warnings` string for a ref
+ * cited under tier 2-4. Tier 1 returns null (no warning needed).
+ */
+export function tierWarning(ref: LegalRef, t: FreshnessTier): string | null {
+  if (t.tier === 1) return null;
+  const name = ref.law_name || 'statute';
+  if (t.tier === 2) {
+    return `Statute '${name}' last verified ${t.ageDays} days ago — within acceptable bounds but flagged for review`;
+  }
+  if (t.tier === 3) {
+    return `Statute '${name}' last verified ${t.ageDays} days ago — stronger review recommended before relying on quantitative figures`;
+  }
+  // tier 4
+  return `Statute '${name}' last verified ${t.ageDays} days ago — CRITICAL: verify before sending`;
+}
+
+/**
+ * Same as `findFreshSubstitute` but walks the tier cascade. Returns the
+ * freshest tier-N substitute found (where N is the lowest tier with a
+ * usable ref). The `tier` field tells the caller which warning to emit;
+ * tier 1 means a "normal" substitute (no warning), tiers 2-4 require a
+ * warning.
+ *
+ * Used by both pre-flight (substitute a stale ref the engine wanted to
+ * cite) and category-chain fallback (borrow from a neighbour category).
+ */
+export async function findTieredSubstitute(
+  supabase: SupabaseClient,
+  category: string,
+  excludeIds: string[],
+): Promise<{ ref: LegalRef; tier: FreshnessTier } | null> {
+  if (!category) return null;
+  let query = supabase
+    .from('legal_references')
+    .select('id, category, subcategory, law_name, section, summary, source_url, verification_status, last_verified, verified_url')
+    .eq('category', category)
+    .in('verification_status', ['current', 'updated', 'verified'])
+    .order('last_verified', { ascending: false })
+    .limit(50);
+  if (excludeIds.length > 0) {
+    query = query.not('id', 'in', `(${excludeIds.map((id) => `"${id}"`).join(',')})`);
+  }
+  const { data } = await query;
+  if (!data || data.length === 0) return null;
+  const now = new Date();
+  let best: { ref: LegalRef; tier: FreshnessTier } | null = null;
+  for (const row of data as LegalRef[]) {
+    const t = freshnessTier(row, now);
+    if (!t) continue;
+    if (!best || t.tier < best.tier.tier || (t.tier === best.tier.tier && t.ageDays < best.tier.ageDays)) {
+      best = { ref: row, tier: t };
+      if (t.tier === 1) break; // can't beat tier 1
+    }
+  }
+  return best;
+}
+
+/**
+ * Walk the category fallback chain. Returns the first chain entry that
+ * yields a tier 1-4 substitute. Caller is expected to emit a
+ * `_compliance_warnings` line referencing the original category and
+ * the fallback that was used.
+ */
+export async function findChainSubstitute(
+  supabase: SupabaseClient,
+  originalCategory: string,
+  excludeIds: string[],
+): Promise<{ ref: LegalRef; tier: FreshnessTier; fallbackCategory: string } | null> {
+  const chain = CATEGORY_FALLBACK_CHAINS[originalCategory] ?? ['general'];
+  for (const fallback of chain) {
+    const found = await findTieredSubstitute(supabase, fallback, excludeIds);
+    if (found) {
+      return { ref: found.ref, tier: found.tier, fallbackCategory: fallback };
+    }
   }
   return null;
 }

--- a/src/lib/legal-refs-guardrail.ts
+++ b/src/lib/legal-refs-guardrail.ts
@@ -358,13 +358,20 @@ export function freshnessTier(ref: LegalRef, now: Date = new Date()): FreshnessT
   const ageMs = now.getTime() - verifiedAt;
   if (ageMs < 0) return { tier: 1, ageDays: 0 };
   const ageDays = Math.floor(ageMs / (24 * 60 * 60 * 1000));
-  const tier1Cap = tier1MaxDays();
-  // Tier 1 follows operator configuration; tiers 2-4 are product-fixed.
+  // 90-day ceiling is a non-negotiable contract — anything older is
+  // unusable regardless of how the operator configured tier 1. Apply
+  // it FIRST so a misconfigured `LEGAL_REF_MAX_AGE_DAYS=180` (or
+  // similar) can't accidentally promote 91-day-old refs to tier 1.
+  if (ageDays > 90) return null;
+  // Tier 1 follows operator configuration but is also clamped to the
+  // tier-2 boundary (30d) so a configuration above 30 doesn't swallow
+  // tier-2 warnings either — operators can only TIGHTEN tier 1, not
+  // widen it past the next tier. Default 14 stays well within bounds.
+  const tier1Cap = Math.min(tier1MaxDays(), 30);
   if (ageDays <= tier1Cap) return { tier: 1, ageDays };
   if (ageDays <= 30) return { tier: 2, ageDays };
   if (ageDays <= 60) return { tier: 3, ageDays };
-  if (ageDays <= 90) return { tier: 4, ageDays };
-  return null;
+  return { tier: 4, ageDays };
 }
 
 /**


### PR DESCRIPTION
## Summary

Three additive safety nets stacked on top of the existing freshness
guardrail so the B2B `/v1/disputes` endpoint essentially never returns
HTTP 503 with `STALE_CITATION` in normal operation.

### 1. Tiered freshness cascade (`src/lib/legal-refs-guardrail.ts`)

Replaced the binary 14-day window with four tiers (14/30/60/90 days):

- **Tier 1 (≤14d)** — cite silently, no warning.
- **Tier 2 (15-30d)** — cite + `_compliance_warnings`: *"within acceptable bounds but flagged for review"*.
- **Tier 3 (31-60d)** — cite + stronger warning.
- **Tier 4 (61-90d)** — cite + critical warning.
- **>90d / ineligible status** — unusable; fall through to substitute / chain.

New helpers: `freshnessTier()`, `tierWarning()`, `findTieredSubstitute()`.

### 2. Category fallback chain

`CATEGORY_FALLBACK_CHAINS` maps each category to legally-adjacent
neighbours. Energy → utilities → general; broadband → telecoms →
general; finance → banking → general; insurance → finance → general;
rail → travel → general; etc. The `general` bucket holds pan-sector
statutes (CRA 2015, CCA 1974) that legitimately apply across verticals.

New helper: `findChainSubstitute()`. Engine emits a warning naming the
original and fallback category whenever the chain fires.

### 3. 503 alarm (`src/app/api/v1/disputes/route.ts`)

When `STALE_CITATION` does 503 (vanishingly rare after the above):

- Fire-and-forget Telegram message via `TELEGRAM_BOT_TOKEN` / `TELEGRAM_FOUNDER_CHAT_ID` (same env vars the B2B Stripe path already uses).
- Fire-and-forget email to `hello@paybacker.co.uk` via Resend.
- Idempotent per `(category, UTC date)` using `compliance_alerts_sent.alert_key` (`b2b-503:{category}:{date}`) so a burst doesn't spam.
- Body includes unsalvageable ref_ids, truncated scenario (≤400 chars), timestamp, API key prefix, request ID.

## Worked example

Energy dispute, every energy-category ref happens to be ≥21 days stale:

1. Pre-flight checks freshness — all energy refs come back stale.
2. Synchronous Perplexity refresh attempted; let's say Perplexity is slow → hit the 5s timeout, no fresh result.
3. **Same-category tiered substitute** walks tier 1 → 4 in `category=energy`. Suppose nothing in energy is fresh enough at any tier.
4. **Chain fallback** walks `['utilities', 'general']`. `utilities` has nothing → tries `general`, finds CRA 2015 verified 9 days ago (tier 1).
5. Engine cites CRA 2015 grounded in the energy scenario. `_compliance_warnings` carries `"No fresh ref for 'energy' — substituted with 'general' (Consumer Rights Act 2015)"`.
6. Response returns 200 with the same shape as a normal call. **No 503.**

503 only fires now if (refresh ❌) AND (tier 1-4 same-category ❌) AND (chain across all fallbacks ❌) — at which point the founder gets a Telegram alert and email within seconds.

## Why each addition reduces 503 probability

- **Tiered freshness** turns a hard cliff at day 14 into a graceful slope to day 90 — most "stale" refs are 15-30 days, well within tier 2.
- **Chain fallback** ensures every category can borrow from `general` (CRA 2015 / CCA 1974), and these pan-sector statutes are by far the most-frequently re-verified.
- **503 alarm** doesn't reduce 503 probability per se but caps founder response time when the rare residual case fires.

## B2C guarantee preserved

The B2C path in `src/app/api/complaints/generate/route.ts` was upgraded
to use the same tier + chain helpers. It **never blocks the user**:
even tier 4 / chain refs are used; only an exhausted chain leads to the
existing strip-and-footer fallback. Tier 2-4 + chain warnings are
appended to the letter footer so the user has the same caveat the B2B
consumer surfaces in `_compliance_warnings`.

## Test plan

- [ ] Unit-test `freshnessTier` boundaries (14/30/60/90 days, ineligible status, missing last_verified).
- [ ] Unit-test `findChainSubstitute` walks the chain in order and stops at the first hit.
- [ ] Smoke-test `/v1/disputes` with `LEGAL_REF_MAX_AGE_DAYS=1` against staging Supabase to force tier 2 path; confirm 200 with `_compliance_warnings`.
- [ ] Force a 503 in staging by aging out an isolated category; confirm one Telegram + one email lands and a duplicate request the same day produces neither.
- [ ] Verify B2C `/api/complaints/generate` still produces a letter when all relevant refs are 60 days old.

🤖 Generated with [Claude Code](https://claude.com/claude-code)