### PR TITLE
feat(compliance): UK legal-authority allowlist for citation sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,18 @@ for both B2C complaints and B2B disputes.
 If you're tempted to add a "trust the AI, just write through" path
 because it would be more elegant, don't. Compliance correctness wins.
 
+## Source authority is non-negotiable
+
+A citation is only as valid as its source. Even a correctly-stated
+statute is unusable if it links to a trade-association site or a
+news article. The UK_LEGAL_AUTHORITY_DOMAINS allowlist in
+src/lib/legal-refs-authority.ts is the canonical list of sources
+the engine will accept. The verifier and discovery cron both gate
+on this list; non-authority sources are dropped, not queued.
+
+If a real citation needs a source we haven't allowlisted, ADD the
+domain to the list — don't bypass the gate.
+
 ---
 
 ## CRITICAL ARCHITECTURE RULES — NEVER VIOLATE THESE

--- a/src/app/api/admin/legal-refs/audit-authority/route.ts
+++ b/src/app/api/admin/legal-refs/audit-authority/route.ts
@@ -1,0 +1,197 @@
+/**
+ * POST /api/admin/legal-refs/audit-authority
+ *
+ * Founder-gated retroactive sweep. Reads every row in legal_references,
+ * runs checkUkLegalAuthority on its source_url, and:
+ *   - returns counts by category (authority / secondary / rejected /
+ *     unrecognised)
+ *   - inserts one legal_ref_corrections row per rejected/unrecognised
+ *     ref with proposer='authority-audit' so the existing review queue
+ *     handles them. proposed_source_url is NULL — the founder must
+ *     research the correct primary source.
+ *
+ * Citation fields on legal_references are NOT mutated. This is purely
+ * a triage step that surfaces bad sources via the existing pending
+ * corrections queue.
+ *
+ * GET on the same path returns the counts WITHOUT inserting anything,
+ * so the founder can preview the sweep before running it.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+function getAdminEmails(): string[] {
+  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim(),
+  );
+}
+
+interface RefRow {
+  id: string;
+  law_name: string;
+  source_url: string;
+  verification_status: string | null;
+}
+
+async function authorise(): Promise<{ ok: boolean; userEmail?: string }> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const allow = getAdminEmails();
+    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
+      return { ok: false };
+    }
+    return { ok: true, userEmail: user.email };
+  } catch {
+    return { ok: false };
+  }
+}
+
+async function classify() {
+  const admin = getAdmin();
+  const { data: refs, error } = await admin
+    .from('legal_references')
+    .select('id, law_name, source_url, verification_status');
+  if (error || !refs) {
+    return { error: error?.message || 'failed to read legal_references' };
+  }
+
+  const buckets = {
+    authority: [] as RefRow[],
+    secondary: [] as RefRow[],
+    rejected: [] as RefRow[],
+    unrecognised: [] as RefRow[],
+  };
+
+  for (const r of refs as RefRow[]) {
+    if (!r.source_url) {
+      buckets.unrecognised.push(r);
+      continue;
+    }
+    const check = checkUkLegalAuthority(r.source_url);
+    buckets[check.reason].push(r);
+  }
+
+  return {
+    counts: {
+      authority: buckets.authority.length,
+      secondary: buckets.secondary.length,
+      rejected: buckets.rejected.length,
+      unrecognised: buckets.unrecognised.length,
+      total: refs.length,
+    },
+    buckets,
+  };
+}
+
+export async function GET() {
+  const auth = await authorise();
+  if (!auth.ok) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const result = await classify();
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+  return NextResponse.json({
+    ok: true,
+    counts: result.counts,
+    sample_rejected: result.buckets.rejected.slice(0, 10).map((r) => ({
+      id: r.id,
+      law_name: r.law_name,
+      source_url: r.source_url,
+    })),
+    sample_unrecognised: result.buckets.unrecognised.slice(0, 10).map((r) => ({
+      id: r.id,
+      law_name: r.law_name,
+      source_url: r.source_url,
+    })),
+  });
+}
+
+export async function POST() {
+  const auth = await authorise();
+  if (!auth.ok) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const result = await classify();
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+
+  const admin = getAdmin();
+  const flagged = [...result.buckets.rejected, ...result.buckets.unrecognised];
+
+  let inserted = 0;
+  let skippedExisting = 0;
+  const errors: string[] = [];
+
+  for (const r of flagged) {
+    // Avoid double-queueing: skip if there's already a pending
+    // authority-audit correction for this ref.
+    const { data: existing } = await admin
+      .from('legal_ref_corrections')
+      .select('id')
+      .eq('ref_id', r.id)
+      .eq('proposer', 'authority-audit')
+      .eq('status', 'pending')
+      .limit(1);
+    if (existing && existing.length > 0) {
+      skippedExisting++;
+      continue;
+    }
+
+    const hostnameCheck = r.source_url ? checkUkLegalAuthority(r.source_url) : null;
+    const hostname = hostnameCheck?.hostname ?? 'unknown';
+    const note =
+      `Source domain ${hostname} is not on the UK legal authority allowlist. ` +
+      `Replace with primary source before relying on this citation.`;
+
+    const { error: insErr } = await admin.from('legal_ref_corrections').insert({
+      ref_id: r.id,
+      proposer: 'authority-audit',
+      before_law_name: r.law_name,
+      before_source_url: r.source_url,
+      before_status: r.verification_status,
+      proposed_law_name: r.law_name,
+      proposed_source_url: null,
+      proposed_status: null,
+      reasoning: note,
+      raw_response: { authority_check: hostnameCheck } as object,
+      confidence: 'high',
+      cost_gbp: 0,
+      status: 'pending',
+    });
+    if (insErr) {
+      errors.push(`${r.id}: ${insErr.message}`);
+    } else {
+      inserted++;
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    counts: result.counts,
+    flagged: flagged.length,
+    inserted,
+    skipped_existing: skippedExisting,
+    errors,
+  });
+}

--- a/src/app/api/admin/legal-refs/verify-all/route.ts
+++ b/src/app/api/admin/legal-refs/verify-all/route.ts
@@ -17,6 +17,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createAdminClient } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/server';
 import { logPerplexityCall } from '@/lib/cost-ledger';
+import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 800;
@@ -86,7 +87,22 @@ async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> 
       body: JSON.stringify({
         model: PERPLEXITY_MODEL,
         messages: [
-          { role: 'system', content: 'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.' },
+          { role: 'system', content: [
+              'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.',
+              '',
+              'CITATION SOURCE RULE (mandatory): Only return URLs from primary UK legal',
+              'authorities. Acceptable sources: legislation.gov.uk, gov.uk and its',
+              'subdomains (.fca.org.uk, .ofcom.org.uk, .ofgem.gov.uk, etc.),',
+              'financial-ombudsman.org.uk, parliament.uk, bailii.org, judiciary.uk,',
+              'supremecourt.uk, ico.org.uk, cma.gov.uk, caa.co.uk, orr.gov.uk, nhs.uk.',
+              '',
+              'NEVER cite trade associations (UK Finance, ABI, BSA), commentary sites,',
+              'news sites, law-firm blogs, Wikipedia, MoneySavingExpert, Which?, or',
+              'consumer-rights aggregators. They are commentary, not authority.',
+              '',
+              'If the only available source is a trade association or commentary site,',
+              'return null for current_url rather than fabricating a primary citation.',
+            ].join('\n') },
           { role: 'user', content: prompt },
         ],
         max_tokens: 500,
@@ -182,17 +198,36 @@ export async function POST(_request: NextRequest) {
         last_verified: new Date().toISOString(),
         verification_notes: notes || null,
       };
-      if (verdict.current_url) update.verified_url = verdict.current_url;
+      // Only treat current_url as a verified URL if it's from an
+      // accepted UK legal authority. Same gate is applied to any URL
+      // we would write into source_url below.
+      const currentUrlAuthority = verdict.current_url
+        ? checkUkLegalAuthority(verdict.current_url)
+        : null;
+      if (verdict.current_url && currentUrlAuthority?.reason === 'authority') {
+        update.verified_url = verdict.current_url;
+      }
 
       let autoCorrected = false;
       if (verdict.confidence === 'high' && verdict.superseded_by) {
         const parsed = parseSuperseded(verdict.superseded_by);
+        const supersededUrlAuthority = parsed.url
+          ? checkUkLegalAuthority(parsed.url)
+          : null;
         update.law_name = parsed.law_name;
-        if (parsed.url) update.source_url = parsed.url;
-        else if (verdict.current_url) update.source_url = verdict.current_url;
+        if (parsed.url && supersededUrlAuthority?.reason === 'authority') {
+          update.source_url = parsed.url;
+        } else if (verdict.current_url && currentUrlAuthority?.reason === 'authority') {
+          update.source_url = verdict.current_url;
+        }
         status = 'superseded';
         autoCorrected = true;
-      } else if (verdict.confidence === 'high' && verdict.valid === false && verdict.current_url) {
+      } else if (
+        verdict.confidence === 'high' &&
+        verdict.valid === false &&
+        verdict.current_url &&
+        currentUrlAuthority?.reason === 'authority'
+      ) {
         update.source_url = verdict.current_url;
         status = 'updated';
         autoCorrected = true;

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -16,6 +16,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createAdminClient } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/server';
 import { logPerplexityCall } from '@/lib/cost-ledger';
+import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -101,7 +102,22 @@ async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> 
           {
             role: 'system',
             content:
-              'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.',
+              [
+                'You are a UK legal-citation verification assistant. Return STRICT JSON only — no markdown, no commentary. If unsure, set confidence to "low" and explain in notes.',
+                '',
+                'CITATION SOURCE RULE (mandatory): Only return URLs from primary UK legal',
+                'authorities. Acceptable sources: legislation.gov.uk, gov.uk and its',
+                'subdomains (.fca.org.uk, .ofcom.org.uk, .ofgem.gov.uk, etc.),',
+                'financial-ombudsman.org.uk, parliament.uk, bailii.org, judiciary.uk,',
+                'supremecourt.uk, ico.org.uk, cma.gov.uk, caa.co.uk, orr.gov.uk, nhs.uk.',
+                '',
+                'NEVER cite trade associations (UK Finance, ABI, BSA), commentary sites,',
+                'news sites, law-firm blogs, Wikipedia, MoneySavingExpert, Which?, or',
+                'consumer-rights aggregators. They are commentary, not authority.',
+                '',
+                'If the only available source is a trade association or commentary site,',
+                'return null for current_url rather than fabricating a primary citation.',
+              ].join('\n'),
           },
           { role: 'user', content: prompt },
         ],
@@ -198,7 +214,10 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
     verification_notes: notes || null,
   };
   if (verdict.current_url) {
-    update.verified_url = verdict.current_url;
+    const authority = checkUkLegalAuthority(verdict.current_url);
+    if (authority.reason === 'authority') {
+      update.verified_url = verdict.current_url;
+    }
   }
 
 

--- a/src/app/api/cron/discover-legal-refs/route.ts
+++ b/src/app/api/cron/discover-legal-refs/route.ts
@@ -34,6 +34,22 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
 import { logPerplexityCall } from '@/lib/cost-ledger';
+import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
+
+const CITATION_SOURCE_RULE = [
+  'CITATION SOURCE RULE (mandatory): Only return URLs from primary UK legal',
+  'authorities. Acceptable sources: legislation.gov.uk, gov.uk and its',
+  'subdomains (.fca.org.uk, .ofcom.org.uk, .ofgem.gov.uk, etc.),',
+  'financial-ombudsman.org.uk, parliament.uk, bailii.org, judiciary.uk,',
+  'supremecourt.uk, ico.org.uk, cma.gov.uk, caa.co.uk, orr.gov.uk, nhs.uk.',
+  '',
+  'NEVER cite trade associations (UK Finance, ABI, BSA), commentary sites,',
+  'news sites, law-firm blogs, Wikipedia, MoneySavingExpert, Which?, or',
+  'consumer-rights aggregators. They are commentary, not authority.',
+  '',
+  'If the only available source is a trade association or commentary site,',
+  'return null for source_url rather than fabricating a primary citation.',
+].join('\n');
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -83,7 +99,10 @@ async function callPerplexity(prompt: string): Promise<{ items: PerplexityCandid
     headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({
       model: 'sonar-pro',
-      messages: [{ role: 'user', content: prompt }],
+      messages: [
+        { role: 'system', content: CITATION_SOURCE_RULE },
+        { role: 'user', content: prompt },
+      ],
       return_citations: true,
     }),
   });
@@ -277,6 +296,8 @@ export async function GET(request: NextRequest) {
   const items = perplexityResult.items.slice(0, MAX_CALLS_PER_RUN); // safety bound
   let added = 0;
   let skipped = 0;
+  let rejectedNonAuthority = 0;
+  let secondaryFlagged = 0;
   const admin = getAdmin();
 
   // Insert run row first so candidates can reference it.
@@ -300,14 +321,36 @@ export async function GET(request: NextRequest) {
       skipped++;
       continue;
     }
+
+    // Authority allowlist gate. Drop rejected/unrecognised entirely.
+    // Secondary sources are queued but force-low-confidence with a
+    // notes warning so the founder must verify before approving.
+    let confidence = item.confidence?.toString().slice(0, 20) || null;
+    let summaryWithWarning = item.summary?.toString().slice(0, 4000) || null;
+    if (item.source_url) {
+      const authority = checkUkLegalAuthority(item.source_url);
+      if (!authority.ok) {
+        rejectedNonAuthority++;
+        skipped++;
+        continue;
+      }
+      if (authority.reason === 'secondary') {
+        secondaryFlagged++;
+        confidence = 'low';
+        const warning =
+          `[secondary source: ${authority.matched_domain}] verify against primary source before approving. `;
+        summaryWithWarning = (warning + (summaryWithWarning ?? '')).slice(0, 4000);
+      }
+    }
+
     const { error } = await admin.from('legal_ref_candidates').insert({
       title: item.title.slice(0, 500),
       source_url: item.source_url?.toString().slice(0, 1000) || null,
       source_type: item.source_type?.toString().slice(0, 80) || null,
-      summary: item.summary?.toString().slice(0, 4000) || null,
+      summary: summaryWithWarning,
       category: (item.category || targetCategory || null)?.toString().slice(0, 80) || null,
       jurisdiction: item.jurisdiction || 'UK',
-      confidence: item.confidence?.toString().slice(0, 20) || null,
+      confidence,
       status: 'pending',
       discovery_run_id: runId,
     });
@@ -320,10 +363,23 @@ export async function GET(request: NextRequest) {
   }
 
   // Update run row with final tallies (best-effort).
+  const authorityNotes =
+    rejectedNonAuthority > 0 || secondaryFlagged > 0
+      ? `authority_filter: {rejected_non_authority: ${rejectedNonAuthority}, secondary: ${secondaryFlagged}}`
+      : null;
   if (runId !== null) {
+    const update: Record<string, unknown> = {
+      candidates_added: added,
+      candidates_skipped_duplicate: skipped,
+    };
+    if (authorityNotes) {
+      // Append to existing notes rather than overwriting the category tag.
+      const existingNote = targetCategory ? `category: ${targetCategory}` : null;
+      update.notes = [existingNote, authorityNotes].filter(Boolean).join(' | ');
+    }
     await admin
       .from('legal_ref_discovery_runs')
-      .update({ candidates_added: added, candidates_skipped_duplicate: skipped })
+      .update(update)
       .eq('id', runId);
   }
 
@@ -334,6 +390,8 @@ export async function GET(request: NextRequest) {
     candidates_found: items.length,
     candidates_added: added,
     candidates_skipped_duplicate: skipped,
+    rejected_non_authority: rejectedNonAuthority,
+    secondary: secondaryFlagged,
     cost_gbp: Number(costGbp.toFixed(6)),
   });
 }

--- a/src/app/api/cron/legal-refs-daily-reverify/route.ts
+++ b/src/app/api/cron/legal-refs-daily-reverify/route.ts
@@ -82,7 +82,17 @@ async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> 
       body: JSON.stringify({
         model: PERPLEXITY_MODEL,
         messages: [
-          { role: 'system', content: 'You are a UK legal-citation verification assistant. Return STRICT JSON only.' },
+          { role: 'system', content: [
+              'You are a UK legal-citation verification assistant. Return STRICT JSON only.',
+              '',
+              'CITATION SOURCE RULE (mandatory): Only return URLs from primary UK legal',
+              'authorities — legislation.gov.uk, gov.uk subdomains, fca.org.uk, ofcom.org.uk,',
+              'ofgem.gov.uk, financial-ombudsman.org.uk, parliament.uk, bailii.org,',
+              'judiciary.uk, supremecourt.uk, ico.org.uk, cma.gov.uk, caa.co.uk, orr.gov.uk, nhs.uk.',
+              'NEVER cite trade associations (UK Finance, ABI, BSA), commentary sites, news,',
+              'law-firm blogs, Wikipedia, MoneySavingExpert, Which?, or aggregators. If the',
+              'only available source is a non-authority site, return null rather than fabricating.',
+            ].join('\n') },
           { role: 'user', content: prompt },
         ],
         max_tokens: 500,

--- a/src/app/api/cron/reverify-all-legal-refs/route.ts
+++ b/src/app/api/cron/reverify-all-legal-refs/route.ts
@@ -17,6 +17,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
 import { logPerplexityCall } from '@/lib/cost-ledger';
+import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
 
 export const runtime = 'nodejs';
 export const maxDuration = 300;
@@ -89,7 +90,22 @@ Rules:
           {
             role: 'system',
             content:
-              'You are a UK consumer-law research assistant. Return STRICT JSON only — no markdown.',
+              [
+                'You are a UK consumer-law research assistant. Return STRICT JSON only — no markdown.',
+                '',
+                'CITATION SOURCE RULE (mandatory): Only return URLs from primary UK legal',
+                'authorities. Acceptable sources: legislation.gov.uk, gov.uk and its',
+                'subdomains (.fca.org.uk, .ofcom.org.uk, .ofgem.gov.uk, etc.),',
+                'financial-ombudsman.org.uk, parliament.uk, bailii.org, judiciary.uk,',
+                'supremecourt.uk, ico.org.uk, cma.gov.uk, caa.co.uk, orr.gov.uk, nhs.uk.',
+                '',
+                'NEVER cite trade associations (UK Finance, ABI, BSA), commentary sites,',
+                'news sites, law-firm blogs, Wikipedia, MoneySavingExpert, Which?, or',
+                'consumer-rights aggregators. They are commentary, not authority.',
+                '',
+                'If the only available source is a trade association or commentary site,',
+                'return null for proposed_source_url rather than fabricating a primary citation.',
+              ].join('\n'),
           },
           { role: 'user', content: prompt },
         ],
@@ -196,12 +212,52 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
+      // Authority allowlist gate — never queue a correction whose
+      // proposed source is a trade association, commentary site, or
+      // unrecognised domain. Only run the check when a URL is actually
+      // proposed (a name-only correction is fine).
+      let extraNotes: string | null = null;
+      let forcedConfidence: 'high' | 'medium' | 'low' = verdict.confidence;
+      if (verdict.proposed_source_url) {
+        const authority = checkUkLegalAuthority(verdict.proposed_source_url);
+        if (!authority.ok) {
+          const reasonNote =
+            authority.reason === 'rejected'
+              ? `rejected: non-authority source (${authority.hostname ?? 'unknown'})`
+              : `unrecognised source (${authority.hostname ?? 'unknown'}) — consider adding to allowlist`;
+          // Audit-log the drop so the founder can see what was filtered.
+          void supabase.from('legal_ref_verifications').insert({
+            ref_id: ref.id,
+            verifier: 'perplexity-sonar-pro',
+            triggered_by: 'reverify-cron',
+            before_status: ref.verification_status,
+            after_status: ref.verification_status,
+            before_url: ref.source_url,
+            after_url: null,
+            changes: { dropped_by_authority_allowlist: true, proposed_url: verdict.proposed_source_url },
+            cost_gbp: COST_PER_CALL_GBP,
+            perplexity_response: raw as object,
+            notes: reasonNote,
+          });
+          continue;
+        }
+        if (authority.reason === 'secondary') {
+          forcedConfidence = 'low';
+          extraNotes =
+            `Source is secondary (${authority.matched_domain}) — verify against primary source before approving.`;
+        }
+      }
+
       // Mark prior pending corrections for the same ref as superseded.
       await supabase
         .from('legal_ref_corrections')
         .update({ status: 'superseded_by_newer', reviewed_at: nowIso, reviewed_by: 'reverify-cron' })
         .eq('ref_id', ref.id)
         .eq('status', 'pending');
+
+      const finalReasoning = extraNotes
+        ? `${extraNotes} ${verdict.reasoning}`.trim()
+        : verdict.reasoning;
 
       const { error: insErr } = await supabase.from('legal_ref_corrections').insert({
         ref_id: ref.id,
@@ -213,9 +269,9 @@ export async function GET(request: NextRequest) {
         proposed_source_url: verdict.proposed_source_url ?? null,
         proposed_status: verdict.status === 'unknown' ? null : verdict.status,
         superseded_by: verdict.superseded_by ?? null,
-        reasoning: verdict.reasoning,
+        reasoning: finalReasoning,
         raw_response: raw as object,
-        confidence: verdict.confidence,
+        confidence: forcedConfidence,
         cost_gbp: COST_PER_CALL_GBP,
         status: 'pending',
       });

--- a/src/lib/legal-refs-authority.test.ts
+++ b/src/lib/legal-refs-authority.test.ts
@@ -1,0 +1,173 @@
+// src/lib/legal-refs-authority.test.ts
+//
+// Tests for the UK legal-authority allowlist used by the compliance
+// pipeline.
+//
+// Run with:
+//   node --experimental-strip-types --test src/lib/legal-refs-authority.test.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkUkLegalAuthority } from './legal-refs-authority.ts';
+
+describe('checkUkLegalAuthority — primary authority', () => {
+  it('legislation.gov.uk path → authority', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.legislation.gov.uk/ukpga/1974/39/contents',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authority');
+    assert.equal(r.matched_domain, 'legislation.gov.uk');
+  });
+
+  it('plain legislation.gov.uk root → authority', () => {
+    const r = checkUkLegalAuthority(
+      'https://legislation.gov.uk/ukpga/1974/39',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authority');
+  });
+
+  it('www.fca.org.uk → authority', () => {
+    const r = checkUkLegalAuthority('https://www.fca.org.uk/firms/handbook');
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authority');
+  });
+
+  it('handbook.fca.org.uk → authority', () => {
+    const r = checkUkLegalAuthority(
+      'https://handbook.fca.org.uk/handbook/CONC/5/3.html',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authority');
+  });
+
+  it('financial-ombudsman.org.uk → authority', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.financial-ombudsman.org.uk/consumers/complaints-can-help',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authority');
+  });
+
+  it('hmrc.gov.uk via gov.uk parent → authority', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.hmrc.gov.uk/some-page',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authority');
+  });
+
+  it('bailii.org case → authority', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.bailii.org/uk/cases/UKSC/2023/1.html',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'authority');
+  });
+});
+
+describe('checkUkLegalAuthority — rejected', () => {
+  it('ukfinance.org.uk → rejected (trade body)', () => {
+    const r = checkUkLegalAuthority('https://www.ukfinance.org.uk/something');
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'rejected');
+  });
+
+  it('en.wikipedia.org → rejected', () => {
+    const r = checkUkLegalAuthority(
+      'https://en.wikipedia.org/wiki/Section_75',
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'rejected');
+  });
+
+  it('moneysavingexpert.com → rejected', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.moneysavingexpert.com/reclaim/',
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'rejected');
+  });
+
+  it('which.co.uk → rejected', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.which.co.uk/consumer-rights/article/x',
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'rejected');
+  });
+
+  it('abi.org.uk → rejected (insurer trade body)', () => {
+    const r = checkUkLegalAuthority('https://www.abi.org.uk/');
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'rejected');
+  });
+});
+
+describe('checkUkLegalAuthority — secondary', () => {
+  it('citizensadvice.org.uk → secondary', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.citizensadvice.org.uk/consumer/',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'secondary');
+  });
+
+  it('moneyhelper.org.uk → secondary', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.moneyhelper.org.uk/en/everyday-money',
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'secondary');
+  });
+});
+
+describe('checkUkLegalAuthority — unrecognised', () => {
+  it('random blog → unrecognised', () => {
+    const r = checkUkLegalAuthority('https://random-blog.com/uk-law');
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'unrecognised');
+  });
+
+  it('empty / garbage → unrecognised', () => {
+    assert.equal(checkUkLegalAuthority('').reason, 'unrecognised');
+    assert.equal(checkUkLegalAuthority('not a url').reason, 'unrecognised');
+  });
+});
+
+describe('checkUkLegalAuthority — domain-spoofing safety', () => {
+  it('badactor-legislation.gov.uk.fake.com → NOT authority', () => {
+    const r = checkUkLegalAuthority(
+      'https://badactor-legislation.gov.uk.fake.com/spoof',
+    );
+    assert.notEqual(r.reason, 'authority');
+  });
+
+  it('legislation.gov.uk.evil.com → NOT authority', () => {
+    const r = checkUkLegalAuthority('https://legislation.gov.uk.evil.com/x');
+    assert.notEqual(r.reason, 'authority');
+  });
+
+  it('notgov.uk → NOT authority (no label boundary)', () => {
+    const r = checkUkLegalAuthority('https://notgov.uk/page');
+    assert.notEqual(r.reason, 'authority');
+  });
+
+  it('xukfinance.org.uk → NOT rejected as ukfinance (label-bounded regex)', () => {
+    // The \b in the rejection pattern means xukfinance.org.uk does not
+    // match the ukfinance.org.uk literal. It will be unrecognised.
+    const r = checkUkLegalAuthority('https://xukfinance.org.uk/');
+    assert.equal(r.reason, 'unrecognised');
+  });
+});
+
+describe('checkUkLegalAuthority — gov.uk/blog', () => {
+  it('gov.uk/blog path → rejected (commentary, not authority)', () => {
+    const r = checkUkLegalAuthority(
+      'https://www.gov.uk/blog/2024/01/some-post',
+    );
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, 'rejected');
+  });
+});

--- a/src/lib/legal-refs-authority.ts
+++ b/src/lib/legal-refs-authority.ts
@@ -1,0 +1,170 @@
+/**
+ * UK legal-citation source authority allowlist.
+ *
+ * The compliance pipeline (Perplexity-driven discovery + verifier) will
+ * only accept proposed citation URLs that come from this allowlist OR
+ * from the small SECONDARY_SOURCE_DOMAINS list (which queues with a
+ * forced low-confidence warning, never auto-applies).
+ *
+ * Rule: a citation URL must be on this allowlist OR be an explicit
+ * subdomain of one. Trade associations, law-firm blogs, news sites,
+ * consumer-rights aggregators, and Wikipedia are NOT acceptable —
+ * they are commentary, not authority.
+ *
+ * Categories:
+ *  - Primary legislation: legislation.gov.uk
+ *  - Government guidance: gov.uk subdomains
+ *  - Statutory regulators: fca.org.uk, ofcom.org.uk, ofgem.gov.uk,
+ *    cma.gov.uk, ico.org.uk, caa.co.uk, orr.gov.uk
+ *  - Statutory ombudsmen: financial-ombudsman.org.uk, lgo.org.uk,
+ *    spso.org.uk, ombudsman-services.org, ombudsman.wales
+ *  - Court decisions: bailii.org, judiciary.uk, supremecourt.uk
+ *  - Parliament: parliament.uk
+ *  - HMRC/DVLA/NHS: covered by gov.uk subdomain match + nhs.uk
+ *  - Legacy retained EU law: legislation.gov.uk only (not europa.eu)
+ */
+export const UK_LEGAL_AUTHORITY_DOMAINS: ReadonlyArray<string> = [
+  'legislation.gov.uk',
+  'gov.uk', // includes hmrc.gov.uk, dvla.gov.uk, ofgem.gov.uk, ico.org.uk via subdomain
+  'parliament.uk',
+  'fca.org.uk',
+  'handbook.fca.org.uk',
+  'ofcom.org.uk',
+  'ofgem.gov.uk',
+  'caa.co.uk',
+  'orr.gov.uk',
+  'cma.gov.uk',
+  'ico.org.uk',
+  'financial-ombudsman.org.uk',
+  'lgo.org.uk',
+  'spso.org.uk',
+  'ombudsman-services.org',
+  'ombudsman.wales',
+  'judiciary.uk',
+  'supremecourt.uk',
+  'bailii.org',
+  'nhs.uk',
+];
+
+/**
+ * Optional EXPANSION list — sources that are useful for context or
+ * cross-reference but should NEVER be the primary cited source. We
+ * don't auto-reject corrections that cite these (because they may be
+ * the only available source), but they MUST be flagged with a warning
+ * for founder review and the existing canonical citation must NOT be
+ * silently overwritten.
+ */
+export const SECONDARY_SOURCE_DOMAINS: ReadonlyArray<string> = [
+  'citizensadvice.org.uk',
+  'moneyhelper.org.uk',
+];
+
+/**
+ * Hard rejection list — known non-authority sources that should never
+ * appear as a citation, even with a warning. Pure commentary.
+ */
+export const REJECTED_SOURCE_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bukfinance\.org\.uk\b/i,
+  /\bwhich\.co\.uk\b/i,
+  /\bmoneysavingexpert\.com\b/i,
+  /\babi\.org\.uk\b/i,
+  /\bbsa\.org\.uk\b/i,
+  /\bukcards-association\b/i,
+  /\bwikipedia\.org\b/i,
+  /\bgov\.uk\/blog\b/i,
+];
+
+export interface AuthorityCheck {
+  ok: boolean;
+  reason: 'authority' | 'secondary' | 'rejected' | 'unrecognised';
+  matched_domain?: string;
+  hostname?: string;
+}
+
+/**
+ * Parse a hostname out of a URL string. Strips protocol, port, path,
+ * leading "www.", and lowercases. Returns null if unparseable.
+ */
+function parseHostname(url: string): string | null {
+  if (!url || typeof url !== 'string') return null;
+  let s = url.trim();
+  if (!s) return null;
+  // Strip scheme
+  s = s.replace(/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//, '');
+  // Strip user:pass@
+  s = s.replace(/^[^@/]*@/, '');
+  // Take up to first / ? # or end
+  const m = s.match(/^([^/?#]+)/);
+  if (!m) return null;
+  let host = m[1];
+  // Strip port
+  host = host.replace(/:\d+$/, '');
+  host = host.toLowerCase();
+  if (!host) return null;
+  // Strip leading www.
+  if (host.startsWith('www.')) host = host.slice(4);
+  return host || null;
+}
+
+/**
+ * True iff `hostname` equals `domain` or is a subdomain of `domain`.
+ * Uses label-boundary matching so badactor-legislation.gov.uk.fake.com
+ * does NOT match legislation.gov.uk.
+ */
+function hostMatchesDomain(hostname: string, domain: string): boolean {
+  const h = hostname.toLowerCase();
+  const d = domain.toLowerCase();
+  if (h === d) return true;
+  return h.endsWith('.' + d);
+}
+
+/**
+ * Returns whether a URL is from an acceptable UK legal authority,
+ * a secondary source (allow with warning), or rejected outright.
+ *
+ *   ok=true  + reason='authority'   → safe to auto-process
+ *   ok=true  + reason='secondary'   → flag for founder review, never auto-apply
+ *   ok=false + reason='rejected'    → drop the proposal entirely; never queue
+ *   ok=false + reason='unrecognised'→ drop and log; founder may add to allowlist
+ */
+export function checkUkLegalAuthority(url: string): AuthorityCheck {
+  const hostname = parseHostname(url);
+  if (!hostname) {
+    return { ok: false, reason: 'unrecognised' };
+  }
+
+  // 1. Hard rejection patterns are tested against the full URL so path-
+  //    based patterns (e.g. gov.uk/blog) work too.
+  for (const re of REJECTED_SOURCE_PATTERNS) {
+    if (re.test(url)) {
+      return { ok: false, reason: 'rejected', hostname };
+    }
+  }
+
+  // 2. Authority allowlist — exact or parent-domain match.
+  for (const domain of UK_LEGAL_AUTHORITY_DOMAINS) {
+    if (hostMatchesDomain(hostname, domain)) {
+      return {
+        ok: true,
+        reason: 'authority',
+        matched_domain: domain,
+        hostname,
+      };
+    }
+  }
+
+  // 3. Secondary list — ditto.
+  for (const domain of SECONDARY_SOURCE_DOMAINS) {
+    if (hostMatchesDomain(hostname, domain)) {
+      return {
+        ok: true,
+        reason: 'secondary',
+        matched_domain: domain,
+        hostname,
+      };
+    }
+  }
+
+  // 4. Anything else.
+  return { ok: false, reason: 'unrecognised', hostname };
+}


### PR DESCRIPTION
## Why

Founder spotted Perplexity proposing corrections that cite **trade-association** websites — e.g. `ukfinance.org.uk`. UK Finance is the banks' lobby group, not a statutory regulator. Citations sourced from there cannot ground UK legal advice. The discovery + verifier prompts asked Perplexity for "the URL" without constraining the source, so anything plausible could land in the pending review queue.

This PR introduces a hard allowlist of acceptable UK legal-authority domains and gates every Perplexity-driven citation path on it.

## Allowlist rationale

`UK_LEGAL_AUTHORITY_DOMAINS` (in `src/lib/legal-refs-authority.ts`) covers:

- Primary legislation: `legislation.gov.uk`
- Government guidance: `gov.uk` (parent — covers hmrc/dvla via subdomain)
- Statutory regulators: `fca.org.uk`, `handbook.fca.org.uk`, `ofcom.org.uk`, `ofgem.gov.uk`, `cma.gov.uk`, `ico.org.uk`, `caa.co.uk`, `orr.gov.uk`
- Statutory ombudsmen: `financial-ombudsman.org.uk`, `lgo.org.uk`, `spso.org.uk`, `ombudsman-services.org`, `ombudsman.wales`
- Courts/Parliament: `parliament.uk`, `judiciary.uk`, `supremecourt.uk`, `bailii.org`
- Health: `nhs.uk`

`SECONDARY_SOURCE_DOMAINS` (`citizensadvice.org.uk`, `moneyhelper.org.uk`) — allowed but force `confidence='low'` and never auto-applied. They're useful for context, not authority.

`REJECTED_SOURCE_PATTERNS` — explicit blocks for the most common false positives: UK Finance, ABI, BSA, UK Cards Association, Wikipedia, MoneySavingExpert, Which?, plus `gov.uk/blog` (commentary, not authority).

Parent-domain matching is **label-bounded** so `badactor-legislation.gov.uk.fake.com` does NOT match `legislation.gov.uk`.

## What changed

- `src/lib/legal-refs-authority.ts` — new module: `UK_LEGAL_AUTHORITY_DOMAINS`, `SECONDARY_SOURCE_DOMAINS`, `REJECTED_SOURCE_PATTERNS`, `checkUkLegalAuthority(url)`.
- `src/lib/legal-refs-authority.test.ts` — 21 tests, including domain-spoofing safety.
- `src/app/api/cron/reverify-all-legal-refs/route.ts` — gates `legal_ref_corrections` inserts. Rejected/unrecognised proposals are dropped and audit-logged to `legal_ref_verifications`. Secondary sources queue with `confidence='low'` + warning.
- `src/app/api/cron/discover-legal-refs/route.ts` — drops rejected/unrecognised candidates; queues secondary candidates with `confidence='low'` + summary warning. New `{rejected_non_authority, secondary}` counters in the run notes column and JSON response.
- `src/app/api/admin/legal-refs/verify/route.ts` and `…/verify-all/route.ts` — only write `source_url` / `verified_url` updates from URLs that pass the authority gate. Trade-association URLs from Perplexity can no longer overwrite canonical citation fields even on the verify-all auto-correct path.
- `src/app/api/cron/legal-refs-daily-reverify/route.ts` — system prompt updated so Perplexity is told upfront not to fabricate non-authority citations.
- All 5 Perplexity system prompts now include the `CITATION SOURCE RULE` so the model is instructed never to cite trade bodies, commentary, news, blogs, Wikipedia, MSE, Which?, or aggregators — return null instead of fabricating.
- `src/app/api/admin/legal-refs/audit-authority/route.ts` — new founder-gated retroactive sweep. **GET** returns counts + samples without writing. **POST** inserts one `legal_ref_corrections` row per rejected/unrecognised ref with `proposer='authority-audit'`, `proposed_source_url=null`, `confidence='high'` (high confidence the source is wrong, not in the replacement) so the founder can research the correct primary source. Skips refs that already have a pending authority-audit correction.
- `CLAUDE.md` — new "Source authority is non-negotiable" paragraph under the compliance principle.

## Retroactive sweep — run-once instructions

After this PR merges, the founder should run the retroactive sweep once to flag every existing `legal_references` row whose `source_url` is not on the allowlist:

1. `GET /api/admin/legal-refs/audit-authority` — preview counts + samples (no writes).
2. `POST /api/admin/legal-refs/audit-authority` — queues `legal_ref_corrections` rows for every rejected/unrecognised ref.

The existing pending-corrections review UI handles the rest. Citation fields on `legal_references` are NOT mutated by the sweep — only the queue is populated.

## Walkthrough

`ukfinance.org.uk` → REJECTED_SOURCE_PATTERNS hit → `checkUkLegalAuthority` returns `{ok:false, reason:'rejected'}` → discovery cron skips the candidate, verifier cron audit-logs the drop to `legal_ref_verifications`, and **no `legal_ref_corrections` row is created**. ✓

## Test plan

- [x] `node --experimental-strip-types --test src/lib/legal-refs-authority.test.ts` → 21/21 pass
- [x] `tsc --noEmit` clean
- [ ] Founder: GET `/api/admin/legal-refs/audit-authority` and review counts
- [ ] Founder: POST `/api/admin/legal-refs/audit-authority` once — verify pending corrections queue surfaces flagged refs
- [ ] Smoke-run `/api/cron/discover-legal-refs?leg=recent` — verify response now includes `rejected_non_authority` and `secondary` counters

## No migrations

Pure code change. No schema mutations. B2C and B2B both consume `legal_references` and neither is broken — only the propose/queue paths are tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)