### PR TITLE
fix(compliance): route verify endpoints through legal_ref_corrections queue

### DIFF
--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -5,11 +5,38 @@
  * to 25 rows in a batch). Calls Perplexity sonar-pro with a strict-JSON
  * prompt asking whether the citation is still accurate, whether the URL
  * still resolves to the right document, and whether it has been
- * superseded. Updates the row with the result and logs the spend to the
- * api_cost_ledger via logPerplexityCall.
+ * superseded.
+ *
+ * COMPLIANCE PRINCIPLE (non-negotiable):
+ *   No code path may directly mutate a citation's law_name, source_url,
+ *   source_type, or verification_status to a non-pending value without
+ *   passing through `legal_ref_corrections` and a founder approval click.
+ *
+ * Implementation:
+ *   - If Perplexity proposes a change to canonical fields (law_name /
+ *     source_url) OR a new authoritative current_url, INSERT a
+ *     `legal_ref_corrections` row with status='pending'. The auto-apply
+ *     sweep (post-enrichment) decides if it can be applied without
+ *     founder click.
+ *   - If Perplexity says the citation is current with no proposed
+ *     change, return `{status: 'no_change'}` and only touch
+ *     `last_verified` / `verification_notes` (observational fields).
+ *   - We never overwrite verification_status to a non-pending value
+ *     directly from this route.
  *
  * Body (single):  { id: string }
  * Body (batch):   { ids: string[] }   // max 25
+ *
+ * Response (single): { updated: VerifyResult }
+ * Response (batch):  { results: VerifyResult[] }
+ *
+ * VerifyResult.status is one of:
+ *   - 'no_change'    — verdict matches canonical; only last_verified touched
+ *   - 'queued'       — proposed correction inserted into legal_ref_corrections
+ *   - 'auto_applied' — proposed correction passed all three auto-apply gates
+ *                      (rare from this route — enrichment is usually run
+ *                      separately by the ζ cron before the η sweep)
+ *   - 'error'        — Perplexity / DB call failed
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -23,6 +50,7 @@ export const maxDuration = 300;
 
 const MAX_BATCH = 25;
 const PERPLEXITY_MODEL = 'sonar-pro';
