### PR TITLE
fix(compliance): sync auth + dashboard tidy + Perplexity URL recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,37 @@ gates in `evaluateCorrection` — don't. The rule "100% correct" depends
 on this being conservative. Founder review only when enrichment can't
 decide.
 
+### Compliance dashboard — daily-driver UX (added 2026-04-29)
+
+The admin page at `/dashboard/admin/legal-refs` is structured for
+glance-then-act, not browse-and-explore:
+
+1. "What needs your attention" — bordered amber panel at the top.
+   Surfaces only action items: pending corrections, url_dead refs
+   needing recovery, "AI auto-correction" rows needing eyeball,
+   discovery candidates pending approval, and last sync outcome.
+   Empty state: "Nothing needs your attention. Last sync clean."
+2. "Compliance ops" toolbar — primary "Run sync now" button.
+3. Pending corrections + Review queue — visible by default.
+4. "All references" — wrapped in `<details>` so the 124-row dump
+   collapses past unless the founder explicitly expands it.
+5. Auto-corrected rows in the full table get an amber row tint and
+   a "⚠ Auto-corrected — verify" badge so Perplexity-overwritten
+   citations stand out for founder review.
+
+If you add a new compliance op, surface it as a counter in the action
+panel rather than a row in the big table — the panel is the
+daily-driver, the table is reference data.
+
+### Compliance endpoint auth (added 2026-04-29)
+
+Admin compliance endpoints that the chained `/api/cron/compliance-sync`
+calls must accept BOTH founder cookie auth AND `Bearer ${CRON_SECRET}`.
+Use `authorizeAdminOrCron(request)` from `src/lib/admin-auth.ts` — never
+the cookie-only `supabase.auth.getUser()` pattern, or the cron leg will
+401. Currently wired: `recover-url-dead`, `audit-authority`. Any new
+phase the cron chains must follow the same pattern.
+
 ---
 
 ## CORE FEATURES

--- a/src/app/api/admin/legal-refs/audit-authority/route.ts
+++ b/src/app/api/admin/legal-refs/audit-authority/route.ts
@@ -20,18 +20,11 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createAdminClient } from '@supabase/supabase-js';
-import { createClient } from '@/lib/supabase/server';
 import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
-
-function getAdminEmails(): string[] {
-  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
-    .split(',')
-    .map((e) => e.trim().toLowerCase())
-    .filter(Boolean);
-}
 
 function getAdmin() {
   return createAdminClient(
@@ -45,22 +38,6 @@ interface RefRow {
   law_name: string;
   source_url: string;
   verification_status: string | null;
-}
-
-async function authorise(): Promise<{ ok: boolean; userEmail?: string }> {
-  try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    const allow = getAdminEmails();
-    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
-      return { ok: false };
-    }
-    return { ok: true, userEmail: user.email };
-  } catch {
-    return { ok: false };
-  }
 }
 
 async function classify() {
@@ -100,10 +77,10 @@ async function classify() {
   };
 }
 
-export async function GET() {
-  const auth = await authorise();
+export async function GET(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
   if (!auth.ok) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return NextResponse.json({ error: auth.reason || 'Unauthorized' }, { status: auth.status });
   }
   const result = await classify();
   if ('error' in result) {
@@ -125,10 +102,10 @@ export async function GET() {
   });
 }
 
-export async function POST() {
-  const auth = await authorise();
+export async function POST(request: NextRequest) {
+  const auth = await authorizeAdminOrCron(request);
   if (!auth.ok) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return NextResponse.json({ error: auth.reason || 'Unauthorized' }, { status: auth.status });
   }
 
   const result = await classify();

--- a/src/app/api/admin/legal-refs/recover-url-dead/route.ts
+++ b/src/app/api/admin/legal-refs/recover-url-dead/route.ts
@@ -20,8 +20,96 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient as createAdminClient } from '@supabase/supabase-js';
-import { createClient } from '@/lib/supabase/server';
 import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { logPerplexityCall } from '@/lib/cost-ledger';
