### PR TITLE
feat(legal-refs): legislation.gov.uk as primary statute source (Perplexity → fallback)

### DIFF
--- a/docs/legal-data-api-research-2026-05-01.md
+++ b/docs/legal-data-api-research-2026-05-01.md
@@ -1,0 +1,151 @@
+# UK legal data API research — replacing Perplexity for `legal_references`
+
+Date: 2026-05-01
+Author: research agent (Paybacker compliance centre)
+
+## 1. Bottom-line recommendation
+
+**Integrate legislation.gov.uk's public Atom + XML API as the primary canonical source for every statute-backed `legal_references` row, and use Find Case Law (TNA) as a secondary feed for case-law citations under a free transactional licence.** Keep Perplexity only as a tertiary fallback for regulator codes (FCA / Ofcom / Ofgem) where no structured government feed exists. legislation.gov.uk is authoritative, free, Open Government Licence v3.0, and exposes a per-document Atom "effects" feed that surfaces amendments at the section level — exactly the supersession signal we currently approximate via Perplexity inference.
+
+## 2. legislation.gov.uk integration plan
+
+### Why it fits
+
+- Every statute we currently cite (CRA 2015, CCA 1974, Limitation Act 1980, Equality Act 2010, GDPR/DPA 2018, Housing Act 1988, Consumer Protection from Unfair Trading Regs 2008, etc.) is hosted there.
+- Our `source_url` column is already in the `https://www.legislation.gov.uk/{type}/{year}/{number}/section/{n}` shape, so re-grounding is a URL-rewrite plus a HEAD check, not a migration.
+- Content negotiation is trivial: append `/data.xml` to any content URI for canonical XML, or `/data.feed` to any list URI for Atom.[1][2]
+- The site exposes an "effects" feed per Act listing every amendment, commencement, and repeal, plus a global publication log of new instruments.[3][4]
+
+### Pipeline
+
+1. **Backfill confirm**: nightly job iterates `legal_references`, HEAD-checks `source_url`, verifies `200` and that the `<ukm:DocumentMainType>` matches the stored `law_name`. Anything failing → `legal_ref_corrections` queue.
+2. **Daily amendments cron** (08:00 UK): pull `https://www.legislation.gov.uk/new/data.feed` (new instruments, last 24h, confirmed live as of 2026-05-01) and the per-Act effects feed for each distinct Act we cite, e.g. `https://www.legislation.gov.uk/ukpga/2015/15/data.feed`. For any entry whose `<ukm:AffectedURI>` matches a section URL stored in `legal_references`, enqueue a correction with `last_changed` = entry `<published>` timestamp.
+3. **Section-level diff**: when an effect lands, fetch `/data.xml` for that section, hash the `<Text>` body, compare with last hash. On change, set `verification_status='superseded'` until a human (or a Perplexity rewrite gated on the new XML) refreshes the `summary`.
+
+### Effort estimate
+
+**Small-to-medium** (3–5 dev-days). One ingestion module, one cron, one new column (`source_xml_hash TEXT`). No vendor cost, no auth, no rate-limit ceiling published — the National Archives ask only for OGL v3.0 attribution and reasonable throttling.[5]
+
+## 3. Per-source findings
+
+| Source | Has API? | Format | Coverage | Freshness | Rate limit | Cost | Recommended use |
+|---|---|---|---|---|---|---|---|
+| **legislation.gov.uk** | Yes (REST + Atom + RDF) | XML, Atom, RDF/XML, HTML — **no JSON**[2] | All UK primary + secondary; devolved (Scotland/Wales/NI); SIs; retained EU law | Same-day for new SIs; effects feed updates per revision | None published; OGL v3.0 attribution | Free | **Primary** for every statute ref |
+| **Find Case Law (TNA)** | Yes (public Atom + XML; privileged Swagger API) | Atom feed at `/atom.xml`, judgments as Akoma Ntoso XML[6][7] | Supreme Court, Court of Appeal, High Court, UT, EAT (post-2003 mostly) | Within hours of hand-down | Bulk/programmatic requires free transactional licence (5-yr term)[8] | Free | **Secondary** for case-law refs (rare) |
+| **FCA Handbook** | Partial — handbook is HTML; instruments PDF; My FCA portal exists but not an open API[9][10] | HTML / PDF only for the handbook itself | All handbook modules (CONC, DISP, BCOBS, ICOBS, MCOBS) | Monthly instrument cycle | n/a | Free read; no machine-readable feed | Keep Perplexity-with-cite, or scrape stable handbook URLs |
+| **FCA Financial Services Register** | Yes (REST API, individual lookups) | JSON | Firms / individuals only — **not handbook rules** | Daily | Per-key throttling[11] | Free with key | Not useful for `legal_references` |
+| **Ofcom** | Yes for broadband/coverage open data; **no** structured API for General Conditions[12] | n/a for GCs | Coverage data only | n/a | n/a | Free | Not useful — scrape GC pages or Perplexity |
+| **Ofgem** | No public licence-conditions API | HTML/PDF | Standard Licence Conditions on epr.ofgem.gov.uk | Manual | n/a | Free | Perplexity fallback |
+| **CMA cases** | Yes via GOV.UK Content API (`document_type=cma_case`) | JSON via `https://www.gov.uk/api/content/cma-cases/{slug}` | All CMA / OIM / SAU cases (2.5k+ pages indexed)[13] | Same-day | Standard GOV.UK rate limit (rare to hit) | Free | Optional: enforcement-precedent feed |
+| **ICO enforcement** | No first-party API (page is OGL); third-party Apify scraper exists[14] | HTML + listed CSV downloads | All UK GDPR/PECR/DPA enforcement | ~Weekly | n/a / Apify paid | Free direct, paid via Apify | Skip until needed; build a thin scraper if so |
+| **CAA UK261** | No API; HTML guidance only | n/a | Passenger rights guidance | Manual | n/a | Free | Perplexity fallback |
+| **Financial Ombudsman** | No API; site has anti-scraper protection (legally upheld 2020)[15] | HTML | 13-yr decision archive | Daily | Adversarial | Free read, no bulk | **Do not scrape**; cite individual decisions only |
+| **Energy / Comms / Housing Ombudsmen** | No APIs | HTML/PDF | Decisions published periodically | Slow | n/a | Free | Skip |
+| **BAILII** | No API; HTML; explicit anti-scrape stance | HTML | Wide UK + commonwealth | Manual | n/a | Free | Skip — Find Case Law is the modern equivalent |
+| **Westlaw / LexisNexis / vLex / Practical Law** | Enterprise APIs (Protégé / Westlaw) | JSON | Comprehensive incl. annotations | Real-time | Per-contract | £15k–£100k+/yr typical enterprise[16] | Skip until £20k+ MRR |
+
+## 4. Implementation notes
+
+### 4.1 legislation.gov.uk — concrete endpoints
+
+- New legislation feed (last 24h-ish): `https://www.legislation.gov.uk/new/data.feed` — confirmed live, ~20 entries per pull, includes `<ukm:DocumentMainType>`, `<ukm:Year>`, `<ukm:Number>`, `<published>`.
+- Per-Act effects: `https://www.legislation.gov.uk/{type}/{year}/{number}/data.feed?feed-type=changes` — Atom of every amendment, with affected section URI in `<leg:AffectedProvisions>`.
+- Per-section canonical XML: `https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml`.
+- Search endpoint: `https://www.legislation.gov.uk/{type}?title={x}&data.feed`.
+
+Sample query for our existing CRA 2015 s.9 ("satisfactory quality") row:
+
+```
+GET https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml
+```
+
+Returns Akoma-Ntoso–like XML with `<Section>`, `<Text>`, version metadata (`<ukm:UnappliedEffects>` flags pending changes not yet incorporated — important: surface these in the UI).
+
+### 4.2 Pipeline placement
+
+```
+[daily cron]
+  -> pull /new/data.feed                      (catches new SIs that may amend)
+  -> for each distinct Act in legal_references: pull effects feed
+  -> match <leg:AffectedProvisions> URI -> legal_references.source_url
+  -> on match: insert legal_ref_corrections (status='pending_review')
+                set legal_references.verification_status='under_review'
+  -> Perplexity is invoked ONLY to draft a new `summary` from the new XML body
+     (no longer doing inference about whether the law changed — XML is canonical)
+```
+
+Net effect: Perplexity moves from "decide if law changed + summarise" to just "summarise authoritative text". Hallucination surface shrinks dramatically.
+
+### 4.3 Find Case Law — secondary
+
+- Apply for transactional licence (free, ~10 working days; email caselawlicence@nationalarchives.gov.uk).[8]
+- Public Atom: `https://caselaw.nationalarchives.gov.uk/atom.xml` (recently updated judgments).[6]
+- Use only if/when we add case-law-backed `legal_references` rows (currently rare).
+
+## 5. What's NOT recommended
+
+- **Westlaw / LexisNexis / vLex APIs** — enterprise pricing (£15k–£100k/yr) is wildly disproportionate to a compliance centre we use ~10–50× a day pre-Series A.[16]
+- **Scraping FOS decisions** — site actively defended a scraper-blocking measure in court (2020), and a programmatic harvest would be both legally dicey and operationally fragile.[15]
+- **BAILII scraping** — explicitly disallowed; superseded by Find Case Law for the cases we'd cite.
+- **Building a global FCA Handbook ingester** — handbook is HTML-only with no semantic markup; would be a 4-week project for marginal gain. Better to keep targeted Perplexity calls per ref and verify the cited handbook URL with a HEAD check.
+- **Apify-based ICO scrape** — fine if/when we need ICO precedent, but it's a paid third-party scraper, not an authoritative source. Defer.
+
+## 6. Caveats
+
+- legislation.gov.uk's `<ukm:UnappliedEffects>` flag means the visible XML is sometimes the *pre-amendment* text with a known pending effect; we must surface this state, not paper over it.
+- Devolved primary legislation (asp/anaw/nia) is in scope but our current refs lean Westminster — verify the URL pattern per type when generalising.
+- No rate limit is published; if we run a daily cron polling ~50 effects feeds we are well within polite use, but a backfill burst should be throttled (≤4 req/s).
+- Find Case Law's transactional licence is required *before* programmatic bulk access, even though the data is OGL — the licence governs computational re-use, not copyright. Approval is routine but not instant.[8]
+- FCA / Ofcom / Ofgem regulator-rule rows will continue to depend on a Perplexity-with-citation pattern; this is a real gap and worth a follow-up RFC if a regulator publishes a structured handbook in the next 12 months. The FCA's "intelligent handbook" is internally machine-readable (Corlytics) but not exposed as an open API.[9]
+- "Uncertain — needs follow-up": whether legislation.gov.uk's effects feed is genuinely real-time (within hours) or batched weekly. Empirical observation over a 30-day window once the cron is live will settle it.
+
+---
+
+### Sources
+
+1. legislation.gov.uk Developer Zone — https://www.legislation.gov.uk/developer
+2. Formats — https://www.legislation.gov.uk/developer/formats (XML / Atom / RDF / HTML; no JSON)
+3. Atom Feeds reference — https://www.legislation.gov.uk/developer/formats/atom
+4. Data-reuse documentation, Atom format — https://legislation.github.io/data-documentation/formats/atom.html
+5. National Archives "Putting APIs first" — https://gds.blog.gov.uk/2012/03/30/putting-apis-first-legislation-gov-uk/
+6. Find Case Law re-use page — https://caselaw.nationalarchives.gov.uk/re-use-find-case-law-records
+7. Find Case Law public API docs — https://nationalarchives.github.io/ds-find-caselaw-docs/public
+8. Find Case Law licence application — https://caselaw.nationalarchives.gov.uk/licence-application-process
+9. Corlytics FCA handbook digitisation case study — https://www.corlytics.com/case_studies/how-can-we-ensure-that-our-handbook-is-digitised-machine-readable-searchable-for-our-users/
+10. FCA Handbook — https://handbook.fca.org.uk/
+11. FCA Register data extract — https://www.fca.org.uk/firms/financial-services-register/data-extract
+12. Ofcom open data — https://www.ofcom.org.uk/about-ofcom/our-research/opendata ; API portal https://api.ofcom.org.uk/
+13. GOV.UK cma_case document type — https://docs.publishing.service.gov.uk/document-types/cma_case.html
+14. ICO enforcement (page OGL; third-party Apify scraper) — https://ico.org.uk/action-weve-taken/enforcement/
+15. Reed Smith — FOS v scraper bot (2020) — https://www.reedsmith.com/en/perspectives/2020/12/financial-ombudsman-service-vanquished-in-battle-of-the-scalper-robots
+16. LexisNexis enterprise pricing overview — https://www.vendr.com/marketplace/lexisnexis ; Thomson Reuters dev portal — https://www.lawnext.com/2024/04/thomson-reuters-launches-developer-portal-giving-access-to-over-100-apis-for-legal-tax-risk-and-fraud.html
+
+---
+
+## Phase 1 — Implemented 2026-05-01
+
+**Branch:** `feat/legislation-gov-uk-integration`
+
+### Shipped
+
+- **`src/lib/legal-data/legislation-gov-uk.ts`** — typed, dependency-free client for legislation.gov.uk:
+  - `fetchStatuteByUri(uri)` — content-negotiates to `/data.xml`, parses Akoma-Ntoso, returns `{ title, fullCitation, sectionText, sectionNumber, inForceOn, lastAmended, sourceUrl, hasUnappliedEffects, raw }`.
+  - `searchByTitle(query, { types, limit })` — Atom search via `/all/data.feed?title=…&type=ukpga&type=uksi`.
+  - `isLegislationGovUkUrl(url)` and `toXmlUri(url)` helpers.
+  - `<ukm:UnappliedEffects>` is surfaced (not papered over) per caveat in §6.
+- **Pipeline integration** — `src/app/api/admin/legal-refs/verify/route.ts` now tries the legislation.gov.uk fetcher FIRST whenever a row's `source_url` is on `legislation.gov.uk`. Perplexity stays as the fallback for everything else (and for the legislation.gov.uk case if the canonical fetch fails).
+- **Three-gate behaviour preserved** — the legislation.gov.uk fetcher produces a `legal_ref_corrections` row tagged `proposer='legislation-gov-uk'` (cost £0). It flows through the existing `evaluateCorrection` auto-apply gates and the same-host fast-path; no canonical fields are written without founder review unless all three gates pass. AI proposes; human confirms.
+- **Cost tracking** — Perplexity calls are skipped (and `cost_gbp` set to 0) on the audit row whenever the canonical fetch served the verdict.
+- **Tests** — `src/lib/legal-data/__tests__/legislation-gov-uk.test.ts` covers parsing, URL normalisation, Atom feed parsing, mocked fetch flow, host gating, and per-call cache dedup. One `describe.skip` integration test hits the real CRA 2015 s.9 endpoint when un-skipped locally. Run with `node --experimental-strip-types --test src/lib/legal-data/__tests__/legislation-gov-uk.test.ts` (matches the existing `legal-refs-authority.test.ts` pattern).
+
+### Pending (follow-up PRs)
+
+- **Find Case Law (TNA)** — needs founder to apply for the free transactional licence (~10 working days). Until then, Perplexity remains the case-law fallback.
+- **GOV.UK Content API** for `cma_case` regulator decisions.
+- **Daily amendments cron** consuming `https://www.legislation.gov.uk/new/data.feed` plus per-Act effects feeds. Hooks into a new `source_xml_hash` column to detect section-level diffs and queue corrections automatically.
+- **Background re-validation** that re-fetches every legislation.gov.uk-sourced ref weekly (cheap — no per-call cost).
+- **Surfacing `<ukm:UnappliedEffects>`** in the founder dashboard so pending-but-not-yet-incorporated changes are flagged on the row, not just in `verification_notes`.
+
+### Source attribution
+
+All content surfaced via this client is © Crown copyright, available under the Open Government Licence v3.0. The `sourceUrl` field is preserved end-to-end so any downstream UI can render the OGL attribution.

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -44,6 +44,11 @@ import { createClient as createAdminClient } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/server';
 import { logPerplexityCall } from '@/lib/cost-ledger';
 import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
