### PR TITLE
feat(admin): consolidate dashboard + disputes nav + AI Team honesty + leads clarified

### DIFF
--- a/docs/admin-dashboard-audit-2026-05-01.md
+++ b/docs/admin-dashboard-audit-2026-05-01.md
@@ -1,0 +1,92 @@
+# Admin Dashboard Audit — 2026-05-01
+
+Audit done off `origin/master` HEAD `97b0ce54`.
+
+## User-side sidebar (src/components/dashboard/DashboardShell.tsx)
+
+NAV groups: Main / Save money / Account.
+
+- Main: Overview, Money Hub, Subscriptions, **Disputes** (already present at line 72), Contract Vault
+- Save money: Deals, Rewards, Pocket Agent, Paybacker Assistant
+- Account: Export, Profile
+
+**Finding:** Disputes link is already wired into the user-side sidebar pointing at `/dashboard/disputes`. Founder report was stale — no change needed for Phase 2. (The badge shows "New" for Pocket Agent only; Disputes is treated as a primary feature, available to all tiers; usage limits are enforced server-side.)
+
+## Admin pages on disk (src/app/dashboard/admin/)
+
+| Path | LoC | Linked from /admin? | Notes |
+|---|---|---|---|
+| `analytics/page.tsx` | 521 | yes (link) | PostHog/funnel analytics |
+| `b2b/page.tsx` | 380 | yes (link) | B2B waitlist + API keys |
+| `billing/page.tsx` | 212 | **NO — added in this PR** | Cost ledger (PR #370) |
+| `cancel-info/page.tsx` | 430 | yes (link) | Cancellation reasons / churn |
+| `consumer-leads/page.tsx` | 23 (+ ConsumerLeadsClient) | yes (link) | Cart-abandonment funnel (PR #400) |
+| `crons/page.tsx` | 255 | yes (link) | Cron schedules + run-now buttons |
+| `dispute-agent/page.tsx` | 195 | **NO — added in this PR** | PR #408 — agent decision telemetry |
+| `dispute-intelligence/page.tsx` | 294 | **NO — added in this PR** | PR #406 — outcome dataset analytics |
+| `legal-refs/page.tsx` | 1637 | yes (link as "Legal Refs") | Compliance Centre |
+| `legal-updates/page.tsx` | 548 | not linked | (separate from legal-refs) |
+| `restore-bank-data/page.tsx` | 254 | yes (link) | Bank txn restore tool |
+| `whatsapp/page.tsx` | 184 | **NO — added in this PR** | PR #404 — Twilio template SIDs |
+
+## Admin tabs inside the unified `page.tsx`
+
+Tabs (state-driven, not separate routes): `overview` / `members` / `tickets` / `leads` / `ai_team`.
+
+- **Overview** — `/api/admin/metrics` returns MRR, ARR, paying customers, free users, tier breakdown, deal health, recent signups. **Real data.**
+- **Members** — `/api/admin/members` list + drill-in. **Real data** (1 row already loads).
+- **Tickets** — `<TicketList>` queries `/api/support/tickets` with `status=active`. **BROKEN — see below.**
+- **Leads** — `<LeadsList>` queries `leads` table directly via Supabase client. Currently 0 rows. Component is healthy, table is empty.
+- **AI Team** — `<AITeamPanel>` queries `/api/admin/team-status`. Recent overhaul wired it to real cron data, but the component still presents the legacy executive C-suite without flagging that most are dormant.
+
+## Supabase-verified row counts (2026-05-01)
+
+```
+support_tickets       16   (15 resolved, 1 awaiting_reply, 0 open/in_progress)
+leads                  0   (social DM funnel — table empty)
+consumer_leads         0   (cart-abandonment CRM — table empty)
+disputes              30
+agent_runs (30d)      44
+agent_messages (30d)   0   (Managed Agents truly not firing — confirms CLAUDE.md)
+business_log (7d)   1110
+```
+
+## Headline findings
+
+1. **Tickets tab broken — query bug, not data.**
+   - `support_tickets` has 16 rows (15 resolved, 1 awaiting_reply).
+   - Default UI filter was `status=active`, which the API mapped to `['open','in_progress']` — **omitting `awaiting_reply`** and resolved/closed.
+   - Result: founder saw a hardcoded "0 tickets" in a system that has been running tickets for weeks.
+   - **Fix in this PR:**
+     - `src/app/api/support/tickets/route.ts` — `'active'` now maps to `['open','in_progress','awaiting_reply']` (the full not-yet-closed set).
+     - `src/components/admin/TicketList.tsx` — default filter changed from `'active'` to `''` (all), so the founder lands on the full ticket history with the active-only one click away.
+
+2. **Dispute Intelligence (PR #406) missing from admin nav.** Page exists at `/dashboard/admin/dispute-intelligence` but the tab strip on `/dashboard/admin` had no link. Added in this PR.
+
+3. **Dispute Agent (PR #408) missing from admin nav.** Page exists at `/dashboard/admin/dispute-agent`. Added.
+
+4. **WhatsApp templates (PR #404) missing from admin nav.** Page exists at `/dashboard/admin/whatsapp`. Added.
+
+5. **Billing (PR #370) missing from admin nav.** Page exists at `/dashboard/admin/billing`. Added.
+
+6. **Disputes already in user sidebar.** Founder report was stale — no change needed.
+
+7. **Leads / Consumer Leads "overlap" is a labelling problem, not a data problem.**
+   - Two distinct tables, two distinct funnels:
+     - `leads` (30 columns: name, email, platform, platform_user_id, first_message, source_post_id, status, follow_up_at, notes, ...) — social DM/comment funnel.
+     - `consumer_leads` (31 columns: stripe_checkout_session_id, intended_tier, funnel_stage, discount_code, ...) — Stripe cart-abandonment + pricing-page exit CRM.
+   - Schemas barely overlap — a single physical UNION view would be lossy on either side.
+   - **Fix in this PR:** kept both, but added a "Source: Social DM funnel" clarifier banner in `<LeadsList>` with a one-click "Open Consumer Leads" link, and renamed the Consumer Leads tooltip to make the split explicit. A future PR can build a unified view if usage data warrants it.
+
+8. **AI Team page is honest now but wasn't.**
+   - `agent_messages` 0 rows in last 30d ⇒ Claude Managed Agents are configured but not firing (confirms the CLAUDE.md audit on 17 Apr).
+   - **Fix in this PR:** added an amber "Honest state" primer at the top of `<AITeamPanel>` that lists the active workers, the configured-but-dormant Managed Agents, and the Railway-disabled C-suite, with a one-click link to the Claude Managed Agents console at `https://claude.ai/code/agents`. A full per-agent drill-in rewrite is out of scope for this PR.
+
+9. **`legal-updates/page.tsx` (548 LoC) is on disk but not linked anywhere** in the admin tab strip. No founder complaint about it; left as-is for follow-up. May be obsolete now that `legal-refs` covers the compliance workflow.
+
+## Out of scope for this PR (filed for follow-up)
+
+- True per-tab `<details>` consolidation of the in-page tabs vs the link strip — the current admin shell mixes both. A follow-up PR can convert all admin pages into proper sidebar entries on the admin shell so the founder can deep-link without the tabbed monolith.
+- Unified Leads view (single UNION query across `leads` + `consumer_leads`).
+- AI Team per-agent drill-in drawer with last-10-runs.
+- Tickets empty-state copy for the active filter.

--- a/src/app/api/support/tickets/route.ts
+++ b/src/app/api/support/tickets/route.ts
@@ -121,7 +121,11 @@ export async function GET(request: NextRequest) {
 
   if (status) {
     if (status === 'active') {
-      query = query.in('status', ['open', 'in_progress']);
+      // "Needs action" = anything not yet resolved/closed.
+      // Previous mapping omitted 'awaiting_reply', which made the
+      // default Tickets tab show 0 even when the awaiting-reply queue
+      // had real items the founder needed to chase.
+      query = query.in('status', ['open', 'in_progress', 'awaiting_reply']);
     } else {
       query = query.eq('status', status);
     }

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -8,6 +8,7 @@ import {
   ShieldAlert, Users, CreditCard, TrendingUp, BarChart3,
   Building2, FileText, Bot, Loader2, ChevronRight, ArrowLeft,
   Banknote, Clock, Mail, Database, Ticket, Brain, Shield, Tag, RefreshCw, Briefcase, UserPlus,
+  Gavel, Activity, MessageSquare, PoundSterling,
 } from 'lucide-react';
 import TicketList from '@/components/admin/TicketList';
 import AITeamPanel from '@/components/admin/AITeamPanel';
@@ -277,9 +278,37 @@ export default function AdminPage() {
         <Link
           href="/dashboard/admin/consumer-leads"
           className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-          title="Consumer abandonment nurture funnel"
+          title="Consumer abandonment nurture funnel — cart-abandonment / pricing-page leads (separate table from social-DM Leads tab above)"
         >
           <UserPlus className="h-4 w-4" /> Consumer Leads
+        </Link>
+        <Link
+          href="/dashboard/admin/dispute-intelligence"
+          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
+          title="Dispute outcome dataset — funnel, win rates, merchant × legal-ref heatmap"
+        >
+          <Activity className="h-4 w-4" /> Dispute Intel
+        </Link>
+        <Link
+          href="/dashboard/admin/dispute-agent"
+          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
+          title="Autonomous dispute-agent decisions, approve/override rate, recommendation effectiveness"
+        >
+          <Gavel className="h-4 w-4" /> Dispute Agent
+        </Link>
+        <Link
+          href="/dashboard/admin/whatsapp"
+          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
+          title="WhatsApp template SIDs + Meta approval status"
+        >
+          <MessageSquare className="h-4 w-4" /> WhatsApp
+        </Link>
+        <Link
+          href="/dashboard/admin/billing"
+          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
+          title="API cost ledger — Anthropic / Perplexity / Resend / Stripe / TrueLayer spend"
+        >
+          <PoundSterling className="h-4 w-4" /> Billing
         </Link>
         <Link
           href="/dashboard/admin/legal-refs"

--- a/src/components/admin/AITeamPanel.tsx
+++ b/src/components/admin/AITeamPanel.tsx
@@ -134,6 +134,45 @@ export default function AITeamPanel() {
 
   return (
     <div>
+      {/* Honest-state primer — 17 Apr 2026 audit revealed the
+          legacy executive C-suite (Casey/Charlie/Sam/Alex/etc) is
+          dormant, the Railway agent-server was disabled around
+          5 Apr, and the nine Claude Managed Agents are configured
+          but not yet wired to a Vercel cron. Reflect that here so
+          the founder isn't misled by the names without status. */}
+      <div className="rounded-2xl border border-slate-200 bg-amber-50 p-4 mb-4 text-sm text-slate-800">
+        <p className="font-semibold mb-1">Honest state (per CLAUDE.md, 17 Apr 2026 audit)</p>
+        <ul className="list-disc pl-5 space-y-0.5 text-xs text-slate-700">
+          <li>
+            <span className="font-medium">Active workers:</span> complaint_writer (on-demand),
+            riley-support-agent, discover_features_cron, dev-sprint-runner,
+            analyze_chatbot_gaps_cron, paperclip-business-monitor, plus the new
+            compliance / nurture / dispute-agent crons.
+          </li>
+          <li>
+            <span className="font-medium">Claude Managed Agents</span> (alert-tester,
+            digest-compiler, support-triager, email-marketer, ux-auditor, feature-tester,
+            bug-triager, reviewer, builder) are <em>configured but not firing</em> —
+            <code className="mx-1 bg-slate-100 px-1 rounded">agent_messages</code> has 0 rows
+            in the last 30 days. They need a Vercel cron entry pointing at
+            <code className="mx-1 bg-slate-100 px-1 rounded">/api/cron/managed-agents</code>.
+          </li>
+          <li>
+            <span className="font-medium">Dormant:</span> Casey / Charlie / Sam / Alex / Jordan /
+            Morgan / Jamie / Taylor / Drew / Pippa / Leo / Nico / Bella / Finn — Railway
+            disabled, no replacement schedule.
+          </li>
+        </ul>
+        <a
+          href="https://claude.ai/code/agents"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-white border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:text-slate-900 hover:border-slate-300 transition-all"
+        >
+          Open Claude Managed Agents console ↗
+        </a>
+      </div>
+
       {/* Health summary bar */}
       {summary && (
         <div className="rounded-2xl border border-slate-200 bg-[#0a1628]/60 p-4 mb-4">

--- a/src/components/admin/LeadsList.tsx
+++ b/src/components/admin/LeadsList.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import { Loader2, MessageCircle, Instagram, Facebook, Filter, RefreshCw, ChevronDown } from 'lucide-react';
+import { Loader2, MessageCircle, Instagram, Facebook, Filter, RefreshCw, ChevronDown, ExternalLink } from 'lucide-react';
+import Link from 'next/link';
 
 interface Lead {
   id: string;
@@ -93,6 +94,26 @@ export default function LeadsList() {
 
   return (
     <div>
+      {/* Source clarifier — the founder previously saw two Leads
+          tabs and couldn't tell what each held. This banner makes
+          the split explicit: this view is social-DM only; cart-
+          abandonment & pricing-page leads live in Consumer Leads. */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm">
+        <div className="text-slate-700">
+          <span className="font-semibold text-slate-900">Source: Social DM funnel</span>
+          <span className="ml-2 text-slate-500">
+            Leads captured from Facebook / Instagram DMs &amp; comments. Stripe cart-abandonment
+            and pricing-page leads are tracked separately.
+          </span>
+        </div>
+        <Link
+          href="/dashboard/admin/consumer-leads"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:text-slate-900 border border-slate-200 hover:border-slate-300 transition-all"
+        >
+          Open Consumer Leads <ExternalLink className="h-3 w-3" />
+        </Link>
+      </div>
+
       {/* Stats row */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         <div className="bg-white border border-slate-200 rounded-xl p-4">

--- a/src/components/admin/TicketList.tsx
+++ b/src/components/admin/TicketList.tsx
@@ -54,7 +54,10 @@ export default function TicketList() {
   const [loading, setLoading] = useState(true);
   const [replyText, setReplyText] = useState('');
   const [sending, setSending] = useState(false);
-  const [filterStatus, setFilterStatus] = useState('active');
+  // Default to 'all' so the founder sees the full ticket history
+  // (resolved + active) rather than an empty tab when the active
+  // queue is short. Active-only is one click away in the dropdown.
+  const [filterStatus, setFilterStatus] = useState('');
   const [filterPriority, setFilterPriority] = useState('');
 
   const loadTickets = async () => {


### PR DESCRIPTION
## Summary

Founder reported the admin shell had drifted: Tickets showed 0, four recent admin pages (Dispute Intelligence, Dispute Agent, WhatsApp, Billing) were not linked from the tab strip, the Leads / Consumer Leads split wasn't labelled, and the AI Team panel didn't reflect the 17 Apr 2026 honest-state audit.

Audit doc: [`docs/admin-dashboard-audit-2026-05-01.md`](./docs/admin-dashboard-audit-2026-05-01.md) (Supabase-verified row counts inline).

- **Tickets tab fixed.** `support_tickets` has 16 rows (15 resolved + 1 awaiting_reply). The API mapped `status='active'` to `['open','in_progress']`, omitting `awaiting_reply`. Now mapped to the full not-yet-closed set, and the UI defaults to `all` so the founder lands on the full ticket history.
- **Four missing admin links added** to `/dashboard/admin` tab strip: Dispute Intel (PR #406), Dispute Agent (PR #408), WhatsApp (PR #404), Billing (PR #370).
- **Leads vs Consumer Leads disambiguated** — `<LeadsList>` now carries a "Source: Social DM funnel" banner with a one-click jump to Consumer Leads. Two physical tables (`leads`, `consumer_leads`) → two clearly-labelled views. Single UNION view filed for follow-up.
- **AI Team panel opens with an honest-state primer** matching the CLAUDE.md `agent_messages = 0 rows / 30d` reality: active workers, configured-but-dormant Managed Agents, Railway-disabled C-suite, plus a one-click link to https://claude.ai/code/agents.
- **User-side Disputes link** already existed (`DashboardShell.tsx:72`) — founder report was stale, no change needed.

## Files changed (6)

- `docs/admin-dashboard-audit-2026-05-01.md` (new — audit + findings)
- `src/app/api/support/tickets/route.ts` (active filter mapping)
- `src/app/dashboard/admin/page.tsx` (4 new tab links)
- `src/components/admin/AITeamPanel.tsx` (honest-state primer)
- `src/components/admin/LeadsList.tsx` (source clarifier banner)
- `src/components/admin/TicketList.tsx` (default filter)

## Out of scope (filed for follow-up)

- True unified UNION view across `leads` + `consumer_leads`
- AI Team per-agent drill-in drawer with last-10-runs
- Promoting all admin pages from in-page tabs to first-class sidebar entries on the admin shell

## Test plan

- [ ] `/dashboard/admin` Tickets tab now shows 16 tickets (was 0)
- [ ] Tab strip includes Dispute Intel, Dispute Agent, WhatsApp, Billing — each link routes to the existing page
- [ ] Leads tab shows source clarifier banner + working "Open Consumer Leads" button
- [ ] AI Team tab opens with the amber honest-state primer + working Managed Agents console link
- [ ] User-side sidebar still has Disputes (no regression)
- [ ] `npx tsc --noEmit` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)