### PR TITLE
feat(admin): all compliance ops runnable from dashboard + fix η column-name bug

### DIFF
--- a/src/app/api/admin/legal-ref-corrections/[id]/revert/route.ts
+++ b/src/app/api/admin/legal-ref-corrections/[id]/revert/route.ts
@@ -42,7 +42,7 @@ export async function POST(
   let correction:
     | {
         id: string;
-        legal_reference_id: string;
+        ref_id: string;
         status: string;
         before_law_name?: string | null;
         before_source_url?: string | null;
@@ -96,7 +96,7 @@ export async function POST(
     const { error } = await supabase
       .from('legal_references')
       .update(restore)
-      .eq('id', correction.legal_reference_id);
+      .eq('id', correction.ref_id);
     if (error) {
       return NextResponse.json(
         { error: `legal_references update failed: ${error.message}` },
@@ -127,7 +127,7 @@ export async function POST(
   // Audit row.
   try {
     await supabase.from('legal_ref_verifications').insert({
-      legal_reference_id: correction.legal_reference_id,
+      legal_reference_id: correction.ref_id,
       verifier: 'founder-revert',
       changes: { restored: restore, correction_id: correction.id },
       reasons: ['Founder one-click revert via admin UI'],

--- a/src/app/api/admin/legal-refs/recover-url-dead/route.ts
+++ b/src/app/api/admin/legal-refs/recover-url-dead/route.ts
@@ -1,0 +1,191 @@
+/**
+ * POST /api/admin/legal-refs/recover-url-dead
+ *
+ * Founder-gated endpoint that lifts the `scripts/recover-url-dead.ts`
+ * core logic into the admin dashboard. Probes every legal_references row
+ * with `verification_status='url_dead'` using both the default fetcher UA
+ * and a real-browser UA (some publishers — ofcom.org.uk, orr.gov.uk —
+ * 403 default fetchers but 200 a normal browser).
+ *
+ * Body: { queue?: boolean }
+ *   - queue=false (default): probe-only, returns counts.
+ *   - queue=true: also INSERT pending rows in legal_ref_corrections so
+ *     a founder can approve via the existing review queue.
+ *
+ * Returns: { probed, still_dead, now_resolves, redirected_to_authority,
+ *            queued, errors }
+ *
+ * No DB mutation of legal_references at any point — corrections only.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/server';
+import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+function getAdminEmails(): string[] {
+  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim(),
+  );
+}
+
+async function authorise(): Promise<{ ok: boolean }> {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    const allow = getAdminEmails();
+    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
+      return { ok: false };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false };
+  }
+}
+
+async function probe(url: string, ua: string | null): Promise<{
+  status: number | 'fetch_error';
+  final_url: string | null;
+}> {
+  const headers: Record<string, string> = ua ? { 'User-Agent': ua } : {};
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      headers,
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    return { status: res.status, final_url: res.url };
+  } catch {
+    return { status: 'fetch_error', final_url: null };
+  }
+}
+
+interface Row {
+  id: string;
+  law_name: string;
+  source_url: string;
+  category: string;
+  verification_status: string;
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await authorise();
+  if (!auth.ok) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: { queue?: boolean } = {};
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  const queue = body.queue === true;
+
+  const admin = getAdmin();
+  const { data, error } = await admin
+    .from('legal_references')
+    .select('id, law_name, source_url, category, verification_status')
+    .eq('verification_status', 'url_dead')
+    .order('category', { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  const rows = (data ?? []) as Row[];
+
+  const summary = {
+    probed: 0,
+    still_dead: 0,
+    now_resolves: 0,
+    redirected_to_authority: 0,
+    queued: 0,
+    errors: [] as string[],
+  };
+
+  for (const row of rows) {
+    summary.probed++;
+    // eslint-disable-next-line no-await-in-loop
+    const def = await probe(row.source_url, null);
+    // eslint-disable-next-line no-await-in-loop
+    const ua = await probe(row.source_url, BROWSER_UA);
+
+    let category: 'still_dead' | 'now_resolves' | 'redirected_to_authority' = 'still_dead';
+    let finalUrl: string | null = null;
+
+    const ok2xx = typeof ua.status === 'number' && ua.status >= 200 && ua.status < 300;
+    const ok3xx = typeof ua.status === 'number' && ua.status >= 300 && ua.status < 400 && ua.final_url;
+
+    if (ok2xx || ok3xx) {
+      finalUrl = ua.final_url ?? row.source_url;
+      const redirected = !!finalUrl && finalUrl !== row.source_url;
+      if (redirected) {
+        const auth = checkUkLegalAuthority(finalUrl);
+        if (auth.reason === 'authority' || auth.reason === 'secondary') {
+          category = 'redirected_to_authority';
+        } else {
+          category = 'now_resolves';
+        }
+      } else {
+        category = 'now_resolves';
+      }
+    }
+
+    if (category === 'still_dead') summary.still_dead++;
+    else if (category === 'now_resolves') summary.now_resolves++;
+    else summary.redirected_to_authority++;
+
+    if (queue && category !== 'still_dead' && finalUrl) {
+      const proposed_source_url = finalUrl !== row.source_url ? finalUrl : null;
+      const reasoning =
+        'Server-side probe found a working URL after the original returned ' +
+        `4xx/5xx (default UA=${def.status}, browser UA=${ua.status}). ` +
+        'Verify the destination still cites the same law before approving.';
+
+      // eslint-disable-next-line no-await-in-loop
+      const { error: insErr } = await admin.from('legal_ref_corrections').insert({
+        ref_id: row.id,
+        proposer: 'url-dead-recovery-2026-04-30',
+        before_law_name: row.law_name,
+        before_source_url: row.source_url,
+        before_status: 'url_dead',
+        proposed_law_name: null,
+        proposed_source_url,
+        proposed_status: null,
+        reasoning,
+        confidence: 'medium',
+        status: 'pending',
+      });
+      if (insErr) {
+        summary.errors.push(`${row.id}: ${insErr.message}`);
+      } else {
+        summary.queued++;
+      }
+    }
+
+    // Polite throttle.
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  return NextResponse.json({ ok: true, ...summary });
+}

--- a/src/app/api/cron/enrich-compliance-pending/route.ts
+++ b/src/app/api/cron/enrich-compliance-pending/route.ts
@@ -414,3 +414,10 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({ ok: true, ...results });
 }
+
+// Mirror GET so the founder can trigger this from the admin dashboard
+// without needing a cron-secret bearer header (the admin UI authenticates
+// via the Supabase session cookie, see authorizeAdminOrCron).
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/src/app/api/cron/legal-refs-auto-apply-sweep/route.ts
+++ b/src/app/api/cron/legal-refs-auto-apply-sweep/route.ts
@@ -122,3 +122,9 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json(summary);
 }
+
+// Mirror GET so the founder admin button can POST without exposing the
+// cron-secret bearer header to the browser bundle.
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -148,6 +148,33 @@ export default function LegalRefsAdminPage() {
   const REVIEW_PAGE_SIZE = 50;
   const supabase = createClient();
 
+  // Compliance-ops toolbar state — wired in feat/compliance-ops-from-dashboard
+  // so the founder can run every compliance op from this page (no terminal
+  // scripts, no hand-curl). Each op shares the same modal pattern: confirm
+  // cost (or zero-cost note), POST, show toast, refresh.
+  const [opModal, setOpModal] = useState<null | {
+    op:
+      | 'recover-url-dead'
+      | 'authority-audit'
+      | 'discover'
+      | 'enrich'
+      | 'auto-apply-sweep'
+      | 'verify-all-baseline';
+    title: string;
+    body: string;
+    action: () => Promise<void>;
+  }>(null);
+  const [opRunning, setOpRunning] = useState<string | null>(null);
+  const [opToast, setOpToast] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+
+  useEffect(() => {
+    if (!opToast) return;
+    const t = setTimeout(() => setOpToast(null), 8000);
+    return () => clearTimeout(t);
+  }, [opToast]);
+
+  const urlDeadCount = refs.filter((r) => r.verification_status === 'url_dead').length;
+
   useEffect(() => {
     const load = async () => {
       const { data: { user } } = await supabase.auth.getUser();
@@ -376,6 +403,172 @@ export default function LegalRefsAdminPage() {
     }
   };
 
+  // ---------- Compliance ops handlers ----------
+  // All ops post to founder-gated endpoints, surface a toast on completion,
+  // and refresh the page state so any new pending corrections become
+  // visible in the existing review queue.
+
+  const runOp = async (
+    op: NonNullable<typeof opModal>['op'],
+    fn: () => Promise<{ ok: boolean; text: string }>,
+  ) => {
+    setOpRunning(op);
+    try {
+      const result = await fn();
+      setOpToast({ kind: result.ok ? 'ok' : 'err', text: result.text });
+      await Promise.all([fetchRefs(), fetchCandidates()]);
+    } catch (err) {
+      setOpToast({
+        kind: 'err',
+        text: `Failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    } finally {
+      setOpRunning(null);
+    }
+  };
+
+  const opRecoverUrlDead = () => {
+    setOpModal({
+      op: 'recover-url-dead',
+      title: 'Recover url_dead refs',
+      body: `Probe ${urlDeadCount} url_dead ref${urlDeadCount === 1 ? '' : 's'} (no API cost — server-side HTTP probes, ~30–60s for typical batches). Recoverable URLs will be queued as pending corrections for your approval.`,
+      action: async () => {
+        await runOp('recover-url-dead', async () => {
+          const res = await fetch('/api/admin/legal-refs/recover-url-dead', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ queue: true }),
+          });
+          const data = await res.json();
+          if (!data.ok) return { ok: false, text: `Error: ${data.error || 'Unknown'}` };
+          return {
+            ok: true,
+            text:
+              `Probed ${data.probed} · still dead ${data.still_dead} · now resolves ${data.now_resolves} · ` +
+              `redirected to authority ${data.redirected_to_authority} · queued ${data.queued} pending correction${data.queued === 1 ? '' : 's'}.`,
+          };
+        });
+      },
+    });
+  };
+
+  const opAuthorityAudit = () => {
+    setOpModal({
+      op: 'authority-audit',
+      title: 'Run authority audit',
+      body: `Audit ${counts.dbTotal} ref source URLs against the UK legal authority allowlist. No API cost — local check. Refs flagged as rejected/unrecognised will be queued as pending corrections.`,
+      action: async () => {
+        await runOp('authority-audit', async () => {
+          const res = await fetch('/api/admin/legal-refs/audit-authority', {
+            method: 'POST',
+            credentials: 'include',
+          });
+          const data = await res.json();
+          if (!data.ok) return { ok: false, text: `Error: ${data.error || 'Unknown'}` };
+          const c = data.counts;
+          return {
+            ok: true,
+            text: `Audit done. Authority ${c.authority} · secondary ${c.secondary} · rejected ${c.rejected} · unrecognised ${c.unrecognised}. Inserted ${data.inserted} pending corrections (skipped ${data.skipped_existing} already-queued).`,
+          };
+        });
+      },
+    });
+  };
+
+  const opDiscover = () => {
+    setOpModal({
+      op: 'discover',
+      title: 'Discover new refs (Perplexity)',
+      body: 'Run Perplexity discovery for recent UK consumer-law updates. Estimated cost ~£0.05–£0.30 depending on candidates found. New candidates appear in the discovery queue for founder approval.',
+      action: async () => {
+        await runOp('discover', async () => {
+          const res = await fetch('/api/cron/discover-legal-refs?leg=recent', {
+            method: 'POST',
+            credentials: 'include',
+          });
+          const data = await res.json();
+          if (!data.ok) return { ok: false, text: `Error: ${data.error || 'Unknown'}` };
+          return {
+            ok: true,
+            text: `Discovery done. ${data.candidates_found ?? 0} found · ${data.candidates_added ?? 0} new · ${data.candidates_skipped_duplicate ?? 0} duplicates.`,
+          };
+        });
+      },
+    });
+  };
+
+  const opEnrich = () => {
+    setOpModal({
+      op: 'enrich',
+      title: 'Enrich pending review queue',
+      body: 'Run enrichment on pending corrections + candidates (adds risk_score + URL diff so the auto-apply sweep can act on low-risk rows). Estimated cost ~£0.01–£0.05 per run.',
+      action: async () => {
+        await runOp('enrich', async () => {
+          const res = await fetch('/api/cron/enrich-compliance-pending', {
+            method: 'POST',
+            credentials: 'include',
+          });
+          const data = await res.json();
+          if (!data.ok) return { ok: false, text: `Error: ${data.error || 'Unknown'}` };
+          return {
+            ok: true,
+            text: `Enrichment done. Corrections ${data.processed_corrections} · candidates ${data.processed_candidates} · low ${data.risk_low} · medium ${data.risk_medium} · high ${data.risk_high} · errors ${data.errors}.`,
+          };
+        });
+      },
+    });
+  };
+
+  const opAutoApplySweep = () => {
+    setOpModal({
+      op: 'auto-apply-sweep',
+      title: 'Run auto-apply sweep',
+      body: 'Evaluate pending corrections through the three auto-apply gates (risk=low, source-text corroboration, no semantic change) and auto-apply LOW-risk rows. Hard cap 50 per run. No API cost — local evaluation.',
+      action: async () => {
+        await runOp('auto-apply-sweep', async () => {
+          const res = await fetch('/api/cron/legal-refs-auto-apply-sweep', {
+            method: 'POST',
+            credentials: 'include',
+          });
+          const data = await res.json();
+          if (data.skipped_table_missing) {
+            return { ok: false, text: 'Skipped: legal_ref_corrections table not available.' };
+          }
+          return {
+            ok: true,
+            text: `Sweep done. Processed ${data.processed} · auto-applied ${data.auto_applied} · still pending ${data.still_pending} · failures ${data.failures}.`,
+          };
+        });
+      },
+    });
+  };
+
+  const opVerifyAllBaseline = () => {
+    setOpModal({
+      op: 'verify-all-baseline',
+      title: 'Re-verify ALL refs (Perplexity baseline)',
+      body: `Re-verify all ${refs.length} refs via Perplexity to establish a clean compliance baseline. Estimated cost ~£${(refs.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(2)}. Corrections route through the pending review queue.`,
+      action: async () => {
+        await runOp('verify-all-baseline', async () => {
+          const res = await fetch('/api/admin/legal-refs/verify-all', {
+            method: 'POST',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({}),
+          });
+          const data = await res.json();
+          if (!data.ok || !data.counts) return { ok: false, text: `Error: ${data.error || 'Unknown'}` };
+          const c = data.counts;
+          return {
+            ok: true,
+            text: `Baseline done. ${c.verified} verified · ${c.updated} auto-updated · ${c.superseded} superseded · ${c.needs_review} needs review · ${c.broken} broken · ${c.error} errors.`,
+          };
+        });
+      },
+    });
+  };
+
   const filtered = refs.filter(r => {
     if (filterStatus === 'needs_review_any') {
       if (!needsReview(r)) return false;
@@ -428,8 +621,125 @@ export default function LegalRefsAdminPage() {
     );
   }
 
+  const opButtons: Array<{
+    key: NonNullable<typeof opModal>['op'];
+    label: string;
+    tooltip: string;
+    onClick: () => void;
+    disabled?: boolean;
+    variant: 'primary' | 'secondary' | 'amber';
+  }> = [
+    {
+      key: 'discover',
+      label: 'Discover new refs',
+      tooltip: 'Perplexity scans for recent UK consumer-law updates. Cost ~£0.05–£0.30.',
+      onClick: opDiscover,
+      variant: 'primary',
+    },
+    {
+      key: 'verify-all-baseline',
+      label: 'Re-verify ALL (baseline)',
+      tooltip: `Perplexity re-verifies all ${refs.length} refs. Cost ~£${(refs.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(2)}.`,
+      onClick: opVerifyAllBaseline,
+      variant: 'amber',
+    },
+    {
+      key: 'authority-audit',
+      label: 'Authority audit',
+      tooltip: 'Audit source URLs against the UK legal authority allowlist. No API cost.',
+      onClick: opAuthorityAudit,
+      variant: 'secondary',
+    },
+    {
+      key: 'recover-url-dead',
+      label: `Recover url_dead (${urlDeadCount})`,
+      tooltip: 'Probe url_dead refs with a real-browser UA. No API cost — server-side HTTP probes.',
+      onClick: opRecoverUrlDead,
+      disabled: urlDeadCount === 0,
+      variant: 'secondary',
+    },
+    {
+      key: 'enrich',
+      label: 'Enrich pending queue',
+      tooltip: 'Add risk_score + URL diff to pending rows so auto-apply can act. Cost ~£0.01–£0.05.',
+      onClick: opEnrich,
+      variant: 'secondary',
+    },
+    {
+      key: 'auto-apply-sweep',
+      label: 'Run auto-apply sweep',
+      tooltip: 'Auto-apply LOW-risk corrections that pass all 3 gates. No API cost.',
+      onClick: opAutoApplySweep,
+      variant: 'secondary',
+    },
+  ];
+
+  const opVariantClass = (v: 'primary' | 'secondary' | 'amber') =>
+    v === 'primary'
+      ? 'bg-emerald-500 hover:bg-emerald-600 text-slate-900 border-emerald-500'
+      : v === 'amber'
+        ? 'bg-amber-500 hover:bg-amber-600 text-slate-900 border-amber-500'
+        : 'bg-white hover:border-emerald-500 text-slate-900 border-slate-200';
+
   return (
     <div className="max-w-7xl">
+      {/* Compliance ops toast */}
+      {opToast && (
+        <div
+          className={`fixed top-4 right-4 z-[60] max-w-md px-4 py-3 rounded-xl shadow-lg border text-sm font-medium ${
+            opToast.kind === 'ok'
+              ? 'bg-emerald-50 border-emerald-300 text-emerald-800'
+              : 'bg-red-50 border-red-300 text-red-800'
+          }`}
+          role="status"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <span>{opToast.text}</span>
+            <button
+              onClick={() => setOpToast(null)}
+              className="text-xs text-slate-500 hover:text-slate-900"
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Compliance ops cost-confirmation modal */}
+      {opModal && (
+        <div
+          className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+          onClick={() => setOpModal(null)}
+        >
+          <div
+            className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl border border-slate-200"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-bold text-slate-900 mb-2">{opModal.title}</h3>
+            <p className="text-sm text-slate-600 mb-5 whitespace-pre-line">{opModal.body}</p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setOpModal(null)}
+                className="px-4 py-2 text-sm text-slate-700 hover:bg-slate-100 rounded-lg"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  const action = opModal.action;
+                  setOpModal(null);
+                  void action();
+                }}
+                className="px-4 py-2 text-sm font-semibold bg-emerald-500 hover:bg-emerald-600 text-slate-900 rounded-lg"
+              >
+                Confirm &amp; run
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div className="mb-6">
         <Link
@@ -454,23 +764,48 @@ export default function LegalRefsAdminPage() {
           </div>
           <div className="flex items-center gap-2 shrink-0">
             <button
-              onClick={() => triggerDiscovery('recent')}
-              disabled={discovering}
-              className="flex items-center gap-2 bg-white border border-slate-200 hover:border-emerald-500 disabled:opacity-50 text-slate-900 font-semibold px-4 py-2.5 rounded-lg transition-all text-sm"
-              title="Run Perplexity discovery for recent UK consumer-law updates"
+              onClick={runVerification}
+              disabled={verifying}
+              className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm"
+              title="Run the cron-based verification pass (legislation.gov.uk staleness + regulator rule diff)"
             >
-              {discovering ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
-              Discover now
+              {verifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+              {verifying ? 'Verifying...' : 'Run Verification'}
             </button>
-          <button
-            onClick={runVerification}
-            disabled={verifying}
-            className="flex items-center gap-2 bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 font-semibold px-5 py-2.5 rounded-lg transition-all text-sm"
-          >
-            {verifying ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-            {verifying ? 'Verifying...' : 'Run Verification'}
-          </button>
           </div>
+        </div>
+      </div>
+
+      {/* Compliance ops toolbar — single pane of glass for all manual triggers
+          (added in feat/compliance-ops-from-dashboard). Each button shows a
+          tooltip with cost estimate, opens a confirmation modal, then fires
+          the op. Long-running ops are fire-and-forget; the page refreshes
+          state on completion so new pending corrections / candidates are
+          immediately visible. */}
+      <div className="mb-6 bg-white border border-slate-200 rounded-2xl p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <p className="text-sm font-semibold text-slate-900">Compliance ops</p>
+            <p className="text-xs text-slate-600">All manual triggers — cost-confirmation before any paid op.</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {opButtons.map((b) => (
+            <button
+              key={b.key}
+              onClick={b.onClick}
+              disabled={!!b.disabled || opRunning !== null}
+              title={b.tooltip}
+              className={`flex items-center gap-2 border disabled:opacity-50 font-semibold px-3.5 py-2 rounded-lg transition-all text-xs ${opVariantClass(b.variant)}`}
+            >
+              {opRunning === b.key ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              {b.label}
+            </button>
+          ))}
         </div>
       </div>
 

--- a/src/lib/legal-refs-auto-apply.ts
+++ b/src/lib/legal-refs-auto-apply.ts
@@ -25,7 +25,11 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 
 export interface LegalRefCorrection {
   id: string;
-  legal_reference_id: string;
+  // Schema uses `ref_id` (FK to legal_references.id). Earlier drafts of this
+  // type used `legal_reference_id`, which silently broke the auto-apply
+  // sweep — the canonical update never matched a row. See PR
+  // feat/compliance-ops-from-dashboard for the fix.
+  ref_id: string;
   status: string;
   before_law_name?: string | null;
   before_source_url?: string | null;
@@ -327,7 +331,7 @@ export async function applyCorrection(
     const { error } = await supabase
       .from('legal_references')
       .update(update)
-      .eq('id', correction.legal_reference_id);
+      .eq('id', correction.ref_id);
     if (error) {
       console.error('[auto-apply] legal_references update failed', error);
       return false;
@@ -355,7 +359,7 @@ export async function applyCorrection(
   // 3. Audit row in legal_ref_verifications (γ). Soft if missing.
   try {
     await supabase.from('legal_ref_verifications').insert({
-      legal_reference_id: correction.legal_reference_id,
+      legal_reference_id: correction.ref_id,
       verifier: 'auto-apply-low-risk',
       changes: {
         before: {


### PR DESCRIPTION
## Summary

Single pane of glass for every compliance op at `/dashboard/admin/legal-refs`. No more terminal scripts.

### What's wired up

- **Op 1 — Recover url_dead refs**: NEW `POST /api/admin/legal-refs/recover-url-dead`. Server-side port of `scripts/recover-url-dead.ts`. Dual-UA probe; classifies into `still_dead`, `now_resolves`, `redirected_to_authority`; queues pending corrections (medium confidence) when `{queue:true}`.
- **Op 2 — Authority audit**: button wired to existing `POST /api/admin/legal-refs/audit-authority`.
- **Op 3 — Discover (Perplexity)**: button wired to `POST /api/cron/discover-legal-refs` (uses existing `authorizeAdminOrCron` session-auth path — no proxy needed).
- **Op 4 — Re-verify ALL baseline**: button wired to `POST /api/admin/legal-refs/verify-all`.
- **Op 5 — Enrich pending queue**: NEW `POST` handler on `/api/cron/enrich-compliance-pending` (mirrors GET) so the admin button can fire it via the Supabase session cookie instead of exposing CRON_SECRET to the browser.
- **Op 6 — Auto-apply sweep**: NEW `POST` handler on `/api/cron/legal-refs-auto-apply-sweep` (mirrors GET).
- **η column-name bug fix**: `LegalRefCorrection.legal_reference_id` → `ref_id` in `src/lib/legal-refs-auto-apply.ts` and the revert route. Schema (PR ε migration) uses `ref_id`. The bug silently broke the auto-apply sweep — the canonical update never matched a row. Now LOW-risk corrections that pass all 3 gates actually mutate `legal_references`.
- **Op 7 — Toolbar**: new "Compliance ops" toolbar at the top of the page groups all 6 manual triggers. Each button has a tooltip with cost estimate, opens a cost-confirmation modal, fires fire-and-forget, shows a result toast and refreshes page state on completion.

### Cost estimates surfaced in the modals

| Op | Cost | API |
|---|---|---|
| Discover | ~£0.05–£0.30 | Perplexity |
| Re-verify ALL | ~£0.50 (auto-computed from row count) | Perplexity |
| Authority audit | £0 | Local check |
| Recover url_dead | £0 | Server-side HTTP probes |
| Enrich pending | ~£0.01–£0.05 | Perplexity (lightweight) |
| Auto-apply sweep | £0 | Local evaluation |

### Safety

- Every new endpoint is founder-gated: admin endpoints via `NEXT_PUBLIC_ADMIN_EMAILS` (or `aireypaul@googlemail.com` fallback), cron POST mirrors via `authorizeAdminOrCron`.
- `legal_references` is never mutated by `recover-url-dead` — it only inserts pending rows in `legal_ref_corrections` (founder approval still required).
- Compliance citation principle preserved end-to-end.
- B2C and B2B both consume `legal_references`; behaviour for both is unchanged.

## Test plan

- [ ] `tsc --noEmit` clean (verified locally — pre-existing module errors absent after `npm install`).
- [ ] Visit `/dashboard/admin/legal-refs` as `aireypaul@googlemail.com`, see new "Compliance ops" toolbar.
- [ ] Each button opens the confirmation modal with correct cost text.
- [ ] Authority audit completes and inserts pending corrections.
- [ ] Recover url_dead probes with browser UA and queues pending corrections for any rows that now resolve.
- [ ] Auto-apply sweep no longer silently no-ops on column mismatch — check `legal_ref_verifications` for `verifier='auto-apply-low-risk'` rows after a sweep.
- [ ] Reverting an auto-applied correction restores the canonical row from `before_*` snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)