### PR TITLE
fix(admin): resizable tab strip + back buttons across admin sub-pages

### DIFF
--- a/src/app/dashboard/admin/b2b/page.tsx
+++ b/src/app/dashboard/admin/b2b/page.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import AdminBackLink from '@/components/admin/AdminBackLink';
 
 interface Signup {
   id: string;
@@ -147,6 +148,7 @@ export default function AdminB2BPage() {
 
   return (
     <div className="max-w-7xl mx-auto p-6 space-y-8">
+      <AdminBackLink className="!mb-0" />
       <div>
         <h1 className="text-2xl font-bold text-slate-900">B2B Operations</h1>
         <p className="text-sm text-slate-500 mt-1">

--- a/src/app/dashboard/admin/billing/page.tsx
+++ b/src/app/dashboard/admin/billing/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { headers } from 'next/headers';
+import AdminBackLink from '@/components/admin/AdminBackLink';
 
 export const dynamic = 'force-dynamic';
 
@@ -62,6 +63,7 @@ export default async function AdminBillingPage() {
   if (!summary) {
     return (
       <div className="p-8 text-white">
+        <AdminBackLink className="!text-slate-400 hover:!text-white" />
         <h1 className="text-2xl font-bold">Billing</h1>
         <p className="text-red-400 mt-4">{fetchErr || 'No data.'}</p>
       </div>
@@ -72,6 +74,7 @@ export default async function AdminBillingPage() {
 
   return (
     <div className="p-6 md:p-8 text-white space-y-8 max-w-6xl">
+      <AdminBackLink className="!text-slate-400 hover:!text-white !mb-0" />
       <header>
         <h1 className="text-2xl md:text-3xl font-bold">API Billing</h1>
         <p className="text-sm text-slate-400 mt-1">

--- a/src/app/dashboard/admin/consumer-leads/page.tsx
+++ b/src/app/dashboard/admin/consumer-leads/page.tsx
@@ -5,12 +5,14 @@
  */
 
 import ConsumerLeadsClient from './ConsumerLeadsClient';
+import AdminBackLink from '@/components/admin/AdminBackLink';
 
 export const dynamic = 'force-dynamic';
 
 export default function ConsumerLeadsPage() {
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <AdminBackLink />
       <h1 className="text-2xl font-bold text-slate-900 mb-2">Consumer abandonment nurture</h1>
       <p className="text-sm text-slate-500 mb-6">
         Captured B2C leads from abandoned Stripe checkouts and pricing-page subscribe clicks. Daily

--- a/src/app/dashboard/admin/page.tsx
+++ b/src/app/dashboard/admin/page.tsx
@@ -5,16 +5,15 @@ export const dynamic = 'force-dynamic';
 import { useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import {
-  ShieldAlert, Users, CreditCard, TrendingUp, BarChart3,
+  ShieldAlert, Users, CreditCard, TrendingUp,
   Building2, FileText, Bot, Loader2, ChevronRight, ArrowLeft,
-  Banknote, Clock, Mail, Database, Ticket, Brain, Shield, Tag, RefreshCw, Briefcase, UserPlus,
-  Gavel, Activity, MessageSquare, PoundSterling,
+  Banknote, Mail, Database, BarChart3, Tag, RefreshCw,
 } from 'lucide-react';
 import TicketList from '@/components/admin/TicketList';
 import AITeamPanel from '@/components/admin/AITeamPanel';
 import MeetingRoom from '@/components/admin/MeetingRoom';
 import LeadsList from '@/components/admin/LeadsList';
-import Link from 'next/link';
+import AdminTabStrip from '@/components/admin/AdminTabStrip';
 
 // Server-side gate now lives in src/app/dashboard/admin/layout.tsx —
 // a non-admin can't reach this component. The client-side check below
@@ -253,102 +252,17 @@ export default function AdminPage() {
 
       {meetingOpen && <MeetingRoom onClose={() => setMeetingOpen(false)} />}
 
-      {/* Tabs */}
-      <div className="flex gap-2 mb-6">
-        <button onClick={() => { setTab('overview'); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${tab === 'overview' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
-          Overview
-        </button>
-        <button onClick={() => { setTab('members'); loadMembers(); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${tab === 'members' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
-          Members
-        </button>
-        <button onClick={() => { setTab('tickets'); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'tickets' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
-          <Ticket className="h-4 w-4" /> Tickets
-        </button>
-        <button onClick={() => { setTab('leads'); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'leads' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
-          <Users className="h-4 w-4" /> Leads
-        </button>
-        <button onClick={() => { setTab('ai_team'); setSelectedMember(null); }}
-          className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 ${tab === 'ai_team' ? 'bg-emerald-500 text-slate-900' : 'bg-slate-100 text-slate-600 hover:text-slate-900'}`}>
-          <Brain className="h-4 w-4" /> AI Team
-        </button>
-        <Link
-          href="/dashboard/admin/consumer-leads"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-          title="Consumer abandonment nurture funnel — cart-abandonment / pricing-page leads (separate table from social-DM Leads tab above)"
-        >
-          <UserPlus className="h-4 w-4" /> Consumer Leads
-        </Link>
-        <Link
-          href="/dashboard/admin/dispute-intelligence"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-          title="Dispute outcome dataset — funnel, win rates, merchant × legal-ref heatmap"
-        >
-          <Activity className="h-4 w-4" /> Dispute Intel
-        </Link>
-        <Link
-          href="/dashboard/admin/dispute-agent"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-          title="Autonomous dispute-agent decisions, approve/override rate, recommendation effectiveness"
-        >
-          <Gavel className="h-4 w-4" /> Dispute Agent
-        </Link>
-        <Link
-          href="/dashboard/admin/whatsapp"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-          title="WhatsApp template SIDs + Meta approval status"
-        >
-          <MessageSquare className="h-4 w-4" /> WhatsApp
-        </Link>
-        <Link
-          href="/dashboard/admin/billing"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-          title="API cost ledger — Anthropic / Perplexity / Resend / Stripe / TrueLayer spend"
-        >
-          <PoundSterling className="h-4 w-4" /> Billing
-        </Link>
-        <Link
-          href="/dashboard/admin/legal-refs"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-        >
-          <Shield className="h-4 w-4" /> Legal Refs
-        </Link>
-        <Link
-          href="/dashboard/admin/crons"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-        >
-          <Clock className="h-4 w-4" /> Crons
-        </Link>
-        <Link
-          href="/dashboard/admin/analytics"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-        >
-          <BarChart3 className="h-4 w-4" /> Analytics
-        </Link>
-        <Link
-          href="/dashboard/admin/cancel-info"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-        >
-          <Tag className="h-4 w-4" /> Cancel Info
-        </Link>
-        <Link
-          href="/dashboard/admin/b2b"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-          title="B2B waitlist + API keys"
-        >
-          <Briefcase className="h-4 w-4" /> B2B
-        </Link>
-        <Link
-          href="/dashboard/admin/restore-bank-data"
-          className="px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 bg-slate-100 text-slate-600 hover:text-slate-900"
-          title="Restore a user's soft-deleted bank transactions (within 30-day window)"
-        >
-          <RefreshCw className="h-4 w-4" /> Restore data
-        </Link>
-      </div>
+      {/* Tabs — primary row stays visible (the daily drivers); the
+          long tail of admin sub-pages moves into a "More" popover so
+          the strip never overflows horizontally. Founder feedback
+          (Apr 2026): 14+ tabs were getting cut off / unclickable on
+          narrow laptop screens. */}
+      <AdminTabStrip
+        tab={tab}
+        setTab={setTab}
+        loadMembers={loadMembers}
+        setSelectedMember={setSelectedMember}
+      />
 
       {/* OVERVIEW TAB */}
       {tab === 'overview' && metrics && (

--- a/src/components/admin/AdminBackLink.tsx
+++ b/src/components/admin/AdminBackLink.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+
+interface AdminBackLinkProps {
+  /** Where the back link points. Defaults to /dashboard/admin. */
+  href?: string;
+  /** Visible label. Defaults to "Back to Admin". */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Consistent back-to-admin link rendered at the top of every admin
+ * sub-page. Centralises styling so the founder always has the same
+ * affordance instead of relying on browser back.
+ */
+export default function AdminBackLink({
+  href = '/dashboard/admin',
+  label = 'Back to Admin',
+  className = '',
+}: AdminBackLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={`inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900 mb-4 ${className}`}
+    >
+      <ChevronLeft className="h-4 w-4" />
+      {label}
+    </Link>
+  );
+}

--- a/src/components/admin/AdminTabStrip.tsx
+++ b/src/components/admin/AdminTabStrip.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import {
+  Ticket, Users, Brain, UserPlus, Activity, Gavel, MessageSquare,
+  PoundSterling, Shield, Clock, BarChart3, Tag, Briefcase, RefreshCw,
+  ChevronDown,
+} from 'lucide-react';
+
+type AdminTab = 'overview' | 'members' | 'tickets' | 'leads' | 'ai_team';
+
+interface Props {
+  tab: AdminTab;
+  setTab: (t: AdminTab) => void;
+  loadMembers: () => void;
+  setSelectedMember: (v: null) => void;
+}
+
+interface AdvancedItem {
+  href: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  title?: string;
+}
+
+const ADVANCED: AdvancedItem[] = [
+  { href: '/dashboard/admin/consumer-leads', label: 'Consumer Leads', icon: UserPlus,
+    title: 'Consumer abandonment nurture funnel — cart-abandonment / pricing-page leads (separate table from social-DM Leads tab above)' },
+  { href: '/dashboard/admin/dispute-intelligence', label: 'Dispute Intel', icon: Activity,
+    title: 'Dispute outcome dataset — funnel, win rates, merchant × legal-ref heatmap' },
+  { href: '/dashboard/admin/dispute-agent', label: 'Dispute Agent', icon: Gavel,
+    title: 'Autonomous dispute-agent decisions, approve/override rate, recommendation effectiveness' },
+  { href: '/dashboard/admin/whatsapp', label: 'WhatsApp', icon: MessageSquare,
+    title: 'WhatsApp template SIDs + Meta approval status' },
+  { href: '/dashboard/admin/legal-refs', label: 'Legal Refs', icon: Shield },
+  { href: '/dashboard/admin/crons', label: 'Crons', icon: Clock },
+  { href: '/dashboard/admin/cancel-info', label: 'Cancel Info', icon: Tag },
+  { href: '/dashboard/admin/b2b', label: 'B2B', icon: Briefcase, title: 'B2B waitlist + API keys' },
+  { href: '/dashboard/admin/restore-bank-data', label: 'Restore data', icon: RefreshCw,
+    title: "Restore a user's soft-deleted bank transactions (within 30-day window)" },
+];
+
+export default function AdminTabStrip({ tab, setTab, loadMembers, setSelectedMember }: Props) {
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click / Esc.
+  useEffect(() => {
+    if (!moreOpen) return;
+    const onClick = (e: MouseEvent) => {
+      if (moreRef.current && !moreRef.current.contains(e.target as Node)) setMoreOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setMoreOpen(false); };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [moreOpen]);
+
+  const baseBtn = 'px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5';
+  const inactive = 'bg-slate-100 text-slate-600 hover:text-slate-900';
+  const active = 'bg-emerald-500 text-slate-900';
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-6">
+      <button
+        onClick={() => { setTab('overview'); setSelectedMember(null); }}
+        className={`${baseBtn} ${tab === 'overview' ? active : inactive}`}
+      >
+        Overview
+      </button>
+      <button
+        onClick={() => { setTab('members'); loadMembers(); setSelectedMember(null); }}
+        className={`${baseBtn} ${tab === 'members' ? active : inactive}`}
+      >
+        Members
+      </button>
+      <button
+        onClick={() => { setTab('tickets'); setSelectedMember(null); }}
+        className={`${baseBtn} ${tab === 'tickets' ? active : inactive}`}
+      >
+        <Ticket className="h-4 w-4" /> Tickets
+      </button>
+      <button
+        onClick={() => { setTab('leads'); setSelectedMember(null); }}
+        className={`${baseBtn} ${tab === 'leads' ? active : inactive}`}
+      >
+        <Users className="h-4 w-4" /> Leads
+      </button>
+      <button
+        onClick={() => { setTab('ai_team'); setSelectedMember(null); }}
+        className={`${baseBtn} ${tab === 'ai_team' ? active : inactive}`}
+      >
+        <Brain className="h-4 w-4" /> AI Team
+      </button>
+      <Link href="/dashboard/admin/billing" className={`${baseBtn} ${inactive}`}
+        title="API cost ledger — Anthropic / Perplexity / Resend / Stripe / TrueLayer spend">
+        <PoundSterling className="h-4 w-4" /> Billing
+      </Link>
+      <Link href="/dashboard/admin/analytics" className={`${baseBtn} ${inactive}`}>
+        <BarChart3 className="h-4 w-4" /> Analytics
+      </Link>
+
+      {/* More popover — long-tail admin tools live here so the primary
+          row never overflows horizontally on narrow viewports. */}
+      <div className="relative" ref={moreRef}>
+        <button
+          type="button"
+          onClick={() => setMoreOpen((v) => !v)}
+          aria-expanded={moreOpen}
+          aria-haspopup="menu"
+          className={`${baseBtn} ${inactive}`}
+        >
+          More
+          <ChevronDown className={`h-4 w-4 transition-transform ${moreOpen ? 'rotate-180' : ''}`} />
+        </button>
+        {moreOpen && (
+          <div
+            role="menu"
+            className="absolute left-0 top-full mt-2 z-30 w-60 bg-white border border-slate-200 rounded-lg shadow-lg py-1.5"
+          >
+            {ADVANCED.map((item) => {
+              const Icon = item.icon;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  title={item.title}
+                  onClick={() => setMoreOpen(false)}
+                  className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900"
+                  role="menuitem"
+                >
+                  <Icon className="h-4 w-4 text-slate-500" />
+                  {item.label}
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The admin tab strip at `/dashboard/admin` had grown to 16 tabs and overflowed horizontally on narrow laptop viewports — tabs at the right edge were clipped and unclickable. Several admin sub-pages also had no back link, forcing browser-back to return to the dashboard.

- **New `<AdminTabStrip>`** keeps daily-driver tabs in a primary row (Overview / Members / Tickets / Leads / AI Team / Billing / Analytics) and moves the long tail (Consumer Leads, Dispute Intel, Dispute Agent, WhatsApp, Legal Refs, Crons, Cancel Info, B2B, Restore data) into a "More" popover with outside-click + Esc dismiss. `flex-wrap` on the container guarantees the primary row never overflows even at 1024px.
- **New `<AdminBackLink>`** renders a consistent chevron + "Back to Admin" link. Added to `consumer-leads`, `b2b`, and `billing` — the three sub-pages that lacked one. The other 9 sub-pages already had bespoke back links.
- Active tab styling preserved (green pill).
- No route or tab-content changes.

## Test plan

- [ ] Visit `/dashboard/admin` at 1280px — primary row fits; "More" popover lists 9 advanced items
- [ ] Resize to 1024px — primary row wraps cleanly; no horizontal cut-off
- [ ] Click each item in "More" — navigates to the right route
- [ ] Outside-click + Esc close the "More" popover
- [ ] Visit `/dashboard/admin/{consumer-leads,b2b,billing}` — back link is visible at the top and returns to `/dashboard/admin`
- [ ] Existing back links on the other 9 sub-pages still work

`npx tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)