### PR TITLE
fix(admin): ensure 'Verify with AI' button is reachable on legal-refs page

### DIFF
--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -51,16 +51,12 @@ function relativeTime(d: string | null): string {
   return years === 1 ? '1 year ago' : `${years} years ago`;
 }
 
-const REVIEW_STATUSES = new Set(['needs_review', 'broken', 'stale', 'error', 'superseded']);
-const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
-
-function isReviewable(r: LegalRef): boolean {
-  if (REVIEW_STATUSES.has(r.verification_status)) return true;
-  if (!r.last_verified) return true;
-  const verifiedAt = new Date(r.last_verified).getTime();
-  if (isNaN(verifiedAt)) return true;
-  return Date.now() - verifiedAt > SIXTY_DAYS_MS;
-}
+// NOTE: the canonical "needs review" predicate is `needsReview` defined below
+// (PR #373). The Review queue uses `needsReview` directly so the stats counter
+// and the queue list always agree — previously a separate `isReviewable`
+// predicate excluded `url_dead` rows, which caused the stats panel to say
+// "28 need review" while the queue rendered empty (and therefore no per-row
+// "Verify with AI" buttons). See fix(admin) on legal-refs page.
 
 const STATUS_CONFIG: Record<string, { label: string; icon: typeof CheckCircle; className: string }> = {
   current: { label: 'Current', icon: CheckCircle, className: 'text-green-400 bg-green-500/10' },
@@ -763,7 +759,7 @@ export default function LegalRefsAdminPage() {
       {/* Review queue — AI-assisted manual verification */}
       {(() => {
         const reviewable = refs
-          .filter(isReviewable)
+          .filter(needsReview)
           .sort((a, b) => {
             // last_verified NULLS FIRST, then created_at DESC
             if (!a.last_verified && b.last_verified) return -1;


### PR DESCRIPTION
## Summary
- The Review queue on `/dashboard/admin/legal-refs` filtered rows with a stale `isReviewable` predicate (set: `needs_review`, `broken`, `stale`, `error`, `superseded`) while the stats counter used `needsReview` (set: `needs_review`, `broken`, `stale`, `error`, `outdated`, `url_dead`).
- Production currently has 28 rows in `verification_status = 'url_dead'`, so the stats panel correctly reported "28 need review" but the queue rendered as empty — and therefore no per-row "Verify with AI" buttons appeared anywhere.
- Aligned the queue to use the canonical `needsReview` predicate (introduced in PR #373) so the counter and the list always agree, and removed the redundant `isReviewable` helper.

## Root cause confirmed via Supabase
```
SELECT verification_status, COUNT(*) FROM legal_references GROUP BY verification_status;
-- current: 58, url_dead: 28, verified: 22, updated: 4
```
None of those 28 rows match `isReviewable`, so the queue rendered the "All references are up to date." empty state.

## Test plan
- [ ] Visit `/dashboard/admin/legal-refs` after deploy
- [ ] Confirm "Review queue" section now lists 28 references
- [ ] Confirm each row has an "Open URL" + "Verify with AI" button on the right
- [ ] Click "Verify with AI" on one row → Perplexity verification runs
- [ ] `npx tsc --noEmit` clean (verified locally — only pre-existing `.next/types/validator.ts` cache errors, none in this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)