+import {
+  fetchStatuteByUri,
+  isLegislationGovUkUrl,
+  type LegislationDoc,
+} from '@/lib/legal-data/legislation-gov-uk';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -266,6 +271,39 @@ function deriveProposal(
   };
 }
 
+/**
+ * Build a PerplexityVerdict-shaped object from a canonical legislation.gov.uk
+ * document. We reuse the existing verdict shape so the rest of the pipeline
+ * (deriveProposal / corrections insert / auto-apply gates) is unchanged —
+ * the only difference is the verifier label on the audit trail.
+ */
+function verdictFromLegislationDoc(
+  ref: LegalRefRow,
+  doc: LegislationDoc,
+): PerplexityVerdict {
+  // Same-host citation that resolves with a body and matching title is
+  // by definition still valid. We never claim "superseded" from this
+  // client; supersession is detected by the per-Act effects feed cron.
+  const sameUrl = normaliseUrl(doc.sourceUrl) === normaliseUrl(ref.source_url) ||
+    normaliseUrl(doc.sourceUrl).replace(/\/data\.xml$/, '') === normaliseUrl(ref.source_url);
+  const titleMatches = doc.title.trim().toLowerCase() === ref.law_name.trim().toLowerCase();
+  return {
+    valid: true,
+    // Strip /data.xml when proposing the canonical URL — we want the
+    // human-readable URL on the row, not the XML representation.
+    current_url: doc.sourceUrl.replace(/\/data\.xml$/, ''),
+    superseded_by: null,
+    confidence: titleMatches && sameUrl ? 'high' : doc.hasUnappliedEffects ? 'medium' : 'high',
+    notes: [
+      `Verified against legislation.gov.uk canonical XML.`,
+      titleMatches ? null : `Title differs: canonical='${doc.title}', stored='${ref.law_name}'.`,
+      doc.hasUnappliedEffects ? `Note: <ukm:UnappliedEffects> flagged — pending change not yet incorporated.` : null,
+      doc.lastAmended ? `Last amended: ${doc.lastAmended}.` : null,
+      `Source: legislation.gov.uk (Crown Copyright, OGL v3.0).`,
+    ].filter(Boolean).join(' '),
+  };
+}
+
 async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
   const admin = getAdmin();
   const { data: ref, error } = await admin
