### PR TITLE
fix(email): un-escape template literals in dispute reminder email

### DIFF
--- a/src/lib/email/dispute-reminders.ts
+++ b/src/lib/email/dispute-reminders.ts
@@ -41,32 +41,32 @@ export async function sendDisputeReminderEmail(
   isEscalation: boolean
 ): Promise<boolean> {
   const name = firstName || 'there';
-  const amountStr = dispute.amount ? ` (£\${dispute.amount.toFixed(2)})` : '';
+  const amountStr = dispute.amount ? ` (£${dispute.amount.toFixed(2)})` : '';
 
   let subject: string;
   let htmlContent: string;
 
   if (isEscalation) {
-    subject = `Your \${dispute.providerName} dispute is \${dispute.daysOld} days old — time to escalate`;
+    subject = `Your ${dispute.providerName} dispute is ${dispute.daysOld} days old — time to escalate`;
     htmlContent = `
-      <div style="\${wrap}">
-        <div style="\${header}">\${Logo()}</div>
-        <div style="\${body}">
-          <h1 style="\${h1}">It's time to escalate your dispute, \${name}</h1>
-          <p style="\${pWhite}">Your dispute with <strong>\${dispute.providerName}</strong>\${amountStr} has been open for \${dispute.daysOld} days.</p>
+      <div style="${wrap}">
+        <div style="${header}">${Logo()}</div>
+        <div style="${body}">
+          <h1 style="${h1}">It's time to escalate your dispute, ${name}</h1>
+          <p style="${pWhite}">Your dispute with <strong>${dispute.providerName}</strong>${amountStr} has been open for ${dispute.daysOld} days.</p>
           
-          <div style="\${tipBox}">
+          <div style="${tipBox}">
             <p style="color:#ef4444;font-weight:700;margin:0 0 6px;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">Your Consumer Rights</p>
             <p style="color:#6B7280;margin:0;font-size:14px;line-height:1.6;">Under UK consumer law, if a company has not resolved your complaint within 8 weeks (56 days), you have the right to escalate your case to the relevant ombudsman or regulator free of charge.</p>
           </div>
 
-          <p style="\${pWhite}">The ombudsman has the power to force companies to refund you, pay compensation, and issue official apologies.</p>
+          <p style="${pWhite}">The ombudsman has the power to force companies to refund you, pay compensation, and issue official apologies.</p>
 
           <div style="text-align:center;margin:28px 0;">
-            <a href="https://paybacker.co.uk/dashboard/complaints/\${dispute.id}" style="\${cta}">Draft Escapation Letter</a>
+            <a href="https://paybacker.co.uk/dashboard/complaints/${dispute.id}" style="${cta}">Draft Escalation Letter</a>
           </div>
 
-          <div style="\${box}">
+          <div style="${box}">
             <p style="color:#E5E7EB;font-weight:600;margin:0 0 6px;font-size:14px;">How to proceed:</p>
             <ol style="color:#6B7280;margin:0;font-size:14px;line-height:1.6;padding-left:20px;">
               <li>Go to your dispute in the dashboard</li>
@@ -75,32 +75,32 @@ export async function sendDisputeReminderEmail(
             </ol>
           </div>
         </div>
-        \${Footer()}
+        ${Footer()}
       </div>
     `;
   } else {
-    subject = `Follow up on your \${dispute.providerName} dispute`;
+    subject = `Follow up on your ${dispute.providerName} dispute`;
     htmlContent = `
-      <div style="\${wrap}">
-        <div style="\${header}">\${Logo()}</div>
-        <div style="\${body}">
-          <h1 style="\${h1}">Checking in on your dispute, \${name}</h1>
-          <p style="\${pWhite}">Your dispute with <strong>\${dispute.providerName}</strong>\${amountStr} was filed \${dispute.daysOld} days ago.</p>
+      <div style="${wrap}">
+        <div style="${header}">${Logo()}</div>
+        <div style="${body}">
+          <h1 style="${h1}">Checking in on your dispute, ${name}</h1>
+          <p style="${pWhite}">Your dispute with <strong>${dispute.providerName}</strong>${amountStr} was filed ${dispute.daysOld} days ago.</p>
           
-          <div style="\${box}">
+          <div style="${box}">
             <p style="color:#E5E7EB;font-weight:600;margin:0 0 6px;font-size:14px;">Have you received a response?</p>
             <p style="color:#6B7280;margin:0;font-size:14px;line-height:1.6;">Most companies are required by industry guidelines to acknowledge official complaints within 5 working days.</p>
           </div>
 
-          <p style="\${pWhite}">If they haven't replied, now is the perfect time to send a quick follow-up to keep the pressure on.</p>
+          <p style="${pWhite}">If they haven't replied, now is the perfect time to send a quick follow-up to keep the pressure on.</p>
 
           <div style="text-align:center;margin:28px 0;">
-            <a href="https://paybacker.co.uk/dashboard/complaints/\${dispute.id}" style="\${cta}">Update Dispute Status</a>
+            <a href="https://paybacker.co.uk/dashboard/complaints/${dispute.id}" style="${cta}">Update Dispute Status</a>
           </div>
 
-          <p style="color:#6B7280;font-size:14px;line-height:1.6;margin:0;">Tip: You can ask the AI chat on the dispute page to <em>"Help me follow up with \${dispute.providerName}"</em> and it will write the email for you.</p>
+          <p style="color:#6B7280;font-size:14px;line-height:1.6;margin:0;">Tip: You can ask the AI chat on the dispute page to <em>"Help me follow up with ${dispute.providerName}"</em> and it will write the email for you.</p>
         </div>
-        \${Footer()}
+        ${Footer()}
       </div>
     `;
   }
@@ -114,12 +114,12 @@ export async function sendDisputeReminderEmail(
       html: htmlContent,
     });
     if (error) {
-      console.error(`Dispute reminder email failed for \${email}:`, error);
+      console.error(`Dispute reminder email failed for ${email}:`, error);
       return false;
     }
     return true;
   } catch (err) {
-    console.error(`Dispute reminder email error for \${email}:`, err);
+    console.error(`Dispute reminder email error for ${email}:`, err);
     return false;
   }
 }


### PR DESCRIPTION
## What

Founder reported receiving an email from Paybacker where the subject and body contained literal placeholder strings:

> Subject: Your \${dispute.providerName} dispute is \${dispute.daysOld} days old — time to escalate

> Body: \${Logo()} It's time to escalate your dispute, \${name}…

## Root cause

Every \`\${...}\` template literal expression in \`src/lib/email/dispute-reminders.ts\` had been backslash-escaped (\`\\\${...}\`). In a JS template literal, \`\\\$\` is the escape for a literal \`$\`, so the runtime string contained literal \`\${dispute.providerName}\` instead of substituting the value. Affected:

- subject lines (both escalation + follow-up branches)
- HTML body interpolation (provider name, amount, days, dispute id, name, all CSS variables, Logo()/Footer() function calls)
- console.error template strings

## Fix

- replaceAll \`\\\${\` → \`\${\` across the file (50 occurrences across 25 lines)
- Fixed \"Draft Escapation Letter\" typo → \"Draft Escalation Letter\"
- \`tsc --noEmit\` clean

## Verification

After merge + Vercel redeploy, the next dispute reminder email should render with proper interpolation. Worth manually running \`/api/cron/dispute-reminders\` once via the admin trigger after deploy to catch any other email templates with the same backslash bug — only this one was flagged but the pattern could exist elsewhere.