+const COST_PER_CALL_GBP = 0.005;
 
 function getAdminEmails(): string[] {
   return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
@@ -47,6 +75,7 @@ interface LegalRefRow {
   summary: string;
   category: string;
   created_at: string;
+  verification_status: string | null;
 }
 
 interface PerplexityVerdict {
@@ -59,9 +88,10 @@ interface PerplexityVerdict {
 
 interface VerifyResult {
   id: string;
-  status: string;
+  status: 'no_change' | 'queued' | 'auto_applied' | 'error';
   current_url: string | null;
   notes: string;
+  correction_id?: string;
   error?: string;
 }
 
@@ -151,18 +181,96 @@ async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> 
   }
 }
 
-function deriveStatus(verdict: PerplexityVerdict): string {
-  if (verdict.superseded_by) return 'superseded';
-  if (!verdict.valid) return 'broken';
-  if (verdict.valid && verdict.confidence !== 'low') return 'verified';
-  return 'needs_review';
+function normaliseUrl(u: string | null | undefined): string {
+  return (u ?? '').replace(/\/$/, '').trim().toLowerCase();
+}
+
+function parseSupersededTitle(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const urlMatch = s.match(/https?:\/\/\S+/);
+  const title = s
+    .replace(urlMatch?.[0] ?? '', '')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^[—–\-:]\s*/, '');
+  return title || null;
+}
+
+/**
+ * Decide whether the verdict represents a real proposed change to canonical
+ * citation fields, or whether it is a no-op (just confirming current state).
+ */
+function deriveProposal(
+  ref: LegalRefRow,
+  verdict: PerplexityVerdict,
+): {
+  hasProposal: boolean;
+  proposed_law_name: string | null;
+  proposed_source_url: string | null;
+  proposed_status: string | null;
+  superseded_by: string | null;
+} {
+  // Never propose a non-authority URL — drop instead.
+  let proposed_source_url: string | null = null;
+  if (verdict.current_url) {
+    const authority = checkUkLegalAuthority(verdict.current_url);
+    if (authority.ok) proposed_source_url = verdict.current_url;
+  }
+
+  let proposed_law_name: string | null = null;
+  let proposed_status: string | null = null;
+  let superseded_by: string | null = null;
+
+  if (verdict.superseded_by) {
+    proposed_law_name = parseSupersededTitle(verdict.superseded_by);
+    proposed_status = 'superseded';
+    superseded_by = verdict.superseded_by;
+  } else if (!verdict.valid && verdict.current_url) {
+    proposed_status = 'updated';
+  } else if (verdict.valid && verdict.confidence !== 'low') {
+    // current — only count as a proposal if URL differs.
+    proposed_status = null;
+  } else if (verdict.confidence === 'low') {
+    proposed_status = 'needs_review';
+  }
+
+  // Filter no-op URL.
+  if (
+    proposed_source_url &&
+    normaliseUrl(proposed_source_url) === normaliseUrl(ref.source_url)
+  ) {
+    proposed_source_url = null;
+  }
+  // Filter no-op name.
+  if (
+    proposed_law_name &&
+    proposed_law_name.trim().toLowerCase() === ref.law_name.trim().toLowerCase()
+  ) {
+    proposed_law_name = null;
+  }
+
+  const hasProposal = !!(
+    proposed_law_name ||
+    proposed_source_url ||
+    proposed_status === 'superseded' ||
+    proposed_status === 'updated'
+  );
+
+  return {
+    hasProposal,
+    proposed_law_name,
+    proposed_source_url,
+    proposed_status,
+    superseded_by,
+  };
 }
 
 async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
   const admin = getAdmin();
   const { data: ref, error } = await admin
     .from('legal_references')
-    .select('id, law_name, section, source_url, source_type, summary, category, created_at')
+    .select('id, law_name, section, source_url, source_type, summary, category, created_at, verification_status')
     .eq('id', id)
     .maybeSingle();
 
@@ -172,7 +280,6 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
 
   const verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
   if (!verdict) {
-    // PR γ — record the failed attempt in the audit table too.
     void admin.from('legal_ref_verifications').insert({
       ref_id: id,
       verifier: 'perplexity-sonar-pro',
@@ -203,63 +310,118 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
     metadata: { legal_reference_id: id },
   });
 
-  const status = deriveStatus(verdict);
+  const refRow = ref as LegalRefRow;
+  const proposal = deriveProposal(refRow, verdict);
   const notes = verdict.superseded_by
     ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
     : verdict.notes;
 
-  const update: Record<string, unknown> = {
-    verification_status: status,
-    last_verified: new Date().toISOString(),
-    verification_notes: notes || null,
-  };
-  if (verdict.current_url) {
-    const authority = checkUkLegalAuthority(verdict.current_url);
-    if (authority.reason === 'authority') {
-      update.verified_url = verdict.current_url;
-    }
-  }
-
-
-  const { error: updateError } = await admin
+  // ALWAYS touch the observational fields (last_verified, verification_notes).
+  // NEVER touch canonical fields (law_name, source_url, source_type) or set
+  // verification_status to a non-pending value here.
+  void admin
     .from('legal_references')
-    .update(update)
+    .update({
+      last_verified: new Date().toISOString(),
+      verification_notes: notes || null,
+    })
     .eq('id', id);
 
-  if (updateError) {
+  // No proposed change → no_change. Don't pollute the corrections queue.
+  if (!proposal.hasProposal) {
+    void admin.from('legal_ref_verifications').insert({
+      ref_id: id,
+      verifier: 'perplexity-sonar-pro',
+      triggered_by: userId ? 'manual-admin' : 'unknown',
+      before_status: refRow.verification_status,
+      after_status: refRow.verification_status,
+      before_url: refRow.source_url,
+      after_url: refRow.source_url,
+      changes: { no_change: true },
+      cost_gbp: COST_PER_CALL_GBP * 0.79,
+      perplexity_response: verdict as any,
+      notes: notes || null,
+    });
+    return {
+      id,
+      status: 'no_change',
+      current_url: verdict.current_url,
+      notes,
+    };
+  }
+
+  // Mark prior pending corrections for this ref as superseded.
+  await admin
+    .from('legal_ref_corrections')
+    .update({
+      status: 'superseded_by_newer',
+      reviewed_at: new Date().toISOString(),
+      reviewed_by: 'verify-route-new-proposal',
+    })
+    .eq('ref_id', id)
+    .eq('status', 'pending');
+
+  // Insert the proposed correction. Founder reviews via /dashboard/admin/legal-refs.
+  const { data: insertedRows, error: insErr } = await admin
+    .from('legal_ref_corrections')
+    .insert({
+      ref_id: id,
+      proposer: 'perplexity-sonar-pro',
+      before_law_name: refRow.law_name,
+      before_source_url: refRow.source_url,
+      before_status: refRow.verification_status,
+      proposed_law_name: proposal.proposed_law_name,
+      proposed_source_url: proposal.proposed_source_url,
+      proposed_status: proposal.proposed_status,
+      superseded_by: proposal.superseded_by,
+      reasoning: notes || null,
+      raw_response: verdict as any,
+      confidence: verdict.confidence,
+      cost_gbp: COST_PER_CALL_GBP,
+      status: 'pending',
+    })
+    .select('id')
+    .limit(1);
+
+  if (insErr) {
     return {
       id,
       status: 'error',
       current_url: verdict.current_url,
       notes,
-      error: `DB update failed: ${updateError.message}`,
+      error: `Corrections insert failed: ${insErr.message}`,
     };
   }
 
-  // PR γ — audit-trail row.
+  const correctionId = insertedRows?.[0]?.id;
+
+  // Audit row in legal_ref_verifications.
   void admin.from('legal_ref_verifications').insert({
     ref_id: id,
     verifier: 'perplexity-sonar-pro',
     triggered_by: userId ? 'manual-admin' : 'unknown',
-    before_status: (ref as any).verification_status ?? null,
-    after_status: status,
-    before_url: (ref as any).source_url ?? null,
-    after_url: verdict.current_url ?? null,
+    before_status: refRow.verification_status,
+    after_status: 'pending-correction-queued',
+    before_url: refRow.source_url,
+    after_url: proposal.proposed_source_url,
     changes: {
-      auto_corrected: false,
-      law_name_changed: false,
-      url_changed: false,
+      queued_correction: true,
+      correction_id: correctionId ?? null,
+      proposed_law_name: proposal.proposed_law_name,
+      proposed_source_url: proposal.proposed_source_url,
+      proposed_status: proposal.proposed_status,
     },
-    cost_gbp: 0.005 * 0.79,
+    cost_gbp: COST_PER_CALL_GBP * 0.79,
     perplexity_response: verdict as any,
     notes: notes || null,
   });
 
   return {
     id,
-    status,
+    status: 'queued',
     current_url: verdict.current_url,
     notes,
+    correction_id: correctionId,
   };
 }
 

--- a/src/app/api/cron/legal-refs-daily-reverify/route.ts
+++ b/src/app/api/cron/legal-refs-daily-reverify/route.ts
@@ -7,9 +7,14 @@
  *      hasn't been verified in the last 7 days.
  *   3. Capped at 30 refs total to keep daily spend under £0.15.
  *
- * Each ref runs through the same Perplexity flow as the admin
- * `/api/admin/legal-refs/verify` endpoint, including the auto-overwrite
- * + audit-row write.
+ * COMPLIANCE PRINCIPLE (non-negotiable): this cron is propose-only. Any
+ * proposed change to canonical fields (law_name, source_url,
+ * verification_status) is INSERTed into `legal_ref_corrections` with
+ * status='pending'. Only the observational fields (last_verified,
+ * verification_notes) are written directly here.
+ *
+ * Auto-apply (if any) happens in the dedicated η sweep cron after ζ has
+ * attached enrichment_data.
  *
  * Auth: standard Vercel cron Bearer (CRON_SECRET).
  */
@@ -17,6 +22,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createAdminClient } from '@supabase/supabase-js';
 import { logPerplexityCall } from '@/lib/cost-ledger';
+import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -26,6 +32,7 @@ const HARD_CAP = 30;
 const OLDEST_TARGET = 20;
 const RECENT_USAGE_HOURS = 24;
 const RECENT_USAGE_REVERIFY_DAYS = 7;
+const COST_PER_CALL_GBP = 0.005;
 
 function getAdmin() {
   return createAdminClient(
@@ -119,23 +126,79 @@ async function askPerplexity(prompt: string): Promise<PerplexityVerdict | null> 
   }
 }
 
-function parseSuperseded(s: string): { law_name: string; url: string | null } {
+function normaliseUrl(u: string | null | undefined): string {
+  return (u ?? '').replace(/\/$/, '').trim().toLowerCase();
+}
+
+function parseSupersededTitle(s: string | null | undefined): string | null {
+  if (!s) return null;
   const urlMatch = s.match(/https?:\/\/\S+/);
-  const url = urlMatch ? urlMatch[0].replace(/[)\].,;]+$/, '') : null;
   const title = s
     .replace(urlMatch?.[0] ?? '', '')
     .replace(/\(\s*\)/g, '')
     .replace(/\s+/g, ' ')
     .trim()
     .replace(/^[—–\-:]\s*/, '');
-  return { law_name: title || s.trim(), url };
+  return title || null;
 }
 
