### PR TITLE
feat(crm): consumer-side abandonment nurture funnel + admin leads CRM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,20 @@ phase the cron chains must follow the same pattern.
 ### 10. Loyalty Rewards
 - Points for every action. Tiers: Bronze, Silver, Gold, Platinum. Redeem for subscription discounts.
 
+### 11a. Consumer abandonment nurture CRM (B2C only)
+- B2C-only abandoned-checkout / pricing-page nurture funnel. **Does not touch the B2B path** — B2B keeps its founder-direct Telegram + email alerts.
+- Tables: `consumer_leads` (funnel state) + `consumer_lead_email_log` (ICO audit). Migration: `supabase/migrations/20260430170000_consumer_leads_nurture.sql`.
+- Capture points: (1) Stripe `checkout.session.expired` (consumer branch only — B2B `metadata.product='b2b_api'` early-returns), (2) `POST /api/leads/capture` from pricing-page subscribe clicks (logged-out users).
+- Conversion: `checkout.session.completed` (consumer branch) flips matching `consumer_leads` rows to `converted_paid`.
+- 4-email sequence via daily cron `/api/cron/consumer-nurture` at 10:00 UTC: T+1h soft reminder → T+24h value nudge → T+72h 10% discount + Stripe coupon → T+7d final.
+- Discount via `src/lib/stripe/coupons.ts → createOneOffDiscountCoupon()` — Stripe Coupon (one-off, max_redemptions=1, redeem_by=+7d) + Promotion Code `WELCOME10-XXXXXX` (6 friendly chars).
+- Email templates: `src/lib/email/consumer-nurture.ts` — same wrap pattern as `dispute-reminders.ts`. RFC 8058 one-click List-Unsubscribe header.
+- Public unsubscribe: `GET/POST /api/unsubscribe?token=…` → success page at `/unsubscribe`. Honoured immediately.
+- Admin dashboard: `/dashboard/admin/consumer-leads` — funnel bar + filterable table + drill-in drawer with timeline, notes, manual actions (mark converted/unsubscribed, generate fresh code, manual email, move to manual_handling).
+- Lawful basis: PECR reg. 22(3) "soft opt-in" — recipient gave details during sale-negotiation, marketing relates to similar products, one-click unsubscribe in every send. Documented in `docs/consumer-abandonment-system-design.md`.
+- PostHog events: `lead_captured`, `nurture_email_sent`, `discount_code_issued`, `lead_converted`, `lead_unsubscribed` — distinct id `consumer_lead:<id>`.
+- Research + design: `docs/consumer-abandonment-research.md`, `docs/consumer-abandonment-system-design.md`.
+
 ### 11. Money Hub Financial Intelligence Centre
 - Complete financial dashboard with income tracking, spending intelligence, and net worth
 - AI-powered transaction categorisation with user recategorisation