+
+const PERPLEXITY_MODEL = 'sonar-pro';
+// sonar-pro flat rate ≈ $0.005 per request. USD→GBP ≈ 0.79.
+const PERPLEXITY_COST_PER_CALL_GBP = 0.005 * 0.79;
+
+interface PerplexityRecovery {
+  current_url: string | null;
+  confidence: 'high' | 'medium' | 'low';
+  reasoning: string;
+}
+
+function publisherDomain(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const parts = u.hostname.toLowerCase().replace(/^www\./, '').split('.');
+    if (parts.length >= 2) return parts.slice(-2).join('.');
+    return u.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+async function askPerplexityForRecovery(args: {
+  oldUrl: string;
+  lawName: string;
+  summary: string;
+  publisherDomain: string;
+}): Promise<PerplexityRecovery | null> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) {
+    console.warn('[recover-url-dead] PERPLEXITY_API_KEY not set');
+    return null;
+  }
+  const summaryShort = (args.summary || '').slice(0, 200);
+  const userPrompt = [
+    `The UK regulator page at ${args.oldUrl} returned 403/404.`,
+    `The page is titled '${args.lawName}' and covers '${summaryShort}'.`,
+    `What is the current canonical URL on the same regulator's website?`,
+    `Return JSON: {current_url: string|null, confidence: 'high'|'medium'|'low', reasoning: string}.`,
+    `Only return URLs on ${args.publisherDomain} (e.g. ofcom.org.uk for an Ofcom ref).`,
+    `If no current URL exists or the page has been removed entirely, return current_url: null.`,
+  ].join(' ');
+  try {
+    const res = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a UK legal-citation URL-recovery assistant. Return STRICT JSON only — no markdown, no commentary. ' +
+              'Only return URLs hosted on the SAME publisher domain provided in the prompt. If no current canonical URL exists on that domain, return current_url: null.',
+          },
+          { role: 'user', content: userPrompt },
+        ],
+        max_tokens: 400,
+        temperature: 0.1,
+      }),
+    });
+    if (!res.ok) {
+      console.error(`[recover-url-dead] Perplexity ${res.status}`);
+      return null;
+    }
+    const data = await res.json();
+    const content: string = data?.choices?.[0]?.message?.content || '';
+    const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]);
+    const conf = parsed.confidence === 'high' || parsed.confidence === 'medium' || parsed.confidence === 'low'
+      ? parsed.confidence
+      : 'low';
+    return {
+      current_url: typeof parsed.current_url === 'string' && parsed.current_url ? parsed.current_url : null,
+      confidence: conf,
+      reasoning: typeof parsed.reasoning === 'string' ? parsed.reasoning : '',
+    };
+  } catch (err) {
+    console.error('[recover-url-dead] Perplexity error:', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -30,32 +118,11 @@ const BROWSER_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/537.36 ' +
   '(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
 
-function getAdminEmails(): string[] {
-  return (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
-    .split(',')
-    .map((e) => e.trim().toLowerCase())
-    .filter(Boolean);
-}
-
 function getAdmin() {
   return createAdminClient(
     (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
     (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim(),
   );
-}
-
-async function authorise(): Promise<{ ok: boolean }> {
-  try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    const allow = getAdminEmails();
-    if (!user?.email || !allow.includes(user.email.toLowerCase())) {
-      return { ok: false };
-    }
-    return { ok: true };
-  } catch {
-    return { ok: false };
-  }
 }
 
 async function probe(url: string, ua: string | null): Promise<{
@@ -85,12 +152,13 @@ interface Row {
   source_url: string;
   category: string;
   verification_status: string;
+  summary: string | null;
 }
 
 export async function POST(request: NextRequest) {
-  const auth = await authorise();
+  const auth = await authorizeAdminOrCron(request);
   if (!auth.ok) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return NextResponse.json({ error: auth.reason || 'Unauthorized' }, { status: auth.status });
   }
 
   let body: { queue?: boolean } = {};
@@ -104,7 +172,7 @@ export async function POST(request: NextRequest) {
   const admin = getAdmin();
   const { data, error } = await admin
     .from('legal_references')
-    .select('id, law_name, source_url, category, verification_status')
+    .select('id, law_name, source_url, category, verification_status, summary')
     .eq('verification_status', 'url_dead')
     .order('category', { ascending: true });
 
@@ -119,6 +187,9 @@ export async function POST(request: NextRequest) {
     now_resolves: 0,
     redirected_to_authority: 0,
     queued: 0,
+    perplexity_calls: 0,
+    perplexity_recovered: 0,
+    perplexity_cost_gbp: 0,
     errors: [] as string[],
   };
 
@@ -179,6 +250,81 @@ export async function POST(request: NextRequest) {
         summary.errors.push(`${row.id}: ${insErr.message}`);
       } else {
         summary.queued++;
+      }
+    } else if (queue && category === 'still_dead') {
+      // Perplexity fallback for Cloudflare-blocked publishers (Ofcom,
+      // Ofgem, ORR) where both UAs 403 — server probe cannot find a
+      // redirect even though the page may have moved on the same domain.
+      const pubDomain = publisherDomain(row.source_url);
+      if (pubDomain) {
+        // eslint-disable-next-line no-await-in-loop
+        const recovery = await askPerplexityForRecovery({
+          oldUrl: row.source_url,
+          lawName: row.law_name,
+          summary: row.summary || '',
+          publisherDomain: pubDomain,
+        });
+        summary.perplexity_calls++;
+        // Attribute spend to cost ledger (fire-and-forget).
+        logPerplexityCall({
+          model: PERPLEXITY_MODEL,
+          endpoint: '/api/admin/legal-refs/recover-url-dead',
+          userId: auth.userId ?? null,
+          metadata: { legal_reference_id: row.id, mode: 'url-recovery' },
+        });
+        summary.perplexity_cost_gbp = +(
+          summary.perplexity_calls * PERPLEXITY_COST_PER_CALL_GBP
+        ).toFixed(4);
+
+        const proposedUrl = recovery?.current_url ?? null;
+        const sameAuthority =
+          proposedUrl && checkUkLegalAuthority(proposedUrl).ok;
+        const samePublisher =
+          proposedUrl && publisherDomain(proposedUrl) === pubDomain;
+        const confOk =
+          recovery?.confidence === 'high' || recovery?.confidence === 'medium';
+
+        if (recovery && proposedUrl && sameAuthority && samePublisher && confOk) {
+          const reasoning =
+            `Original URL 403/404 (default UA=${def.status}, browser UA=${ua.status}). ` +
+            `Perplexity sonar-pro proposed canonical URL on same publisher domain ` +
+            `(${pubDomain}) with confidence=${recovery.confidence}. Reasoning: ${recovery.reasoning}`;
+          // eslint-disable-next-line no-await-in-loop
+          const { error: insErr } = await admin.from('legal_ref_corrections').insert({
+            ref_id: row.id,
+            proposer: 'url-recovery-perplexity-2026-04-30',
+            before_law_name: row.law_name,
+            before_source_url: row.source_url,
+            before_status: 'url_dead',
+            proposed_law_name: null,
+            proposed_source_url: proposedUrl,
+            proposed_status: null,
+            reasoning,
+            confidence: recovery.confidence,
+            status: 'pending',
+          });
+          if (insErr) {
+            summary.errors.push(`${row.id}: ${insErr.message}`);
+          } else {
+            summary.queued++;
+            summary.perplexity_recovered++;
+          }
+        } else {
+          // Null / low confidence / off-domain — leave url_dead, log for
+          // founder so manual research is visible in business_log.
+          // eslint-disable-next-line no-await-in-loop
+          await admin.from('business_log').insert({
+            category: 'compliance',
+            title: `url_dead — manual research needed: ${row.law_name}`,
+            content:
+              `Ref ${row.id} (${row.law_name}) source ${row.source_url} ` +
+              `still 4xx after browser-UA probe. Perplexity recovery returned ` +
+              `${proposedUrl ? `URL ${proposedUrl}` : 'no URL'} ` +
+              `with confidence=${recovery?.confidence ?? 'n/a'}` +
+              (recovery?.reasoning ? `. Reasoning: ${recovery.reasoning}` : '.'),
+            created_by: 'system',
+          });
+        }
       }
     }
 

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -169,6 +169,12 @@ export default function LegalRefsAdminPage() {
   const [opRunning, setOpRunning] = useState<string | null>(null);
   const [opToast, setOpToast] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
 
+  // Action-panel state (Section A — "What needs your attention")
+  const [pendingCorrectionsCount, setPendingCorrectionsCount] = useState<number>(0);
+  const [lastSyncRun, setLastSyncRun] = useState<{ at: string; ok: boolean; failedPhases: string[] } | null>(null);
+  const [allRefsExpanded, setAllRefsExpanded] = useState<boolean>(false);
+  const [expandedNotes, setExpandedNotes] = useState<Set<string>>(new Set());
+
   useEffect(() => {
     if (!opToast) return;
     const t = setTimeout(() => setOpToast(null), 8000);
@@ -186,7 +192,7 @@ export default function LegalRefsAdminPage() {
         return;
       }
       setAuthorized(true);
-      await Promise.all([fetchRefs(), fetchCandidates()]);
+      await Promise.all([fetchRefs(), fetchCandidates(), fetchActionPanelCounts()]);
     };
     load();
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -231,6 +237,47 @@ export default function LegalRefsAdminPage() {
       }
     } catch {}
     setLoading(false);
+  };
+
+  const fetchActionPanelCounts = async () => {
+    // Pending corrections — count only.
+    try {
+      const { count } = await supabase
+        .from('legal_ref_corrections')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'pending');
+      setPendingCorrectionsCount(typeof count === 'number' ? count : 0);
+    } catch {
+      // Table may be missing on dev — non-fatal.
+    }
+    // Last sync run — most recent business_log row tagged compliance_sync_run.
+    try {
+      const { data } = await supabase
+        .from('business_log')
+        .select('content, created_at, title')
+        .eq('category', 'compliance')
+        .order('created_at', { ascending: false })
+        .limit(20);
+      const row = (data || []).find((r: { title?: string | null }) =>
+        (r.title || '').toLowerCase().includes('compliance sync'),
+      ) || (data || [])[0];
+      if (row) {
+        // Heuristic: content includes 'failed' or names of phases when failed.
+        const content = (row as { content?: string }).content || '';
+        const failedPhases: string[] = [];
+        const m = content.match(/failed phases?:\s*([\w\-,\s]+)/i);
+        if (m) {
+          failedPhases.push(...m[1].split(',').map((s: string) => s.trim()).filter(Boolean));
+        }
+        setLastSyncRun({
+          at: (row as { created_at: string }).created_at,
+          ok: failedPhases.length === 0 && !/error|fail/i.test(content),
+          failedPhases,
+        });
+      }
+    } catch {
+      // non-fatal
+    }
   };
 
   const fetchCandidates = async () => {
@@ -418,7 +465,7 @@ export default function LegalRefsAdminPage() {
     try {
       const result = await fn();
       setOpToast({ kind: result.ok ? 'ok' : 'err', text: result.text });
-      await Promise.all([fetchRefs(), fetchCandidates()]);
+      await Promise.all([fetchRefs(), fetchCandidates(), fetchActionPanelCounts()]);
     } catch (err) {
       setOpToast({
         kind: 'err',
@@ -818,6 +865,78 @@ export default function LegalRefsAdminPage() {
         </div>
       </div>
 
+      {/* Section A — "What needs your attention". Daily-driver summary
+          panel that surfaces only the action items: pending corrections,
+          url_dead refs needing recovery, AI auto-corrections needing
+          founder eyeball, candidates pending approval, and last sync
+          outcome. Founder reads this, clicks the right link, deals with
+          what matters — without scrolling through 124-row tables. */}
+      {(() => {
+        const autoCorrectedCount = refs.filter((r) => r.auto_corrected === true).length;
+        const items: Array<{ label: string; count: number; href?: string; tone: 'amber' | 'red' | 'slate' }> = [
+          { label: 'pending corrections need review', count: pendingCorrectionsCount, href: '#pending-corrections', tone: 'amber' },
+          { label: 'URL_DEAD refs need recovery', count: urlDeadCount, href: '#review-queue', tone: 'red' },
+          { label: '"AI auto-correction" rows need verification', count: autoCorrectedCount, href: '#review-queue', tone: 'amber' },
+          { label: 'candidates pending approval', count: pendingCandCount, tone: 'slate' },
+        ];
+        const totalAction = items.reduce((s, i) => s + i.count, 0);
+        const tonePill = (t: 'amber' | 'red' | 'slate') =>
+          t === 'red'
+            ? 'bg-red-100 text-red-700 border-red-200'
+            : t === 'amber'
+              ? 'bg-amber-100 text-amber-700 border-amber-200'
+              : 'bg-slate-100 text-slate-700 border-slate-200';
+        return (
+          <div className="mb-6 bg-white border-2 border-amber-300 rounded-2xl p-5 shadow-sm">
+            <div className="flex items-center gap-2 mb-3">
+              <AlertTriangle className="h-5 w-5 text-amber-600" />
+              <h2 className="text-lg font-bold text-slate-900">What needs your attention</h2>
+            </div>
+            {totalAction === 0 ? (
+              <p className="text-sm text-emerald-700 font-medium flex items-center gap-2">
+                <CheckCircle className="h-4 w-4" />
+                Nothing needs your attention. Last sync clean.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {items
+                  .filter((i) => i.count > 0)
+                  .map((i) => (
+                    <li key={i.label} className="flex items-center gap-3 text-sm">
+                      <span className={`inline-flex items-center justify-center min-w-[2rem] h-7 px-2 rounded-full border text-xs font-bold ${tonePill(i.tone)}`}>
+                        {i.count}
+                      </span>
+                      {i.href ? (
+                        <a href={i.href} className="text-slate-800 hover:text-emerald-700 hover:underline">
+                          {i.label}
+                        </a>
+                      ) : (
+                        <span className="text-slate-800">{i.label}</span>
+                      )}
+                    </li>
+                  ))}
+              </ul>
+            )}
+            <div className="mt-4 pt-3 border-t border-slate-200 text-xs text-slate-600">
+              {lastSyncRun ? (
+                <span>
+                  Last sync run: {formatDate(lastSyncRun.at)} —{' '}
+                  {lastSyncRun.ok ? (
+                    <span className="text-emerald-700 font-medium">success</span>
+                  ) : (
+                    <span className="text-red-600 font-medium">
+                      failed{lastSyncRun.failedPhases.length > 0 ? ` (${lastSyncRun.failedPhases.join(', ')})` : ''}
+                    </span>
+                  )}
+                </span>
+              ) : (
+                <span>No sync runs recorded yet.</span>
+              )}
+            </div>
+          </div>
+        );
+      })()}
+
       {/* Single end-to-end compliance pipeline button. The chained
           /api/cron/compliance-sync runs the same phases as the nightly
           cron: recover url_dead → authority audit → discover → enrich →
@@ -1016,10 +1135,25 @@ export default function LegalRefsAdminPage() {
       </div>
 
       {/* Pending corrections (PR ε — human-in-loop gate) */}
-      <PendingCorrectionsSection />
+      <div id="pending-corrections">
+        <PendingCorrectionsSection />
+      </div>
 
+      {/* Section C — "All references" collapsed by default. Founder
+          rarely needs the full 124-row dump — it's reference data, not a
+          daily-driver. Wrapped in <details> so it scrolls past unless
+          they want to dig. */}
+      <details
+        className="mb-6 bg-white border border-slate-200 rounded-2xl"
+        open={allRefsExpanded}
+        onToggle={(e) => setAllRefsExpanded((e.target as HTMLDetailsElement).open)}
+      >
+        <summary className="cursor-pointer px-5 py-3 text-sm font-semibold text-slate-900 hover:bg-slate-50 select-none">
+          All references ({counts.dbTotal}) — click to expand
+        </summary>
+        <div className="px-5 pb-5">
       {/* Filters */}
-      <div className="flex flex-wrap gap-3 mb-4">
+      <div className="flex flex-wrap gap-3 mb-4 mt-3">
         <div className="flex-1 min-w-[200px] relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-700" />
           <input
@@ -1087,7 +1221,11 @@ export default function LegalRefsAdminPage() {
                   <tr
                     key={ref.id}
                     id={`ref-${ref.id}`}
-                    className={`border-b border-slate-200 hover:bg-slate-100/50 transition-colors ${i % 2 === 0 ? '' : 'bg-slate-100/30'}`}
+                    className={`border-b border-slate-200 hover:bg-slate-100/50 transition-colors ${
+                      ref.auto_corrected
+                        ? 'bg-amber-50'
+                        : i % 2 === 0 ? '' : 'bg-slate-100/30'
+                    }`}
                   >
                     <td className="px-5 py-4">
                       <p className="text-slate-900 text-sm font-medium">{ref.law_name}</p>
@@ -1095,9 +1233,34 @@ export default function LegalRefsAdminPage() {
                         <p className="text-slate-700 text-xs mt-0.5">{ref.section}</p>
                       )}
                       <p className="text-slate-600 text-xs mt-1 line-clamp-2 max-w-sm">{ref.summary}</p>
-                      {ref.verification_notes && (
-                        <p className="text-amber-600/70 text-[11px] mt-1 line-clamp-1">{ref.verification_notes}</p>
-                      )}
+                      {ref.verification_notes && (() => {
+                        const notes = ref.verification_notes!;
+                        const expanded = expandedNotes.has(ref.id);
+                        const tail = notes.length > 80 ? notes.slice(-80) : notes;
+                        const display = expanded ? notes : (notes.length > 80 ? `…${tail}` : notes);
+                        const toggle = () => setExpandedNotes((prev) => {
+                          const next = new Set(prev);
+                          if (next.has(ref.id)) next.delete(ref.id);
+                          else next.add(ref.id);
+                          return next;
+                        });
+                        return (
+                          <div className="mt-1">
+                            <p className={`text-amber-700 text-[11px] ${expanded ? 'whitespace-pre-wrap' : 'line-clamp-1'} max-w-sm`}>
+                              {display}
+                            </p>
+                            {notes.length > 80 && (
+                              <button
+                                type="button"
+                                onClick={toggle}
+                                className="text-[11px] text-emerald-700 hover:text-emerald-800 mt-0.5"
+                              >
+                                {expanded ? 'collapse ▴' : 'expand ▾'}
+                              </button>
+                            )}
+                          </div>
+                        );
+                      })()}
                     </td>
                     <td className="px-5 py-4">
                       <span className="text-xs bg-slate-100 text-slate-700 px-2.5 py-1 rounded-full border border-slate-200">
@@ -1113,9 +1276,9 @@ export default function LegalRefsAdminPage() {
                         {status.label}
                       </span>
                       {ref.auto_corrected && (
-                        <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
+                        <div className="mt-1 inline-flex items-center gap-1 text-[11px] font-bold px-2 py-1 rounded-full bg-amber-200 text-amber-900 border-2 border-amber-400 shadow-sm" title="Perplexity auto-overwrote the canonical citation. Please verify before relying on this ref.">
                           <AlertTriangle className="h-3 w-3" />
-                          AI auto-correction
+                          ⚠ Auto-corrected — verify
                         </div>
                       )}
                     </td>
@@ -1172,6 +1335,8 @@ export default function LegalRefsAdminPage() {
           </div>
         )}
       </div>
+        </div>
+      </details>
 
       {/* Review queue — AI-assisted manual verification */}
       {(() => {
@@ -1195,7 +1360,7 @@ export default function LegalRefsAdminPage() {
         const totalCost = (reviewable.length * PERPLEXITY_COST_PER_ROW_GBP).toFixed(3);
         const anyVerifying = aiVerifyingIds.size > 0;
         return (
-          <div className="mt-10">
+          <div className="mt-10" id="review-queue">
             <div className="flex flex-wrap items-end justify-between gap-3 mb-3">
               <div>
                 <h2 className="text-2xl font-bold text-slate-900 font-[family-name:var(--font-heading)]">

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -22,6 +22,20 @@ import { createClient } from '@/lib/supabase/server';
 
 export const ADMIN_EMAIL = 'aireypaul@googlemail.com';
 
+function getAdminEmails(): string[] {
+  // Founder gate via NEXT_PUBLIC_ADMIN_EMAILS (comma-separated). Falls back
+  // to the canonical ADMIN_EMAIL so localhost / preview deploys without the
+  // env var still authorise the founder.
+  const fromEnv = (process.env.NEXT_PUBLIC_ADMIN_EMAILS || '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  if (fromEnv.length === 0) return [ADMIN_EMAIL.toLowerCase()];
+  return fromEnv.includes(ADMIN_EMAIL.toLowerCase())
+    ? fromEnv
+    : [...fromEnv, ADMIN_EMAIL.toLowerCase()];
+}
+
 export interface AuthResult {
   ok: boolean;
   status: 401 | 403 | 200;
@@ -41,7 +55,8 @@ export async function authorizeAdminOrCron(request: NextRequest | Request): Prom
   try {
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
-    if (user && user.email === ADMIN_EMAIL) {
+    const allow = getAdminEmails();
+    if (user?.email && allow.includes(user.email.toLowerCase())) {
       return { ok: true, status: 200, userId: user.id };
     }
     if (user) {


### PR DESCRIPTION
## Summary

Three fixes to the compliance pipeline + admin dashboard. Founder reported "Run sync now" failing in `recover-url-dead` and `authority-audit`, plus the dashboard being unreadable.

### Issue 1 — Sync auth bug (P0)
- `recover-url-dead` and `audit-authority` rejected the chained `/api/cron/compliance-sync` because they only accepted cookie auth. Replaced their inline `authorise()` helpers with `authorizeAdminOrCron(request)` so they now accept BOTH founder session cookie AND `Bearer ${CRON_SECRET}`.
- `src/lib/admin-auth.ts` now honours `NEXT_PUBLIC_ADMIN_EMAILS` instead of hard-coding the founder email.
- Files: `src/app/api/admin/legal-refs/recover-url-dead/route.ts`, `src/app/api/admin/legal-refs/audit-authority/route.ts`, `src/lib/admin-auth.ts`.

### Issue 2 — Dashboard restructure
- New "What needs your attention" amber panel at the top of `/dashboard/admin/legal-refs` summarising pending corrections, url_dead refs, "AI auto-correction" rows needing eyeball, candidates pending approval, and last sync outcome. Empty state shows "Nothing needs your attention. Last sync clean."
- Full 124-row "All references" table wrapped in `<details>`, collapsed by default. Filters live inside the disclosure.
- Per-row `verification_notes` default-collapsed to a one-line tail (~80 chars) with expand/collapse toggle.
- Rows where `auto_corrected=true` get an amber row tint + prominent "⚠ Auto-corrected — verify" badge.
- File: `src/app/dashboard/admin/legal-refs/page.tsx`.

### Issue 3 — Perplexity-based URL recovery for 403'd publishers
- `recover-url-dead` now falls back to Perplexity sonar-pro when both UA probes return 4xx and `queue=true`. Strict gating: only proposes when the returned URL is on the same publisher domain AND passes `checkUkLegalAuthority` AND confidence ≥ medium.
- Proposals INSERT into `legal_ref_corrections` with `proposer='url-recovery-perplexity-2026-04-30'` (pending — never auto-applies). Null/low-confidence results log to `business_log` for manual research.
- Response includes `perplexity_calls` and `perplexity_cost_gbp` (~£0.005/call × 28 url_dead = ~£0.14 worst case).
- File: `src/app/api/admin/legal-refs/recover-url-dead/route.ts`.

### Constraints honoured
- 100% correct citations: Perplexity recovery proposes only — never auto-applies.
- Same-publisher domain gate prevents cross-domain bait.
- `tsc --noEmit` clean on changed files.
- CLAUDE.md updated with both new rules.

## Test plan
- [ ] Click "Run sync now" — all 7 phases now complete without 401 in recover-url-dead / authority-audit.
- [ ] Action panel renders correct counts and "Last sync run" date.
- [ ] "All references" section starts collapsed; expanding reveals filters + table.
- [ ] Auto-corrected rows visibly stand out (amber tint + badge).
- [ ] After a recover-url-dead run, 24 Ofcom/Ofgem url_dead rows have new pending corrections proposed by `url-recovery-perplexity-2026-04-30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)