### PR TITLE
fix(whatsapp): trailing-variable fix for 11 unapproved templates

### DIFF
--- a/src/lib/whatsapp/template-registry.ts
+++ b/src/lib/whatsapp/template-registry.ts
@@ -2,6 +2,54 @@
  * WhatsApp Template Registry — single source of truth for the 16 templates
  * submitted to Meta on 2026-04-27.
  *
+ * ────────────────────────────────────────────────────────────────────────
+ * RESUBMISSION REQUIRED — see PR fix(whatsapp): trailing-variable fix
+ * ────────────────────────────────────────────────────────────────────────
+ *
+ * Meta rejects any template whose body **ends with a `{{N}}` placeholder**
+ * (or `{{N}}` followed only by punctuation). On 2026-04-27 four templates
+ * were rejected for this reason and resubmitted in commit `e4097cbc` with
+ * a trailing static CTA appended after the variable. The fix worked — those
+ * four are now approved and live.
+ *
+ * The remaining 11 templates below were submitted with the same trailing-
+ * variable shape and are silently failing to send (the 4 known-rejected
+ * + this batch of 11 + the deferred AUTHENTICATION OTP = 16 total). The
+ * `body` field on each entry now reflects the **fixed** body the founder
+ * must use when resubmitting via the Twilio Content API.
+ *
+ * Templates needing resubmission (SIDs set to `PENDING_RESUBMISSION`):
+ *   - paybacker_welcome
+ *   - paybacker_alert_price_increase
+ *   - paybacker_alert_renewal
+ *   - paybacker_alert_unusual_charge
+ *   - paybacker_alert_trial_ending
+ *   - paybacker_money_recovered
+ *   - paybacker_outcome_check
+ *   - paybacker_morning_summary
+ *   - paybacker_savings_goal_milestone
+ *   - paybacker_budget_alert
+ *   - paybacker_recovery_total_weekly
+ *
+ * Already-approved (do NOT resubmit — these are live):
+ *   - paybacker_complaint_letter_ready, paybacker_dispute_reply,
+ *     paybacker_reconnect_required, paybacker_better_deal_found
+ *
+ * Deferred (separate Meta-permission issue, not a trailing-variable issue):
+ *   - paybacker_login_code (AUTHENTICATION category — see comment on entry)
+ *
+ * Founder workflow per pending template:
+ *   1. In Twilio Console → Content Template Builder, **delete** the rejected
+ *      version (or just create a new one — the rejected version becomes a
+ *      dead SID).
+ *   2. Create a new Content Template with the exact `body` string from this
+ *      file (variables already in `{{1}}, {{2}}…` order matching `vars`).
+ *   3. Submit it for WhatsApp approval (`category: UTILITY` for all here
+ *      except `paybacker_better_deal_found`'s peer if you ever re-do it).
+ *   4. When Meta approves (usually <24h for utility), copy the new
+ *      `HX…` SID and replace `'PENDING_RESUBMISSION'` for that template.
+ *   5. Commit the SID update with message `fix(whatsapp): SID for <name>`.
+ *
  * Why this lives here and not in the DB:
  * - SIDs are baked into Meta's approval and never change once a template is
  *   approved. Storing them as a typed const lets call-sites get autocomplete +
@@ -20,12 +68,20 @@
  *   1. Run scripts/submit-whatsapp-template.ts to create + submit to Meta
  *   2. Add the entry below with the returned SID
  *   3. Add a row to whatsapp_message_templates (additive migration)
+ *   4. **Never let the body end on a `{{N}}` placeholder** — always append
+ *      a static CTA-style sentence after the last variable.
  */
 
 export type TemplateCategory = 'UTILITY' | 'AUTHENTICATION' | 'MARKETING';
 
+/** Sentinel SID used while a template is awaiting Meta resubmission/approval.
+ *  Send paths must guard on this and skip dispatch (with a logged warning)
+ *  rather than handing it to Twilio. */
+export const PENDING_RESUBMISSION = 'PENDING_RESUBMISSION' as const;
+
 export interface WhatsAppTemplate {
-  /** Twilio Content SID — what we pass as `contentSid` when sending */
+  /** Twilio Content SID — what we pass as `contentSid` when sending.
+   *  May be `PENDING_RESUBMISSION` while awaiting Meta approval. */
   sid: string;
   /** Meta-side category (drives pricing per outbound message) */
   category: TemplateCategory;
@@ -35,6 +91,9 @@ export interface WhatsAppTemplate {
   description: string;
   /** Pro-only? When true the cron/agent must skip non-Pro recipients */
   proOnly: boolean;
+  /** Canonical body text submitted to Meta. Source-of-truth for resubmission.
+   *  Must NOT end on a `{{N}}` placeholder (Meta rejects those). */
+  body: string;
 }
 
 /**
@@ -62,119 +121,144 @@ export function fillVars<T extends WhatsAppTemplate>(
 export const TEMPLATES = {
   /** Sent once after a user opts in / completes their first link */
   paybacker_welcome: {
-    sid: 'HXd0a7d989fbaa8d254d530119a276eace',
+    // Resubmission required — original body ended on `{{1}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['name'] as const,
     description: 'First-touch welcome after WhatsApp opt-in',
     proOnly: true,
+    body: "Welcome to Paybacker, {{1}}. We'll flag price hikes, renewals and refunds straight here. Reply HELP any time.",
   },
   /** Triggered by price-increase-detector.ts when a sub goes up */
   paybacker_alert_price_increase: {
-    sid: 'HX0b581b6ef1076aebe6f6a1c9101d32e2',
+    // Resubmission required — original body ended on `{{4}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['merchant', 'old_price', 'new_price', 'effective_date'] as const,
     description: 'Subscription price hike detected',
     proOnly: true,
+    body: '{{1}} is going up from £{{2}} to £{{3}} on {{4}}. Tap to switch or cancel.',
   },
   /** Contract end ≤30 days, looks at contract_end_date on subscriptions */
   paybacker_alert_renewal: {
-    sid: 'HXd6fbd2bf402a63e920e4d375f20502e6',
+    // Resubmission required — original body ended on `{{3}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['service', 'days_left', 'monthly_cost'] as const,
     description: 'Contract renewal approaching',
     proOnly: true,
+    body: 'Your {{1}} contract renews in {{2}} days at £{{3}}/month. Tap to review or cancel.',
   },
   /** Bank scanner spots a charge >20% above the merchant's rolling avg */
   paybacker_alert_unusual_charge: {
-    sid: 'HXacdc466915dbdb08a7c49a9ccd815137',
+    // Resubmission required — original body ended on `{{4}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['merchant', 'current_amount', 'average_amount', 'percent_higher'] as const,
     description: 'Bill anomaly detected',
     proOnly: true,
+    body: '{{1}} just charged £{{2}} vs your usual £{{3}} — that is {{4}}% higher. Tap to dispute.',
   },
   /** Free trial → first auto-charge ≤3 days away */
   paybacker_alert_trial_ending: {
-    sid: 'HX2e7e125b3fbf60386f633eee8cf744fc',
+    // Resubmission required — original body ended on `{{3}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['service', 'days_left', 'auto_charge_amount'] as const,
     description: 'Free trial ending — auto-charge incoming',
     proOnly: true,
+    body: 'Your {{1}} trial ends in {{2}} days — you will be charged £{{3}}. Tap to cancel before then.',
   },
   /** Complaint letter generated and ready to download */
   paybacker_complaint_letter_ready: {
     // Resubmitted 2026-04-27 with trailing static text — Meta rejected the
-    // first version (HXcb08a...) for ending in `{{2}}`.
+    // first version (HXcb08a...) for ending in `{{2}}`. APPROVED — do not change.
     sid: 'HXb161ad4a72531943fd57068fe81074f3',
     category: 'UTILITY',
     vars: ['merchant', 'letter_url'] as const,
     description: 'Complaint letter ready (action loop)',
     proOnly: true,
+    body: 'Your complaint letter to {{1}} is ready: {{2}} — review, sign and send when you are happy.',
   },
   /** Bank sync detects a refund hitting a Paybacker-tracked dispute */
   paybacker_money_recovered: {
-    sid: 'HX83686935274d67997fac8999e02a2763',
+    // Resubmission required — original body ended on `{{3}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['amount', 'merchant', 'lifetime_total'] as const,
     description: 'Refund hit account — money recovered',
     proOnly: true,
+    body: '£{{1}} from {{2}} just landed in your account. Lifetime recovered: £{{3}}. Tap to see the breakdown.',
   },
   /** Watchdog email scanner finds a merchant reply to an open dispute */
   paybacker_dispute_reply: {
-    // Resubmitted 2026-04-27 — first version ended with `{{3}}` URL.
+    // Resubmitted 2026-04-27 — first version ended with `{{3}}` URL. APPROVED — do not change.
     sid: 'HXff77c9745533c248df3b9e0ee5c7fa95',
     category: 'UTILITY',
     vars: ['merchant', 'summary', 'thread_url'] as const,
     description: 'Merchant replied to your dispute',
     proOnly: true,
+    body: '{{1}} replied to your dispute: "{{2}}". Open the thread here: {{3}} — we will draft a response.',
   },
   /** T+7d nudge after dispute sent — did it work? */
   paybacker_outcome_check: {
-    sid: 'HXb1608da640949c62e7f66b9ce4f1ff9c',
+    // Resubmission required — original body ended on `{{2}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['merchant', 'action_type'] as const,
     description: 'Outcome check after dispute / cancellation',
     proOnly: true,
+    body: 'A week ago you sent a {{2}} to {{1}}. Did it work? Tap to log the outcome.',
   },
   /** Pro-only daily 8am brief */
   paybacker_morning_summary: {
-    sid: 'HX4eae8f7c8806c540fac25e69c528faa5',
+    // Resubmission required — original body ended on `{{4}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['name', 'scanned_count', 'opportunities_count', 'top_focus'] as const,
     description: 'Daily 8am morning summary (Pro only)',
     proOnly: true,
+    body: 'Morning {{1}}. Overnight we scanned {{2}} items and found {{3}} opportunities. Top focus: {{4}}. Tap to open today\'s brief.',
   },
   /** Savings goal milestone (25/50/75/100% bands) */
   paybacker_savings_goal_milestone: {
-    sid: 'HXf547f5b569adb3132963eaf2908387e0',
+    // Resubmission required — original body ended on `{{4}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['goal_name', 'percent', 'amount_saved', 'target_amount'] as const,
     description: 'Savings goal milestone hit',
     proOnly: true,
+    body: 'Goal "{{1}}" just hit {{2}}% — £{{3}} saved of £{{4}}. Tap to see your progress.',
   },
   /** Budget approaching/over limit per category */
   paybacker_budget_alert: {
-    sid: 'HX718530984745f0cbb79469b671999370',
+    // Resubmission required — original body ended on `{{4}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['category', 'percent_used', 'amount_left', 'end_date'] as const,
     description: 'Budget threshold reached',
     proOnly: true,
+    body: 'Your {{1}} budget is at {{2}}% — £{{3}} left until {{4}}. Tap to review what is driving it.',
   },
   /** Bank/email connection token expired — needs user action */
   paybacker_reconnect_required: {
-    // Resubmitted 2026-04-27 — first version ended with `{{2}}` URL.
+    // Resubmitted 2026-04-27 — first version ended with `{{2}}` URL. APPROVED — do not change.
     sid: 'HXaf764eed43ddd1147c48bf3fc855e0d8',
     category: 'UTILITY',
     vars: ['provider', 'reconnect_url'] as const,
     description: 'OAuth/banking token expired',
     proOnly: true,
+    body: 'Your {{1}} connection has expired. Reconnect here: {{2}} — alerts pause until you do.',
   },
   /** Sunday 9am weekly recovery digest */
   paybacker_recovery_total_weekly: {
-    sid: 'HX88de4d980c0f450e33a3792ffebf3528',
+    // Resubmission required — original body ended on `{{2}}`.
+    sid: PENDING_RESUBMISSION,
     category: 'UTILITY',
     vars: ['amount_this_week', 'lifetime_amount'] as const,
     description: 'Weekly recovery digest (Sunday 9am)',
     proOnly: true,
+    body: 'This week Paybacker recovered £{{1}} for you. Lifetime total: £{{2}}. Tap to see the wins.',
   },
   /**
    * OTP for sensitive actions (password reset, plan change, etc.)
@@ -198,6 +282,10 @@ export const TEMPLATES = {
    * approved AND we've sent real outbound volume for ~1-2 weeks, Meta auto-
    * grants AUTHENTICATION category. If still blocked, open a Meta Business
    * Support Home ticket on WABA id `1480242643594364`.
+   *
+   * Note: this rejection is unrelated to the trailing-variable issue — the
+   * AUTHENTICATION body is fine, the WABA just lacks permission. No
+   * resubmission of the body needed.
    */
   paybacker_login_code: {
     sid: 'HXc0ebfb1775a8a713221583a70c739334', // ⚠️ NOT APPROVED — see comment above
@@ -207,15 +295,17 @@ export const TEMPLATES = {
     // Auth codes are not Pro-gated when they eventually work — anyone
     // who's enabled WhatsApp 2FA gets them.
     proOnly: false,
+    body: 'Your Paybacker login code is {{1}}. It expires in 5 minutes. Do not share it with anyone.',
   },
   /** Switchcraft-style cheaper-deal nudge (MARKETING — needs separate opt-in) */
   paybacker_better_deal_found: {
-    // Resubmitted 2026-04-27 — first version ended with `{{3}}` URL.
+    // Resubmitted 2026-04-27 — first version ended with `{{3}}` URL. APPROVED — do not change.
     sid: 'HXef2f3aa52beec5a2591154096faf741b',
     category: 'MARKETING',
     vars: ['category', 'saving_per_year', 'switch_url'] as const,
     description: 'Cheaper provider found in user category',
     proOnly: true,
+    body: 'We found a cheaper {{1}} deal — could save you about £{{2}}/year. See it here: {{3}} — switch in a couple of taps.',
   },
 } as const satisfies Record<string, WhatsAppTemplate>;
 


### PR DESCRIPTION
## Summary

Meta rejects any WhatsApp template body that ends on a `{{N}}` placeholder. Commit e4097cbc fixed 4 of the 16 templates submitted on 2026-04-27 by appending a static CTA after the trailing variable. The remaining 11 utility/marketing templates were submitted with the same shape and have been silently failing — proactive sends (renewal alerts, price-increase alerts, etc.) never reached the founder. PR #402 made those failures visible; this PR fixes them.

The deferred AUTHENTICATION OTP (`paybacker_login_code`) is **not** in this batch — its rejection is a separate WABA-permission issue, not a body issue.

## What changed

- Added a `body` field to `WhatsAppTemplate` so the Meta-facing canonical body lives in-repo as the founder's source of truth for resubmission.
- Rewrote each pending body to end on a short British, plain, action-oriented CTA. Variable counts and order are unchanged; semantic meaning preserved.
- Set `sid: PENDING_RESUBMISSION` (typed sentinel) on the 11 pending templates so dispatch paths can guard before handing off to Twilio.
- Left the 4 already-approved templates untouched and tagged each with an "APPROVED — do not change" comment.
- Added a header block at the top of the registry pointing the founder at the resubmission workflow.

## Templates fixed (before → after)

All variable counts/order preserved. Trailing CTA appended after the last variable.

| Template | vars | Before (ends on) | After (appended CTA) |
|---|---|---|---|
| `paybacker_welcome` | 1 | `Welcome to Paybacker, {{1}}.` | `… Reply HELP any time.` |
| `paybacker_alert_price_increase` | 4 | `… on {{4}}.` | `… Tap to switch or cancel.` |
| `paybacker_alert_renewal` | 3 | `… at £{{3}}/month.` | `… Tap to review or cancel.` |
| `paybacker_alert_unusual_charge` | 4 | `… {{4}}% higher.` | `… Tap to dispute.` |
| `paybacker_alert_trial_ending` | 3 | `… charged £{{3}}.` | `… Tap to cancel before then.` |
| `paybacker_money_recovered` | 3 | `Lifetime recovered: £{{3}}.` | `… Tap to see the breakdown.` |
| `paybacker_outcome_check` | 2 | `A week ago you sent a {{2}}.` | `… Did it work? Tap to log the outcome.` |
| `paybacker_morning_summary` | 4 | `Top focus: {{4}}.` | `… Tap to open today's brief.` |
| `paybacker_savings_goal_milestone` | 4 | `£{{3}} saved of £{{4}}.` | `… Tap to see your progress.` |
| `paybacker_budget_alert` | 4 | `£{{3}} left until {{4}}.` | `… Tap to review what is driving it.` |
| `paybacker_recovery_total_weekly` | 2 | `Lifetime total: £{{2}}.` | `… Tap to see the wins.` |

## Untouched (already approved on 2026-04-27 via e4097cbc)

- `paybacker_complaint_letter_ready`
- `paybacker_dispute_reply`
- `paybacker_reconnect_required`
- `paybacker_better_deal_found`

## Untouched (separate issue — WABA AUTHENTICATION permission)

- `paybacker_login_code` — body is fine; blocked on Meta WABA permission.

## Why Meta rejected

Per Meta WhatsApp Business policy, message template bodies cannot start or end with a variable placeholder. The trailing-variable shape is most common with URL/value alerts where the natural-language sentence reads "… is X." or "… here: {{url}}." Appending a static CTA (e.g. "Tap to review.") after the last variable resolves it without changing the variable contract.

## Founder follow-up (per pending template)

1. Open Twilio Console → Content Template Builder.
2. Create a new Content Template using the exact `body` from `template-registry.ts` for that template.
3. Submit for WhatsApp approval (UTILITY for all 11 here).
4. When Meta approves (usually <24h), copy the new `HX…` SID and replace `'PENDING_RESUBMISSION'` for that entry.
5. Commit the SID update with `fix(whatsapp): SID for <template_name>`.

## Test plan

- [ ] CI: `tsc --noEmit` clean (no new errors introduced in `template-registry.ts`).
- [ ] Verify the 4 approved SIDs are unchanged in the diff.
- [ ] Verify all 11 pending templates have `sid: PENDING_RESUBMISSION` and a `body` ending with a non-variable token.
- [ ] After founder resubmits, verify dispatch logs (per PR #402) show successful sends for one of the formerly-failing templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)