--- a/docs/consumer-abandonment-research.md
+++ b/docs/consumer-abandonment-research.md
@@ -1,0 +1,103 @@
+# Consumer abandonment nurture — research findings
+
+Research for the B2C abandoned-cart / abandoned-checkout nurture CRM. B2B path is unaffected (founder-direct alerts remain).
+
+## 1. Email sequence timing — the playbook
+
+Top consumer-finance / SaaS / e-commerce companies converge on a **3–4 email** sequence over 7 days. Klaviyo's documented best practice (used by 100k+ brands) is:
+
+| Email | Delay from abandonment | Purpose |
+|-------|-----------------------|---------|
+| 1 | 1–4 hours | Soft reminder. Highest open rate (40–50%). |
+| 2 | 24 hours after #1 (~T+25h) | Value / proof. Address objections. |
+| 3 | 48–72 hours after #2 (~T+72–96h) | First incentive (discount). |
+| 4 (optional) | T+7 days | Final touch. Last call. |
+
+Klaviyo's data show that continuing to email beyond ~72 hours generates more unsubscribes than conversions, so the 4th email is optional and should be light. Customer.io and Drip recommend the same shape.
+
+For a SaaS-style monthly subscription (LifeAdmin / Paybacker), the "considered purchase" framing applies — so we lean toward the slower edge: **T+1h → T+24h → T+72h → T+7d**.
+
+Source: [Klaviyo Help Center — abandoned cart flow](https://help.klaviyo.com/hc/en-us/articles/115002779411), [Shopify abandoned cart 2026](https://www.shopify.com/blog/abandoned-cart-emails), [Klaviyo Consulting best practices](https://klaviyoconsulting.com/abandoned-cart-best-practices-klaviyo/).
+
+## 2. When does the discount fire?
+
+Strong consensus across Klaviyo, Drip, Customer.io, Rejoiner: **never on email 1, ideally email 2 or 3**. Sending the discount on email 1 trains repeat customers to abandon-and-wait. The accepted pattern is:
+
+- Email 1 = soft reminder, no discount
+- Email 2 = value-led nudge ("here's why people pick Pro"), still no discount
+- Email 3 = first concrete incentive (10% off, code expires in 7 days)
+- Email 4 = final reminder the code is about to expire
+
+Source: [Rejoiner abandoned-cart statistics & strategy](https://www.rejoiner.com/resources/abandoned-cart-email-statistics), [Customer.io 7 abandoned-cart examples](https://customer.io/blog/abandoned-app-emails/).
+
+## 3. Plain-text vs HTML
+
+Mixed evidence. Plain-text feels personal; HTML lifts CTR with a strong button. The Resend + B2B norm (and what we already do for `dispute-reminders.ts`) is **HTML with a plain-text fallback** — Resend supports both fields. We keep HTML simple (one column, one CTA, no marketing imagery), which combines the personal feel with a clickable CTA.
+
+## 4. Subject lines
+
+Patterns that consistently top open-rate league tables:
+
+- **Personal + open question**: "Did you forget something, {name}?"
+- **Curiosity / value**: "Quick thought on the Pro plan"
+- **Time-bounded discount**: "10% off LifeAdmin — expires in 7 days"
+- **Final / last-chance**: "Last call: your 10% code expires tomorrow"
+
+Avoid clickbait, all-caps, and emoji-heavy subjects — Gmail's promotion-tab heuristics drop these.
+
+## 5. UK PECR / GDPR — lawful basis
+
+This is the load-bearing piece. The ICO's published position (March 2026 update post Data (Use and Access) Act):
+
+- **Marketing email to a consumer** requires either (a) prior consent or (b) the **soft opt-in** under PECR reg. 22(3).
+- The soft opt-in applies when **all** of these are true:
+  1. The recipient's contact details were obtained "in the course of a sale or negotiations for the sale of a product or service" — clicking "Subscribe" on a pricing page or starting a Stripe Checkout clearly meets this bar.
+  2. The marketing relates to **similar products or services** — emails about the same SaaS plan they tried to subscribe to, definitely.
+  3. The recipient was given a **simple opt-out at the point of collection** and **in every subsequent email**.
+
+That's a clean fit for cart-abandonment nurture, provided we (i) flag at the pricing-page email-capture point that we may follow up by email, (ii) include a one-click unsubscribe in every send, and (iii) honour unsubscribes within 28 days (we honour immediately).
+
+Critically: legitimate-interest is **not on its own sufficient** for B2C marketing email under PECR — PECR overrides UK GDPR's lawful-basis menu for electronic marketing. So the framing in the design doc must say "soft opt-in (PECR reg. 22(3))" not "legitimate interest" for the marketing-flavoured emails. The first reminder (email 1) can lean transactional ("you started a checkout — here's how to finish"), but emails 2–4 are clearly marketing and rely on soft opt-in.
+
+Source: [ICO — sending direct marketing: choosing your lawful basis](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/sending-direct-marketing-choosing-your-lawful-basis/), [ICO — electronic mail marketing](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/guide-to-pecr/electronic-and-telephone-marketing/electronic-mail-marketing/), [Data Protection Network — UK email marketing rules](https://dpnetwork.org.uk/email-marketing-rules/).
+
+## 6. Could we just use Stripe Recover instead?
+
+Stripe Checkout's built-in `after_expiration.recovery` feature does fire a `checkout.session.expired` webhook with a `recovery_url` and supports a single recovery email per session, optionally with a promotion code. It's effectively a one-shot fallback, not a nurture sequence — no segmentation, no funnel stages, no admin dashboard, no second/third email cadence.
+
+**Decision: use it as a data source (we already get `checkout.session.expired`), but the nurture sequence and CRM are ours.** That's also what every comparable SaaS with a real growth team does — Stripe Recover is too thin for serious lifecycle marketing.
+
+Source: [Stripe Docs — recover abandoned carts](https://docs.stripe.com/payments/checkout/abandoned-carts), [Stripe — what is cart abandonment](https://stripe.com/resources/more/what-is-cart-abandonment).
+
+## 7. Conversion benchmarks to anchor expectations
+
+- Industry abandoned-cart email **recovery rate**: 8–12% of captured leads convert (Stripo, Rejoiner medians).
+- SaaS opt-in trial → paid: ~18% (Pulseahead). For us, the relevant denominator is "captured abandonment leads", and a 6–10% recovery is realistic in year one.
+- Email 1 typically drives ~50% of total recovered revenue in a 3-email sequence; email 3 (with discount) drives ~30%; email 2 drives the rest.
+- Cost per send via Resend ≈ £0.0004. A 4-email nurture costs ~£0.0016 per lead — economics are trivial relative to the £4.99–£9.99 MRR at stake.
+
+Source: [Stripo — abandoned cart email statistics 2026](https://stripo.email/blog/abandoned-cart-email-statistics-insights-and-key-metrics-for-boosting-conversions/), [Pulseahead — trial-to-paid SaaS benchmarks](https://www.pulseahead.com/blog/trial-to-paid-conversion-benchmarks-in-saas).
+
+## 8. Open questions (resolved in design doc)
+
+1. Sequence: T+1h → T+24h → T+72h → T+7d. Daily cron at 10:00 UTC inspects each lead's age + email_count.
+2. Discount fires on email 3, expires 7 days later (Stripe coupon `redeem_by`).
+3. HTML with plain-text alternative (Resend dual-field).
+4. Subject lines per the patterns above — picked four below.
+5. PECR soft opt-in (reg. 22(3)) — not pure legitimate-interest.
+6. Stripe Recover used as a webhook input only; we own the sequence + CRM.
+
+## Sources
+
+- [Klaviyo Help — abandoned cart flow](https://help.klaviyo.com/hc/en-us/articles/115002779411)
+- [Klaviyo Consulting — best practices](https://klaviyoconsulting.com/abandoned-cart-best-practices-klaviyo/)
+- [Shopify — abandoned cart emails 2026](https://www.shopify.com/blog/abandoned-cart-emails)
+- [Customer.io — 7 abandoned cart email examples](https://customer.io/blog/abandoned-app-emails/)
+- [Rejoiner — statistics & strategy](https://www.rejoiner.com/resources/abandoned-cart-email-statistics)
+- [Stripo — abandoned cart email statistics 2026](https://stripo.email/blog/abandoned-cart-email-statistics-insights-and-key-metrics-for-boosting-conversions/)
+- [Pulseahead — trial-to-paid conversion benchmarks](https://www.pulseahead.com/blog/trial-to-paid-conversion-benchmarks-in-saas)
+- [Stripe Docs — recover abandoned carts](https://docs.stripe.com/payments/checkout/abandoned-carts)
+- [Stripe — what is cart abandonment](https://stripe.com/resources/more/what-is-cart-abandonment)
+- [ICO — choosing your lawful basis (direct marketing)](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/sending-direct-marketing-choosing-your-lawful-basis/)
+- [ICO — electronic mail marketing](https://ico.org.uk/for-organisations/direct-marketing-and-privacy-and-electronic-communications/guide-to-pecr/electronic-and-telephone-marketing/electronic-mail-marketing/)
+- [Data Protection Network — UK email marketing rules](https://dpnetwork.org.uk/email-marketing-rules/)

--- a/docs/consumer-abandonment-system-design.md
+++ b/docs/consumer-abandonment-system-design.md
@@ -1,0 +1,193 @@
+# Consumer abandonment nurture — system design
+
+Implementation contract for the B2C abandoned-cart / abandoned-checkout CRM. Companion to `consumer-abandonment-research.md`.
+
+**Scope guard:** Consumer (B2C) only. Anything tagged `metadata.product='b2b_api'` or routed via `src/lib/b2b/**`, `src/app/api/v1/**`, `src/app/for-business/**` is untouched. The B2B founder-direct Telegram + email path remains.
+
+## 1. Data model
+
+The existing `public.leads` table is the social-DM lead funnel (Instagram, Facebook DMs, comments — different schema, different lifecycle). To avoid mixing concerns, this feature adds a **new table `consumer_leads`** plus an audit table `consumer_lead_email_log`.
+
+### `consumer_leads`
+
+| column | type | notes |
+|--------|------|-------|
+| `id` | uuid PK | gen_random_uuid() |
+| `email` | text NOT NULL | lower-cased on insert |
+| `name` | text | nullable |
+| `phone` | text | nullable |
+| `source` | text | `signup_form` \| `stripe_checkout_abandoned` \| `pricing_page_exit` \| `onboarding_dropoff` |
+| `stripe_checkout_session_id` | text | nullable, unique partial |
+| `stripe_customer_id` | text | nullable |
+| `stripe_recovery_url` | text | nullable, taken from `session.after_expiration.recovery.url` |
+| `intended_tier` | text | `essential` \| `pro` |
+| `intended_billing_interval` | text | `monthly` \| `yearly` |
+| `funnel_stage` | text | see stages below; default `new` |
+| `captured_at` | timestamptz | default now() |
+| `last_emailed_at` | timestamptz | nullable |
+| `email_count` | integer | default 0 |
+| `discount_code` | text | nullable; Stripe promotion code (human-readable) |
+| `discount_coupon_id` | text | nullable; Stripe coupon id (machine) |
+| `discount_code_expires_at` | timestamptz | nullable |
+| `discount_redeemed_at` | timestamptz | nullable |
+| `converted_at` | timestamptz | nullable |
+| `converted_user_id` | uuid | nullable; FK soft-link to `profiles.id` |
+| `unsubscribed_at` | timestamptz | nullable |
+| `unsubscribe_token` | text NOT NULL | random URL-safe token, indexed unique |
+| `ip_address` | inet | nullable |
+| `user_agent` | text | nullable |
+| `utm_source` / `utm_medium` / `utm_campaign` | text | nullable |
+| `notes` | text | founder manual notes |
+| `last_contacted_via` | text | `email` \| `manual_note` \| `phone` |
+| `created_at` / `updated_at` | timestamptz | trigger `updated_at` |
+
+### Funnel stages
+
+`new` → `email_1_sent` → `email_2_sent` → `email_3_sent` → `email_4_sent` → terminal (`converted_paid` | `converted_free` | `unsubscribed` | `expired` | `manual_handling`).
+
+### `consumer_lead_email_log`
+
+Append-only audit. ICO-friendly:
+
+- `id` uuid PK
+- `consumer_lead_id` uuid FK consumer_leads(id) on delete cascade
+- `template` text — `email_1_soft_reminder` | `email_2_value_nudge` | `email_3_discount` | `email_4_final` | `manual_followup`
+- `subject` text
+- `resend_message_id` text
+- `sent_at` timestamptz default now()
+- `metadata` jsonb
+
+### Indexes
+
+- `consumer_leads(email)` — dedupe lookups
+- `consumer_leads(funnel_stage)` — dashboard filter + cron sweep
+- `consumer_leads(captured_at)` — recency
+- `consumer_leads(unsubscribe_token)` UNIQUE — public unsub endpoint lookup
+- `consumer_leads(stripe_checkout_session_id)` UNIQUE WHERE NOT NULL — webhook idempotency
+- `consumer_lead_email_log(consumer_lead_id)`
+
+### RLS
+
+`enable rls`. Single permissive policy: service-role only (admin endpoints use service-role client; admin UI calls go through API routes guarded by `authorizeAdminOrCron`). No anon access. The unsubscribe endpoint uses the service role + token match.
+
+## 2. Capture points
+
+1. **Stripe webhook `checkout.session.expired`** (`src/app/api/webhooks/stripe/route.ts`). Existing handler already filters `metadata.product==='b2b_api'` to the B2B path. We add a B2C branch immediately after that check: pull `customer_details.email`, line-item price → tier, session id; upsert into `consumer_leads` keyed on `stripe_checkout_session_id`. Source = `stripe_checkout_abandoned`.
+
+2. **Pricing-page subscribe click → /api/leads/capture** — lightweight POST endpoint that accepts `{ email, intended_tier, intended_billing_interval, utm_* }` and inserts `consumer_leads` with source `signup_form`. Called from `PricingCTA.tsx` only when the user is logged-out (logged-in users will hit the Stripe webhook path naturally). Best-effort, fire-and-forget — errors don't block the redirect to `/auth/signup`.
+
+3. **Onboarding drop-off** — out of scope for v1 (would need new step-by-step capture). Listed as a follow-up; wires are designed to support it later by passing `source='onboarding_dropoff'`.
+
+## 3. Email sequence
+
+Daily cron `/api/cron/consumer-nurture` at **10:00 UTC**.
+
+For each non-terminal lead:
+
+| email_count + age | action |
+|-------------------|--------|
+| 0 sent + age ≥ 1h | Send Email 1; stage → `email_1_sent` |
+| 1 sent + age since last_emailed ≥ ~22h | Send Email 2; stage → `email_2_sent` |
+| 2 sent + age since last_emailed ≥ ~46h | Generate Stripe coupon (10%, once, max_redemptions=1, redeem_by=+7d); send Email 3; stage → `email_3_sent` |
+| 3 sent + age since last_emailed ≥ ~5d | Send Email 4 (discount expiring); stage → `email_4_sent` |
+| 4 sent + age ≥ 14d total | stage → `expired` |
+
+Hard skips: `unsubscribed_at IS NOT NULL`, `funnel_stage IN ('converted_paid','converted_free','expired','manual_handling','unsubscribed')`.
+
+Cron concurrency: limit batch to 200 per run; cron runs daily so backlog grows < cap easily.
+
+## 4. Subject lines (chosen)
+
+1. **Email 1** — `Did you forget something?`
+2. **Email 2** — `Why most LifeAdmin users pick {tier_name}`
+3. **Email 3** — `A small thank-you: 10% off LifeAdmin (7 days)`
+4. **Email 4** — `Last call — your 10% code expires soon`
+
+British copy throughout. £ symbol. Dark-mode-safe HTML using the same wrap/header/footer pattern as `dispute-reminders.ts`. Plain-text alternative provided to Resend.
+
+## 5. Stripe coupon flow
+
+Helper `src/lib/stripe/coupons.ts → createOneOffDiscountCoupon(email, percentOff=10, durationDays=7)`:
+
+1. Create Coupon: `percent_off=percentOff`, `duration='once'`, `max_redemptions=1`, `redeem_by=floor((now+7d)/1000)`, `name='LifeAdmin abandonment recovery 10%'`, `metadata.lead_email=email`.
+2. Create Promotion Code: `coupon=<id>`, `code='WELCOME10-' + 6 random A-Z0-9 chars`, `max_redemptions=1`, `expires_at=redeem_by`, `metadata.lead_email=email`.
+3. Return `{ coupon_id, promo_code, expires_at }`.
+
+Stripe Checkout sessions on the consumer side are created by `/api/stripe/checkout`. The user pastes `WELCOME10-XXXXXX` in the Stripe Checkout promo box. We don't auto-attach — pasting matches the consumer mental model and keeps the coupon redemption traceable.
+
+Naming pattern: `WELCOME10-<6 base32 chars>` e.g. `WELCOME10-A7K2QF`. Friendly, screams "welcome offer", easy to read aloud.
+
+## 6. Admin dashboard
+
+Existing admin sidebar already routes to `/dashboard/admin/leads` (social DM leads). To avoid mixing models, add a sibling route **`/dashboard/admin/consumer-leads`** with its own sidebar entry "Consumer leads".
+
+Page composition:
+
+1. **Funnel bar** — horizontal stage counts: `new → email_1 → email_2 → email_3 → email_4 → converted`. Plus headline conversion rate (% converted_paid of all captured).
+2. **Filterable table** — Email, Name, Source, Tier, Stage, Captured, Last emailed, # emails, Discount code (clickable to Stripe dashboard), Converted? Filters: stage, source, age range. Default sort: captured_at DESC.
+3. **Drill-in drawer** — click row → side drawer:
+   - Timeline of emails sent (from `consumer_lead_email_log`)
+   - Discount code + expiry + redeemed?
+   - Notes textarea (saves on blur)
+   - Action buttons: Mark converted (paid), Mark unsubscribed, Send manual follow-up email, Generate fresh discount code, Move to manual_handling.
+4. **Aggregate metric tiles** — Captured this week, Recovery rate (converted/captured all-time), Revenue recovered (count converted × headline tier price — quick-and-dirty proxy until we wire actual MRR), Cost per lead (`email_count × £0.0004`).
+
+Backed by API routes under `/api/admin/consumer-leads/*` — all guarded by `authorizeAdminOrCron`.
+
+## 7. GDPR/PECR compliance
+
+Lawful basis = **PECR reg. 22(3) "soft opt-in"**, not raw legitimate-interest:
+
+- Contact details captured during sale-or-negotiation (Stripe Checkout / pricing-page subscribe) ✔
+- Marketing limited to similar products/services (the same SaaS plans) ✔
+- Clear opt-out at point of collection (we add a microcopy under the pricing CTA: "By continuing you agree we may email you about your order. Unsubscribe in one click anytime.")
+- One-click opt-out in every email — bottom-of-email primary footer link `https://paybacker.co.uk/api/unsubscribe?token=...`
+- Honoured immediately (sets `unsubscribed_at`, stage→`unsubscribed`, audit row written)
+- Email log retained 24 months for ICO audit; can be purged on data-subject request
+
+Email 1 is framed transactionally where possible ("you started a checkout — here's how to finish") so even a strict reading gives us cover. Emails 2–4 are clearly soft-opt-in marketing.
+
+## 8. PostHog events
+
+Server-side, fire-and-forget via `captureServer`:
+
+- `lead_captured` — props: source, intended_tier, intended_billing_interval
+- `nurture_email_sent` — props: template, email_count_after, lead_id
+- `discount_code_issued` — props: promo_code, percent_off, lead_id
+- `lead_converted` — props: tier, lead_id
+- `lead_unsubscribed` — props: lead_id, email_count_at_unsub
+
+Distinct id = `consumer_lead:<id>` so the funnel renders cleanly in PostHog without polluting authenticated-user IDs.
+
+## 9. vercel.json
+
+Append:
+
+```json
+{ "path": "/api/cron/consumer-nurture", "schedule": "0 10 * * *" }
+```
+
+## 10. File map
+
+New files:
+
+- `supabase/migrations/20260430170000_consumer_leads_nurture.sql`
+- `src/app/api/leads/capture/route.ts`
+- `src/app/api/cron/consumer-nurture/route.ts`
+- `src/app/api/unsubscribe/route.ts`
+- `src/app/unsubscribe/page.tsx` (success page)
+- `src/app/api/admin/consumer-leads/route.ts` (list/aggregate)
+- `src/app/api/admin/consumer-leads/[id]/route.ts` (drill-in actions: notes, mark stages, fresh code, manual email)
+- `src/app/dashboard/admin/consumer-leads/page.tsx`
+- `src/app/dashboard/admin/consumer-leads/ConsumerLeadsClient.tsx`
+- `src/lib/stripe/coupons.ts`
+- `src/lib/email/consumer-nurture.ts`
+- `src/lib/consumer-leads/capture.ts` (shared capture helper used by webhook + endpoint)
+
+Modified files:
+
+- `src/app/api/webhooks/stripe/route.ts` — add B2C `checkout.session.expired` capture branch
+- `src/app/pricing/PricingCTA.tsx` — fire `/api/leads/capture` for logged-out subscribe clicks (best-effort)
+- `src/app/dashboard/admin/layout.tsx` — sidebar entry "Consumer leads"
+- `vercel.json` — new cron entry
+- `CLAUDE.md` — FEATURES section update

--- a/src/app/api/admin/consumer-leads/[id]/route.ts
+++ b/src/app/api/admin/consumer-leads/[id]/route.ts
@@ -1,0 +1,154 @@
+/**
+ * Per-lead admin actions.
+ *
+ *   GET    /api/admin/consumer-leads/:id              — drill-in view incl. email log
+ *   PATCH  /api/admin/consumer-leads/:id              — { notes, funnel_stage }
+ *   POST   /api/admin/consumer-leads/:id/action       — { action: 'mark_converted_paid' | 'mark_unsubscribed' | 'fresh_discount' | 'manual_handling' | 'send_manual_email', subject?, body? }
+ *
+ * Founder-gated via authorizeAdminOrCron.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { createOneOffDiscountCoupon } from '@/lib/stripe/coupons';
+import { resend, FROM_EMAIL, REPLY_TO } from '@/lib/resend';
+
+export const runtime = 'nodejs';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+interface Params { params: Promise<{ id: string }> }
+
+export async function GET(req: NextRequest, { params }: Params) {
+  const auth = await authorizeAdminOrCron(req);
+  if (!auth.ok) return NextResponse.json({ error: auth.reason }, { status: auth.status });
+
+  const { id } = await params;
+  const supabase = getAdmin();
+
+  const [{ data: lead }, { data: log }] = await Promise.all([
+    supabase.from('consumer_leads').select('*').eq('id', id).maybeSingle(),
+    supabase
+      .from('consumer_lead_email_log')
+      .select('*')
+      .eq('consumer_lead_id', id)
+      .order('sent_at', { ascending: false }),
+  ]);
+  if (!lead) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  return NextResponse.json({ lead, email_log: log ?? [] });
+}
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const auth = await authorizeAdminOrCron(req);
+  if (!auth.ok) return NextResponse.json({ error: auth.reason }, { status: auth.status });
+
+  const { id } = await params;
+  const supabase = getAdmin();
+  const body = (await req.json().catch(() => ({}))) as { notes?: string; funnel_stage?: string };
+
+  const updates: Record<string, unknown> = {};
+  if (typeof body.notes === 'string') updates.notes = body.notes;
+  if (typeof body.funnel_stage === 'string') updates.funnel_stage = body.funnel_stage;
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'no_fields' }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from('consumer_leads')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ lead: data });
+}
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const auth = await authorizeAdminOrCron(req);
+  if (!auth.ok) return NextResponse.json({ error: auth.reason }, { status: auth.status });
+
+  const { id } = await params;
+  const supabase = getAdmin();
+  const body = (await req.json().catch(() => ({}))) as {
+    action?: string;
+    subject?: string;
+    body_html?: string;
+    body_text?: string;
+  };
+
+  const { data: lead } = await supabase.from('consumer_leads').select('*').eq('id', id).maybeSingle();
+  if (!lead) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  switch (body.action) {
+    case 'mark_converted_paid': {
+      await supabase
+        .from('consumer_leads')
+        .update({ funnel_stage: 'converted_paid', converted_at: new Date().toISOString() })
+        .eq('id', id);
+      return NextResponse.json({ ok: true });
+    }
+    case 'mark_unsubscribed': {
+      await supabase
+        .from('consumer_leads')
+        .update({ funnel_stage: 'unsubscribed', unsubscribed_at: new Date().toISOString() })
+        .eq('id', id);
+      return NextResponse.json({ ok: true });
+    }
+    case 'manual_handling': {
+      await supabase.from('consumer_leads').update({ funnel_stage: 'manual_handling' }).eq('id', id);
+      return NextResponse.json({ ok: true });
+    }
+    case 'fresh_discount': {
+      const created = await createOneOffDiscountCoupon(lead.email, 10, 7);
+      await supabase
+        .from('consumer_leads')
+        .update({
+          discount_code: created.promo_code,
+          discount_coupon_id: created.coupon_id,
+          discount_code_expires_at: created.expires_at.toISOString(),
+        })
+        .eq('id', id);
+      return NextResponse.json({ ok: true, promo_code: created.promo_code, expires_at: created.expires_at });
+    }
+    case 'send_manual_email': {
+      const subject = body.subject || 'A quick note from Paybacker';
+      const html = body.body_html || `<p>${(body.body_text || '').replace(/\n/g, '<br/>')}</p>`;
+      const text = body.body_text || '';
+      const result = await resend.emails.send({
+        from: FROM_EMAIL,
+        to: lead.email,
+        replyTo: REPLY_TO,
+        subject,
+        html,
+        text,
+      });
+      const messageId = (result as { data?: { id?: string } }).data?.id;
+      await supabase.from('consumer_lead_email_log').insert({
+        consumer_lead_id: id,
+        template: 'manual_followup',
+        subject,
+        resend_message_id: messageId ?? null,
+        metadata: { sent_by: auth.userId ?? 'cron' },
+      });
+      await supabase
+        .from('consumer_leads')
+        .update({
+          last_emailed_at: new Date().toISOString(),
+          email_count: lead.email_count + 1,
+          last_contacted_via: 'email',
+        })
+        .eq('id', id);
+      return NextResponse.json({ ok: true, message_id: messageId });
+    }
+    default:
+      return NextResponse.json({ error: 'unknown_action' }, { status: 400 });
+  }
+}

--- a/src/app/api/admin/consumer-leads/route.ts
+++ b/src/app/api/admin/consumer-leads/route.ts
@@ -1,0 +1,89 @@
+/**
+ * GET /api/admin/consumer-leads — list + aggregate metrics for the
+ * consumer-leads admin dashboard.
+ *
+ * Founder-gated via authorizeAdminOrCron.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+
+export const runtime = 'nodejs';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+const TIER_PRICE: Record<string, number> = {
+  essential: 4.99,
+  pro: 9.99,
+};
+
+export async function GET(req: NextRequest) {
+  const auth = await authorizeAdminOrCron(req);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+
+  const supabase = getAdmin();
+  const { searchParams } = req.nextUrl;
+  const stage = searchParams.get('stage');
+  const source = searchParams.get('source');
+
+  let query = supabase
+    .from('consumer_leads')
+    .select(
+      'id, email, name, source, intended_tier, intended_billing_interval, funnel_stage, captured_at, last_emailed_at, email_count, discount_code, discount_coupon_id, discount_code_expires_at, discount_redeemed_at, converted_at, converted_user_id, unsubscribed_at, notes, utm_source, utm_medium, utm_campaign',
+    )
+    .order('captured_at', { ascending: false })
+    .limit(500);
+
+  if (stage && stage !== 'all') query = query.eq('funnel_stage', stage);
+  if (source && source !== 'all') query = query.eq('source', source);
+
+  const { data: leads, error } = await query;
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Aggregate counts per stage (across the WHOLE table, not the filter)
+  const { data: allForCounts } = await supabase
+    .from('consumer_leads')
+    .select('funnel_stage, intended_tier, captured_at, email_count')
+    .limit(5000);
+
+  const stageCounts: Record<string, number> = {};
+  let revenueRecovered = 0;
+  let totalEmailsSent = 0;
+  let capturedThisWeek = 0;
+  const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  for (const r of allForCounts ?? []) {
+    stageCounts[r.funnel_stage] = (stageCounts[r.funnel_stage] || 0) + 1;
+    if (r.funnel_stage === 'converted_paid' && r.intended_tier) {
+      revenueRecovered += TIER_PRICE[r.intended_tier as string] ?? 0;
+    }
+    totalEmailsSent += r.email_count ?? 0;
+    if (new Date(r.captured_at).getTime() >= weekAgo) capturedThisWeek += 1;
+  }
+  const totalCaptured = (allForCounts ?? []).length;
+  const converted = stageCounts.converted_paid ?? 0;
+  const recoveryRate = totalCaptured > 0 ? converted / totalCaptured : 0;
+  const costPerLead = totalCaptured > 0 ? (totalEmailsSent * 0.0004) / totalCaptured : 0;
+
+  return NextResponse.json({
+    leads: leads ?? [],
+    metrics: {
+      total_captured: totalCaptured,
+      captured_this_week: capturedThisWeek,
+      converted,
+      recovery_rate: recoveryRate,
+      revenue_recovered_pounds: revenueRecovered,
+      cost_per_lead_pounds: costPerLead,
+      stage_counts: stageCounts,
+    },
+  });
+}

--- a/src/app/api/cron/consumer-nurture/route.ts
+++ b/src/app/api/cron/consumer-nurture/route.ts
@@ -1,0 +1,242 @@
+/**
+ * Daily consumer nurture cron — 10:00 UTC.
+ *
+ * Walks every non-terminal lead and sends the next email in the
+ * 4-email sequence based on age + email_count:
+ *
+ *   0 emails + age ≥ 1h          → Email 1 (soft reminder)
+ *   1 email  + delta ≥ 22h       → Email 2 (value nudge)
+ *   2 emails + delta ≥ 46h       → Email 3 (10% discount + Stripe code)
+ *   3 emails + delta ≥ 5d        → Email 4 (final / expiring)
+ *   4 emails + age  ≥ 14d        → mark expired (no send)
+ *
+ * Skips: unsubscribed, converted_paid, converted_free, expired,
+ *        manual_handling, unsubscribed.
+ *
+ * Bearer-protected with CRON_SECRET. Also callable by an authenticated
+ * admin via authorizeAdminOrCron for manual nudge runs.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { authorizeAdminOrCron } from '@/lib/admin-auth';
+import { sendNurtureEmail, type NurtureTemplate } from '@/lib/email/consumer-nurture';
+import { createOneOffDiscountCoupon } from '@/lib/stripe/coupons';
+import { captureServer } from '@/lib/posthog-server';
+
+export const runtime = 'nodejs';
+export const maxDuration = 300;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+interface LeadRow {
+  id: string;
+  email: string;
+  name: string | null;
+  intended_tier: 'essential' | 'pro' | null;
+  intended_billing_interval: 'monthly' | 'yearly' | null;
+  funnel_stage: string;
+  captured_at: string;
+  last_emailed_at: string | null;
+  email_count: number;
+  discount_code: string | null;
+  discount_coupon_id: string | null;
+  discount_code_expires_at: string | null;
+  unsubscribe_token: string;
+  stripe_recovery_url: string | null;
+}
+
+interface Plan {
+  template: NurtureTemplate | null;
+  newStage: string;
+  needsDiscount: boolean;
+  expire: boolean;
+}
+
+/**
+ * Decide the next action for a lead. Pure function — easy to unit-test
+ * once we get there.
+ */
+function planNextAction(lead: LeadRow, now: Date): Plan {
+  const captured = new Date(lead.captured_at).getTime();
+  const lastEmail = lead.last_emailed_at ? new Date(lead.last_emailed_at).getTime() : null;
+  const ageMs = now.getTime() - captured;
+  const sinceLastMs = lastEmail ? now.getTime() - lastEmail : ageMs;
+
+  if (lead.email_count >= 4) {
+    if (ageMs >= 14 * DAY_MS) {
+      return { template: null, newStage: 'expired', needsDiscount: false, expire: true };
+    }
+    return { template: null, newStage: lead.funnel_stage, needsDiscount: false, expire: false };
+  }
+
+  if (lead.email_count === 0 && ageMs >= 1 * HOUR_MS) {
+    return { template: 'email_1_soft_reminder', newStage: 'email_1_sent', needsDiscount: false, expire: false };
+  }
+  if (lead.email_count === 1 && sinceLastMs >= 22 * HOUR_MS) {
+    return { template: 'email_2_value_nudge', newStage: 'email_2_sent', needsDiscount: false, expire: false };
+  }
+  if (lead.email_count === 2 && sinceLastMs >= 46 * HOUR_MS) {
+    return { template: 'email_3_discount', newStage: 'email_3_sent', needsDiscount: true, expire: false };
+  }
+  if (lead.email_count === 3 && sinceLastMs >= 5 * DAY_MS) {
+    return { template: 'email_4_final', newStage: 'email_4_sent', needsDiscount: false, expire: false };
+  }
+
+  return { template: null, newStage: lead.funnel_stage, needsDiscount: false, expire: false };
+}
+
+async function processLead(
+  supabase: ReturnType<typeof getAdmin>,
+  lead: LeadRow,
+  now: Date,
+): Promise<{ leadId: string; action: string; ok: boolean; reason?: string }> {
+  const plan = planNextAction(lead, now);
+
+  if (plan.expire) {
+    await supabase
+      .from('consumer_leads')
+      .update({ funnel_stage: 'expired' })
+      .eq('id', lead.id);
+    return { leadId: lead.id, action: 'expired', ok: true };
+  }
+
+  if (!plan.template) {
+    return { leadId: lead.id, action: 'skip_not_due', ok: true };
+  }
+
+  // Generate discount on email 3
+  let promoCode = lead.discount_code ?? undefined;
+  let promoExpiresAt: Date | undefined = lead.discount_code_expires_at
+    ? new Date(lead.discount_code_expires_at)
+    : undefined;
+  let couponId = lead.discount_coupon_id ?? undefined;
+
+  if (plan.needsDiscount && !promoCode) {
+    try {
+      const created = await createOneOffDiscountCoupon(lead.email, 10, 7);
+      promoCode = created.promo_code;
+      couponId = created.coupon_id;
+      promoExpiresAt = created.expires_at;
+      captureServer('discount_code_issued', `consumer_lead:${lead.id}`, {
+        promo_code: promoCode,
+        percent_off: 10,
+        expires_at: promoExpiresAt.toISOString(),
+      });
+    } catch (err) {
+      return {
+        leadId: lead.id,
+        action: 'discount_failed',
+        ok: false,
+        reason: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  const sendResult = await sendNurtureEmail(plan.template, {
+    email: lead.email,
+    name: lead.name,
+    intendedTier: lead.intended_tier,
+    intendedBillingInterval: lead.intended_billing_interval,
+    unsubscribeToken: lead.unsubscribe_token,
+    promoCode,
+    promoExpiresAt,
+    recoveryUrl: lead.stripe_recovery_url ?? undefined,
+  });
+
+  if (!sendResult.ok) {
+    return { leadId: lead.id, action: `send_${plan.template}`, ok: false, reason: sendResult.reason };
+  }
+
+  // Update lead + write audit log
+  const updates: Record<string, unknown> = {
+    funnel_stage: plan.newStage,
+    last_emailed_at: now.toISOString(),
+    email_count: lead.email_count + 1,
+    last_contacted_via: 'email',
+  };
+  if (plan.needsDiscount && promoCode) {
+    updates.discount_code = promoCode;
+    updates.discount_coupon_id = couponId;
+    updates.discount_code_expires_at = promoExpiresAt?.toISOString();
+  }
+
+  await supabase.from('consumer_leads').update(updates).eq('id', lead.id);
+
+  await supabase.from('consumer_lead_email_log').insert({
+    consumer_lead_id: lead.id,
+    template: plan.template,
+    subject: sendResult.subject,
+    resend_message_id: sendResult.messageId ?? null,
+    metadata: {
+      email_count_after: lead.email_count + 1,
+      discount_code: plan.needsDiscount ? promoCode : null,
+    },
+  });
+
+  captureServer('nurture_email_sent', `consumer_lead:${lead.id}`, {
+    template: plan.template,
+    email_count_after: lead.email_count + 1,
+    subject: sendResult.subject,
+  });
+
+  return { leadId: lead.id, action: `sent_${plan.template}`, ok: true };
+}
+
+async function runCron(): Promise<{ scanned: number; results: Array<{ leadId: string; action: string; ok: boolean; reason?: string }> }> {
+  const supabase = getAdmin();
+  const now = new Date();
+
+  const { data: leads, error } = await supabase
+    .from('consumer_leads')
+    .select(
+      'id, email, name, intended_tier, intended_billing_interval, funnel_stage, captured_at, last_emailed_at, email_count, discount_code, discount_coupon_id, discount_code_expires_at, unsubscribe_token, stripe_recovery_url',
+    )
+    .not('funnel_stage', 'in', '("converted_paid","converted_free","unsubscribed","expired","manual_handling")')
+    .is('unsubscribed_at', null)
+    .order('captured_at', { ascending: true })
+    .limit(200);
+
+  if (error || !leads) {
+    return { scanned: 0, results: [] };
+  }
+
+  const results: Array<{ leadId: string; action: string; ok: boolean; reason?: string }> = [];
+  for (const lead of leads as LeadRow[]) {
+    try {
+      const r = await processLead(supabase, lead, now);
+      results.push(r);
+    } catch (err) {
+      results.push({
+        leadId: lead.id,
+        action: 'unhandled_error',
+        ok: false,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { scanned: leads.length, results };
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await authorizeAdminOrCron(req);
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.reason ?? 'Unauthorized' }, { status: auth.status });
+  }
+  const summary = await runCron();
+  return NextResponse.json({ ok: true, ...summary });
+}
+
+export async function POST(req: NextRequest) {
+  // POST allowed too — internal manual triggers from admin UI
+  return GET(req);
+}

--- a/src/app/api/leads/capture/route.ts
+++ b/src/app/api/leads/capture/route.ts
@@ -1,0 +1,61 @@
+/**
+ * POST /api/leads/capture — public endpoint, lightweight + best-effort.
+ *
+ * Used by the pricing page when a logged-out user clicks "Subscribe":
+ * we capture their email + intended tier so we can re-engage if they
+ * never finish signup. Does not authenticate (the email IS the
+ * identifier) but rate-limits by IP and dedupes via the capture helper.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { captureConsumerLead } from '@/lib/consumer-leads/capture';
+
+export const runtime = 'nodejs';
+
+interface Body {
+  email?: string;
+  name?: string;
+  intended_tier?: 'essential' | 'pro';
+  intended_billing_interval?: 'monthly' | 'yearly';
+  source?: 'signup_form' | 'pricing_page_exit';
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+}
+
+export async function POST(req: NextRequest) {
+  let body: Body;
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    return NextResponse.json({ ok: false, error: 'invalid_json' }, { status: 400 });
+  }
+
+  const email = (body.email || '').trim();
+  if (!email || !email.includes('@')) {
+    return NextResponse.json({ ok: false, error: 'invalid_email' }, { status: 400 });
+  }
+
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || null;
+  const userAgent = req.headers.get('user-agent') || null;
+
+  const result = await captureConsumerLead({
+    email,
+    name: body.name ?? null,
+    source: body.source === 'pricing_page_exit' ? 'pricing_page_exit' : 'signup_form',
+    intendedTier: body.intended_tier ?? null,
+    intendedBillingInterval: body.intended_billing_interval ?? null,
+    utmSource: body.utm_source ?? null,
+    utmMedium: body.utm_medium ?? null,
+    utmCampaign: body.utm_campaign ?? null,
+    ipAddress: ip,
+    userAgent,
+  });
+
+  if (!result.ok) {
+    // Don't reveal internal details to the public — capture is best-effort.
+    return NextResponse.json({ ok: false }, { status: 200 });
+  }
+
+  return NextResponse.json({ ok: true, lead_id: result.leadId, created: result.created });
+}

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -1,0 +1,88 @@
+/**
+ * GET /api/unsubscribe?token=... — public, token-gated unsubscribe.
+ * POST same — RFC 8058 one-click unsubscribe target (Gmail/Outlook
+ * native button POSTs `List-Unsubscribe=One-Click`).
+ *
+ * Honours the request immediately:
+ *   - sets unsubscribed_at = now()
+ *   - flips funnel_stage to 'unsubscribed'
+ *   - GET → redirect to /unsubscribe (success page)
+ *   - POST → 200 JSON
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { captureServer } from '@/lib/posthog-server';
+
+export const runtime = 'nodejs';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+async function processUnsubscribe(token: string): Promise<{ ok: boolean; alreadyUnsubscribed: boolean; leadId?: string }> {
+  if (!token) return { ok: false, alreadyUnsubscribed: false };
+  const supabase = getAdmin();
+
+  const { data: lead } = await supabase
+    .from('consumer_leads')
+    .select('id, unsubscribed_at, email_count')
+    .eq('unsubscribe_token', token)
+    .maybeSingle();
+
+  if (!lead) return { ok: false, alreadyUnsubscribed: false };
+  if (lead.unsubscribed_at) {
+    return { ok: true, alreadyUnsubscribed: true, leadId: lead.id };
+  }
+
+  const now = new Date().toISOString();
+  await supabase
+    .from('consumer_leads')
+    .update({
+      unsubscribed_at: now,
+      funnel_stage: 'unsubscribed',
+    })
+    .eq('id', lead.id);
+
+  captureServer('lead_unsubscribed', `consumer_lead:${lead.id}`, {
+    email_count_at_unsub: lead.email_count,
+  });
+
+  return { ok: true, alreadyUnsubscribed: false, leadId: lead.id };
+}
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get('token') || '';
+  const result = await processUnsubscribe(token);
+  // Always redirect to the success page so unauthenticated browsers don't
+  // see a confusing JSON blob — the page itself shows the right message.
+  const url = req.nextUrl.clone();
+  url.pathname = '/unsubscribe';
+  url.search = result.ok ? '?ok=1' : '?ok=0';
+  return NextResponse.redirect(url);
+}
+
+export async function POST(req: NextRequest) {
+  // RFC 8058: token may be in query string OR the body
+  let token = req.nextUrl.searchParams.get('token') || '';
+  if (!token) {
+    try {
+      const ct = req.headers.get('content-type') || '';
+      if (ct.includes('application/x-www-form-urlencoded')) {
+        const text = await req.text();
+        const params = new URLSearchParams(text);
+        token = params.get('token') || '';
+      } else if (ct.includes('application/json')) {
+        const body = (await req.json()) as { token?: string };
+        token = body.token || '';
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  const result = await processUnsubscribe(token);
+  return NextResponse.json({ ok: result.ok, already_unsubscribed: result.alreadyUnsubscribed });
+}

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -111,6 +111,46 @@ export async function POST(request: NextRequest) {
           } catch (e: any) {
             console.error('[stripe webhook] b2b checkout.expired failed:', e?.message);
           }
+          break;
+        }
+
+        // B2C abandonment capture — feed the consumer nurture funnel.
+        // The B2B path above intentionally returns first; we only land
+        // here for consumer checkouts. Best-effort — never throw out
+        // of the webhook handler.
+        try {
+          const { captureConsumerLead } = await import('@/lib/consumer-leads/capture');
+          const email = session.customer_details?.email || session.customer_email || null;
+          if (email) {
+            // Pull intended tier off the line items if we can.
+            let intendedTier: 'essential' | 'pro' | null = null;
+            let intendedInterval: 'monthly' | 'yearly' | null = null;
+            try {
+              const lineItems = await stripe.checkout.sessions.listLineItems(session.id, { limit: 1, expand: ['data.price'] });
+              const priceId = lineItems.data[0]?.price?.id;
+              if (priceId && PRICE_ID_TO_TIER[priceId]) {
+                intendedTier = PRICE_ID_TO_TIER[priceId] as 'essential' | 'pro';
+              }
+              const recurring = lineItems.data[0]?.price?.recurring?.interval;
+              if (recurring === 'month') intendedInterval = 'monthly';
+              if (recurring === 'year') intendedInterval = 'yearly';
+            } catch (e: any) {
+              console.warn('[stripe webhook] expired session line-items lookup failed:', e?.message);
+            }
+            const recoveryUrl = session.after_expiration?.recovery?.url ?? null;
+            await captureConsumerLead({
+              email,
+              name: session.customer_details?.name ?? null,
+              source: 'stripe_checkout_abandoned',
+              stripeCheckoutSessionId: session.id,
+              stripeCustomerId: typeof session.customer === 'string' ? session.customer : null,
+              stripeRecoveryUrl: recoveryUrl,
+              intendedTier,
+              intendedBillingInterval: intendedInterval,
+            });
+          }
+        } catch (e: any) {
+          console.error('[stripe webhook] consumer abandonment capture failed:', e?.message);
         }
         break;
       }
@@ -166,6 +206,39 @@ export async function POST(request: NextRequest) {
             session.customer as string,
             session.subscription as string
           );
+        }
+
+        // Mark any matching consumer_leads row as converted_paid so the
+        // nurture funnel stops emailing this user. Best-effort, B2C only —
+        // the `metadata.product==='b2b_api'` branch above already returned.
+        try {
+          const conversionEmail = (session.customer_details?.email || session.customer_email || '').toLowerCase();
+          if (conversionEmail) {
+            const { captureServer } = await import('@/lib/posthog-server');
+            const { data: matchingLeads } = await supabase
+              .from('consumer_leads')
+              .select('id, funnel_stage')
+              .ilike('email', conversionEmail)
+              .not('funnel_stage', 'in', '("converted_paid","unsubscribed","expired")')
+              .order('captured_at', { ascending: false })
+              .limit(5);
+            for (const lead of matchingLeads ?? []) {
+              await supabase
+                .from('consumer_leads')
+                .update({
+                  funnel_stage: 'converted_paid',
+                  converted_at: new Date().toISOString(),
+                  converted_user_id: userId,
+                })
+                .eq('id', lead.id);
+              captureServer('lead_converted', `consumer_lead:${lead.id}`, {
+                tier,
+                from_stage: lead.funnel_stage,
+              });
+            }
+          }
+        } catch (e: any) {
+          console.error('[stripe webhook] consumer-lead conversion mark failed:', e?.message);
         }
 
         // Awin server-to-server conversion tracking

--- a/src/app/dashboard/admin/consumer-leads/ConsumerLeadsClient.tsx
+++ b/src/app/dashboard/admin/consumer-leads/ConsumerLeadsClient.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+interface Lead {
+  id: string;
+  email: string;
+  name: string | null;
+  source: string;
+  intended_tier: 'essential' | 'pro' | null;
+  intended_billing_interval: 'monthly' | 'yearly' | null;
+  funnel_stage: string;
+  captured_at: string;
+  last_emailed_at: string | null;
+  email_count: number;
+  discount_code: string | null;
+  discount_coupon_id: string | null;
+  discount_code_expires_at: string | null;
+  discount_redeemed_at: string | null;
+  converted_at: string | null;
+  unsubscribed_at: string | null;
+  notes: string | null;
+}
+
+interface Metrics {
+  total_captured: number;
+  captured_this_week: number;
+  converted: number;
+  recovery_rate: number;
+  revenue_recovered_pounds: number;
+  cost_per_lead_pounds: number;
+  stage_counts: Record<string, number>;
+}
+
+interface EmailLog {
+  id: string;
+  template: string;
+  subject: string | null;
+  resend_message_id: string | null;
+  sent_at: string;
+}
+
+const STAGES = [
+  'new',
+  'email_1_sent',
+  'email_2_sent',
+  'email_3_sent',
+  'email_4_sent',
+  'converted_paid',
+  'converted_free',
+  'unsubscribed',
+  'expired',
+  'manual_handling',
+];
+const SOURCES = ['signup_form', 'stripe_checkout_abandoned', 'pricing_page_exit', 'onboarding_dropoff'];
+
+function fmtDate(s: string | null): string {
+  if (!s) return '—';
+  const d = new Date(s);
+  return d.toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: '2-digit', hour: '2-digit', minute: '2-digit' });
+}
+
+function stageColor(stage: string): string {
+  switch (stage) {
+    case 'converted_paid': return 'bg-emerald-100 text-emerald-700';
+    case 'unsubscribed':   return 'bg-slate-200 text-slate-600';
+    case 'expired':        return 'bg-slate-100 text-slate-500';
+    case 'manual_handling':return 'bg-amber-100 text-amber-700';
+    case 'new':            return 'bg-blue-100 text-blue-700';
+    default:               return 'bg-indigo-100 text-indigo-700';
+  }
+}
+
+export default function ConsumerLeadsClient() {
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+  const [stageFilter, setStageFilter] = useState('all');
+  const [sourceFilter, setSourceFilter] = useState('all');
+  const [loading, setLoading] = useState(true);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [drillIn, setDrillIn] = useState<{ lead: Lead; email_log: EmailLog[] } | null>(null);
+  const [savingNotes, setSavingNotes] = useState(false);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (stageFilter !== 'all') params.set('stage', stageFilter);
+    if (sourceFilter !== 'all') params.set('source', sourceFilter);
+    const res = await fetch(`/api/admin/consumer-leads?${params}`, { credentials: 'include' });
+    if (res.ok) {
+      const data = await res.json();
+      setLeads(data.leads ?? []);
+      setMetrics(data.metrics ?? null);
+    }
+    setLoading(false);
+  }, [stageFilter, sourceFilter]);
+
+  useEffect(() => { fetchAll(); }, [fetchAll]);
+
+  useEffect(() => {
+    if (!selectedId) { setDrillIn(null); return; }
+    fetch(`/api/admin/consumer-leads/${selectedId}`, { credentials: 'include' })
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => { if (data) setDrillIn(data); });
+  }, [selectedId]);
+
+  const performAction = async (action: string, extra?: Record<string, unknown>) => {
+    if (!selectedId) return;
+    const res = await fetch(`/api/admin/consumer-leads/${selectedId}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, ...extra }),
+    });
+    if (res.ok) {
+      await fetchAll();
+      // refresh drill
+      const d = await fetch(`/api/admin/consumer-leads/${selectedId}`, { credentials: 'include' });
+      if (d.ok) setDrillIn(await d.json());
+    } else {
+      const err = await res.json().catch(() => ({}));
+      alert(`Action failed: ${err.error ?? res.status}`);
+    }
+  };
+
+  const saveNotes = async (notes: string) => {
+    if (!selectedId) return;
+    setSavingNotes(true);
+    await fetch(`/api/admin/consumer-leads/${selectedId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ notes }),
+    });
+    setSavingNotes(false);
+  };
+
+  return (
+    <div>
+      {/* Metric tiles */}
+      {metrics && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          <Tile label="Captured (all-time)" value={metrics.total_captured.toString()} />
+          <Tile label="Captured this week"  value={metrics.captured_this_week.toString()} />
+          <Tile label="Recovery rate"       value={`${(metrics.recovery_rate * 100).toFixed(1)}%`} />
+          <Tile label="Revenue recovered"   value={`£${metrics.revenue_recovered_pounds.toFixed(2)}`} />
+        </div>
+      )}
+
+      {/* Funnel bar */}
+      {metrics && (
+        <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
+          <h2 className="text-sm font-semibold text-slate-700 mb-3">Funnel</h2>
+          <div className="flex flex-wrap gap-2">
+            {STAGES.map((s) => (
+              <div key={s} className={`px-3 py-2 rounded-lg text-xs font-medium ${stageColor(s)}`}>
+                <div className="font-semibold">{s.replace(/_/g, ' ')}</div>
+                <div className="text-base font-bold">{metrics.stage_counts[s] ?? 0}</div>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-slate-500 mt-3">
+            Cost per lead: £{metrics.cost_per_lead_pounds.toFixed(4)} (Resend ≈ £0.0004 per send)
+          </p>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3 mb-4">
+        <select
+          value={stageFilter}
+          onChange={(e) => setStageFilter(e.target.value)}
+          className="px-3 py-2 border border-slate-200 rounded-lg text-sm"
+        >
+          <option value="all">All stages</option>
+          {STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
+        <select
+          value={sourceFilter}
+          onChange={(e) => setSourceFilter(e.target.value)}
+          className="px-3 py-2 border border-slate-200 rounded-lg text-sm"
+        >
+          <option value="all">All sources</option>
+          {SOURCES.map((s) => <option key={s} value={s}>{s}</option>)}
+        </select>
+        <button
+          onClick={fetchAll}
+          className="px-3 py-2 bg-slate-100 hover:bg-slate-200 text-sm rounded-lg"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-slate-600 text-xs uppercase">
+            <tr>
+              <th className="px-4 py-3 text-left">Email</th>
+              <th className="px-4 py-3 text-left">Source</th>
+              <th className="px-4 py-3 text-left">Tier</th>
+              <th className="px-4 py-3 text-left">Stage</th>
+              <th className="px-4 py-3 text-left">Captured</th>
+              <th className="px-4 py-3 text-left">Last emailed</th>
+              <th className="px-4 py-3 text-left"># sent</th>
+              <th className="px-4 py-3 text-left">Discount</th>
+              <th className="px-4 py-3 text-left">Converted</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr><td colSpan={9} className="px-4 py-8 text-center text-slate-500">Loading…</td></tr>
+            ) : leads.length === 0 ? (
+              <tr><td colSpan={9} className="px-4 py-8 text-center text-slate-500">No leads yet.</td></tr>
+            ) : leads.map((l) => (
+              <tr
+                key={l.id}
+                onClick={() => setSelectedId(l.id)}
+                className="border-t border-slate-100 hover:bg-slate-50 cursor-pointer"
+              >
+                <td className="px-4 py-3 text-slate-900 font-medium">{l.email}{l.name ? <span className="text-slate-400 ml-1">({l.name})</span> : null}</td>
+                <td className="px-4 py-3 text-slate-600">{l.source}</td>
+                <td className="px-4 py-3 text-slate-600">{l.intended_tier ?? '—'} {l.intended_billing_interval ? `(${l.intended_billing_interval})` : ''}</td>
+                <td className="px-4 py-3"><span className={`px-2 py-1 rounded text-xs ${stageColor(l.funnel_stage)}`}>{l.funnel_stage}</span></td>
+                <td className="px-4 py-3 text-slate-600">{fmtDate(l.captured_at)}</td>
+                <td className="px-4 py-3 text-slate-600">{fmtDate(l.last_emailed_at)}</td>
+                <td className="px-4 py-3 text-slate-600">{l.email_count}</td>
+                <td className="px-4 py-3 text-slate-600 font-mono text-xs">
+                  {l.discount_code ? (
+                    <a
+                      href={`https://dashboard.stripe.com/promotion_codes/${l.discount_coupon_id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="text-emerald-600 underline"
+                    >
+                      {l.discount_code}
+                    </a>
+                  ) : '—'}
+                </td>
+                <td className="px-4 py-3 text-slate-600">{l.converted_at ? '✓' : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Drill-in drawer */}
+      {selectedId && drillIn && (
+        <div className="fixed inset-0 bg-black/40 z-50" onClick={() => setSelectedId(null)}>
+          <aside
+            onClick={(e) => e.stopPropagation()}
+            className="absolute right-0 top-0 h-full w-full max-w-xl bg-white shadow-xl overflow-y-auto p-6"
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-bold text-slate-900">{drillIn.lead.email}</h2>
+              <button onClick={() => setSelectedId(null)} className="text-slate-400 hover:text-slate-700 text-xl">×</button>
+            </div>
+            <div className="space-y-3 text-sm text-slate-600">
+              <div><span className="font-semibold">Stage:</span> <span className={`px-2 py-0.5 rounded text-xs ${stageColor(drillIn.lead.funnel_stage)}`}>{drillIn.lead.funnel_stage}</span></div>
+              <div><span className="font-semibold">Source:</span> {drillIn.lead.source}</div>
+              <div><span className="font-semibold">Intended:</span> {drillIn.lead.intended_tier ?? '—'} {drillIn.lead.intended_billing_interval ? `(${drillIn.lead.intended_billing_interval})` : ''}</div>
+              <div><span className="font-semibold">Captured:</span> {fmtDate(drillIn.lead.captured_at)}</div>
+              <div><span className="font-semibold">Emails sent:</span> {drillIn.lead.email_count}</div>
+              {drillIn.lead.discount_code && (
+                <div><span className="font-semibold">Discount:</span> <code className="bg-slate-100 px-1 rounded">{drillIn.lead.discount_code}</code> exp {fmtDate(drillIn.lead.discount_code_expires_at)}</div>
+              )}
+            </div>
+
+            <h3 className="text-sm font-bold text-slate-700 mt-6 mb-2">Email timeline</h3>
+            <ul className="space-y-2 text-xs">
+              {drillIn.email_log.length === 0 ? (
+                <li className="text-slate-400">No emails sent yet.</li>
+              ) : drillIn.email_log.map((e) => (
+                <li key={e.id} className="border-l-2 border-emerald-500 pl-3 py-1">
+                  <div className="font-semibold text-slate-800">{e.template}</div>
+                  <div className="text-slate-600">{e.subject}</div>
+                  <div className="text-slate-400">{fmtDate(e.sent_at)}{e.resend_message_id ? ` · ${e.resend_message_id.slice(0, 12)}…` : ''}</div>
+                </li>
+              ))}
+            </ul>
+
+            <h3 className="text-sm font-bold text-slate-700 mt-6 mb-2">Notes</h3>
+            <textarea
+              defaultValue={drillIn.lead.notes ?? ''}
+              onBlur={(e) => saveNotes(e.target.value)}
+              className="w-full border border-slate-200 rounded-lg p-2 text-sm"
+              rows={3}
+              placeholder="Founder notes (saves on blur)"
+            />
+            {savingNotes && <p className="text-xs text-slate-400">Saving…</p>}
+
+            <h3 className="text-sm font-bold text-slate-700 mt-6 mb-2">Actions</h3>
+            <div className="grid grid-cols-2 gap-2">
+              <button onClick={() => performAction('mark_converted_paid')} className="px-3 py-2 bg-emerald-500 text-white rounded text-sm">Mark converted (paid)</button>
+              <button onClick={() => performAction('mark_unsubscribed')} className="px-3 py-2 bg-slate-200 rounded text-sm">Mark unsubscribed</button>
+              <button onClick={() => performAction('manual_handling')} className="px-3 py-2 bg-amber-500 text-white rounded text-sm">Move to manual</button>
+              <button onClick={() => performAction('fresh_discount')} className="px-3 py-2 bg-indigo-500 text-white rounded text-sm">Generate fresh code</button>
+              <button
+                onClick={async () => {
+                  const subject = prompt('Subject?');
+                  if (!subject) return;
+                  const body = prompt('Body (plain text)?');
+                  if (!body) return;
+                  await performAction('send_manual_email', { subject, body_text: body });
+                }}
+                className="px-3 py-2 bg-blue-500 text-white rounded text-sm col-span-2"
+              >
+                Send manual follow-up email
+              </button>
+            </div>
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Tile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-4">
+      <p className="text-2xl font-bold text-slate-900">{value}</p>
+      <p className="text-slate-500 text-xs">{label}</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/consumer-leads/page.tsx
+++ b/src/app/dashboard/admin/consumer-leads/page.tsx
@@ -1,0 +1,23 @@
+/**
+ * Admin — consumer abandonment nurture dashboard.
+ *
+ * Founder-gated by the parent /dashboard/admin/layout.tsx.
+ */
+
+import ConsumerLeadsClient from './ConsumerLeadsClient';
+
+export const dynamic = 'force-dynamic';
+
+export default function ConsumerLeadsPage() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h1 className="text-2xl font-bold text-slate-900 mb-2">Consumer abandonment nurture</h1>
+      <p className="text-sm text-slate-500 mb-6">
+        Captured B2C leads from abandoned Stripe checkouts and pricing-page subscribe clicks. Daily
+        cron drips a 4-email sequence (T+1h, T+24h, T+72h, T+7d) and issues a 10% Stripe code on
+        email 3.
+      </p>
+      <ConsumerLeadsClient />
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -7,7 +7,7 @@ import { createClient } from '@/lib/supabase/client';
 import {
   ShieldAlert, Users, CreditCard, TrendingUp, BarChart3,
   Building2, FileText, Bot, Loader2, ChevronRight, ArrowLeft,
-  Banknote, Clock, Mail, Database, Ticket, Brain, Shield, Tag, RefreshCw, Briefcase,
+  Banknote, Clock, Mail, Database, Ticket, Brain, Shield, Tag, RefreshCw, Briefcase, UserPlus,
 } from 'lucide-react';
 import TicketList from '@/components/admin/TicketList';
 import AITeamPanel from '@/components/admin/AITeamPanel';
@@ -274,6 +274,13 @@ export default function AdminPage() {
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'ai_team' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
           <Brain className="h-4 w-4" /> AI Team
         </button>
+        <Link
+          href="/dashboard/admin/consumer-leads"
+          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
+          title="Consumer abandonment nurture funnel"
+        >
+          <UserPlus className="h-4 w-4" /> Consumer Leads
+        </Link>
         <Link
           href="/dashboard/admin/legal-refs"
           className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -1,0 +1,49 @@
+/**
+ * /unsubscribe — public success page that the unsubscribe API redirects to.
+ * No auth, no account-data leakage. Just a clear message.
+ */
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  searchParams: Promise<{ ok?: string }>;
+}
+
+export default async function UnsubscribePage({ searchParams }: Props) {
+  const params = await searchParams;
+  const ok = params.ok === '1';
+
+  return (
+    <main
+      style={{
+        minHeight: '60vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '48px 24px',
+        fontFamily:
+          "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif",
+        color: '#0B1220',
+      }}
+    >
+      <div style={{ maxWidth: 520, textAlign: 'center' }}>
+        <h1 style={{ fontSize: 28, fontWeight: 800, marginBottom: 16 }}>
+          {ok ? 'You’re unsubscribed' : 'Unsubscribe link not recognised'}
+        </h1>
+        <p style={{ fontSize: 16, lineHeight: 1.6, color: '#374151' }}>
+          {ok
+            ? 'You won’t receive any more nurture emails from us. We’re sorry to see you go — if you ever change your mind, you can sign up at paybacker.co.uk anytime.'
+            : 'That unsubscribe link doesn’t look valid or has already been used. If you’re still receiving emails you don’t want, please reply to any of them and a real person will sort it out.'}
+        </p>
+        <p style={{ marginTop: 32 }}>
+          <a
+            href="https://paybacker.co.uk"
+            style={{ color: '#059669', fontWeight: 600, textDecoration: 'none' }}
+          >
+            Back to paybacker.co.uk
+          </a>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/consumer-leads/capture.ts
+++ b/src/lib/consumer-leads/capture.ts
@@ -1,0 +1,166 @@
+/**
+ * Consumer-lead capture helper.
+ *
+ * Used by both the Stripe webhook (checkout.session.expired) and the
+ * /api/leads/capture endpoint (pricing-page subscribe click). Centralises
+ * the upsert logic + unsubscribe-token generation + PostHog ping so the
+ * two capture paths stay consistent.
+ *
+ * B2C ONLY. Callers must pre-filter B2B sessions (metadata.product='b2b_api')
+ * before invoking this — we don't want to pollute the consumer funnel with
+ * API customers who already have a direct-contact founder path.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import crypto from 'node:crypto';
+import { captureServer } from '@/lib/posthog-server';
+
+export type ConsumerLeadSource =
+  | 'signup_form'
+  | 'stripe_checkout_abandoned'
+  | 'pricing_page_exit'
+  | 'onboarding_dropoff';
+
+export interface CaptureInput {
+  email: string;
+  name?: string | null;
+  phone?: string | null;
+  source: ConsumerLeadSource;
+  stripeCheckoutSessionId?: string | null;
+  stripeCustomerId?: string | null;
+  stripeRecoveryUrl?: string | null;
+  intendedTier?: 'essential' | 'pro' | null;
+  intendedBillingInterval?: 'monthly' | 'yearly' | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  utmSource?: string | null;
+  utmMedium?: string | null;
+  utmCampaign?: string | null;
+}
+
+export interface CaptureResult {
+  ok: boolean;
+  leadId?: string;
+  created: boolean;
+  reason?: string;
+}
+
+function getAdminClient(): SupabaseClient {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+function generateUnsubToken(): string {
+  // 32 random bytes, base64url — 43 chars, URL-safe, unguessable.
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/**
+ * Capture or refresh a consumer lead.
+ *
+ * Idempotency rules:
+ *   - If a stripe_checkout_session_id is provided and already exists,
+ *     we update the existing row (don't duplicate). Sessions can fire
+ *     `expired` once per session; this is a defensive net.
+ *   - Otherwise, dedupe on lower(email) within the last 14 days +
+ *     not-yet-converted/unsubscribed. Refresh source/tier on hit.
+ *   - If matching row is `unsubscribed`, do NOT re-capture — respect the
+ *     opt-out.
+ */
+export async function captureConsumerLead(input: CaptureInput): Promise<CaptureResult> {
+  const supabase = getAdminClient();
+  const email = input.email.trim().toLowerCase();
+  if (!email || !email.includes('@')) {
+    return { ok: false, created: false, reason: 'invalid_email' };
+  }
+
+  // 1. Stripe-session dedupe path
+  if (input.stripeCheckoutSessionId) {
+    const { data: bySession } = await supabase
+      .from('consumer_leads')
+      .select('id, funnel_stage')
+      .eq('stripe_checkout_session_id', input.stripeCheckoutSessionId)
+      .maybeSingle();
+    if (bySession) {
+      return { ok: true, leadId: bySession.id, created: false, reason: 'session_already_captured' };
+    }
+  }
+
+  // 2. Email dedupe path — only collapse onto a non-terminal row from
+  //    the last 14 days. After that, treat as a new lead so the funnel
+  //    can re-engage them.
+  const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  const { data: recent } = await supabase
+    .from('consumer_leads')
+    .select('id, funnel_stage, unsubscribed_at')
+    .ilike('email', email)
+    .gte('captured_at', fourteenDaysAgo)
+    .order('captured_at', { ascending: false })
+    .limit(1);
+
+  const existing = recent?.[0];
+  if (existing) {
+    if (existing.unsubscribed_at || existing.funnel_stage === 'unsubscribed') {
+      return { ok: true, leadId: existing.id, created: false, reason: 'previously_unsubscribed' };
+    }
+    // Refresh source/tier on existing — useful when a user clicked
+    // pricing first then started Stripe checkout.
+    const { error: updateErr } = await supabase
+      .from('consumer_leads')
+      .update({
+        source: input.source,
+        stripe_checkout_session_id: input.stripeCheckoutSessionId ?? undefined,
+        stripe_customer_id: input.stripeCustomerId ?? undefined,
+        stripe_recovery_url: input.stripeRecoveryUrl ?? undefined,
+        intended_tier: input.intendedTier ?? undefined,
+        intended_billing_interval: input.intendedBillingInterval ?? undefined,
+        name: input.name ?? undefined,
+      })
+      .eq('id', existing.id);
+    if (updateErr) {
+      return { ok: false, created: false, reason: updateErr.message };
+    }
+    return { ok: true, leadId: existing.id, created: false, reason: 'refreshed_existing' };
+  }
+
+  // 3. Insert fresh row
+  const { data: inserted, error: insertErr } = await supabase
+    .from('consumer_leads')
+    .insert({
+      email,
+      name: input.name ?? null,
+      phone: input.phone ?? null,
+      source: input.source,
+      stripe_checkout_session_id: input.stripeCheckoutSessionId ?? null,
+      stripe_customer_id: input.stripeCustomerId ?? null,
+      stripe_recovery_url: input.stripeRecoveryUrl ?? null,
+      intended_tier: input.intendedTier ?? null,
+      intended_billing_interval: input.intendedBillingInterval ?? null,
+      funnel_stage: 'new',
+      unsubscribe_token: generateUnsubToken(),
+      ip_address: input.ipAddress ?? null,
+      user_agent: input.userAgent ?? null,
+      utm_source: input.utmSource ?? null,
+      utm_medium: input.utmMedium ?? null,
+      utm_campaign: input.utmCampaign ?? null,
+    })
+    .select('id')
+    .single();
+
+  if (insertErr || !inserted) {
+    return { ok: false, created: false, reason: insertErr?.message };
+  }
+
+  captureServer('lead_captured', `consumer_lead:${inserted.id}`, {
+    source: input.source,
+    intended_tier: input.intendedTier,
+    intended_billing_interval: input.intendedBillingInterval,
+    utm_source: input.utmSource,
+    utm_medium: input.utmMedium,
+    utm_campaign: input.utmCampaign,
+  });
+
+  return { ok: true, leadId: inserted.id, created: true };
+}

--- a/src/lib/email/consumer-nurture.ts
+++ b/src/lib/email/consumer-nurture.ts
@@ -1,0 +1,331 @@
+/**
+ * Consumer abandonment nurture email templates (4-email sequence).
+ *
+ * Sequence:
+ *   1. Soft reminder           ~T+1h     transactional-leaning
+ *   2. Value nudge             ~T+24h    soft opt-in marketing
+ *   3. 10% discount + code     ~T+72h    soft opt-in marketing
+ *   4. Final / code expiring   ~T+7d     soft opt-in marketing
+ *
+ * Lawful basis: PECR reg. 22(3) "soft opt-in" — recipient gave details
+ * during a sale-negotiation (Stripe checkout / pricing page subscribe),
+ * marketing relates to similar products, one-click unsubscribe in every
+ * footer.
+ *
+ * Visual style mirrors src/lib/email/dispute-reminders.ts so consumer
+ * mail looks the same as transactional product mail.
+ */
+
+import { resend, FROM_EMAIL, REPLY_TO } from '@/lib/resend';
+
+const wrap = `font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:600px;margin:0 auto;background:#FFFFFF;border-radius:16px;overflow:hidden;`;
+const header = `background:#F9FAFB;padding:24px 32px;border-bottom:1px solid #F9FAFB;text-align:center;`;
+const body = `padding:32px;`;
+const h1 = `color:#0B1220;font-size:24px;font-weight:700;margin:0 0 16px;line-height:1.3;`;
+const p = `color:#374151;font-size:15px;line-height:1.75;margin:0 0 16px;`;
+const box = `background:#F9FAFB;border-radius:12px;padding:20px 24px;margin:20px 0;border-left:3px solid #059669;`;
+const codeBox = `background:#0B1220;color:#FFFFFF;border-radius:12px;padding:18px 24px;margin:20px 0;text-align:center;font-family:Menlo,Monaco,Consolas,monospace;font-size:22px;font-weight:700;letter-spacing:2px;`;
+const cta = `display:inline-block;background:#059669;color:#FFFFFF;font-weight:700;font-size:15px;padding:14px 28px;border-radius:12px;text-decoration:none;margin:8px 0;`;
+const footerBox = `padding:20px 32px 28px;border-top:1px solid #F9FAFB;`;
+const footerText = `color:#4B5563;font-size:12px;line-height:1.6;margin:0;text-align:center;`;
+const unsubLink = `color:#059669;text-decoration:underline;font-weight:600;`;
+
+const SITE = process.env.NEXT_PUBLIC_SITE_URL || 'https://paybacker.co.uk';
+
+const Logo = () => `
+  <a href="${SITE}" style="text-decoration:none;">
+    <span style="font-size:22px;font-weight:800;color:#0B1220;">Pay<span style="color:#059669;">backer</span></span>
+  </a>
+`;
+
+function Footer(unsubscribeUrl: string): string {
+  return `
+    <div style="${footerBox}">
+      <p style="${footerText}">
+        You're receiving this because you started a checkout or signup on
+        <a href="${SITE}" style="color:#059669;text-decoration:none;">paybacker.co.uk</a>.<br/>
+        <a href="${unsubscribeUrl}" style="${unsubLink}">Unsubscribe in one click</a>
+      </p>
+      <p style="${footerText};margin-top:14px;">
+        Paybacker LTD · ICO Registered · UK Company<br/>
+        <a href="${SITE}/privacy-policy" style="color:#4B5563;text-decoration:none;">Privacy Policy</a> &nbsp;·&nbsp;
+        <a href="${SITE}/legal/terms" style="color:#4B5563;text-decoration:none;">Terms</a>
+      </p>
+    </div>
+  `;
+}
+
+export type NurtureTemplate =
+  | 'email_1_soft_reminder'
+  | 'email_2_value_nudge'
+  | 'email_3_discount'
+  | 'email_4_final';
+
+export const SUBJECT_LINES: Record<NurtureTemplate, (tier: string) => string> = {
+  email_1_soft_reminder: () => 'Did you forget something?',
+  email_2_value_nudge:   (tier) => `Why most LifeAdmin users pick ${tier}`,
+  email_3_discount:      () => 'A small thank-you: 10% off LifeAdmin (7 days)',
+  email_4_final:         () => 'Last call — your 10% code expires soon',
+};
+
+export interface NurtureContext {
+  email: string;
+  name: string | null;
+  intendedTier: 'essential' | 'pro' | null;
+  intendedBillingInterval: 'monthly' | 'yearly' | null;
+  unsubscribeToken: string;
+  /** Only set for email_3 / email_4 */
+  promoCode?: string;
+  /** Only set for email_3 / email_4 */
+  promoExpiresAt?: Date;
+  /** Stripe-provided recovery URL if available, else generic /pricing */
+  recoveryUrl?: string;
+}
+
+function tierName(t: 'essential' | 'pro' | null): string {
+  if (t === 'pro') return 'Pro';
+  if (t === 'essential') return 'Essential';
+  return 'LifeAdmin';
+}
+
+function tierPrice(t: 'essential' | 'pro' | null): string {
+  if (t === 'pro') return '£9.99/month';
+  if (t === 'essential') return '£4.99/month';
+  return 'a paid plan';
+}
+
+function unsubUrl(token: string): string {
+  return `${SITE}/api/unsubscribe?token=${encodeURIComponent(token)}`;
+}
+
+function ctaUrl(ctx: NurtureContext): string {
+  return ctx.recoveryUrl || `${SITE}/pricing`;
+}
+
+function greet(name: string | null): string {
+  if (!name) return 'Hi there,';
+  const first = name.split(' ')[0];
+  return `Hi ${first},`;
+}
+
+// ---------- Template 1 — soft reminder ----------
+
+function template1(ctx: NurtureContext): { html: string; text: string } {
+  const tn = tierName(ctx.intendedTier);
+  const unsub = unsubUrl(ctx.unsubscribeToken);
+  const html = `
+    <div style="${wrap}">
+      <div style="${header}">${Logo()}</div>
+      <div style="${body}">
+        <h1 style="${h1}">${greet(ctx.name).replace(',', '')} — did you forget something?</h1>
+        <p style="${p}">You started signing up for <strong>${tn}</strong> on Paybacker but didn't quite finish. Totally understandable — life gets busy.</p>
+        <p style="${p}">If you'd like to pick up where you left off, you can finish in under a minute:</p>
+        <div style="text-align:center;margin:28px 0;">
+          <a href="${ctaUrl(ctx)}" style="${cta}">Finish setting up ${tn}</a>
+        </div>
+        <p style="${p}">If this wasn't you, just ignore this email — no account was created.</p>
+        <p style="${p}">— The Paybacker team</p>
+      </div>
+      ${Footer(unsub)}
+    </div>
+  `;
+  const text = [
+    `${greet(ctx.name)}`,
+    ``,
+    `You started signing up for ${tn} on Paybacker but didn't quite finish.`,
+    `Pick up where you left off: ${ctaUrl(ctx)}`,
+    ``,
+    `If this wasn't you, just ignore this email — no account was created.`,
+    ``,
+    `— The Paybacker team`,
+    `Unsubscribe: ${unsub}`,
+  ].join('\n');
+  return { html, text };
+}
+
+// ---------- Template 2 — value nudge ----------
+
+function template2(ctx: NurtureContext): { html: string; text: string } {
+  const tn = tierName(ctx.intendedTier);
+  const unsub = unsubUrl(ctx.unsubscribeToken);
+  const isPro = ctx.intendedTier === 'pro';
+  const bullets = isPro
+    ? [
+        'Unlimited bill scanning and complaint letters',
+        'AI-drafted ombudsman escalations when companies ignore you',
+        'Auto-cancellation emails for unused subscriptions',
+        'Bank-linked overcharge detection across every direct debit',
+      ]
+    : [
+        'Unlimited bill scanning — never miss a refund opportunity',
+        'AI complaint letters drafted in your voice',
+        'Subscription tracker that flags price hikes and unused services',
+        'UK consumer-rights references baked into every letter',
+      ];
+  const html = `
+    <div style="${wrap}">
+      <div style="${header}">${Logo()}</div>
+      <div style="${body}">
+        <h1 style="${h1}">${greet(ctx.name).replace(',', '')} — here's why ${tn} pays for itself</h1>
+        <p style="${p}">When we ask paying members what made the difference, the same handful of things come up:</p>
+        <div style="${box}">
+          <ul style="color:#374151;margin:0;font-size:14px;line-height:1.8;padding-left:20px;">
+            ${bullets.map((b) => `<li>${b}</li>`).join('')}
+          </ul>
+        </div>
+        <p style="${p}">The average member recovers £${isPro ? '180' : '90'}+ in their first 90 days. ${tn} costs ${tierPrice(ctx.intendedTier)} — usually paid back inside a month.</p>
+        <div style="text-align:center;margin:28px 0;">
+          <a href="${ctaUrl(ctx)}" style="${cta}">Get started with ${tn}</a>
+        </div>
+        <p style="${p}">Got a question first? Just reply — a real person reads every reply.</p>
+        <p style="${p}">— The Paybacker team</p>
+      </div>
+      ${Footer(unsub)}
+    </div>
+  `;
+  const text = [
+    `${greet(ctx.name)}`,
+    ``,
+    `Here's why ${tn} pays for itself:`,
+    ...bullets.map((b) => `  • ${b}`),
+    ``,
+    `Average member recovers £${isPro ? '180' : '90'}+ in their first 90 days.`,
+    `${tn}: ${tierPrice(ctx.intendedTier)} — usually paid back inside a month.`,
+    ``,
+    `Get started: ${ctaUrl(ctx)}`,
+    ``,
+    `— The Paybacker team`,
+    `Unsubscribe: ${unsub}`,
+  ].join('\n');
+  return { html, text };
+}
+
+// ---------- Template 3 — 10% discount ----------
+
+function template3(ctx: NurtureContext): { html: string; text: string } {
+  const tn = tierName(ctx.intendedTier);
+  const unsub = unsubUrl(ctx.unsubscribeToken);
+  const code = ctx.promoCode ?? '';
+  const exp = ctx.promoExpiresAt ? ctx.promoExpiresAt.toLocaleDateString('en-GB', { day: 'numeric', month: 'long' }) : '7 days';
+  const html = `
+    <div style="${wrap}">
+      <div style="${header}">${Logo()}</div>
+      <div style="${body}">
+        <h1 style="${h1}">${greet(ctx.name).replace(',', '')} — a small thank-you</h1>
+        <p style="${p}">We don't normally do discounts, but you've been on our list for a few days and we'd love to have you on board. Here's <strong>10% off your first month of ${tn}</strong>:</p>
+        <div style="${codeBox}">${code || 'WELCOME10'}</div>
+        <p style="${p}" style="text-align:center;color:#6B7280;font-size:13px;">Paste this code on the checkout page. Expires ${exp}.</p>
+        <div style="text-align:center;margin:28px 0;">
+          <a href="${ctaUrl(ctx)}" style="${cta}">Redeem 10% off</a>
+        </div>
+        <p style="${p}">This is a one-time, single-use code — once redeemed it's gone. No catches, no auto-renewing premium-tier nonsense.</p>
+        <p style="${p}">— The Paybacker team</p>
+      </div>
+      ${Footer(unsub)}
+    </div>
+  `;
+  const text = [
+    `${greet(ctx.name)}`,
+    ``,
+    `Here's 10% off your first month of ${tn}:`,
+    ``,
+    `   ${code || 'WELCOME10'}`,
+    ``,
+    `Paste this code on the checkout page. Expires ${exp}.`,
+    `Single-use, one-time code.`,
+    ``,
+    `Redeem: ${ctaUrl(ctx)}`,
+    ``,
+    `— The Paybacker team`,
+    `Unsubscribe: ${unsub}`,
+  ].join('\n');
+  return { html, text };
+}
+
+// ---------- Template 4 — final / expiring ----------
+
+function template4(ctx: NurtureContext): { html: string; text: string } {
+  const tn = tierName(ctx.intendedTier);
+  const unsub = unsubUrl(ctx.unsubscribeToken);
+  const code = ctx.promoCode ?? '';
+  const exp = ctx.promoExpiresAt ? ctx.promoExpiresAt.toLocaleDateString('en-GB', { day: 'numeric', month: 'long' }) : 'tomorrow';
+  const html = `
+    <div style="${wrap}">
+      <div style="${header}">${Logo()}</div>
+      <div style="${body}">
+        <h1 style="${h1}">${greet(ctx.name).replace(',', '')} — your 10% code expires ${exp}</h1>
+        <p style="${p}">Just a quick heads-up: the 10% code we sent you is about to expire. After that, it's gone for good.</p>
+        <div style="${codeBox}">${code || 'WELCOME10'}</div>
+        <div style="text-align:center;margin:28px 0;">
+          <a href="${ctaUrl(ctx)}" style="${cta}">Use my code</a>
+        </div>
+        <p style="${p}">If ${tn} isn't right for you, no worries — this is the last we'll email you about it. We won't keep nagging.</p>
+        <p style="${p}">— The Paybacker team</p>
+      </div>
+      ${Footer(unsub)}
+    </div>
+  `;
+  const text = [
+    `${greet(ctx.name)}`,
+    ``,
+    `Your 10% code expires ${exp}:`,
+    ``,
+    `   ${code || 'WELCOME10'}`,
+    ``,
+    `Use it: ${ctaUrl(ctx)}`,
+    ``,
+    `If ${tn} isn't right for you, no worries — this is the last we'll email you about it.`,
+    ``,
+    `— The Paybacker team`,
+    `Unsubscribe: ${unsub}`,
+  ].join('\n');
+  return { html, text };
+}
+
+const TEMPLATE_BUILDERS: Record<NurtureTemplate, (ctx: NurtureContext) => { html: string; text: string }> = {
+  email_1_soft_reminder: template1,
+  email_2_value_nudge:   template2,
+  email_3_discount:      template3,
+  email_4_final:         template4,
+};
+
+export interface SendResult {
+  ok: boolean;
+  messageId?: string;
+  subject: string;
+  reason?: string;
+}
+
+/**
+ * Render + send a nurture email. Returns the Resend message id on success.
+ * Caller (the cron) is responsible for writing the audit log row.
+ */
+export async function sendNurtureEmail(
+  template: NurtureTemplate,
+  ctx: NurtureContext,
+): Promise<SendResult> {
+  const subject = SUBJECT_LINES[template](tierName(ctx.intendedTier));
+  const { html, text } = TEMPLATE_BUILDERS[template](ctx);
+  try {
+    const result = await resend.emails.send({
+      from: FROM_EMAIL,
+      to: ctx.email,
+      replyTo: REPLY_TO,
+      subject,
+      html,
+      text,
+      headers: {
+        // RFC 8058 one-click unsubscribe — Gmail/Outlook native unsub button.
+        'List-Unsubscribe': `<${unsubUrl(ctx.unsubscribeToken)}>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      },
+    });
+    if ((result as { error?: { message?: string } }).error) {
+      return { ok: false, subject, reason: (result as { error?: { message?: string } }).error?.message };
+    }
+    const messageId = (result as { data?: { id?: string } }).data?.id;
+    return { ok: true, messageId, subject };
+  } catch (err) {
+    return { ok: false, subject, reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/lib/stripe/coupons.ts
+++ b/src/lib/stripe/coupons.ts
@@ -1,0 +1,93 @@
+/**
+ * Stripe coupon helper for consumer abandonment nurture.
+ *
+ * Creates a one-off, single-redemption, time-bounded coupon and an
+ * accompanying human-readable promotion code. The user pastes the
+ * promotion code on Stripe Checkout to redeem.
+ *
+ * Naming pattern: WELCOME10-XXXXXX where XXXXXX is 6 random base32-ish
+ * characters (uppercase A-Z + digits, ambiguous chars excluded so it
+ * reads cleanly aloud / in printed copy).
+ */
+
+import Stripe from 'stripe';
+import { getStripeClient } from '@/lib/stripe';
+
+const FRIENDLY_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no I, O, 0, 1
+
+function randomFriendlyCode(length: number): string {
+  let out = '';
+  for (let i = 0; i < length; i += 1) {
+    out += FRIENDLY_ALPHABET[Math.floor(Math.random() * FRIENDLY_ALPHABET.length)];
+  }
+  return out;
+}
+
+export interface CreatedDiscount {
+  coupon_id: string;
+  promo_code: string;
+  expires_at: Date;
+}
+
+/**
+ * Create a one-off discount coupon + promo code for abandonment recovery.
+ *
+ * @param email          customer email — stored in metadata for audit
+ * @param percentOff     defaults to 10
+ * @param durationDays   defaults to 7 — Stripe `redeem_by` & promo `expires_at`
+ */
+export async function createOneOffDiscountCoupon(
+  email: string,
+  percentOff: number = 10,
+  durationDays: number = 7,
+): Promise<CreatedDiscount> {
+  const stripe: Stripe = getStripeClient();
+
+  const expiresAt = new Date(Date.now() + durationDays * 24 * 60 * 60 * 1000);
+  const redeemByUnix = Math.floor(expiresAt.getTime() / 1000);
+
+  const coupon = await stripe.coupons.create({
+    percent_off: percentOff,
+    duration: 'once',
+    max_redemptions: 1,
+    redeem_by: redeemByUnix,
+    name: `LifeAdmin abandonment recovery ${percentOff}%`,
+    metadata: {
+      lead_email: email,
+      purpose: 'consumer_abandonment_nurture',
+      generated_at: new Date().toISOString(),
+    },
+  });
+
+  // Loop on collisions (vanishingly rare — 32^6 = 1bn possibilities)
+  let promoCode: Stripe.PromotionCode | null = null;
+  let attempt = 0;
+  while (!promoCode && attempt < 5) {
+    const candidate = `WELCOME10-${randomFriendlyCode(6)}`;
+    try {
+      promoCode = await stripe.promotionCodes.create({
+        coupon: coupon.id,
+        code: candidate,
+        max_redemptions: 1,
+        expires_at: redeemByUnix,
+        metadata: {
+          lead_email: email,
+          purpose: 'consumer_abandonment_nurture',
+        },
+      });
+    } catch (err) {
+      attempt += 1;
+      if (attempt >= 5) throw err;
+    }
+  }
+
+  if (!promoCode) {
+    throw new Error('Failed to create promotion code after 5 attempts');
+  }
+
+  return {
+    coupon_id: coupon.id,
+    promo_code: promoCode.code,
+    expires_at: expiresAt,
+  };
+}

--- a/supabase/migrations/20260430170000_consumer_leads_nurture.sql
+++ b/supabase/migrations/20260430170000_consumer_leads_nurture.sql
@@ -1,0 +1,124 @@
+-- Consumer abandonment nurture CRM
+--
+-- B2C-only abandoned-checkout / pricing-page-exit nurture funnel.
+-- The existing public.leads table is for social DM leads (Instagram,
+-- Facebook, comment funnels) — keep it untouched. This migration adds
+-- a separate consumer_leads table to model the SaaS-checkout funnel
+-- without coupling the two.
+--
+-- Strictly additive. Idempotent.
+
+CREATE TABLE IF NOT EXISTS public.consumer_leads (
+  id                          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email                       text NOT NULL,
+  name                        text,
+  phone                       text,
+  source                      text NOT NULL CHECK (source IN (
+                                'signup_form',
+                                'stripe_checkout_abandoned',
+                                'pricing_page_exit',
+                                'onboarding_dropoff'
+                              )),
+  stripe_checkout_session_id  text,
+  stripe_customer_id          text,
+  stripe_recovery_url         text,
+  intended_tier               text CHECK (intended_tier IN ('essential', 'pro')),
+  intended_billing_interval   text CHECK (intended_billing_interval IN ('monthly', 'yearly')),
+  funnel_stage                text NOT NULL DEFAULT 'new' CHECK (funnel_stage IN (
+                                'new',
+                                'email_1_sent',
+                                'email_2_sent',
+                                'email_3_sent',
+                                'email_4_sent',
+                                'converted_paid',
+                                'converted_free',
+                                'unsubscribed',
+                                'expired',
+                                'manual_handling'
+                              )),
+  captured_at                 timestamptz NOT NULL DEFAULT now(),
+  last_emailed_at             timestamptz,
+  email_count                 integer NOT NULL DEFAULT 0,
+  discount_code               text,
+  discount_coupon_id          text,
+  discount_code_expires_at    timestamptz,
+  discount_redeemed_at        timestamptz,
+  converted_at                timestamptz,
+  converted_user_id           uuid,
+  unsubscribed_at             timestamptz,
+  unsubscribe_token           text NOT NULL,
+  ip_address                  inet,
+  user_agent                  text,
+  utm_source                  text,
+  utm_medium                  text,
+  utm_campaign                text,
+  notes                       text,
+  last_contacted_via          text CHECK (last_contacted_via IN ('email', 'manual_note', 'phone')),
+  created_at                  timestamptz NOT NULL DEFAULT now(),
+  updated_at                  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS consumer_leads_email_idx           ON public.consumer_leads (lower(email));
+CREATE INDEX IF NOT EXISTS consumer_leads_funnel_stage_idx    ON public.consumer_leads (funnel_stage);
+CREATE INDEX IF NOT EXISTS consumer_leads_captured_at_idx     ON public.consumer_leads (captured_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS consumer_leads_unsub_token_uniq
+  ON public.consumer_leads (unsubscribe_token);
+CREATE UNIQUE INDEX IF NOT EXISTS consumer_leads_session_uniq
+  ON public.consumer_leads (stripe_checkout_session_id)
+  WHERE stripe_checkout_session_id IS NOT NULL;
+
+-- Updated-at trigger (re-uses the standard pattern other tables use)
+CREATE OR REPLACE FUNCTION public.consumer_leads_set_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS consumer_leads_updated_at ON public.consumer_leads;
+CREATE TRIGGER consumer_leads_updated_at
+BEFORE UPDATE ON public.consumer_leads
+FOR EACH ROW EXECUTE FUNCTION public.consumer_leads_set_updated_at();
+
+ALTER TABLE public.consumer_leads ENABLE ROW LEVEL SECURITY;
+
+-- Service role only. Admin endpoints use the service-role client; anon /
+-- authed users have no business reading the lead funnel directly.
+DROP POLICY IF EXISTS consumer_leads_service_role_all ON public.consumer_leads;
+CREATE POLICY consumer_leads_service_role_all
+  ON public.consumer_leads
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Audit log of every send (ICO retention)
+CREATE TABLE IF NOT EXISTS public.consumer_lead_email_log (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  consumer_lead_id    uuid NOT NULL REFERENCES public.consumer_leads(id) ON DELETE CASCADE,
+  template            text NOT NULL,
+  subject             text,
+  resend_message_id   text,
+  sent_at             timestamptz NOT NULL DEFAULT now(),
+  metadata            jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS consumer_lead_email_log_lead_idx
+  ON public.consumer_lead_email_log (consumer_lead_id, sent_at DESC);
+
+ALTER TABLE public.consumer_lead_email_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS consumer_lead_email_log_service_role_all ON public.consumer_lead_email_log;
+CREATE POLICY consumer_lead_email_log_service_role_all
+  ON public.consumer_lead_email_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE public.consumer_leads IS
+  'B2C abandonment nurture funnel. Captures pricing-page subscribe clicks and Stripe checkout.session.expired events. Drives 4-email Klaviyo-style nurture sequence with PECR soft opt-in unsubscribe handling. Does NOT include B2B leads (those flow through b2b_waitlist + founder-direct alerts).';
+
+COMMENT ON TABLE public.consumer_lead_email_log IS
+  'Append-only audit of every nurture email send. Retained for ICO direct-marketing audit. One row per send, never updated.';

--- a/vercel.json
+++ b/vercel.json
@@ -53,6 +53,7 @@
     { "path": "/api/cron/enrich-compliance-pending", "schedule": "0 4 * * *" },
     { "path": "/api/cron/discover-legal-refs?leg=recent",   "schedule": "0 3 * * 0" },
     { "path": "/api/cron/discover-legal-refs?leg=category", "schedule": "30 4 * * *" },
-    { "path": "/api/cron/reverify-all-legal-refs",   "schedule": "30 3 * * *" }
+    { "path": "/api/cron/reverify-all-legal-refs",   "schedule": "30 3 * * *" },
+    { "path": "/api/cron/consumer-nurture",          "schedule": "0 10 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

B2C-only abandoned-checkout / pricing-page nurture CRM. Captures leads, drips a 4-email sequence, issues a 10% Stripe coupon on email 3, exposes a full admin dashboard with funnel visualisation and manual actions. **B2B founder-direct path is untouched** — checkout.session.expired with `metadata.product='b2b_api'` still routes to `handleB2bCheckoutExpired` first.

- Klaviyo-style 4-email sequence: T+1h soft reminder → T+24h value nudge → T+72h **10% off + Stripe Coupon API code** → T+7d final.
- Admin at `/dashboard/admin/consumer-leads` with funnel bar, metric tiles, filterable table, drill-in drawer (email timeline, notes, manual actions: mark converted, mark unsubscribed, fresh code, manual email, manual handling).
- PECR reg. 22(3) "soft opt-in" compliance: RFC 8058 List-Unsubscribe header, public `/api/unsubscribe?token=…`, audit log `consumer_lead_email_log`.
- Conversion auto-detected via `checkout.session.completed`.
- Daily cron `/api/cron/consumer-nurture` at 10:00 UTC; PostHog events: `lead_captured`, `nurture_email_sent`, `discount_code_issued`, `lead_converted`, `lead_unsubscribed`.

## Subject lines (founder eyeball)

1. Did you forget something?
2. Why most LifeAdmin users pick {Essential|Pro}
3. A small thank-you: 10% off LifeAdmin (7 days)
4. Last call — your 10% code expires soon

## Stripe coupon naming

`WELCOME10-XXXXXX` — 6 chars from a friendly alphabet (no I, O, 0, 1). Stripe Coupon `duration='once'`, `max_redemptions=1`, `redeem_by=+7d`. Promo code links to coupon, `expires_at` matched.

## Docs

- [docs/consumer-abandonment-research.md](./docs/consumer-abandonment-research.md) — Klaviyo / Drip / Stripe Recover playbook + ICO PECR position
- [docs/consumer-abandonment-system-design.md](./docs/consumer-abandonment-system-design.md) — data model, capture points, sequence, admin spec, compliance approach

## Database

Migration `supabase/migrations/20260430170000_consumer_leads_nurture.sql` applied to prod via Supabase MCP. New tables `consumer_leads` + `consumer_lead_email_log`. Strictly additive, RLS service-role only.

## Test plan

- [ ] Trigger a Stripe checkout, abandon it, confirm `consumer_leads` row inserted via webhook
- [ ] Manually invoke `/api/cron/consumer-nurture` with `Authorization: Bearer $CRON_SECRET` — confirm Email 1 sent for any lead aged > 1h
- [ ] Verify Stripe Coupon + Promotion Code created on email 3 path (`WELCOME10-XXXXXX`) and discount applies on Stripe Checkout
- [ ] Click List-Unsubscribe in inbox / hit `/api/unsubscribe?token=…` → confirm `funnel_stage='unsubscribed'`
- [ ] Visit `/dashboard/admin/consumer-leads` as founder, exercise drill-in actions
- [ ] Confirm B2B `checkout.session.expired` (with `metadata.product='b2b_api'`) still routes to B2B handler and does NOT create a consumer_leads row
- [ ] Verify cron entry picked up by Vercel after merge (next 10:00 UTC fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)