### PR TITLE
fix(mcp): add 'essential' tier to finance-snapshot price map

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -330,13 +330,13 @@ const TOOLS = [
   {
     name: "get_finance_snapshot",
     description:
-      "Returns a structured snapshot of Paybacker's financial state from Supabase: user counts by tier (free/plus/pro), active paying users, estimated MRR + ARR, signups (last 7d/30d), active onboarding trials, trial conversions / expiries (7d/30d), recent plan downgrade events, subscriptions expiring soon, and upcoming payments. Read-only. Use this on every finance-analyst session before reasoning about revenue health.",
+      "Returns a structured snapshot of Paybacker's financial state from Supabase: user counts by tier (free/essential/pro — 'plus' is the legacy alias for 'essential'), active paying users, estimated MRR + ARR, signups (last 7d/30d), active onboarding trials, trial conversions / expiries (7d/30d), recent plan downgrade events, subscriptions expiring soon, and upcoming payments. Read-only. Use this on every finance-analyst session before reasoning about revenue health.",
     inputSchema: {
       type: "object" as const,
       properties: {
         tier_prices_gbp: {
           type: "object",
-          description: "Optional override for tier monthly prices in GBP. Defaults to the canonical {free:0, plus:4.99, pro:9.99} from src/lib/plan-limits.ts. Use only if the live pricing config has changed and you want the agent to compute MRR with new prices.",
+          description: "Optional override for tier monthly prices in GBP. Defaults to the canonical {free:0, essential:4.99, pro:9.99} from src/lib/plan-limits.ts. The legacy 'plus' slug is mapped to the same £4.99 price for backwards compatibility with rows written before the 2026-04-22 rename. Use only if the live pricing config has changed and you want the agent to compute MRR with new prices.",
         },
       },
     },
@@ -711,8 +711,13 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
     case "get_finance_snapshot": {
       const { url, key } = getSupabaseCredentials();
       const tierPricesArg = args.tier_prices_gbp as Record<string, number> | undefined;
+      // Canonical tiers (per CLAUDE.md, src/lib/plan-limits.ts): free / essential / pro.
+      // 'plus' is the legacy slug for what's now 'essential' (renamed 2026-04-22).
+      // Keeping it in the default map at the same £4.99 price so any rows still
+      // tagged 'plus' continue to contribute correctly to MRR.
       const tierPrices: Record<string, number> = tierPricesArg ?? {
         free: 0,
+        essential: 4.99,
         plus: 4.99,
         pro: 9.99,
       };


### PR DESCRIPTION
## Why
Telegram alert from finance-analyst flagged \"Unknown tier slug 'essential' — MRR understated by ~£9.98/mo\".

The MCP \`get_finance_snapshot\` price map only knew \`free / plus / pro\`. The canonical tiers per \`CLAUDE.md\` and \`src/lib/plan-limits.ts\` are \`free / essential / pro\` — 'essential' replaced 'plus' as the canonical slug on 2026-04-22.

Result: 2 essential subscribers were counted as 'unknown_tiers_seen' and contributed £0 to reported MRR. Reported MRR was £9.99 (1 Pro); true MRR was £19.97. ~50% understatement, reporting only — Stripe was billing correctly.

## What

- \`mcp-server/src/index.ts:714-718\` — add \`essential: 4.99\` to default \`tierPrices\`. Keep \`plus: 4.99\` as a legacy alias so any rows still tagged 'plus' continue to count.
- \`mcp-server/src/index.ts:333\` — update tool description to document both slugs and the rename history.
- \`mcp-server/src/index.ts:339\` — update \`tier_prices_gbp\` parameter description to match.

## Verification
\`tsc --noEmit\` clean. Next finance-analyst snapshot will pick up the £9.98 from the 2 essential subscribers and the 'unknown_tiers_seen' alert will stop firing.