### PR TITLE
fix(whatsapp): unblock rejected templates + stop dispute-agent retry storm

### DIFF
--- a/src/lib/pocket-agent/dispatch.ts
+++ b/src/lib/pocket-agent/dispatch.ts
@@ -165,14 +165,24 @@ export async function dispatchPocketAgentAlert(args: {
       const { getTemplateSid } = await import('@/lib/whatsapp/template-sids');
       const liveSid = await getTemplateSid(templateName);
       if (!liveSid) {
+        // Pre-flight guard: template not approved by Meta yet. Skip the
+        // Twilio call entirely (it would 4xx) and dedup the log so we
+        // don't get a retry storm in business_log when the dispute-agent
+        // cron loops over many users with the same unapproved template.
         const err = `template not yet approved`;
-        await logWhatsAppDispatchOutcome({
-          session,
-          alertType,
-          ok: false,
-          error: err,
+        const skipped = await logSkippedDispatch({
           templateName,
+          userId: session.user_id,
         });
+        if (!skipped.alreadyLogged) {
+          await logWhatsAppDispatchOutcome({
+            session,
+            alertType,
+            ok: false,
+            error: err,
+            templateName,
+          });
+        }
         return { ok: false, channel: 'whatsapp', error: err };
       }
       const tpl = (TEMPLATES as Record<string, { vars: readonly string[] }>)[templateName];
@@ -309,6 +319,53 @@ async function logWhatsAppDispatchOutcome(args: {
     });
   } catch (e) {
     console.warn('[pocket-agent/dispatch] business_log insert failed:', e);
+  }
+}
+
+/**
+ * Dedup helper for "template not yet approved" skips. The dispute-agent
+ * cron can loop over hundreds of disputes per tick — without dedup, every
+ * loop iteration writes a business_log row for the same unapproved
+ * template, producing the retry storm seen on 2026-04-29 (10 rows in 11s
+ * for `paybacker_dispute_agent_action`). We piggyback on the existing
+ * compliance_alerts_sent table — its UNIQUE alert_key gives us
+ * one-log-per-(template, user, day) for free.
+ *
+ * Returns { alreadyLogged: true } when the (template_name, user_id, today)
+ * skip is already recorded for the day — caller should suppress the
+ * business_log write. Returns { alreadyLogged: false } on first write.
+ */
+async function logSkippedDispatch(args: {
+  templateName: string;
+  userId: string;
+}): Promise<{ alreadyLogged: boolean }> {
+  try {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return { alreadyLogged: false };
+    const sb = createClient(url, key);
+    const day = new Date().toISOString().slice(0, 10);
+    const alertKey = `wa-skip:${args.templateName}:${args.userId}:${day}`;
+    const { error } = await sb
+      .from('compliance_alerts_sent')
+      .insert({
+        alert_key: alertKey,
+        channel: 'whatsapp_skip',
+        metadata: {
+          template_name: args.templateName,
+          user_id: args.userId,
+          reason: 'template_not_approved',
+        },
+      });
+    // 23505 = unique_violation → already logged today.
+    if (error && (error.code === '23505' || /duplicate key/i.test(error.message))) {
+      return { alreadyLogged: true };
+    }
+    return { alreadyLogged: false };
+  } catch {
+    // On dedup-helper failure, fall through to regular logging — better
+    // to log twice than miss a real signal.
+    return { alreadyLogged: false };
   }
 }
 

--- a/src/lib/whatsapp/template-registry.ts
+++ b/src/lib/whatsapp/template-registry.ts
@@ -3,6 +3,18 @@
  * submitted to Meta on 2026-04-27.
  *
  * ────────────────────────────────────────────────────────────────────────
+ * LESSON LEARNT (2026-04-29) — VARIABLES AT EITHER END
+ * ────────────────────────────────────────────────────────────────────────
+ * Meta rejects templates with variables at EITHER start OR end. Always
+ * wrap variables with static text on BOTH sides. The 2026-04-27 fix only
+ * caught the trailing-variable case. On 2026-04-29 Meta re-rejected
+ * `paybacker_alert_price_increase` and `paybacker_alert_unusual_charge`
+ * (subCode 2388299, "Variables can't be at the start or end of the
+ * template.") because their bodies opened with `{{1}}`. Both are now
+ * prefixed with short static lead-ins ("Heads up —" / "Spotted something —")
+ * and remain at PENDING_RESUBMISSION for the next resubmit cycle.
+ *
+ * ────────────────────────────────────────────────────────────────────────
  * RESUBMISSION REQUIRED — see PR fix(whatsapp): trailing-variable fix
  * ────────────────────────────────────────────────────────────────────────
  *
@@ -68,8 +80,9 @@
  *   1. Run scripts/submit-whatsapp-template.ts to create + submit to Meta
  *   2. Add the entry below with the returned SID
  *   3. Add a row to whatsapp_message_templates (additive migration)
- *   4. **Never let the body end on a `{{N}}` placeholder** — always append
- *      a static CTA-style sentence after the last variable.
+ *   4. **Never let the body start OR end on a `{{N}}` placeholder** — Meta
+ *      rejects either case (subCode 2388299). Always wrap variables with
+ *      static text on BOTH sides.
  */
 
 export type TemplateCategory = 'UTILITY' | 'AUTHENTICATION' | 'MARKETING';
@@ -137,7 +150,7 @@ export const TEMPLATES = {
     vars: ['merchant', 'old_price', 'new_price', 'effective_date'] as const,
     description: 'Subscription price hike detected',
     proOnly: true,
-    body: '{{1}} is going up from £{{2}} to £{{3}} on {{4}}. Tap to switch or cancel.',
+    body: 'Heads up — {{1}} is going up from £{{2}} to £{{3}} on {{4}}. Tap to switch or cancel.',
   },
   /** Contract end ≤30 days, looks at contract_end_date on subscriptions */
   paybacker_alert_renewal: {
@@ -157,7 +170,7 @@ export const TEMPLATES = {
     vars: ['merchant', 'current_amount', 'average_amount', 'percent_higher'] as const,
     description: 'Bill anomaly detected',
     proOnly: true,
-    body: '{{1}} just charged £{{2}} vs your usual £{{3}} — that is {{4}}% higher. Tap to dispute.',
+    body: 'Spotted something — {{1}} just charged £{{2}} vs your usual £{{3}} — that is {{4}}% higher. Tap to dispute.',
   },
   /** Free trial → first auto-charge ≤3 days away */
   paybacker_alert_trial_ending: {


### PR DESCRIPTION
## Summary

Two issues on the WhatsApp Pocket Agent path, fixed in one PR.

### 1. Templates re-rejected because the body STARTS with a variable

Meta rejects templates with variables at **either** start or end (subCode `2388299`, "Variables can't be at the start or end of the template."). The 2026-04-27 trailing-variable fix only handled trailing placeholders, so two templates whose bodies opened with `{{1}}` were re-rejected on 2026-04-29:

| Template | Before | After |
|---|---|---|
| `paybacker_alert_price_increase` | `{{1}} is going up from £{{2}}…` | `Heads up — {{1}} is going up from £{{2}}…` |
| `paybacker_alert_unusual_charge` | `{{1}} just charged £{{2}}…` | `Spotted something — {{1}} just charged £{{2}}…` |

Both keep `sid: PENDING_RESUBMISSION` so the next resubmit picks them up. Registry comment block updated with the lesson: **wrap variables with static text on BOTH sides.**

Audit of the other 14 templates: only these two literally start with `{{N}}`. The remaining bodies all have static lead-ins (`Your {{1}} contract…`, `Welcome to Paybacker, {{1}}…`, `Goal "{{1}}"…`, etc.).

### 2. Dispute-agent retry storm

`business_log` was getting 10 rows in 11 seconds for `paybacker_dispute_agent_action` — the cron loops over disputes, the dispatch returns "template not yet approved" for each, and every iteration wrote a fresh `business_log` row.

`src/lib/pocket-agent/dispatch.ts`:
- Pre-flight guard via `getTemplateSid` already short-circuits before Twilio is hit (returns `{ ok: false, error: 'template not yet approved' }` without sending).
- New `logSkippedDispatch` helper dedups via the existing `compliance_alerts_sent` table (key `wa-skip:<template>:<user>:<YYYY-MM-DD>`). First skip per user/template/day writes a `business_log` row; subsequent skips are silent.
- Email fallback in `/api/cron/dispute-agent` already fires when `surfacedVia.length === 0`, so users still get the prompt when WhatsApp is skipped.

No new tables — reuses `compliance_alerts_sent` (UNIQUE `alert_key`), so no migration needed.

## Test plan

- [ ] `tsc --noEmit` clean (verified locally).
- [ ] After merge: hit `/api/cron/whatsapp/resubmit-pending` with `CRON_SECRET` to push fixed template bodies to Twilio/Meta.
- [ ] Hit `/api/cron/whatsapp/template-status-check` (or equivalent) to refresh `whatsapp_template_sids.approval_status`.
- [ ] Trigger `/api/cron/dispute-agent` once and confirm at most one `wa-skip:paybacker_dispute_agent_action:<user>:<date>` row appears in `compliance_alerts_sent` per user (was: ~10 `business_log` rows per user before).
- [ ] Confirm a user with WA-but-no-approval gets the email fallback (existing path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)