-function deriveStatus(verdict: PerplexityVerdict): string {
-  if (verdict.superseded_by) return 'superseded';
-  if (!verdict.valid) return 'broken';
-  if (verdict.valid && verdict.confidence !== 'low') return 'verified';
-  return 'needs_review';
+function deriveProposal(
+  ref: LegalRefRow,
+  verdict: PerplexityVerdict,
+): {
+  hasProposal: boolean;
+  proposed_law_name: string | null;
+  proposed_source_url: string | null;
+  proposed_status: string | null;
+  superseded_by: string | null;
+} {
+  let proposed_source_url: string | null = null;
+  if (verdict.current_url) {
+    const authority = checkUkLegalAuthority(verdict.current_url);
+    if (authority.ok) proposed_source_url = verdict.current_url;
+  }
+
+  let proposed_law_name: string | null = null;
+  let proposed_status: string | null = null;
+  let superseded_by: string | null = null;
+
+  if (verdict.superseded_by) {
+    proposed_law_name = parseSupersededTitle(verdict.superseded_by);
+    proposed_status = 'superseded';
+    superseded_by = verdict.superseded_by;
+  } else if (!verdict.valid && verdict.current_url) {
+    proposed_status = 'updated';
+  } else if (verdict.confidence === 'low') {
+    proposed_status = 'needs_review';
+  }
+
+  if (
+    proposed_source_url &&
+    normaliseUrl(proposed_source_url) === normaliseUrl(ref.source_url)
+  ) {
+    proposed_source_url = null;
+  }
+  if (
+    proposed_law_name &&
+    proposed_law_name.trim().toLowerCase() === ref.law_name.trim().toLowerCase()
+  ) {
+    proposed_law_name = null;
+  }
+
+  const hasProposal = !!(
+    proposed_law_name ||
+    proposed_source_url ||
+    proposed_status === 'superseded' ||
+    proposed_status === 'updated'
+  );
+
+  return {
+    hasProposal,
+    proposed_law_name,
+    proposed_source_url,
+    proposed_status,
+    superseded_by,
+  };
 }
 
 export async function GET(request: NextRequest) {
@@ -147,14 +210,12 @@ export async function GET(request: NextRequest) {
 
   const admin = getAdmin();
 
-  // 1. Oldest by last_verified, NULLS FIRST.
   const { data: oldest } = await admin
     .from('legal_references')
     .select('id, law_name, section, source_url, source_type, category, verification_status, last_verified, created_at')
     .order('last_verified', { ascending: true, nullsFirst: true })
     .limit(OLDEST_TARGET);
 
-  // 2. Recently used + not verified in last 7 days.
   const since24h = new Date(Date.now() - RECENT_USAGE_HOURS * 60 * 60 * 1000).toISOString();
   const sevenDaysAgo = new Date(Date.now() - RECENT_USAGE_REVERIFY_DAYS * 24 * 60 * 60 * 1000).toISOString();
   const { data: recentlyUsed } = await admin
@@ -173,7 +234,6 @@ export async function GET(request: NextRequest) {
     recentRefs = (data as LegalRefRow[]) || [];
   }
 
-  // Merge + dedupe + cap at HARD_CAP.
   const seen = new Set<string>();
   const queue: LegalRefRow[] = [];
   for (const r of [...(oldest || []), ...recentRefs] as LegalRefRow[]) {
@@ -183,7 +243,7 @@ export async function GET(request: NextRequest) {
     if (queue.length >= HARD_CAP) break;
   }
 
-  const counts = { processed: 0, errors: 0, auto_corrected: 0 };
+  const counts = { processed: 0, errors: 0, queued: 0, no_change: 0 };
 
   for (const ref of queue) {
     const verdict = await askPerplexity(buildPrompt(ref));
@@ -209,55 +269,113 @@ export async function GET(request: NextRequest) {
       metadata: { legal_reference_id: ref.id },
     });
 
-    let status = deriveStatus(verdict);
     const notes = verdict.superseded_by
       ? `Superseded by: ${verdict.superseded_by}. ${verdict.notes}`.trim()
       : verdict.notes;
-    const update: Record<string, unknown> = {
-      last_verified: new Date().toISOString(),
-      verification_notes: notes || null,
-    };
-    if (verdict.current_url) update.verified_url = verdict.current_url;
 
-    let autoCorrected = false;
-    if (verdict.confidence === 'high' && verdict.superseded_by) {
-      const parsed = parseSuperseded(verdict.superseded_by);
-      update.law_name = parsed.law_name;
-      if (parsed.url) update.source_url = parsed.url;
-      else if (verdict.current_url) update.source_url = verdict.current_url;
-      status = 'superseded';
-      autoCorrected = true;
-    } else if (verdict.confidence === 'high' && verdict.valid === false && verdict.current_url) {
-      update.source_url = verdict.current_url;
-      status = 'updated';
-      autoCorrected = true;
-    } else if (verdict.confidence === 'medium') {
-      status = 'needs_review';
-    } else if (verdict.confidence === 'low') {
-      status = 'broken';
+    // Touch ONLY observational fields. Never canonical from this route.
+    const nowIso = new Date().toISOString();
+    await admin
+      .from('legal_references')
+      .update({
+        last_verified: nowIso,
+        verification_notes: notes || null,
+      })
+      .eq('id', ref.id);
+
+    const proposal = deriveProposal(ref, verdict);
+
+    if (!proposal.hasProposal) {
+      counts.no_change += 1;
+      void admin.from('legal_ref_verifications').insert({
+        ref_id: ref.id,
+        verifier: 'perplexity-sonar-pro',
+        triggered_by: 'cron',
+        before_status: ref.verification_status,
+        after_status: ref.verification_status,
+        before_url: ref.source_url,
+        after_url: ref.source_url,
+        changes: { no_change: true },
+        cost_gbp: COST_PER_CALL_GBP * 0.79,
+        perplexity_response: verdict as any,
+        notes: notes || null,
+      });
+      counts.processed += 1;
+      await new Promise((r) => setTimeout(r, 200));
+      continue;
     }
 
-    update.verification_status = status;
-    if (autoCorrected) {
-      update.auto_corrected = true;
-      counts.auto_corrected += 1;
+    // Mark prior pending corrections for this ref as superseded.
+    await admin
+      .from('legal_ref_corrections')
+      .update({
+        status: 'superseded_by_newer',
+        reviewed_at: nowIso,
+        reviewed_by: 'daily-reverify-new-proposal',
+      })
+      .eq('ref_id', ref.id)
+      .eq('status', 'pending');
+
+    const { data: insertedRows, error: insErr } = await admin
+      .from('legal_ref_corrections')
+      .insert({
+        ref_id: ref.id,
+        proposer: 'perplexity-sonar-pro',
+        before_law_name: ref.law_name,
+        before_source_url: ref.source_url,
+        before_status: ref.verification_status,
+        proposed_law_name: proposal.proposed_law_name,
+        proposed_source_url: proposal.proposed_source_url,
+        proposed_status: proposal.proposed_status,
+        superseded_by: proposal.superseded_by,
+        reasoning: notes || null,
+        raw_response: verdict as any,
+        confidence: verdict.confidence,
+        cost_gbp: COST_PER_CALL_GBP,
+        status: 'pending',
+      })
+      .select('id')
+      .limit(1);
+
+    const correctionId = insertedRows?.[0]?.id;
+
+    if (insErr) {
+      counts.errors += 1;
+      void admin.from('legal_ref_verifications').insert({
+        ref_id: ref.id,
+        verifier: 'perplexity-sonar-pro',
+        triggered_by: 'cron',
+        before_status: ref.verification_status,
+        after_status: 'error',
+        before_url: ref.source_url,
+        after_url: null,
+        changes: { corrections_insert_failed: true, error: insErr.message },
+        cost_gbp: COST_PER_CALL_GBP * 0.79,
+        perplexity_response: verdict as any,
+        notes: `corrections insert failed: ${insErr.message}`,
+      });
+    } else {
+      counts.queued += 1;
+      void admin.from('legal_ref_verifications').insert({
+        ref_id: ref.id,
+        verifier: 'perplexity-sonar-pro',
+        triggered_by: 'cron',
+        before_status: ref.verification_status,
+        after_status: 'pending-correction-queued',
+        before_url: ref.source_url,
+        after_url: proposal.proposed_source_url,
+        changes: {
+          queued_correction: true,
+          correction_id: correctionId ?? null,
+          proposed_law_name: proposal.proposed_law_name,
+          proposed_source_url: proposal.proposed_source_url,
+          proposed_status: proposal.proposed_status,
+        },
+        cost_gbp: COST_PER_CALL_GBP * 0.79,
+        perplexity_response: verdict as any,
+        notes: notes || null,
+      });
     }
-
-    await admin.from('legal_references').update(update).eq('id', ref.id);
-
-    void admin.from('legal_ref_verifications').insert({
-      ref_id: ref.id,
-      verifier: 'perplexity-sonar-pro',
-      triggered_by: 'cron',
-      before_status: ref.verification_status,
-      after_status: status,
-      before_url: ref.source_url,
-      after_url: (update.source_url as string | undefined) ?? (verdict.current_url ?? null),
-      changes: { auto_corrected: autoCorrected },
-      cost_gbp: 0.005 * 0.79,
-      perplexity_response: verdict as any,
-      notes: notes || null,
-    });
 
     counts.processed += 1;
     await new Promise((r) => setTimeout(r, 200));

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -297,6 +297,11 @@ export default function LegalRefsAdminPage() {
         const data = await res.json();
         const u = data?.updated;
         if (u) {
+          // The verify route is now propose-only. Possible statuses:
+          //   - 'no_change'    — observational fields touched only
+          //   - 'queued'       — correction inserted into legal_ref_corrections
+          //   - 'auto_applied' — rare; correction passed all auto-apply gates
+          //   - 'error'        — surface the error, don't mutate row state
           setAiResults(prev => ({
             ...prev,
             [u.id]: {
@@ -305,13 +310,17 @@ export default function LegalRefsAdminPage() {
               ok: u.status !== 'error',
             },
           }));
-          setRefs(prev => prev.map(r => (r.id === u.id ? {
-            ...r,
-            verification_status: u.status === 'error' ? r.verification_status : u.status,
-            verified_url: u.current_url ?? r.verified_url,
-            verification_notes: u.notes ?? r.verification_notes,
-            last_verified: u.status === 'error' ? r.last_verified : new Date().toISOString(),
-          } : r)));
+          setRefs(prev => prev.map(r => {
+            if (r.id !== u.id) return r;
+            if (u.status === 'error') return r;
+            // Only refresh observational fields. Canonical verification_status
+            // is mutated only by the auto-apply sweep or a founder approval click.
+            return {
+              ...r,
+              verification_notes: u.notes ?? r.verification_notes,
+              last_verified: new Date().toISOString(),
+            };
+          }));
         }
       } else {
         // Batch in chunks of 25.
@@ -339,10 +348,11 @@ export default function LegalRefsAdminPage() {
           setRefs(prev => prev.map(r => {
             const u = results.find(x => x.id === r.id);
             if (!u || u.status === 'error') return r;
+            // Propose-only: only refresh observational fields client-side.
+            // Canonical verification_status is mutated by the auto-apply
+            // sweep or a founder approval click, not this route.
             return {
               ...r,
-              verification_status: u.status,
-              verified_url: u.current_url ?? r.verified_url,
               verification_notes: u.notes ?? r.verification_notes,
               last_verified: new Date().toISOString(),
             };
@@ -997,7 +1007,12 @@ export default function LegalRefsAdminPage() {
                             </div>
                             {result && (
                               <p className={`text-[11px] mt-1.5 text-right ${result.ok ? 'text-emerald-600' : 'text-red-500'}`}>
-                                {result.ok ? '✓ ' : '✗ '}{result.ok ? `Verified · ${result.status}` : result.notes || 'Failed'}
+                                {result.ok ? '✓ ' : '✗ '}{result.ok ? (
+                                  result.status === 'no_change' ? 'No change · still current'
+                                  : result.status === 'queued' ? 'Correction queued for review'
+                                  : result.status === 'auto_applied' ? 'Auto-applied (low-risk)'
+                                  : `Verified · ${result.status}`
+                                ) : (result.notes || 'Failed')}
                               </p>
                             )}
                           </td>


### PR DESCRIPTION
## Summary
- /api/admin/legal-refs/verify and /api/cron/legal-refs-daily-reverify were directly mutating canonical citation fields (law_name, source_url, verification_status), violating the compliance principle that all citation changes must pass through legal_ref_corrections + founder approval (or the auto-apply sweep's three gates).
- Both routes are now propose-only. A verdict that matches canonical returns no_change (touching only last_verified + verification_notes). A real proposal is INSERTed into legal_ref_corrections with status='pending'; prior pending rows for the same ref are marked superseded_by_newer first.
- Non-authority proposed URLs are dropped at the allowlist gate (already enforced in reverify-all-legal-refs).
- Admin UI handles new response shape: no_change / queued / auto_applied / error. Client-side row state no longer mutates verification_status from this route.

This is a code-only refactor — no schema changes, no migrations.

## Test plan
- [ ] tsc --noEmit clean (verified locally)
- [ ] Founder triggers Verify with AI on a stable ref → response 'no_change', no corrections row
- [ ] Founder triggers Verify with AI on a known-superseded ref → response 'queued', new pending row in legal_ref_corrections
- [ ] Daily cron tick (manual fire) → counts.queued + counts.no_change rather than direct mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)