### PR TITLE
feat(crm): pricing-page email gate + hourly nurture cron timing

### DIFF
--- a/src/app/api/cron/consumer-nurture/route.ts
+++ b/src/app/api/cron/consumer-nurture/route.ts
@@ -1,17 +1,33 @@
 /**
- * Daily consumer nurture cron — 10:00 UTC.
+ * Hourly consumer nurture cron — runs at the top of every hour (UTC).
+ *
+ * Schedule changed from daily 10:00 UTC → hourly on 2026-04-29 so the
+ * actual send timing tracks the design (T+1h, T+24h, T+72h, T+7d) much
+ * more closely instead of being clamped to one daily firing window.
  *
  * Walks every non-terminal lead and sends the next email in the
- * 4-email sequence based on age + email_count:
+ * 4-email sequence based on age + email_count. Predicates are tight
+ * INTERVAL gates so the hourly cadence cannot double-send a row that
+ * advanced earlier in the same day:
  *
- *   0 emails + age ≥ 1h          → Email 1 (soft reminder)
- *   1 email  + delta ≥ 22h       → Email 2 (value nudge)
- *   2 emails + delta ≥ 46h       → Email 3 (10% discount + Stripe code)
- *   3 emails + delta ≥ 5d        → Email 4 (final / expiring)
- *   4 emails + age  ≥ 14d        → mark expired (no send)
+ *   email_count=0 + age              ≥ 1h    → Email 1 (soft reminder, ~T+1h)
+ *   email_count=1 + sinceLastEmail   ≥ 23h   → Email 2 (value nudge,   ~T+24h)
+ *   email_count=2 + sinceLastEmail   ≥ 48h   → Email 3 (10% discount,  ~T+72h)
+ *   email_count=3 + sinceLastEmail   ≥ 4d    → Email 4 (final,         ~T+7d)
+ *   email_count=4 + age              ≥ 14d   → mark expired (no send)
  *
- * Skips: unsubscribed, converted_paid, converted_free, expired,
- *        manual_handling, unsubscribed.
+ * Each row only advances when its own `email_count` + `last_emailed_at`
+ * is overdue, and the update of those fields after a successful send
+ * makes the predicate idempotent for the rest of the day. There is no
+ * date-truncation that assumes the cron only fires once a day.
+ *
+ * Per-run cap: PER_RUN_SEND_CAP. We stop initiating new sends once we
+ * hit the cap to stay well under Resend's per-second / per-minute rate
+ * limits if a flood of leads ever hits the queue. Skipped rows just
+ * pick up on the next hourly tick.
+ *
+ * Skips: converted_paid, converted_free, expired, manual_handling,
+ *        unsubscribed (and rows with unsubscribed_at set).
  *
  * Bearer-protected with CRON_SECRET. Also callable by an authenticated
  * admin via authorizeAdminOrCron for manual nudge runs.
@@ -29,6 +45,15 @@ export const maxDuration = 300;
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
+
+/**
+ * Soft cap on how many emails we'll initiate per cron tick. With the
+ * cron now firing hourly, this is 100/hr ≈ 2,400/day worst-case —
+ * comfortably below Resend's published 10 req/sec ceiling. If we ever
+ * hit the cap, leftover leads roll to the next hourly tick (the
+ * predicates are idempotent, so they won't be skipped, just delayed).
+ */
+const PER_RUN_SEND_CAP = 100;
 
 function getAdmin() {
   return createClient(
@@ -78,16 +103,24 @@ function planNextAction(lead: LeadRow, now: Date): Plan {
     return { template: null, newStage: lead.funnel_stage, needsDiscount: false, expire: false };
   }
 
+  // Tight INTERVAL gates — using `last_emailed_at` (not date-trunc) so
+  // a row that advanced 30 minutes ago in this same hour is NOT eligible
+  // again until its own predicate is overdue. This is what makes hourly
+  // firing safe.
   if (lead.email_count === 0 && ageMs >= 1 * HOUR_MS) {
+    // T+1h since capture
     return { template: 'email_1_soft_reminder', newStage: 'email_1_sent', needsDiscount: false, expire: false };
   }
-  if (lead.email_count === 1 && sinceLastMs >= 22 * HOUR_MS) {
+  if (lead.email_count === 1 && sinceLastMs >= 23 * HOUR_MS) {
+    // ≥23h since email 1 → ~T+24h since capture
     return { template: 'email_2_value_nudge', newStage: 'email_2_sent', needsDiscount: false, expire: false };
   }
-  if (lead.email_count === 2 && sinceLastMs >= 46 * HOUR_MS) {
+  if (lead.email_count === 2 && sinceLastMs >= 48 * HOUR_MS) {
+    // ≥48h since email 2 → ~T+72h since capture
     return { template: 'email_3_discount', newStage: 'email_3_sent', needsDiscount: true, expire: false };
   }
-  if (lead.email_count === 3 && sinceLastMs >= 5 * DAY_MS) {
+  if (lead.email_count === 3 && sinceLastMs >= 4 * DAY_MS) {
+    // ≥4d since email 3 → ~T+7d since capture
     return { template: 'email_4_final', newStage: 'email_4_sent', needsDiscount: false, expire: false };
   }
 
@@ -191,7 +224,12 @@ async function processLead(
   return { leadId: lead.id, action: `sent_${plan.template}`, ok: true };
 }
 
-async function runCron(): Promise<{ scanned: number; results: Array<{ leadId: string; action: string; ok: boolean; reason?: string }> }> {
+async function runCron(): Promise<{
+  scanned: number;
+  results: Array<{ leadId: string; action: string; ok: boolean; reason?: string }>;
+  sendsInitiated?: number;
+  capped?: boolean;
+}> {
   const supabase = getAdmin();
   const now = new Date();
 
@@ -210,10 +248,21 @@ async function runCron(): Promise<{ scanned: number; results: Array<{ leadId: st
   }
 
   const results: Array<{ leadId: string; action: string; ok: boolean; reason?: string }> = [];
+  let sendsInitiated = 0;
+  let capped = false;
   for (const lead of leads as LeadRow[]) {
+    // Per-run cap — once we've kicked off PER_RUN_SEND_CAP outbound
+    // sends in this tick, stop initiating new ones. The remainder will
+    // be picked up on the next hourly tick (predicates are idempotent).
+    if (sendsInitiated >= PER_RUN_SEND_CAP) {
+      capped = true;
+      results.push({ leadId: lead.id, action: 'skip_per_run_cap', ok: true });
+      continue;
+    }
     try {
       const r = await processLead(supabase, lead, now);
       results.push(r);
+      if (r.action.startsWith('sent_')) sendsInitiated += 1;
     } catch (err) {
       results.push({
         leadId: lead.id,
@@ -224,7 +273,7 @@ async function runCron(): Promise<{ scanned: number; results: Array<{ leadId: st
     }
   }
 
-  return { scanned: leads.length, results };
+  return { scanned: leads.length, results, sendsInitiated, capped };
 }
 
 export async function GET(req: NextRequest) {

--- a/src/app/pricing/PricingCTA.tsx
+++ b/src/app/pricing/PricingCTA.tsx
@@ -35,6 +35,30 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
 import { PRICE_IDS } from '@/lib/stripe';
+import { capture as posthogCapture } from '@/lib/posthog';
+
+// Basic-but-sensible email regex — local@host.tld, no spaces, no
+// double-@. Real validation is server-side; this just stops obvious
+// typos so we don't push junk into consumer_leads.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Read UTM params from the current URL — best-effort, never throws. */
+function readUtm(): { utm_source?: string; utm_medium?: string; utm_campaign?: string } {
+  if (typeof window === 'undefined') return {};
+  try {
+    const sp = new URLSearchParams(window.location.search);
+    const out: { utm_source?: string; utm_medium?: string; utm_campaign?: string } = {};
+    const s = sp.get('utm_source');
+    const m = sp.get('utm_medium');
+    const c = sp.get('utm_campaign');
+    if (s) out.utm_source = s;
+    if (m) out.utm_medium = m;
+    if (c) out.utm_campaign = c;
+    return out;
+  } catch {
+    return {};
+  }
+}
 
 type Plan = 'free' | 'essential' | 'pro';
 
@@ -68,6 +92,10 @@ export default function PricingCTA({ plan, className, children, style, billingCy
   const [isAuthed, setIsAuthed] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(false);
   const [preview, setPreview] = useState<PreviewState | null>(null);
+  // Inline email gate for logged-out paid-plan clicks.
+  const [showEmailGate, setShowEmailGate] = useState(false);
+  const [gateEmail, setGateEmail] = useState('');
+  const [gateError, setGateError] = useState<string | null>(null);
   const supabase = createClient();
   const priceId = priceIdFor(plan, billingCycle);
 
@@ -120,12 +148,153 @@ export default function PricingCTA({ plan, className, children, style, billingCy
     );
   }
 
-  // Logged-out → preserve original behaviour
+  // Logged-out, paid plan → inline email gate (Option A).
+  // Capture email before bouncing to /auth/signup so we still have a
+  // lead row even if the visitor bails at signup or Stripe.
+  //
+  // The flow is intentionally non-modal: the CTA button morphs into a
+  // small inline email input + Continue / Cancel pair, sized to fit the
+  // existing button slot so the pricing card layout doesn't reflow. On
+  // submit we POST /api/leads/capture (best-effort — DB hiccups never
+  // block the redirect to signup) and fire a `lead_captured` PostHog
+  // event, then redirect to /auth/signup?plan=… so the existing signup
+  // flow handles auth + Stripe checkout from there.
   if (!isAuthed) {
+    if (!showEmailGate) {
+      return (
+        <a
+          className={className}
+          href={`/auth/signup?plan=${plan}`}
+          style={style}
+          onClick={(e) => {
+            e.preventDefault();
+            setGateEmail('');
+            setGateError(null);
+            setShowEmailGate(true);
+          }}
+        >
+          {children}
+        </a>
+      );
+    }
+
+    const submitGate = async (e: React.FormEvent) => {
+      e.preventDefault();
+      const email = gateEmail.trim();
+      if (!EMAIL_RE.test(email)) {
+        setGateError('Please enter a valid email address.');
+        return;
+      }
+      setGateError(null);
+      setLoading(true);
+
+      // Best-effort lead capture. We deliberately do NOT block the
+      // redirect on this — if our DB hiccups, we still want the
+      // visitor to reach the signup flow.
+      const utm = readUtm();
+      try {
+        await fetch('/api/leads/capture', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email,
+            // server enum is 'pricing_page_exit' — covers pricing-page
+            // captures, including bounces before reaching Stripe.
+            source: 'pricing_page_exit',
+            intended_tier: plan,
+            intended_billing_interval: billingCycle,
+            ...utm,
+          }),
+        });
+      } catch {
+        // Swallow — capture is best-effort.
+      }
+
+      try {
+        posthogCapture('lead_captured', {
+          source: 'pricing_page',
+          intended_tier: plan,
+          intended_billing_interval: billingCycle,
+          ...utm,
+        });
+      } catch {
+        // Swallow — analytics is best-effort.
+      }
+
+      // Pass the email through to signup so the form is pre-filled.
+      const params = new URLSearchParams({ plan, email });
+      window.location.href = `/auth/signup?${params.toString()}`;
+    };
+
+    // Inline gate — sized to fit roughly inside the existing CTA slot.
     return (
-      <Link className={className} href={`/auth/signup?plan=${plan}`} style={style}>
-        {children}
-      </Link>
+      <form
+        onSubmit={submitGate}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          width: '100%',
+          ...style,
+        }}
+        aria-label="Enter your email to continue"
+      >
+        <input
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          autoFocus
+          required
+          placeholder="you@example.com"
+          value={gateEmail}
+          onChange={(e) => setGateEmail(e.target.value)}
+          aria-label="Email address"
+          aria-invalid={gateError ? true : undefined}
+          style={{
+            padding: '12px 14px',
+            fontSize: 15,
+            borderRadius: 10,
+            border: '1px solid var(--divider)',
+            background: '#fff',
+            color: 'var(--text-primary)',
+            outline: 'none',
+          }}
+        />
+        {gateError && (
+          <div role="alert" style={{ fontSize: 13, color: '#B91C1C' }}>{gateError}</div>
+        )}
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            type="submit"
+            className={className}
+            disabled={loading}
+            style={{ flex: 1, cursor: loading ? 'wait' : 'pointer' }}
+            aria-busy={loading}
+          >
+            {loading ? 'Continuing…' : 'Continue to checkout →'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setShowEmailGate(false);
+              setGateError(null);
+            }}
+            disabled={loading}
+            style={{
+              padding: '0 14px',
+              fontSize: 14,
+              background: 'transparent',
+              border: '1px solid var(--divider)',
+              borderRadius: 10,
+              color: 'var(--text-secondary)',
+              cursor: 'pointer',
+            }}
+            aria-label="Cancel"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
     );
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -54,6 +54,6 @@
     { "path": "/api/cron/discover-legal-refs?leg=recent",   "schedule": "0 3 * * 0" },
     { "path": "/api/cron/discover-legal-refs?leg=category", "schedule": "30 4 * * *" },
     { "path": "/api/cron/reverify-all-legal-refs",   "schedule": "30 3 * * *" },
-    { "path": "/api/cron/consumer-nurture",          "schedule": "0 10 * * *" }
+    { "path": "/api/cron/consumer-nurture",          "schedule": "0 * * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

Two consumer-CRM follow-ups on top of #400.

### Task 1 — Pricing-page email gate (Option A + Option B shortcut)

Logged-out users that click "Subscribe" on a paid tier no longer disappear into Stripe with no record. The CTA now morphs into an inline email input (no modal, no popup — sized to fit the existing button slot so the pricing card layout doesn't reflow) with a Continue / Cancel pair.

Flow:
1. Visitor clicks "Start Essential / Start Pro" → CTA is replaced inline by an email input + Continue / Cancel buttons.
2. On submit (basic regex validation) we POST `/api/leads/capture` with `source: 'pricing_page_exit'`, `intended_tier`, `intended_billing_interval`, plus `utm_source` / `utm_medium` / `utm_campaign` read from `window.location.search`.
3. We fire a `lead_captured` PostHog event with `source: 'pricing_page'`.
4. We redirect to `/auth/signup?plan=…&email=…` so the existing signup → Stripe flow takes over with the email pre-filled.

Failure modes are non-blocking:
- DB hiccup on `/api/leads/capture` → still redirect to signup (try/catch, swallowed).
- PostHog throw → still redirect (try/catch, swallowed).
- Invalid email → inline error message, no redirect.

Logged-in shortcut (Option B): if `supabase.auth.getUser()` resolves to a user, the existing upgrade / fresh-subscribe path runs unchanged — their email is already known so we skip the gate entirely. Free tier still routes straight to `/auth/signup`.

### Task 2 — Hourly nurture cron timing

`vercel.json`: `/api/cron/consumer-nurture` moved from `0 10 * * *` (daily 10:00 UTC) to `0 * * * *` (top of every hour). The actual send timing now tracks the design (T+1h, T+24h, T+72h, T+7d) instead of being clamped to one daily firing window.

Predicates in `src/app/api/cron/consumer-nurture/route.ts` already used `last_emailed_at` deltas (not date-trunc), so they were already safe for hourly firing — but I tightened the constants to exactly match the founder's spec and documented the idempotency contract:

| email_count | gate                  | lands at  |
|-------------|-----------------------|-----------|
| 0           | age ≥ 1h              | ~T+1h     |
| 1           | sinceLastMs ≥ 23h     | ~T+24h    |
| 2           | sinceLastMs ≥ 48h     | ~T+72h    |
| 3           | sinceLastMs ≥ 4d      | ~T+7d     |
| 4           | age ≥ 14d → expire    | —         |

Each row only advances when its own `email_count` + `last_emailed_at` is overdue, and the post-send update of those fields makes the predicate idempotent for the rest of the hour — a row that advanced 30 minutes ago in this same hour is NOT eligible again.

Also added a `PER_RUN_SEND_CAP = 100` per-tick safety cap. With hourly firing that's 100/hr ≈ 2,400/day worst-case — comfortably under Resend's 10 req/sec ceiling. If we ever hit the cap, leftover leads roll to the next hourly tick (predicates are idempotent, so they're delayed not skipped). Documented in the route header.

### Constraints

- B2B paths untouched (no edits under `src/app/for-business/**`, `src/app/api/v1/**`, `src/lib/b2b/**`).
- `tsc --noEmit` clean.
- No `git add -A`.

## Test plan

- [ ] Visit `/pricing` logged out, click "Start Essential — £4.99/mo" → inline email input appears in place of the button.
- [ ] Submit a valid email → POST to `/api/leads/capture` fires (check Network tab + `consumer_leads` table) with UTM params if present, PostHog `lead_captured` event fires, redirect to `/auth/signup?plan=essential&email=…`.
- [ ] Submit an invalid email → inline error, no redirect.
- [ ] Click Cancel → returns to original CTA state.
- [ ] Visit `/pricing?utm_source=reddit&utm_medium=organic&utm_campaign=test` and confirm UTMs land on the captured row.
- [ ] Visit `/pricing` logged in → click Subscribe → existing upgrade / fresh-subscribe flow (no email gate).
- [ ] Manual trigger `/api/cron/consumer-nurture` with no due rows → returns `sendsInitiated: 0, capped: false`.
- [ ] Auto-merge after CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)