### PR TITLE
fix(whatsapp): surface silent Pocket Agent template send failures

### DIFF
--- a/src/lib/pocket-agent/dispatch.ts
+++ b/src/lib/pocket-agent/dispatch.ts
@@ -144,22 +144,22 @@ export async function dispatchPocketAgentAlert(args: {
   // WhatsApp path — match alert type to the approved template.
   if (session.channel === 'whatsapp') {
     if (!whatsappVars) {
-      return { ok: false, channel: 'whatsapp', error: 'no whatsapp vars provided' };
+      const err = 'no whatsapp vars provided';
+      await logWhatsAppDispatchOutcome({ session, alertType, ok: false, error: err, templateName: null });
+      return { ok: false, channel: 'whatsapp', error: err };
+    }
+    const templateName = templateForAlertType(alertType);
+    if (!templateName) {
+      const err = `no whatsapp template registered for alert type ${alertType}`;
+      await logWhatsAppDispatchOutcome({ session, alertType, ok: false, error: err, templateName: null });
+      return { ok: false, channel: 'whatsapp', error: err };
     }
     try {
-      const { sendWhatsAppTemplate } = await import('@/lib/whatsapp');
-      const templateName = templateForAlertType(alertType);
-      if (!templateName) {
-        return {
-          ok: false,
-          channel: 'whatsapp',
-          error: `no whatsapp template registered for alert type ${alertType}`,
-        };
-      }
       // Send via the existing twilio-provider, which resolves the
       // template SID from the registry (added 2026-04-28 fallback).
       // Template parameters are positional — we get the template
       // shape from the registry to order them correctly.
+      const { sendWhatsAppTemplate } = await import('@/lib/whatsapp');
       const { TEMPLATES } = await import('@/lib/whatsapp/template-registry');
       const tpl = (TEMPLATES as Record<string, { vars: readonly string[] }>)[templateName];
       const positional = tpl.vars.map((name) => {
@@ -174,9 +174,39 @@ export async function dispatchPocketAgentAlert(args: {
         templateName,
         parameters: positional,
       });
+      // 2026-04-30 — log every send to whatsapp_message_log so
+      // future silence is visible. Previously only the
+      // dispute_followup path wrote outbound rows, which is why
+      // the founder's price_increase / renewal_imminent alerts
+      // were never visible in the table even when they fired.
+      await logWhatsAppOutbound({
+        session,
+        templateName,
+        providerMessageId: result.providerMessageId,
+        previewText: positional.join(' | '),
+      });
+      await logWhatsAppDispatchOutcome({
+        session,
+        alertType,
+        ok: true,
+        templateName,
+        providerMessageId: result.providerMessageId,
+      });
       return { ok: true, channel: 'whatsapp', messageId: result.providerMessageId };
     } catch (e) {
-      return { ok: false, channel: 'whatsapp', error: e instanceof Error ? e.message : String(e) };
+      const errMsg = e instanceof Error ? e.message : String(e);
+      // Twilio rejects sends for unapproved/paused Meta templates with
+      // 4xx errors. Without this log line, the cron silently swallows
+      // the failure and the founder gets nothing — which is exactly
+      // what was happening on 2026-04-30. Surface every failure.
+      await logWhatsAppDispatchOutcome({
+        session,
+        alertType,
+        ok: false,
+        error: errMsg,
+        templateName,
+      });
+      return { ok: false, channel: 'whatsapp', error: errMsg };
     }
   }
 
@@ -189,6 +219,85 @@ export async function dispatchPocketAgentAlert(args: {
  * alert type — the caller should skip the WhatsApp send and rely
  * on the Telegram cron's queued evening digest path.
  */
+/**
+ * Best-effort write to whatsapp_message_log so every outbound
+ * template send is visible in the table — not just dispute_followup.
+ * Fire-and-forget. Uses its own admin Supabase client (the dispatch
+ * helper is called from contexts where we don't have a Supabase
+ * handle to thread through).
+ */
+async function logWhatsAppOutbound(args: {
+  session: ActiveSession;
+  templateName: string;
+  providerMessageId?: string;
+  previewText: string;
+}): Promise<void> {
+  try {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return;
+    const sb = createClient(url, key);
+    await sb.from('whatsapp_message_log').insert({
+      user_id: args.session.user_id,
+      whatsapp_phone: String(args.session.destination),
+      direction: 'outbound',
+      message_type: 'template',
+      template_name: args.templateName,
+      message_text: `[Pocket Agent template: ${args.templateName}] ${args.previewText}`.slice(0, 500),
+      provider: 'twilio',
+      provider_message_id: args.providerMessageId ?? null,
+    });
+  } catch (e) {
+    // Logging must never break the send path.
+    console.warn('[pocket-agent/dispatch] whatsapp_message_log insert failed:', e);
+  }
+}
+
+/**
+ * Surface dispatch outcome (success + failure) in business_log so
+ * the founder + alert-tester agent can spot silent regressions.
+ *
+ * Why: prior to 2026-04-30 the cron called sendWhatsAppTemplate, got
+ * a Twilio 4xx for unapproved/paused templates, caught the exception,
+ * returned ok=false — and nothing else. No business_log row, no
+ * outbound row, no Telegram ping. Founder got zero alerts and didn't
+ * know why. This helper closes the visibility gap.
+ */
+async function logWhatsAppDispatchOutcome(args: {
+  session: ActiveSession;
+  alertType: AlertType;
+  ok: boolean;
+  error?: string;
+  templateName: string | null;
+  providerMessageId?: string;
+}): Promise<void> {
+  try {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return;
+    const sb = createClient(url, key);
+    const status = args.ok ? 'ok' : 'failed';
+    const title = args.ok
+      ? `WhatsApp template sent: ${args.templateName ?? args.alertType}`
+      : `WhatsApp template send FAILED: ${args.templateName ?? args.alertType}`;
+    const content = JSON.stringify({
+      user_id: args.session.user_id,
+      phone: String(args.session.destination),
+      alert_type: args.alertType,
+      template_name: args.templateName,
+      provider_message_id: args.providerMessageId,
+      error: args.error,
+    });
+    await sb.from('business_log').insert({
+      category: `whatsapp_dispatch_${status}`,
+      title,
+      content,
+    });
+  } catch (e) {
+    console.warn('[pocket-agent/dispatch] business_log insert failed:', e);
+  }
+}
+
 function templateForAlertType(alertType: AlertType): string | null {
   switch (alertType) {
     case 'price_increase':


### PR DESCRIPTION
## Why

Founder reported zero WhatsApp Pocket Agent template messages today despite the cron creating `detected_issues` rows for renewals (Energie Fitness, Lbh, Loqbox, DVLA) and price increases. Investigation shows the cron returns `ok=true` and stamps `delivered_at`, yet the founder's phone gets nothing and `whatsapp_message_log` shows zero outbound rows for those templates.

Two compounding bugs hide the failure:

1. **`src/lib/pocket-agent/dispatch.ts`** WhatsApp branch catches Twilio exceptions silently. When Meta hasn't approved a template (or paused one), Twilio rejects with 4xx, we catch, return `{ok:false}`, and emit nothing. No `business_log`, no row. **The founder is dark with no signal.**
2. **`/api/cron/telegram-alerts`** only writes outbound rows to `whatsapp_message_log` for the `dispute_followup` path (lines 472-490). Price-increase / renewal / budget / unusual-charge / money-recovered paths skip the log entirely. Confirmed in prod: `paybacker_dispute_reply` is the **only** template ever logged outbound — every other template is invisible whether it succeeded or failed.

## What

Adds two fire-and-forget helpers in `src/lib/pocket-agent/dispatch.ts`:

- `logWhatsAppOutbound`: every successful template send writes a `whatsapp_message_log` row (not just dispute_followup).
- `logWhatsAppDispatchOutcome`: every attempt — success and failure — writes a `business_log` row tagged `whatsapp_dispatch_ok` or `whatsapp_dispatch_failed`, including the Twilio error string.

No behaviour change to the success path. No migration. Logging never throws.

## Smoke test

- [x] `tsc --noEmit` clean for the changed file (pre-existing unrelated errors untouched)
- [ ] After merge + Vercel deploy, the next `/api/cron/telegram-alerts` run (every 6h) will produce one row per attempt: `SELECT category, title, content FROM business_log WHERE category LIKE 'whatsapp_dispatch%' ORDER BY created_at DESC` will reveal exactly which templates Meta is rejecting.
- [ ] Founder can then resubmit rejected templates with corrected variable suffixes (the same pattern that fixed 4 templates on 2026-04-27 in commit `e4097cbc`).

## Surface

B2C only — `src/lib/pocket-agent/dispatch.ts`. Does not touch `/for-business/**` or `/api/v1/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)