@@ -278,11 +316,29 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
     return { id, status: 'error', current_url: null, notes: '', error: 'Reference not found' };
   }
 
-  const verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
+  // PRIMARY SOURCE: legislation.gov.uk.
+  // Per docs/legal-data-api-research-2026-05-01.md, every UK statute we
+  // cite is hosted on legislation.gov.uk and can be fetched canonically
+  // as Akoma-Ntoso XML. If the stored source_url is on that host, we
+  // try the canonical fetcher FIRST and only fall back to Perplexity
+  // when the fetch fails or returns no body.
+  let verdict: PerplexityVerdict | null = null;
+  let verifierLabel: 'legislation-gov-uk' | 'perplexity-sonar-pro' = 'perplexity-sonar-pro';
+  if (isLegislationGovUkUrl((ref as LegalRefRow).source_url)) {
+    const doc = await fetchStatuteByUri((ref as LegalRefRow).source_url);
+    if (doc && doc.title) {
+      verdict = verdictFromLegislationDoc(ref as LegalRefRow, doc);
+      verifierLabel = 'legislation-gov-uk';
+    }
+  }
+
+  if (!verdict) {
+    verdict = await askPerplexity(buildPrompt(ref as LegalRefRow));
+  }
   if (!verdict) {
     void admin.from('legal_ref_verifications').insert({
       ref_id: id,
-      verifier: 'perplexity-sonar-pro',
+      verifier: verifierLabel,
       triggered_by: userId ? 'manual-admin' : 'unknown',
       before_status: (ref as any).verification_status ?? null,
       after_status: 'error',
@@ -291,24 +347,26 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
       changes: null,
       cost_gbp: null,
       perplexity_response: null,
-      notes: 'Perplexity call failed',
+      notes: 'Verification call failed (legislation.gov.uk + Perplexity)',
     });
     return {
       id,
       status: 'error',
       current_url: null,
       notes: '',
-      error: 'Perplexity call failed',
+      error: 'Verification call failed',
     };
   }
 
-  // Log spend (fire-and-forget).
-  logPerplexityCall({
-    model: PERPLEXITY_MODEL,
-    endpoint: '/api/admin/legal-refs/verify',
-    userId,
-    metadata: { legal_reference_id: id },
-  });
+  // Log spend (fire-and-forget) — only when we actually paid Perplexity.
+  if (verifierLabel === 'perplexity-sonar-pro') {
+    logPerplexityCall({
+      model: PERPLEXITY_MODEL,
+      endpoint: '/api/admin/legal-refs/verify',
+      userId,
+      metadata: { legal_reference_id: id },
+    });
+  }
 
   const refRow = ref as LegalRefRow;
   const proposal = deriveProposal(refRow, verdict);
@@ -331,14 +389,14 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
   if (!proposal.hasProposal) {
     void admin.from('legal_ref_verifications').insert({
       ref_id: id,
-      verifier: 'perplexity-sonar-pro',
+      verifier: verifierLabel,
       triggered_by: userId ? 'manual-admin' : 'unknown',
       before_status: refRow.verification_status,
       after_status: refRow.verification_status,
       before_url: refRow.source_url,
       after_url: refRow.source_url,
       changes: { no_change: true },
-      cost_gbp: COST_PER_CALL_GBP * 0.79,
+      cost_gbp: verifierLabel === 'perplexity-sonar-pro' ? COST_PER_CALL_GBP * 0.79 : 0,
       perplexity_response: verdict as any,
       notes: notes || null,
     });
@@ -366,7 +424,7 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
     .from('legal_ref_corrections')
     .insert({
       ref_id: id,
-      proposer: 'perplexity-sonar-pro',
+      proposer: verifierLabel,
       before_law_name: refRow.law_name,
       before_source_url: refRow.source_url,
       before_status: refRow.verification_status,
@@ -377,7 +435,7 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
       reasoning: notes || null,
       raw_response: verdict as any,
       confidence: verdict.confidence,
-      cost_gbp: COST_PER_CALL_GBP,
+      cost_gbp: verifierLabel === 'perplexity-sonar-pro' ? COST_PER_CALL_GBP : 0,
       status: 'pending',
     })
     .select('id')
@@ -398,7 +456,7 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
   // Audit row in legal_ref_verifications.
   void admin.from('legal_ref_verifications').insert({
     ref_id: id,
-    verifier: 'perplexity-sonar-pro',
+    verifier: verifierLabel,
     triggered_by: userId ? 'manual-admin' : 'unknown',
     before_status: refRow.verification_status,
     after_status: 'pending-correction-queued',
@@ -411,7 +469,7 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
       proposed_source_url: proposal.proposed_source_url,
       proposed_status: proposal.proposed_status,
     },
-    cost_gbp: COST_PER_CALL_GBP * 0.79,
+    cost_gbp: verifierLabel === 'perplexity-sonar-pro' ? COST_PER_CALL_GBP * 0.79 : 0,
     perplexity_response: verdict as any,
     notes: notes || null,
   });

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -46,6 +46,7 @@ import { logPerplexityCall } from '@/lib/cost-ledger';
 import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
 import {
   fetchStatuteByUri,
+  isLegislationDocAuthoritative,
   isLegislationGovUkUrl,
   type LegislationDoc,
 } from '@/lib/legal-data/legislation-gov-uk';
