### PR TITLE
fix(pocket-agent): quote actual email body when user asks about correspondence

### DIFF
--- a/docs/marketing/pocket-agent-onestream-thread-link-2026-04-30.md
+++ b/docs/marketing/pocket-agent-onestream-thread-link-2026-04-30.md
@@ -130,6 +130,11 @@ demand", the engine MUST quote/extract from the linked email body,
 not infer from other context. See the corresponding fix PR for
 detail.
 
+Fix PR: #388 — adds `quote_email_from_thread` shared tool +
+"CITATION RULE — NON-NEGOTIABLE" preamble to both the Telegram and
+WhatsApp Pocket Agent system prompts, plus a `tsc`-time smoke test
+that fails if either surface drops the citation rule.
+
 ## Use cases this snippet supports
 
 - LinkedIn post #6 ("Four ways UK fintechs are using /v1/disputes")

--- a/docs/marketing/pocket-agent-onestream-thread-link-2026-04-30.md
+++ b/docs/marketing/pocket-agent-onestream-thread-link-2026-04-30.md
@@ -1,0 +1,147 @@
+# Pocket Agent — Email-thread linking, end-to-end (30 April 2026)
+
+A real founder-on-Paybacker walkthrough showing the WhatsApp Pocket
+Agent linking an existing email thread to an open dispute, then
+extracting concrete legal arguments and money figures from the
+attached correspondence.
+
+The agent (a) found 5 candidate threads across two connected inboxes,
+(b) ranked them with a clear most-likely match, (c) linked the chosen
+thread to the dispute on confirmation, (d) read the full 13-message
+thread, (e) summarised the offer / counter-offer / legal grounds, and
+(f) named the concrete next-step deadline (FCA 8-week clock) — all
+inside WhatsApp.
+
+This is one of the cleanest illustrations of why the Pocket Agent +
+email-watchdog pairing is a Pro-tier feature: the customer never
+opens the dashboard or the email client. They run the entire
+correspondence audit from chat.
+
+## Conversation
+
+> **User**
+> For my open onestream dispute can you link the latest OneStream
+> email in my info@airproperty.co.uk inbox as the latest email in
+> the thread as this shows my latest response to their offer of
+> compensation
+
+> **Pocket Agent**
+> Here are the matching threads I found. Since you want the one
+> from your info@airproperty.co.uk inbox, the best match looks like:
+>
+> **Option 2** — Onestream Technical Support from
+> tickets@onestream.co.uk (28 Apr, 13 messages) in
+> **info@airproperty.co.uk** ✅
+>
+> There's also Option 5 (Engineer Appointment Confirmed) from
+> info@airproperty.co.uk but that's just 1 message.
+>
+> Which would you like me to link? Reply with the number (1–5) 😊
+
+> **User**
+> What are all the options?
+
+> **Pocket Agent**
+> Here are all 5 options:
+>
+> 1. Complaints Onestream — complaints@onestream.co.uk · 28 Apr · 10 msgs (in aireypaul@googlemail.com)
+> 2. Onestream Technical Support — tickets@onestream.co.uk · 28 Apr · 13 msgs (in info@airproperty.co.uk) ✅ your preferred inbox
+> 3. Onestream - Technical Support — tickets@onestream.co.uk · 8 Apr · 19 msgs (in aireypaul@googlemail.com)
+> 4. Total loss of service — customerservices@onestream.co.uk · 26 Mar · 1 msg (in aireypaul@googlemail.com)
+> 5. Engineer Appointment Confirmed — noreply@onestream.co.uk · 23 Apr · 1 msg (in info@airproperty.co.uk)
+>
+> Since you want your latest response to their offer from
+> info@airproperty.co.uk, option **2** looks the best match (13 messages,
+> most recent). Which would you like to link? 😊
+
+> **User**
+> Yes I believe it's option 2
+
+> **Pocket Agent**
+> ✅ **Linked!** The thread "Onestream Technical Support" from your
+> info@airproperty.co.uk inbox is now attached to your OneStream
+> dispute.
+>
+> The 13-message thread will appear in the dispute timeline within
+> 30 minutes as the watchdog syncs it.
+
+> **User**
+> Can you confirm what my last response was in that thread and
+> what their response was that I replied to?
+
+> **Pocket Agent**
+> Got it — I've read through the full thread. Here's a summary of
+> the last exchange:
+>
+> 📨 **OneStream's latest offer (28/04/2026 — from their complaints team):**
+>
+> They confirmed service was restored and offered:
+> - 🏠 Flat 1 — 35 days down → £68.31 (1.5 months credit)
+> - 🏠 Flat 2 — 17 days down → £38.65 (1 month credit)
+> - 💰 Total: £106.96 as account credit
+>
+> ✍️ **Your last response (28/04/2026 — your 16th formal letter):**
+>
+> You **rejected the £106.96 offer in full**, arguing:
+> - The compensation is a **legal right under Consumer Rights Act
+>   2015 (ss.54–56)**, not a goodwill gesture
+> - You demanded pro-rata credits, wasted journey costs (2 wasted
+>   days attending the property), and consequential losses
+> - You cited OneStream's failure to participate in **Ofcom's
+>   Automatic Compensation Scheme** as a factor
+>
+> So the dispute is currently sitting with **OneStream awaiting
+> their response** to your rejection letter. The FCA 8-week clock
+> started 26/03/2026 — that takes you to **~20 May 2026**, so
+> you're very close to being able to go straight to the
+> **Ombudsman Services: Communications** if they don't respond
+> satisfactorily.
+>
+> Want me to draft a follow-up or prepare the ombudsman referral? 📋
+
+## Notable moments worth highlighting
+
+- **Cross-inbox candidate ranking** — agent surfaces threads from
+  both connected inboxes, defers to the user's stated preference,
+  and explicitly flags the option in the preferred inbox.
+- **Confirmation gate before mutating state** — link only happens
+  after the user picks. No silent attachment.
+- **Watchdog handoff** — agent doesn't claim instant sync; tells the
+  user the watchdog will populate the dispute timeline within 30
+  minutes.
+- **Concrete legal grounding** — once linked, agent cites CRA 2015
+  ss.54–56 and Ofcom Automatic Compensation Scheme by name.
+- **Deadline awareness** — agent computes the 20 May 2026 FCA 8-week
+  cutoff and offers the next concrete escalation route (Ombudsman
+  Services: Communications).
+
+## What it taught us — Pocket Agent quoting bug
+
+The follow-up turn ("can you confirm the full amount I requested in
+my email?") exposed a real bug. The agent's first answer calculated
+pro-rata from OneStream's offer figures (~£74.87) instead of
+extracting the user's actual demand from the linked letter. Only on
+user push-back ("closer to £500") did it re-read the correspondence
+properly and surface the Ofcom-day-rate argument totalling ~£500+.
+
+That bug is being patched in a follow-up PR — the rule going
+forward is: when the user asks "what did I write" / "what did I
+demand", the engine MUST quote/extract from the linked email body,
+not infer from other context. See the corresponding fix PR for
+detail.
+
+## Use cases this snippet supports
+
+- LinkedIn post #6 ("Four ways UK fintechs are using /v1/disputes")
+  — the same pattern works behind their CX agent UI.
+- LinkedIn post #5 ("Five things UK households are entitled to but
+  don't claim") — Ofcom Automatic Compensation Scheme is a high-
+  intent example.
+- Sales decks for the WhatsApp Pocket Agent Pro tier — concrete proof
+  the chat surface alone takes a household from "I have an open
+  dispute" to "I have a referral plan with a deadline".
+
+> Founder note (Paul, 30 April 2026): the email-thread linking is
+> exactly the kind of feature most users wouldn't think to ask for
+> but find indispensable once they have it. Save this for the next
+> Pro-tier launch deck.

--- a/src/lib/pocket-agent/__tests__/quote-from-email.test.ts
+++ b/src/lib/pocket-agent/__tests__/quote-from-email.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Smoke / wiring assertions for the `quote_email_from_thread` tool.
+ *
+ * Like the rest of `src/lib/__tests__/*.ts` in this repo, this file is
+ * compiled by `tsc --noEmit` and used for contract drift detection — it
+ * never runs end-to-end (that would need a live Anthropic + Supabase).
+ *
+ * The bug it exists to prevent regressing:
+ * On 2026-04-29 a real WhatsApp Pocket Agent conversation showed the
+ * agent answering "what amount did I demand in my 16th letter to
+ * OneStream?" by inferring ~£74 pro-rata from the company's offer
+ * figures, when the user's actual letter demanded ~£500+ driven by
+ * Ofcom Automatic Compensation Scheme day rates. The agent had access
+ * to the linked email thread but composed the answer from in-context
+ * summary instead of reading the body. Full screenshot trail in
+ * docs/marketing/pocket-agent-onestream-thread-link-2026-04-30.md.
+ *
+ * The fix layered three things; we assert each is wired:
+ *   1. Tool registered in the shared tool list (`telegramTools`)
+ *      — both Telegram and WhatsApp pull from this list, so one
+ *      registration covers both surfaces.
+ *   2. Tool description carries the assertive "ALWAYS / NEVER" language
+ *      that pushes Claude away from inference.
+ *   3. System prompts on BOTH channels (Telegram + WhatsApp) carry the
+ *      "CITATION RULE — NON-NEGOTIABLE" preamble so the model reaches
+ *      for the tool before composing.
+ */
+
+import { telegramTools } from '@/lib/telegram/tools';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// ----------------------------------------------------------------------
+// 1. Tool exists in the registered list
+// ----------------------------------------------------------------------
+
+const quoteTool = telegramTools.find((t) => t.name === 'quote_email_from_thread');
+
+if (!quoteTool) {
+  throw new Error(
+    'quote_email_from_thread is missing from telegramTools — Pocket Agent will hallucinate email content again. See docs/marketing/pocket-agent-onestream-thread-link-2026-04-30.md.',
+  );
+}
+
+// ----------------------------------------------------------------------
+// 2. Tool description is assertive about WHEN to call it
+// ----------------------------------------------------------------------
+
+const desc = quoteTool.description ?? '';
+const REQUIRED_PHRASES = [
+  'ALWAYS call this tool',
+  'NEVER infer',
+  'verbatim',
+];
+for (const phrase of REQUIRED_PHRASES) {
+  if (!desc.includes(phrase)) {
+    throw new Error(
+      `quote_email_from_thread description is missing the assertive phrase "${phrase}". Without it, Claude will fall back to inference.`,
+    );
+  }
+}
+
+// Schema sanity — provider is required, direction + limit optional.
+type ToolSchema = {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: readonly string[];
+};
+const schema = quoteTool.input_schema as ToolSchema;
+if (!schema.required || !schema.required.includes('provider')) {
+  throw new Error('quote_email_from_thread must require `provider`.');
+}
+const props = schema.properties ?? {};
+for (const expected of ['provider', 'direction', 'limit']) {
+  if (!(expected in props)) {
+    throw new Error(`quote_email_from_thread schema missing property "${expected}".`);
+  }
+}
+
+// ----------------------------------------------------------------------
+// 3. Both system prompts carry the citation rule
+// ----------------------------------------------------------------------
+
+// We can't import the prompts directly (they're const-internal to the
+// bot files and importing them pulls in @anthropic-ai/sdk + the whole
+// Supabase admin path at module-eval time). Read the source instead —
+// this is what the legal-refs-guardrail test does for the same reason.
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
+const TELEGRAM_BOT_SRC = readFileSync(
+  join(REPO_ROOT, 'src', 'lib', 'telegram', 'user-bot.ts'),
+  'utf8',
+);
+const WHATSAPP_BOT_SRC = readFileSync(
+  join(REPO_ROOT, 'src', 'lib', 'whatsapp', 'user-bot.ts'),
+  'utf8',
+);
+
+const PROMPT_REQUIREMENTS = [
+  'CITATION RULE',
+  'NON-NEGOTIABLE',
+  'quote_email_from_thread',
+];
+
+for (const phrase of PROMPT_REQUIREMENTS) {
+  if (!TELEGRAM_BOT_SRC.includes(phrase)) {
+    throw new Error(
+      `Telegram bot system prompt is missing "${phrase}" — citation rule is unwired on Telegram.`,
+    );
+  }
+  if (!WHATSAPP_BOT_SRC.includes(phrase)) {
+    throw new Error(
+      `WhatsApp bot system prompt is missing "${phrase}" — citation rule is unwired on WhatsApp. WhatsApp users (Pro tier) hit this regression first.`,
+    );
+  }
+}
+
+// ----------------------------------------------------------------------
+// 4. Handler returns structured fields when the tool is called
+// ----------------------------------------------------------------------
+//
+// We don't run the handler against live Supabase here — that would
+// require credentials and a real dispute row. We assert the dispatch
+// case exists by string-matching the handler source, the same approach
+// the rest of the smoke tests in this repo use.
+
+const HANDLERS_SRC = readFileSync(
+  join(REPO_ROOT, 'src', 'lib', 'telegram', 'tool-handlers.ts'),
+  'utf8',
+);
+
+if (!HANDLERS_SRC.includes("case 'quote_email_from_thread':")) {
+  throw new Error('tool-handlers.ts is missing the dispatch case for quote_email_from_thread.');
+}
+if (!HANDLERS_SRC.includes('async function quoteEmailFromThread(')) {
+  throw new Error('tool-handlers.ts is missing the quoteEmailFromThread implementation.');
+}
+// The fields the agent needs to quote correctly:
+for (const field of ['message_index_in_thread', 'subject', 'body', 'direction', 'sender', 'recipient']) {
+  if (!HANDLERS_SRC.includes(field)) {
+    throw new Error(
+      `quoteEmailFromThread handler is missing the structured field "${field}". The agent needs all of {date, sender, recipient, subject, body, direction, message_index_in_thread} to answer "my 16th letter"-style questions.`,
+    );
+  }
+}
+
+export {};

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -168,6 +168,12 @@ export async function executeToolCall(
       return getIncomeBreakdown(supabase, userId, toolInput.month as string | undefined);
     case 'get_dispute_detail':
       return getDisputeDetail(supabase, userId, toolInput.provider as string);
+    case 'quote_email_from_thread':
+      return quoteEmailFromThread(supabase, userId, {
+        provider: toolInput.provider as string,
+        direction: (toolInput.direction as 'sent' | 'received' | 'all' | undefined) ?? 'all',
+        limit: typeof toolInput.limit === 'number' ? (toolInput.limit as number) : 5,
+      });
     case 'find_email_thread_for_dispute':
       return findEmailThreadForDispute(supabase, userId, {
         provider: toolInput.provider as string,
@@ -2277,6 +2283,175 @@ async function getDisputeDetail(
   }
 
   return { text };
+}
+
+/**
+ * Read the user's actual correspondence body text on a dispute, with full
+ * body content (not summaries or snippets) and structured fields.
+ *
+ * Built 2026-04-30 after a real WhatsApp Pocket Agent regression: the
+ * agent answered "what amount did I demand in my 16th letter to OneStream?"
+ * by inferring ~£74 pro-rata from the company's offer numbers, when the
+ * user's actual letter demanded ~£500+ driven by Ofcom Automatic
+ * Compensation Scheme day rates. The agent had access to the linked
+ * email thread but composed an answer from in-context summary instead
+ * of reading the body.
+ *
+ * The fix: a dedicated tool whose description tells Claude "ALWAYS call
+ * this when the user asks about content/amounts/dates from their own
+ * email or letter — never infer". The system prompts (Telegram +
+ * WhatsApp) carry a matching citation rule so Claude reaches for this
+ * tool before composing.
+ *
+ * Direction maps:
+ *  - 'sent'     → entry_type IN ('ai_letter', 'user_note')   (user → company)
+ *  - 'received' → entry_type IN ('company_email', 'company_letter', 'company_response')
+ *  - 'all'      → both, interleaved by entry_date
+ *
+ * Body cap: 8000 chars per message — generous enough to keep the figure /
+ * deadline / cited statute, bounded to keep Claude's context manageable.
+ */
+const QUOTE_BODY_CHAR_CAP = 8000;
+const QUOTE_DEFAULT_LIMIT = 5;
+const QUOTE_MAX_LIMIT = 20;
+
+const SENT_ENTRY_TYPES = new Set(['ai_letter', 'user_note']);
+const RECEIVED_ENTRY_TYPES = new Set(['company_email', 'company_letter', 'company_response']);
+
+async function quoteEmailFromThread(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  args: {
+    provider: string;
+    direction: 'sent' | 'received' | 'all';
+    limit: number;
+  },
+): Promise<ToolResult> {
+  const { provider, direction } = args;
+  const limit = Math.min(Math.max(1, args.limit ?? QUOTE_DEFAULT_LIMIT), QUOTE_MAX_LIMIT);
+
+  // Resolve dispute the same way getDisputeDetail does (active first,
+  // disambiguate if multiple actives) so the bot reads from the same
+  // dispute the user means.
+  const RESOLVED_STATUSES = new Set(['resolved_won', 'resolved_partial', 'resolved_lost', 'closed']);
+  const { data: matches } = await supabase
+    .from('disputes')
+    .select('id, provider_name, status, created_at')
+    .eq('user_id', userId)
+    .ilike('provider_name', `%${provider}%`)
+    .order('created_at', { ascending: false });
+
+  if (!matches || matches.length === 0) {
+    return { text: `No dispute found matching "${provider}".` };
+  }
+  type DisputeRow = { id: string; provider_name: string; status: string; created_at: string };
+  const active = (matches as DisputeRow[]).filter((m) => !RESOLVED_STATUSES.has(m.status));
+  const resolved = (matches as DisputeRow[]).filter((m) => RESOLVED_STATUSES.has(m.status));
+  if (active.length > 1) {
+    let text = `You have ${active.length} active disputes matching "${provider}". Tell me which one you mean before I read the thread:\n`;
+    for (const m of active) {
+      text += `\n• ${m.provider_name} — ${m.status} · opened ${fmtDate(m.created_at)}`;
+    }
+    return { text };
+  }
+  const dispute = active[0] ?? resolved[0];
+  if (!dispute) {
+    return { text: `No dispute found matching "${provider}".` };
+  }
+
+  const { data: rows } = await supabase
+    .from('correspondence')
+    .select('entry_type, title, content, entry_date, sender_address, sender_name')
+    .eq('dispute_id', dispute.id)
+    .eq('user_id', userId)
+    .order('entry_date', { ascending: true });
+
+  type CorrRow = {
+    entry_type: string;
+    title: string | null;
+    content: string | null;
+    entry_date: string | null;
+    sender_address: string | null;
+    sender_name: string | null;
+  };
+  const all: CorrRow[] = (rows ?? []) as CorrRow[];
+  if (all.length === 0) {
+    return {
+      text: `No correspondence found on the *${dispute.provider_name}* dispute. There's no linked email thread or saved letter to quote from yet.`,
+    };
+  }
+
+  // Number every entry by chronological position in the thread (1 =
+  // first message ever sent on this dispute) so the agent can say
+  // accurately "your 16th letter" when the user references it.
+  const indexed = all.map((r, idx) => ({
+    row: r,
+    message_index_in_thread: idx + 1,
+    direction:
+      SENT_ENTRY_TYPES.has(r.entry_type)
+        ? ('sent' as const)
+        : RECEIVED_ENTRY_TYPES.has(r.entry_type)
+          ? ('received' as const)
+          : ('other' as const),
+  }));
+
+  const filtered = indexed.filter((e) => {
+    if (direction === 'all') return true;
+    if (direction === 'sent') return e.direction === 'sent';
+    if (direction === 'received') return e.direction === 'received';
+    return true;
+  });
+
+  // Most-recent first, then trim to limit.
+  const ordered = [...filtered].reverse().slice(0, limit);
+
+  if (ordered.length === 0) {
+    return {
+      text: `No ${direction} correspondence found on the *${dispute.provider_name}* dispute. The thread has ${all.length} entr${all.length === 1 ? 'y' : 'ies'} but none in the requested direction.`,
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push(`*Quoting from dispute: ${dispute.provider_name}*`);
+  lines.push(
+    `Returning ${ordered.length} of ${all.length} thread entr${all.length === 1 ? 'y' : 'ies'} (direction=${direction}, most recent first).`,
+  );
+  lines.push('');
+
+  for (const e of ordered) {
+    const r = e.row;
+    const body = (r.content ?? '').slice(0, QUOTE_BODY_CHAR_CAP);
+    const truncated = (r.content ?? '').length > QUOTE_BODY_CHAR_CAP;
+    // Sender / recipient — for user-sent entries the user is the
+    // sender; for company-received entries the company is. We don't
+    // have a structured user-email field here so we leave the
+    // counterpart side as the dispute's provider_name.
+    const senderLabel =
+      e.direction === 'sent'
+        ? 'user'
+        : (r.sender_name || r.sender_address || dispute.provider_name);
+    const recipientLabel =
+      e.direction === 'sent'
+        ? dispute.provider_name
+        : 'user';
+    lines.push(
+      `[entry ${e.message_index_in_thread}/${all.length}] ${fmtDate(r.entry_date)} — direction=${e.direction} — type=${r.entry_type}`,
+    );
+    lines.push(`subject: ${r.title ?? '(no subject)'}`);
+    lines.push(`sender: ${senderLabel}`);
+    lines.push(`recipient: ${recipientLabel}`);
+    lines.push('body:');
+    lines.push(body);
+    if (truncated) {
+      lines.push(`… [truncated at ${QUOTE_BODY_CHAR_CAP} chars]`);
+    }
+    lines.push('');
+  }
+  lines.push(
+    'Quote VERBATIM from the body field above when answering the user. Do not infer figures, dates, or demands from offer numbers, dispute metadata, or summaries — read the body.',
+  );
+
+  return { text: lines.join('\n') };
 }
 
 // ============================================================

--- a/src/lib/telegram/tools.ts
+++ b/src/lib/telegram/tools.ts
@@ -284,6 +284,33 @@ export const telegramTools: Tool[] = [
   },
 
   {
+    name: 'quote_email_from_thread',
+    description:
+      "Read the actual body text of the user's correspondence on a dispute — the linked email thread plus AI-drafted letters they've sent. ALWAYS call this tool when the user asks about content, amounts, dates, deadlines, demands, requests, or specific words from any email or letter on a dispute (e.g. 'what did I write', 'what amount did I demand', 'what was in my last letter', 'what did they offer', 'what date did they say', 'confirm the figure I quoted'). NEVER infer email content from summaries, dispute metadata, offer figures, or earlier conversation context — always call this tool first and quote verbatim from the returned `body` field. Returns the most recent N entries with FULL body text (not snippets), ordered most-recent first, with structured fields {date, sender, recipient, subject, body, direction, message_index_in_thread}.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        provider: {
+          type: 'string',
+          description:
+            'Provider/dispute name (case-insensitive partial match — e.g. "OneStream" matches "Onestream"). Used to find the active dispute whose correspondence we read.',
+        },
+        direction: {
+          type: 'string',
+          enum: ['sent', 'received', 'all'],
+          description:
+            "Filter which messages to return. 'sent' = only the user's outbound letters/notes (ai_letter, user_note). 'received' = only the company's replies (company_email, company_letter, company_response). 'all' = both directions interleaved by date. Defaults to 'all'.",
+        },
+        limit: {
+          type: 'number',
+          description: 'Max number of correspondence entries to return. Defaults to 5. Capped at 20.',
+        },
+      },
+      required: ['provider'],
+    },
+  },
+
+  {
     name: 'find_email_thread_for_dispute',
     description:
       "Search the user's connected inboxes (Gmail / Outlook) for email threads that could be linked to one of their disputes. Use when the user says 'link an email', 'connect a thread', 'find the email about X', or 'attach the response from Y'. Returns up to 5 candidate threads with subject + sender + date + the connection_id and thread_id needed for link_email_thread_to_dispute. Always present the list to the user and ask them to pick before linking — never auto-link the top result.",

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -113,6 +113,8 @@ const SESSION_EXPIRY_DAYS = 90;
 
 const SYSTEM_PROMPT = `You are Paybacker's Pocket Agent — a fully connected financial assistant for UK consumers. You have access to EVERYTHING the user can see on the Paybacker website. This includes Money Hub, Subscriptions, Contracts, Disputes, Scanner, Rewards, Profile, Tasks, and all financial data. Never say you can't access something — if there's a tool for it, use it.
 
+CITATION RULE — NON-NEGOTIABLE: When the user references their own email or letter ("my email", "my last letter", "my 16th letter", "what I demanded", "what I requested", "what I wrote", "what I quoted", "the amount I asked for", "confirm the figure I cited", or anything that asks for the content/amount/date/wording of correspondence on a dispute), you MUST call quote_email_from_thread BEFORE answering. The same rule applies if they ask what the company actually said in their reply ("their last email", "what they wrote", "what date did they give"). Do not calculate, infer, or summarise from offer figures, dispute metadata, prior assistant turns, or earlier conversation context. Read the actual body via the tool and quote verbatim. If the body doesn't contain the answer, say "I couldn't find that figure in the linked thread" rather than inferring. This rule overrides any urge to answer faster from context — correctness wins.
+
 COMPLETE TOOL REFERENCE (always call the tool — never make up data or say "I can't"):
 
 READ TOOLS — Core:
@@ -124,7 +126,8 @@ READ TOOLS — Core:
 - get_upcoming_renewals — Subscriptions and contracts renewing within 30 days
 - get_price_alerts — Active price increase alerts on recurring payments
 - get_disputes — Dispute/complaint cases and their status
-- get_dispute_detail — Full detail and correspondence for a specific dispute
+- get_dispute_detail — Full detail and correspondence for a specific dispute (high-level overview; for the actual body of any letter/email use quote_email_from_thread instead)
+- quote_email_from_thread — Read the FULL body text of the user's letters and the company's replies on a dispute. ALWAYS call this when the user asks about content, amounts, dates, deadlines, demands, or specific words from their own email/letter or the company's reply. Never infer from summaries or offer figures — quote the body verbatim.
 - get_financial_overview — Complete financial overview: income, spending, net position, open disputes
 - get_savings_goals — Savings goals with progress, target amount, and target date
 - get_savings_challenges — Active gamified savings challenges (No-Spend Week, etc.)

--- a/src/lib/whatsapp/user-bot.ts
+++ b/src/lib/whatsapp/user-bot.ts
@@ -49,7 +49,9 @@ const HISTORY_MESSAGES = 10;
 // If a tool/rule changes here, mirror it in src/lib/telegram/user-bot.ts.
 const SYSTEM_PROMPT = `You are Paybacker's Pocket Agent — a fully connected financial assistant for UK consumers, now talking over WhatsApp. You have access to EVERYTHING the user can see on the Paybacker website. Money Hub, Subscriptions, Contracts, Disputes, Scanner, Rewards, Profile, Tasks, all financial data. Never say you can't access something — if there's a tool for it, use it.
 
-The available tools and their semantics are identical to the dashboard agent. See the tool definitions for what each one does.
+CITATION RULE — NON-NEGOTIABLE: When the user references their own email or letter ("my email", "my last letter", "my 16th letter", "what I demanded", "what I requested", "what I wrote", "what I quoted", "the amount I asked for", "confirm the figure I cited", or anything that asks for the content/amount/date/wording of correspondence on a dispute), you MUST call quote_email_from_thread BEFORE answering. The same rule applies if they ask what the company actually said in their reply ("their last email", "what they wrote", "what date did they give"). Do not calculate, infer, or summarise from offer figures, dispute metadata, prior assistant turns, or earlier conversation context. Read the actual body via the tool and quote verbatim. If the body doesn't contain the answer, say "I couldn't find that figure in the linked thread" rather than inferring. This rule overrides any urge to answer faster from context — correctness wins.
+
+The available tools and their semantics are identical to the dashboard agent. See the tool definitions for what each one does. In particular: quote_email_from_thread is the tool you reach for whenever the user asks what was actually written in their correspondence — never paraphrase from get_dispute_detail or earlier turns.
 
 WHATSAPP-SPECIFIC RULES:
 - Keep replies tight: WhatsApp users are mobile, often one-handed. Short bullets + bold headers, no essays.


### PR DESCRIPTION
## The bug

Captured 2026-04-29 in a real WhatsApp Pocket Agent conversation about the user's open OneStream dispute (full screenshot trail in `docs/marketing/pocket-agent-onestream-thread-link-2026-04-30.md`, included in this PR).

When the founder asked _"what amount did I demand in my 16th letter to OneStream?"_ the Pocket Agent answered **~£74.87** — a pro-rata calculation derived from OneStream's £106.96 offer figures.

The actual answer in the user's letter body was **~£500+**, driven by Ofcom Automatic Compensation Scheme day rates of £9.76/day. The agent had access to the linked email thread but composed an answer from in-context summary instead of reading the body. Only when the user pushed back did the agent re-read the thread and produce the correct figure.

This is a correctness regression. When a user asks about their own email content, the agent must quote the actual stored body — not infer.

## The fix

Four layers, all in this PR:

1. **New shared tool `quote_email_from_thread`** (`src/lib/telegram/tools.ts` + handler in `src/lib/telegram/tool-handlers.ts`). Both Telegram and WhatsApp Pocket Agents pull from this shared registry, so one registration covers both surfaces. Returns the most recent N correspondence entries (default 5, max 20) with FULL body text capped at 8000 chars per message — not summaries, not snippets — structured as `{date, sender, recipient, subject, body, direction, message_index_in_thread}`, ordered most-recent first. Supports a `direction` filter (`'sent' | 'received' | 'all'`).

2. **Assertive tool description.** Tells Claude: _"ALWAYS call this tool when the user asks about content, amounts, dates, deadlines, demands, or specific words from any email or letter… NEVER infer email content from summaries — always call this tool first."_

3. **CITATION RULE — NON-NEGOTIABLE** added near the top of BOTH system prompts (`src/lib/telegram/user-bot.ts` + `src/lib/whatsapp/user-bot.ts`). Forces the agent to call `quote_email_from_thread` before answering any _"what did I write / demand / request / quote"_ question, with explicit guidance not to compose from offer figures, dispute metadata, or earlier conversation context.

4. **Smoke test** at `src/lib/pocket-agent/__tests__/quote-from-email.test.ts` (compiles via `tsc --noEmit`, matching the existing `legal-refs-guardrail.test.ts` pattern). Asserts: tool registered, description carries the ALWAYS/NEVER/verbatim language, both system prompts contain the citation rule + tool name, dispatch case wired, handler emits all six structured fields.

## Files touched

- `src/lib/telegram/tools.ts` — new tool definition
- `src/lib/telegram/tool-handlers.ts` — dispatch case + `quoteEmailFromThread` handler
- `src/lib/telegram/user-bot.ts` — citation rule + tool reference in system prompt
- `src/lib/whatsapp/user-bot.ts` — citation rule + tool reference (mirrors Telegram)
- `src/lib/pocket-agent/__tests__/quote-from-email.test.ts` — wiring smoke test
- `docs/marketing/pocket-agent-onestream-thread-link-2026-04-30.md` — original screenshot trail (was already staged on master prep)

## Test plan

- [ ] `tsc --noEmit` clean (verified locally — zero errors on touched files)
- [ ] Manual: ask the WhatsApp bot _"what did I demand in my last letter to OneStream?"_ and confirm it calls `quote_email_from_thread` and quotes the body verbatim
- [ ] Manual: ask the Telegram bot the same question and confirm parity
- [ ] Manual: ask _"what did they offer?"_ — should also route through `quote_email_from_thread` (received direction)
- [ ] Manual: ask about a dispute with no linked thread — should respond _"I couldn't find that figure in the linked thread"_ rather than inferring

🤖 Generated with [Claude Code](https://claude.com/claude-code)