@@ -326,9 +327,21 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
   let verifierLabel: 'legislation-gov-uk' | 'perplexity-sonar-pro' = 'perplexity-sonar-pro';
   if (isLegislationGovUkUrl((ref as LegalRefRow).source_url)) {
     const doc = await fetchStatuteByUri((ref as LegalRefRow).source_url);
-    if (doc && doc.title) {
+    // We must NOT treat the canonical fetch as authoritative just because
+    // the XML parsed and had a title. If the URL targets a section but the
+    // parser didn't find that section, OR the URL targets a whole Act but
+    // the title doesn't match the stored law_name, we have to fall through
+    // to Perplexity — otherwise an unmatched fetch silently masquerades as
+    // "no_change" and never gets re-grounded. (Codex P1 #415)
+    const auth = isLegislationDocAuthoritative(doc, ref as LegalRefRow);
+    if (doc && auth.authoritative) {
       verdict = verdictFromLegislationDoc(ref as LegalRefRow, doc);
       verifierLabel = 'legislation-gov-uk';
+    } else {
+      console.warn(
+        '[legal-refs/verify] legislation.gov.uk fetch not authoritative; falling back to Perplexity',
+        { ref_id: id, source_url: (ref as LegalRefRow).source_url, reason: auth.reason },
+      );
     }
   }
 

--- a/src/lib/legal-data/__tests__/fixtures/cra-2015-s9.xml
+++ b/src/lib/legal-data/__tests__/fixtures/cra-2015-s9.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Legislation xmlns:ukm="http://www.legislation.gov.uk/namespaces/metadata"
+             xmlns:dc="http://purl.org/dc/elements/1.1/"
+             xmlns="http://www.legislation.gov.uk/namespaces/legislation">
+  <ukm:Metadata>
+    <dc:title>Consumer Rights Act 2015</dc:title>
+    <ukm:PrimaryMetadata>
+      <ukm:DocumentMainType Value="UnitedKingdomPublicGeneralAct"/>
+      <ukm:Year Value="2015"/>
+      <ukm:Number Value="15"/>
+      <ukm:DocumentVersion date="2015-03-26"/>
+      <ukm:Modified Date="2024-04-06"/>
+    </ukm:PrimaryMetadata>
+    <ukm:UnappliedEffects>
+      <ukm:UnappliedEffect EffectId="key-foo" Type="words substituted" AffectingURI="/id/ukpga/2024/13"/>
+    </ukm:UnappliedEffects>
+  </ukm:Metadata>
+  <Body>
+    <Part>
+      <Number>1</Number>
+      <Section>
+        <Number>9</Number>
+        <Title>Goods to be of satisfactory quality</Title>
+        <P1>
+          <P1para>
+            <Text>(1) Every contract to supply goods is to be treated as including a term that the quality of the goods is satisfactory.</Text>
+          </P1para>
+        </P1>
+        <P1>
+          <P1para>
+            <Text>(2) The quality of goods is satisfactory if they meet the standard that a reasonable person would consider satisfactory, taking account of any description of the goods, the price or other consideration for the goods (if relevant), and all the other relevant circumstances (see subsection (5)).</Text>
+          </P1para>
+        </P1>
+      </Section>
+    </Part>
+  </Body>
+</Legislation>

--- a/src/lib/legal-data/__tests__/legislation-gov-uk.test.ts
+++ b/src/lib/legal-data/__tests__/legislation-gov-uk.test.ts
@@ -1,0 +1,215 @@
+// src/lib/legal-data/__tests__/legislation-gov-uk.test.ts
+//
+// Tests for the legislation.gov.uk fetcher. Mirrors the style of
+// src/lib/legal-refs-authority.test.ts so the project keeps a single
+// test-runner story (node:test, no jest/vitest dep).
+//
+// Run with:
+//   node --experimental-strip-types --test src/lib/legal-data/__tests__/legislation-gov-uk.test.ts
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  fetchStatuteByUri,
+  isLegislationGovUkUrl,
+  parseAtomFeed,
+  parseLegislationXml,
+  toXmlUri,
+} from '../legislation-gov-uk.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE_PATH = join(__dirname, 'fixtures', 'cra-2015-s9.xml');
+const FIXTURE_XML = readFileSync(FIXTURE_PATH, 'utf8');
+
+describe('toXmlUri', () => {
+  it('appends /data.xml to a section URL', () => {
+    assert.equal(
+      toXmlUri('https://www.legislation.gov.uk/ukpga/2015/15/section/9'),
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml',
+    );
+  });
+  it('is idempotent when /data.xml is already there', () => {
+    assert.equal(
+      toXmlUri('https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml'),
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml',
+    );
+  });
+  it('strips /data.feed before appending /data.xml', () => {
+    assert.equal(
+      toXmlUri('https://www.legislation.gov.uk/ukpga/2015/15/data.feed'),
+      'https://www.legislation.gov.uk/ukpga/2015/15/data.xml',
+    );
+  });
+  it('accepts Akoma-Ntoso bare paths', () => {
+    assert.equal(
+      toXmlUri('/ukpga/2015/15/section/9'),
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml',
+    );
+  });
+  it('rejects non-legislation hosts', () => {
+    assert.equal(toXmlUri('https://www.example.com/ukpga/2015/15'), null);
+    assert.equal(toXmlUri('https://gov.uk/some/page'), null);
+  });
+});
+
+describe('isLegislationGovUkUrl', () => {
+  it('matches both www and apex hosts', () => {
+    assert.equal(isLegislationGovUkUrl('https://www.legislation.gov.uk/ukpga/2015/15'), true);
+    assert.equal(isLegislationGovUkUrl('https://legislation.gov.uk/ukpga/2015/15'), true);
+  });
+  it('rejects other hosts', () => {
+    assert.equal(isLegislationGovUkUrl('https://gov.uk/foo'), false);
+    assert.equal(isLegislationGovUkUrl('https://evil.legislation.gov.uk.fake.com/x'), false);
+    assert.equal(isLegislationGovUkUrl(null), false);
+    assert.equal(isLegislationGovUkUrl(''), false);
+  });
+});
+
+describe('parseLegislationXml — Consumer Rights Act 2015 s.9 fixture', () => {
+  const sourceUrl = 'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml';
+  const doc = parseLegislationXml(FIXTURE_XML, sourceUrl);
+
+  it('extracts the document title from <dc:title>', () => {
+    assert.equal(doc.title, 'Consumer Rights Act 2015');
+  });
+
+  it('derives the section number from the source URL', () => {
+    assert.equal(doc.sectionNumber, '9');
+  });
+
+  it('builds a full citation with the section number', () => {
+    assert.equal(doc.fullCitation, 'Consumer Rights Act 2015, section 9');
+  });
+
+  it('extracts the section text body', () => {
+    assert.ok(doc.sectionText, 'sectionText should be populated');
+    assert.match(
+      doc.sectionText!,
+      /quality of the goods is satisfactory/i,
+      'section body should include the canonical s.9(1) language',
+    );
+    assert.match(
+      doc.sectionText!,
+      /reasonable person/i,
+      'section body should include s.9(2) language',
+    );
+  });
+
+  it('flags pending unapplied effects', () => {
+    assert.equal(doc.hasUnappliedEffects, true);
+  });
+
+  it('captures last-amended date from <ukm:Modified>', () => {
+    assert.equal(doc.lastAmended, '2024-04-06');
+  });
+
+  it('preserves the canonical sourceUrl', () => {
+    assert.equal(doc.sourceUrl, sourceUrl);
+  });
+
+  it('keeps the raw XML for downstream hashing', () => {
+    assert.equal(doc.raw, FIXTURE_XML);
+  });
+});
+
+describe('parseAtomFeed', () => {
+  it('returns [] for empty feed input', () => {
+    assert.deepEqual(parseAtomFeed('<feed></feed>'), []);
+  });
+  it('extracts entries with title and link', () => {
+    const xml = `<?xml version="1.0"?>
+      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:ukm="http://www.legislation.gov.uk/namespaces/metadata">
+        <entry>
+          <title>Consumer Rights Act 2015</title>
+          <link href="https://www.legislation.gov.uk/ukpga/2015/15"/>
+          <published>2015-03-26T00:00:00Z</published>
+          <ukm:Year Value="2015"/>
+          <ukm:Number Value="15"/>
+          <ukm:DocumentMainType Value="UnitedKingdomPublicGeneralAct"/>
+        </entry>
+      </feed>`;
+    const out = parseAtomFeed(xml);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].title, 'Consumer Rights Act 2015');
+    assert.equal(out[0].url, 'https://www.legislation.gov.uk/ukpga/2015/15');
+    assert.equal(out[0].year, 2015);
+    assert.equal(out[0].number, 15);
+  });
+});
+
+describe('fetchStatuteByUri — mocked fetch', () => {
+  const realFetch = globalThis.fetch;
+  before(() => {
+    globalThis.fetch = (async (input: any) => {
+      const url = typeof input === 'string' ? input : input?.url ?? '';
+      if (url.endsWith('/data.xml')) {
+        return new Response(FIXTURE_XML, {
+          status: 200,
+          headers: { 'content-type': 'application/xml' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch;
+  });
+  after(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('returns a parsed LegislationDoc for a legislation.gov.uk URL', async () => {
+    const doc = await fetchStatuteByUri(
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9',
+    );
+    assert.ok(doc, 'expected a LegislationDoc');
+    assert.equal(doc!.title, 'Consumer Rights Act 2015');
+    assert.equal(doc!.sectionNumber, '9');
+    assert.match(doc!.sectionText ?? '', /satisfactory/i);
+  });
+
+  it('returns null for non-authority hosts', async () => {
+    const doc = await fetchStatuteByUri('https://example.com/ukpga/2015/15/section/9');
+    assert.equal(doc, null);
+  });
+
+  it('uses the supplied cache to dedupe repeat fetches', async () => {
+    let calls = 0;
+    const counting: typeof fetch = (async (...args: Parameters<typeof fetch>) => {
+      calls += 1;
+      return realFetch
+        ? new Response(FIXTURE_XML, { status: 200 })
+        : new Response(FIXTURE_XML, { status: 200 });
+    }) as typeof fetch;
+    globalThis.fetch = counting;
+    const cache = new Map();
+    const a = await fetchStatuteByUri(
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9',
+      { cache },
+    );
+    const b = await fetchStatuteByUri(
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9',
+      { cache },
+    );
+    assert.ok(a && b);
+    assert.equal(calls, 1, 'second call should hit cache');
+  });
+});
+
+// Network-touching integration test. Skipped by default — flip the
+// describe.skip to describe to run against the live legislation.gov.uk
+// service when iterating locally.
+describe.skip('fetchStatuteByUri — live network (Consumer Rights Act 2015 s.9)', () => {
+  it('hits the real legislation.gov.uk endpoint', async () => {
+    const doc = await fetchStatuteByUri(
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9',
+      { timeoutMs: 15_000 },
+    );
+    assert.ok(doc, 'expected a real fetch to return a doc');
+    assert.match(doc!.title, /Consumer Rights Act 2015/i);
+    assert.equal(doc!.sectionNumber, '9');
+    assert.ok(doc!.sectionText && doc!.sectionText.length > 0);
+  });
+});

--- a/src/lib/legal-data/__tests__/legislation-gov-uk.test.ts
+++ b/src/lib/legal-data/__tests__/legislation-gov-uk.test.ts
@@ -15,6 +15,8 @@ import { dirname, join } from 'node:path';
 
 import {
   fetchStatuteByUri,
+  fuzzyTitleMatch,
+  isLegislationDocAuthoritative,
   isLegislationGovUkUrl,
   parseAtomFeed,
   parseLegislationXml,
@@ -195,6 +197,88 @@ describe('fetchStatuteByUri — mocked fetch', () => {
     );
     assert.ok(a && b);
     assert.equal(calls, 1, 'second call should hit cache');
+  });
+});
+
+describe('isLegislationDocAuthoritative — Codex P1 #415 guard', () => {
+  const sectionUrl = 'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml';
+  const wholeActUrl = 'https://www.legislation.gov.uk/ukpga/2015/15';
+
+  it('(a) section URI with parser hit → authoritative', () => {
+    const doc = parseLegislationXml(FIXTURE_XML, sectionUrl);
+    const ref = {
+      source_url: sectionUrl,
+      law_name: 'Consumer Rights Act 2015',
+    };
+    const result = isLegislationDocAuthoritative(doc, ref);
+    assert.equal(result.authoritative, true, result.reason);
+    assert.equal(result.reason, 'doc:section-match');
+  });
+
+  it('(b) section URI with parser miss → NOT authoritative (fallback to Perplexity)', () => {
+    // Strip the <Section>…</Section> block so the parser cannot find s.9.
+    const xmlMissingSection = FIXTURE_XML.replace(
+      /<Section>[\s\S]*?<\/Section>/,
+      '<!-- section removed for test -->',
+    );
+    const doc = parseLegislationXml(xmlMissingSection, sectionUrl);
+    // Sanity: parse still extracted the title, but section text is null.
+    assert.equal(doc.title, 'Consumer Rights Act 2015');
+    assert.equal(doc.sectionText, null);
+    const ref = {
+      source_url: sectionUrl,
+      law_name: 'Consumer Rights Act 2015',
+    };
+    const result = isLegislationDocAuthoritative(doc, ref);
+    assert.equal(result.authoritative, false);
+    assert.equal(result.reason, 'doc:section-text-missing');
+  });
+
+  it('(c) whole-Act URI with matching title → authoritative', () => {
+    const doc = parseLegislationXml(FIXTURE_XML, wholeActUrl);
+    const ref = {
+      source_url: wholeActUrl,
+      // Stored title may include the chapter suffix; fuzzy match handles it.
+      law_name: 'Consumer Rights Act 2015 (c. 15)',
+    };
+    const result = isLegislationDocAuthoritative(doc, ref);
+    assert.equal(result.authoritative, true, result.reason);
+    assert.equal(result.reason, 'doc:title-match');
+  });
+
+  it('whole-Act URI with mismatched title → NOT authoritative', () => {
+    const doc = parseLegislationXml(FIXTURE_XML, wholeActUrl);
+    const ref = {
+      source_url: wholeActUrl,
+      law_name: 'Equality Act 2010',
+    };
+    const result = isLegislationDocAuthoritative(doc, ref);
+    assert.equal(result.authoritative, false);
+    assert.match(result.reason, /title-mismatch/);
+  });
+
+  it('null doc → NOT authoritative', () => {
+    const result = isLegislationDocAuthoritative(null, {
+      source_url: sectionUrl,
+      law_name: 'Consumer Rights Act 2015',
+    });
+    assert.equal(result.authoritative, false);
+    assert.equal(result.reason, 'doc:null');
+  });
+});
+
+describe('fuzzyTitleMatch', () => {
+  it('matches identical titles after normalisation', () => {
+    assert.equal(fuzzyTitleMatch('Consumer Rights Act 2015', 'consumer rights act 2015'), true);
+  });
+  it('matches when one contains the other (chapter suffix)', () => {
+    assert.equal(
+      fuzzyTitleMatch('Consumer Rights Act 2015', 'Consumer Rights Act 2015 (c. 15)'),
+      true,
+    );
+  });
+  it('rejects unrelated titles', () => {
+    assert.equal(fuzzyTitleMatch('Consumer Rights Act 2015', 'Equality Act 2010'), false);
   });
 });
 

--- a/src/lib/legal-data/legislation-gov-uk.ts
+++ b/src/lib/legal-data/legislation-gov-uk.ts
@@ -1,0 +1,365 @@
+/**
+ * src/lib/legal-data/legislation-gov-uk.ts
+ *
+ * Typed client for legislation.gov.uk — the PRIMARY canonical source for
+ * every UK statute we cite. See `docs/legal-data-api-research-2026-05-01.md`
+ * for the full integration plan.
+ *
+ * Why this exists:
+ *   Until now, every `legal_references` row was re-grounded by Perplexity
+ *   (sonar-pro). That worked, but Perplexity is (a) paid per call, (b) a
+ *   probabilistic re-statement of authoritative text rather than the text
+ *   itself, and (c) prone to citing commentary sites unless tightly
+ *   constrained. legislation.gov.uk publishes the same statutes as
+ *   Akoma-Ntoso XML at a deterministic URL — content negotiation is just
+ *   "append `/data.xml`". This client fetches and parses that XML so the
+ *   compliance pipeline can use canonical text first and fall back to
+ *   Perplexity only when no statute hit exists.
+ *
+ * Output rights:
+ *   All content from legislation.gov.uk is Crown Copyright, available
+ *   under the Open Government Licence v3.0. Any caller surfacing this
+ *   data MUST attribute the source (we always retain `sourceUrl` and
+ *   surface it in the UI; that satisfies OGL v3.0 attribution).
+ *
+ * No external XML parser dependency:
+ *   We parse only a small, well-known subset of the Akoma-Ntoso /
+ *   `<ukm:Metadata>` envelope. A regex extractor over the
+ *   `<Section>` / `<P1para>` block is sufficient and avoids adding a
+ *   new runtime dep. If we later need full schema-aware parsing we can
+ *   swap in fast-xml-parser without changing this module's surface.
+ */
+// We deliberately don't import from `legal-refs-authority` here:
+//   - The compliance authority allowlist is broader than this client
+//     needs (it accepts gov.uk, fca.org.uk, etc.).
+//   - Avoiding the import keeps this module dependency-free, which lets
+//     it run under `node --test` without a path-alias resolver.
+// Host gating is done locally via HOST_ALLOW below; callers that need
+// the broader UK legal-authority gate should run `checkUkLegalAuthority`
+// from `legal-refs-authority` themselves before/after invoking us.
+
+export interface LegislationDoc {
+  /** Canonical title from `<dc:title>` or `<FRBRname>`. */
+  title: string;
+  /** Best-guess full citation, e.g. "Consumer Rights Act 2015, section 9". */
+  fullCitation: string;
+  /** Plain-text body of the requested section, if a section was addressed. */
+  sectionText: string | null;
+  /** Numeric/alphanumeric section identifier (e.g. "9", "9A"), if any. */
+  sectionNumber: string | null;
+  /** Date the section is in force on (`<ukm:UnappliedEffects>` aware). */
+  inForceOn: string | null;
+  /** Last amendment timestamp from `<ukm:Modified>` if present. */
+  lastAmended: string | null;
+  /** Canonical https://www.legislation.gov.uk URL the doc was fetched from. */
+  sourceUrl: string;
+  /** Whether `<ukm:UnappliedEffects>` flagged a pending change not yet applied. */
+  hasUnappliedEffects: boolean;
+  /** Raw XML body for downstream hashing / diffing. */
+  raw: string;
+}
+
+export interface LegislationSearchResult {
+  title: string;
+  url: string;
+  documentType: string | null;
+  year: number | null;
+  number: number | null;
+  published: string | null;
+}
+
+const HOST_ALLOW = new Set(['www.legislation.gov.uk', 'legislation.gov.uk']);
+
+/**
+ * Per-request in-memory cache. We deliberately do NOT use a module-scoped
+ * Map here because Vercel reuses module state across requests — that would
+ * leak cache between users / cron runs. Callers can pass their own cache
+ * via the `cache` arg if they want short-lived dedup.
+ */
+export type FetchCache = Map<string, LegislationDoc | null>;
+
+/**
+ * Normalise any legislation.gov.uk URL or Akoma-Ntoso URI into the canonical
+ * XML representation by appending `/data.xml`. Idempotent.
+ */
+export function toXmlUri(uriOrUrl: string): string | null {
+  if (!uriOrUrl) return null;
+  let u: URL;
+  try {
+    // Accept Akoma-Ntoso bare URIs ("/ukpga/2015/15/section/9") too.
+    if (uriOrUrl.startsWith('/')) {
+      u = new URL(`https://www.legislation.gov.uk${uriOrUrl}`);
+    } else {
+      u = new URL(uriOrUrl);
+    }
+  } catch {
+    return null;
+  }
+  if (!HOST_ALLOW.has(u.hostname)) return null;
+  // Strip any trailing slash.
+  let path = u.pathname.replace(/\/+$/, '');
+  // Already pointing at /data.xml ?
+  if (path.endsWith('/data.xml')) return `https://${u.hostname}${path}`;
+  // Strip a trailing /data.feed or /data.htm if a caller mixed up content
+  // negotiation suffixes.
+  path = path.replace(/\/data\.(feed|htm|html|rdf|akn)$/i, '');
+  return `https://${u.hostname}${path}/data.xml`;
+}
+
+/**
+ * Pull a single tag's text content (first match only). The Akoma-Ntoso
+ * documents we care about are well-formed and don't nest the tags we
+ * extract here — a regex is sufficient and keeps us dep-free.
+ */
+function firstTagText(xml: string, tag: string): string | null {
+  const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
+  const m = xml.match(re);
+  if (!m) return null;
+  return decodeXmlEntities(stripTags(m[1])).trim() || null;
+}
+
+function firstAttr(xml: string, tag: string, attr: string): string | null {
+  const re = new RegExp(`<${tag}\\b[^>]*\\b${attr}=("([^"]*)"|'([^']*)')`, 'i');
+  const m = xml.match(re);
+  if (!m) return null;
+  return (m[2] ?? m[3] ?? null) || null;
+}
+
+function stripTags(s: string): string {
+  return s.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ');
+}
+
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)));
+}
+
+/**
+ * Extract the section block matching the given URL's `/section/<n>` segment.
+ * Handles both `<Section ...>` and `<P1para ...>` Akoma-Ntoso shapes.
+ */
+function extractSection(xml: string, sectionNumber: string | null): string | null {
+  if (!sectionNumber) return null;
+  // Try <Section> with matching <Number>N</Number>
+  const sectionRe = new RegExp(
+    `<Section\\b[^>]*>[\\s\\S]*?<Number>\\s*${escapeRe(sectionNumber)}\\s*<\\/Number>[\\s\\S]*?<\\/Section>`,
+    'i',
+  );
+  const sm = xml.match(sectionRe);
+  if (sm) {
+    return decodeXmlEntities(stripTags(sm[0])).replace(/\s+/g, ' ').trim() || null;
+  }
+  // Try <P1para> wrapper used in some SI documents.
+  const paraRe = new RegExp(
+    `<P1para\\b[^>]*\\bid=("|')[^"']*-${escapeRe(sectionNumber)}\\1[^>]*>[\\s\\S]*?<\\/P1para>`,
+    'i',
+  );
+  const pm = xml.match(paraRe);
+  if (pm) {
+    return decodeXmlEntities(stripTags(pm[0])).replace(/\s+/g, ' ').trim() || null;
+  }
+  return null;
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function parseSectionNumberFromUrl(url: string): string | null {
+  const m = url.match(/\/section\/([^/?#]+)/i);
+  return m ? m[1] : null;
+}
+
+/**
+ * Parse a legislation.gov.uk XML document into a LegislationDoc.
+ * Exported for tests; production callers should use `fetchStatuteByUri`.
+ */
+export function parseLegislationXml(xml: string, sourceUrl: string): LegislationDoc {
+  const title =
+    firstTagText(xml, 'dc:title') ||
+    firstTagText(xml, 'FRBRname') ||
+    firstAttr(xml, 'FRBRname', 'value') ||
+    firstTagText(xml, 'ukm:Title') ||
+    'Untitled UK legislation';
+
+  const sectionNumber = parseSectionNumberFromUrl(sourceUrl);
+  const sectionText = extractSection(xml, sectionNumber);
+
+  // Best-effort metadata extraction. Several dialects of the metadata
+  // header exist; we try the most common ones.
+  const inForceOn =
+    firstAttr(xml, 'ukm:DocumentVersion', 'date') ||
+    firstAttr(xml, 'FRBRdate', 'date') ||
+    null;
+  const lastAmended =
+    firstAttr(xml, 'ukm:Modified', 'Date') ||
+    firstAttr(xml, 'ukm:Modified', 'date') ||
+    null;
+
+  // <ukm:UnappliedEffects> presence indicates that the visible XML may be
+  // pre-amendment text with a known pending effect. Surface this so the
+  // pipeline can flag the citation rather than paper over it.
+  const hasUnappliedEffects = /<ukm:UnappliedEffects\b[^>]*>[\s\S]*?<\/ukm:UnappliedEffects>/i.test(xml)
+    || /<ukm:UnappliedEffects\b[^>]*\/>/i.test(xml);
+
+  const fullCitation = sectionNumber
+    ? `${title}, section ${sectionNumber}`
+    : title;
+
+  return {
+    title,
+    fullCitation,
+    sectionText,
+    sectionNumber,
+    inForceOn,
+    lastAmended,
+    sourceUrl,
+    hasUnappliedEffects,
+    raw: xml,
+  };
+}
+
+/**
+ * Fetch a single statute (or section thereof) from legislation.gov.uk.
+ *
+ * @param uri  Either a full https URL or an Akoma-Ntoso path. Anything
+ *             not on legislation.gov.uk returns `null` immediately —
+ *             we never proxy non-authority hosts through this client.
+ * @param opts Optional cache + abort signal. Cache is per-call: pass the
+ *             same Map across multiple invocations within a single
+ *             request to dedupe.
+ */
+export async function fetchStatuteByUri(
+  uri: string,
+  opts: { cache?: FetchCache; signal?: AbortSignal; timeoutMs?: number } = {},
+): Promise<LegislationDoc | null> {
+  const xmlUrl = toXmlUri(uri);
+  if (!xmlUrl) return null;
+
+  if (opts.cache?.has(xmlUrl)) {
+    return opts.cache.get(xmlUrl) ?? null;
+  }
+
+  const controller = opts.signal ? null : new AbortController();
+  const timeout = opts.timeoutMs ?? 10_000;
+  const timer = controller ? setTimeout(() => controller.abort(), timeout) : null;
+
+  try {
+    const res = await fetch(xmlUrl, {
+      headers: {
+        // Be polite: identify ourselves so TNA can throttle or contact us.
+        'User-Agent': 'paybacker-compliance-bot/1.0 (+https://paybacker.co.uk)',
+        Accept: 'application/xml, text/xml',
+      },
+      signal: opts.signal ?? controller?.signal,
+    });
+    if (!res.ok) {
+      opts.cache?.set(xmlUrl, null);
+      return null;
+    }
+    const xml = await res.text();
+    if (!xml || xml.length < 50) {
+      opts.cache?.set(xmlUrl, null);
+      return null;
+    }
+    const doc = parseLegislationXml(xml, xmlUrl);
+    opts.cache?.set(xmlUrl, doc);
+    return doc;
+  } catch (err) {
+    // Network / timeout / abort — return null so callers fall back gracefully.
+    console.warn('[legislation-gov-uk] fetch failed', xmlUrl, (err as Error)?.message);
+    opts.cache?.set(xmlUrl, null);
+    return null;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Search legislation.gov.uk's Atom feed by title. Returns the parsed
+ * entries (with no body — callers should `fetchStatuteByUri` to hydrate
+ * the canonical text for any hit they want to use).
+ *
+ * Defaults to UK Public General Acts + Statutory Instruments since
+ * those cover ~all of our consumer-rights citations.
+ */
+export async function searchByTitle(
+  query: string,
+  opts: { types?: ReadonlyArray<string>; limit?: number; signal?: AbortSignal } = {},
+): Promise<LegislationSearchResult[]> {
+  if (!query || query.trim().length === 0) return [];
+  const types = opts.types && opts.types.length > 0 ? opts.types : ['ukpga', 'uksi'];
+  const limit = Math.max(1, Math.min(opts.limit ?? 20, 50));
+
+  // legislation.gov.uk Atom search URL — `/all` accepts repeated `type=`.
+  const params = new URLSearchParams();
+  params.set('title', query);
+  for (const t of types) params.append('type', t);
+  const url = `https://www.legislation.gov.uk/all/data.feed?${params.toString()}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': 'paybacker-compliance-bot/1.0 (+https://paybacker.co.uk)',
+        Accept: 'application/atom+xml, application/xml',
+      },
+      signal: opts.signal,
+    });
+    if (!res.ok) return [];
+    const xml = await res.text();
+    return parseAtomFeed(xml).slice(0, limit);
+  } catch (err) {
+    console.warn('[legislation-gov-uk] search failed', query, (err as Error)?.message);
+    return [];
+  }
+}
+
+/**
+ * Parse an Atom feed from legislation.gov.uk. Exported for tests.
+ */
+export function parseAtomFeed(xml: string): LegislationSearchResult[] {
+  const out: LegislationSearchResult[] = [];
+  const entryRe = /<entry\b[^>]*>([\s\S]*?)<\/entry>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = entryRe.exec(xml))) {
+    const block = m[1];
+    const title = firstTagText(block, 'title') || '';
+    const linkHref = firstAttr(block, 'link', 'href') || '';
+    const published = firstTagText(block, 'published') || firstTagText(block, 'updated');
+    const docType = firstTagText(block, 'ukm:DocumentMainType') ||
+      firstAttr(block, 'ukm:DocumentMainType', 'Value');
+    const year = Number(firstTagText(block, 'ukm:Year') || firstAttr(block, 'ukm:Year', 'Value'));
+    const number = Number(firstTagText(block, 'ukm:Number') || firstAttr(block, 'ukm:Number', 'Value'));
+    if (!title || !linkHref) continue;
+    out.push({
+      title,
+      url: linkHref,
+      documentType: docType || null,
+      year: Number.isFinite(year) && year > 0 ? year : null,
+      number: Number.isFinite(number) && number > 0 ? number : null,
+      published: published || null,
+    });
+  }
+  return out;
+}
+
+/**
+ * Convenience: returns true if the given URL is hosted by legislation.gov.uk.
+ * Use this to gate the "primary statute fetcher" branch in the enrichment
+ * pipeline — anything else falls through to Perplexity.
+ */
+export function isLegislationGovUkUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const u = new URL(url);
+    return HOST_ALLOW.has(u.hostname);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/legal-data/legislation-gov-uk.ts
+++ b/src/lib/legal-data/legislation-gov-uk.ts
@@ -350,6 +350,96 @@ export function parseAtomFeed(xml: string): LegislationSearchResult[] {
 }
 
 /**
+ * Decide whether a fetched LegislationDoc is authoritative enough to skip
+ * the Perplexity fallback in the verify pipeline.
+ *
+ * A canonical fetch returning XML with a non-empty <dc:title> is NOT, on
+ * its own, sufficient — the parser may have missed the requested section
+ * (mismatched id, SI-only `<P1para>` shape we don't recognise, etc.) or
+ * the URL may target a whole Act whose title doesn't actually match the
+ * ref's stored statute name. In either case we'd silently mark the row
+ * as `no_change` even though we never confirmed the cited provision.
+ *
+ * Authoritative iff:
+ *   - doc.title is non-empty, AND
+ *   - if the source URL targets a /section/<n>: doc.sectionText non-empty
+ *     AND doc.sectionNumber matches the URL's section, OR
+ *   - if the source URL targets a whole Act (no /section/...): the
+ *     canonical title fuzzy-matches the ref's stored law_name.
+ *
+ * Returns `{ authoritative: boolean, reason: string }` so callers can log
+ * exactly why they fell back to Perplexity.
+ */
+export function isLegislationDocAuthoritative(
+  doc: LegislationDoc | null | undefined,
+  ref: { source_url: string; law_name: string },
+): { authoritative: boolean; reason: string } {
+  if (!doc) return { authoritative: false, reason: 'doc:null' };
+  if (!doc.title || !doc.title.trim()) {
+    return { authoritative: false, reason: 'doc:no-title' };
+  }
+
+  const urlSection = parseSectionNumberFromUrlExternal(ref.source_url);
+  if (urlSection) {
+    if (!doc.sectionText || !doc.sectionText.trim()) {
+      return { authoritative: false, reason: 'doc:section-text-missing' };
+    }
+    if (!doc.sectionNumber) {
+      return { authoritative: false, reason: 'doc:section-number-missing' };
+    }
+    if (doc.sectionNumber.trim().toLowerCase() !== urlSection.trim().toLowerCase()) {
+      return {
+        authoritative: false,
+        reason: `doc:section-mismatch(url=${urlSection},doc=${doc.sectionNumber})`,
+      };
+    }
+    return { authoritative: true, reason: 'doc:section-match' };
+  }
+
+  // Whole-Act URI — require fuzzy title match against ref.law_name.
+  if (!fuzzyTitleMatch(doc.title, ref.law_name)) {
+    return {
+      authoritative: false,
+      reason: `doc:title-mismatch(doc='${doc.title}',ref='${ref.law_name}')`,
+    };
+  }
+  return { authoritative: true, reason: 'doc:title-match' };
+}
+
+/** Same logic as `parseSectionNumberFromUrl` but tolerant of bare URIs. */
+function parseSectionNumberFromUrlExternal(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const m = url.match(/\/section\/([^/?#]+)/i);
+  return m ? m[1] : null;
+}
+
+/** Strip punctuation & collapse whitespace; lowercase. */
+function normaliseTitle(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Loose title match used by `isLegislationDocAuthoritative` for whole-Act
+ * URIs. Accepts either an exact normalised match or a containment relation
+ * (one side fully contains the other after normalisation) — that handles
+ * things like canonical "Consumer Rights Act 2015" vs stored
+ * "Consumer Rights Act 2015 (c. 15)" without false positives across
+ * unrelated statutes.
+ */
+export function fuzzyTitleMatch(a: string, b: string): boolean {
+  const na = normaliseTitle(a);
+  const nb = normaliseTitle(b);
+  if (!na || !nb) return false;
+  if (na === nb) return true;
+  if (na.includes(nb) || nb.includes(na)) return true;
+  return false;
+}
+
+/**
  * Convenience: returns true if the given URL is hosted by legislation.gov.uk.
  * Use this to gate the "primary statute fetcher" branch in the enrichment
  * pipeline — anything else falls through to Perplexity.


### PR DESCRIPTION
## Summary

Implements **Phase 1** of `docs/legal-data-api-research-2026-05-01.md`: a typed, dependency-free client for legislation.gov.uk wired into the legal-refs verification pipeline as the **primary** canonical source for UK statute citations. Perplexity stays in place as the fallback for everything else (and for legislation.gov.uk fetches that fail).

- `src/lib/legal-data/legislation-gov-uk.ts` — `fetchStatuteByUri`, `searchByTitle`, `isLegislationGovUkUrl`, `toXmlUri`, `parseLegislationXml`, `parseAtomFeed`. Surfaces `<ukm:UnappliedEffects>` rather than papering over it.
- `src/app/api/admin/legal-refs/verify/route.ts` — when a ref's `source_url` is on legislation.gov.uk, the canonical XML fetcher runs first and produces the verdict. Perplexity is only called if the canonical fetch fails.
- B2C/B2B-agnostic: lives in `src/lib/legal-data/`, no merchant or product coupling. Both products benefit because both call `generateComplaintLetter` and read the same `legal_references` table.

## Integration point + three-gate behaviour

The legislation.gov.uk client produces a `legal_ref_corrections` row tagged `proposer='legislation-gov-uk'` with `cost_gbp=0`. It flows through the existing `evaluateCorrection` auto-apply gates and the same-host fast-path documented in CLAUDE.md ("Compliance citation principle, refined 2026-04-30"). **No canonical fields are written without founder approval** unless all three gates pass (risk_score=low + corroboration + no semantic change) or the same-host redirect fast-path applies.

The `legal_ref_verifications` audit row uses `verifier='legislation-gov-uk'` so the founder dashboard can distinguish canonical-source verdicts from Perplexity ones.

## Tests

- `src/lib/legal-data/__tests__/legislation-gov-uk.test.ts` — 20 tests (all passing) using the existing project pattern (`node:test`, `--experimental-strip-types`). Covers URL normalisation, host gating, XML parsing against a CRA 2015 s.9 fixture (`__tests__/fixtures/cra-2015-s9.xml`), Atom feed parsing, mocked fetch flow, and per-call cache dedup.
- One `describe.skip` integration-style test hits the real `legislation.gov.uk/ukpga/2015/15/section/9/data.xml` endpoint — un-skip locally to verify against live data.

```
node --experimental-strip-types --test src/lib/legal-data/__tests__/legislation-gov-uk.test.ts
# tests 20  pass 20  fail 0
```

`npx tsc --noEmit` is clean (only pre-existing `.next/types/validator.ts` Yapily-related errors remain, unrelated to this PR).

## Out of scope (follow-ups)

- **Find Case Law (TNA)** — needs founder to apply for the free transactional licence (~10 working days; email `caselawlicence@nationalarchives.gov.uk`). Until then Perplexity remains the case-law fallback.
- **GOV.UK Content API** for `cma_case` regulator decisions.
- **Daily amendments cron** consuming `https://www.legislation.gov.uk/new/data.feed` + per-Act effects feeds (with a new `source_xml_hash` column for section-level diffing).
- **Background re-validation** that re-fetches every legislation.gov.uk-sourced ref weekly (free — no per-call cost).
- **Surfacing `<ukm:UnappliedEffects>`** as a row badge in `/dashboard/admin/legal-refs` rather than just a `verification_notes` line.

## Test plan

- [ ] `node --experimental-strip-types --test src/lib/legal-data/__tests__/legislation-gov-uk.test.ts` → 20 pass
- [ ] `npx tsc --noEmit` → no new errors
- [ ] Spot-check a single legislation.gov.uk-hosted `legal_references` row via `POST /api/admin/legal-refs/verify` with `{ id }` — confirm `proposer='legislation-gov-uk'` on the resulting correction (or no_change row) and `cost_gbp=0`
- [ ] Spot-check a non-legislation.gov.uk row (e.g. an FCA Handbook URL) — confirm Perplexity still runs and `proposer='perplexity-sonar-pro'`
- [ ] Verify a `<ukm:UnappliedEffects>` carrier (e.g. CRA 2015 s.9 today) surfaces the warning in `verification_notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)