### PR TITLE
fix(admin/analytics): current-month metrics rendering as zero

### DIFF
--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -20,7 +20,15 @@ export const maxDuration = 60;
 export const dynamic = 'force-dynamic';
 
 const ADMIN_EMAIL = 'aireypaul@googlemail.com';
-const MIN_SEGMENT_SIZE = 2; // Drop rows where fewer than N distinct users contribute
+// Minimum distinct users required for a segment (category, merchant, income type,
+// subscription provider) to leave the server. Default 2 for production privacy.
+// Override via ANALYTICS_MIN_SEGMENT_SIZE — useful in dev / small datasets where
+// every segment has only a single user and would otherwise be suppressed entirely.
+const MIN_SEGMENT_SIZE = (() => {
+  const raw = process.env.ANALYTICS_MIN_SEGMENT_SIZE;
+  const n = raw ? Number(raw) : NaN;
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 2;
+})();
 
 function monthKey(d = new Date()) {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
@@ -75,8 +83,15 @@ export async function GET() {
     agentRunsRes,
     overridesCountRes,
   ] = await Promise.all([
+    // NOTE: profiles has no `last_active_at` or `health_score` columns
+    // (verified against initial_schema.sql + every additive migration).
+    // Selecting non-existent columns made PostgREST return a 400 with
+    // data: null — silently swallowed by `?? []` below — which zeroed
+    // out total users, tier breakdown, new signups, and active counts.
+    // We approximate "last active" via `updated_at` (touched on profile
+    // mutations) until a real activity timestamp is wired up.
     admin.from('profiles')
-      .select('id, subscription_tier, subscription_status, created_at, last_active_at, health_score'),
+      .select('id, subscription_tier, subscription_status, created_at, updated_at'),
     admin.from('bank_transactions')
       .select('user_id, amount, timestamp, category, user_category, income_type, merchant_name, description')
       .gte('timestamp', thisMonthStart)
@@ -115,6 +130,30 @@ export async function GET() {
       .select('id', { count: 'exact', head: true }),
   ]);
 
+  // Surface query failures so the next "all zeros" regression doesn't
+  // hide silently behind ?? [] / ?? 0. Logged once per request.
+  const queryResults: Array<[string, { error?: { message?: string } | null }]> = [
+    ['profiles', profilesRes],
+    ['txnsThisMonth', txnsThisMonthRes],
+    ['txnsLastMonth', txnsLastMonthRes],
+    ['bankConns', bankConnsRes],
+    ['emailConns', emailConnsRes],
+    ['subs', subsRes],
+    ['disputes', disputesRes],
+    ['priceAlerts', priceAlertsRes],
+    ['telegram', telegramRes],
+    ['tasks', tasksRes],
+    ['contractsEnding', contractsEndingRes],
+    ['agentRuns', agentRunsRes],
+    ['overridesCount', overridesCountRes],
+  ];
+  for (const [name, res] of queryResults) {
+    if (res.error) {
+      // eslint-disable-next-line no-console
+      console.error(`[admin/analytics] ${name} query failed:`, res.error);
+    }
+  }
+
   const profiles = profilesRes.data ?? [];
   const txnsThisMonth = txnsThisMonthRes.data ?? [];
   const txnsLastMonth = txnsLastMonthRes.data ?? [];
@@ -139,11 +178,14 @@ export async function GET() {
   const newSignupsThisMonth = profiles.filter(
     (p) => p.created_at && p.created_at >= thisMonthStart,
   ).length;
+  // Approximate "active" via profile.updated_at — set on tier change,
+  // stripe sync, onboarding step completion, etc. Not a perfect activity
+  // signal, but the closest available column today.
   const activeLast7d = profiles.filter(
-    (p) => p.last_active_at && p.last_active_at >= sevenDaysAgo,
+    (p) => p.updated_at && p.updated_at >= sevenDaysAgo,
   ).length;
   const activeLast30d = profiles.filter(
-    (p) => p.last_active_at && p.last_active_at >= thirtyDaysAgo,
+    (p) => p.updated_at && p.updated_at >= thirtyDaysAgo,
   ).length;
 
   // ── Money flowing through platform ───────────────────────────────
@@ -348,14 +390,11 @@ export async function GET() {
     ?? disputes.length > 0 ? new Set(disputes.map((d) => d.user_id)).size : 0;
 
   // ── Health score distribution ────────────────────────────────────
-  const scores = profiles.map((p) => Number(p.health_score)).filter((s) => Number.isFinite(s) && s > 0);
-  const avgHealthScore = scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : 0;
-  const healthDist = {
-    excellent: scores.filter((s) => s >= 80).length,
-    good: scores.filter((s) => s >= 60 && s < 80).length,
-    fair: scores.filter((s) => s >= 40 && s < 60).length,
-    poor: scores.filter((s) => s < 40).length,
-  };
+  // `profiles.health_score` does not exist in the schema today. Keep the
+  // response shape so the dashboard doesn't error, but report zeros until
+  // the column is added by a future migration.
+  const avgHealthScore = 0;
+  const healthDist = { excellent: 0, good: 0, fair: 0, poor: 0 };
 
   // ── AI usage ─────────────────────────────────────────────────────
   const totalAiCostThisMonth = agentRuns.reduce((s, r) => s + (Number(r.estimated_cost) || 0), 0);


### PR DESCRIPTION
## Root cause

`/api/admin/analytics` selected `last_active_at` and `health_score` from `profiles`, but **neither column exists** in the schema (verified against `supabase/migrations/20260101000000_initial_schema.sql` plus every additive migration since). PostgREST returned a 400 for the whole profiles query, and `profilesRes.data ?? []` silently swallowed it.

Admin Overview (`/api/admin/metrics`) avoided the bug because it only counts profile rows via `count: 'exact', head: true` — no column projection, so the bad columns never came into play. That's why Overview reported 49 users while Analytics reported 0.

The empty `profiles` array then zeroed out: total users, tier breakdown, new signups, active 7d / 30d, and the health-score panel. The `last_month_spend` of £88,082 was correct because `bank_transactions` queries are independent and use real columns.

## Before / after

| Metric | Before | After |
|---|---|---|
| Total Users | 0 | matches Overview (49) |
| By Tier F·E·P | 0·0·0 | populated from `subscription_tier` |
| New This Month | 0 | populated from `created_at` |
| Active Last 7d / 30d | 0 / 0 | populated (proxy via `updated_at` until a real `last_active_at` column is added) |
| Spend Last Month | £88,082 | unchanged (already correct) |
| Spend This Month | £0 | real number once May transactions sync |
| MoM | -100% | recomputed against real value |
| Top Categories / Merchants | empty | populated (subject to MIN_SEGMENT_SIZE) |
| Health scores | broken (empty array math) | zeros, correct response shape |

## Changes

- Drop `last_active_at` and `health_score` from the profiles select; substitute `updated_at` as the closest available "last active" proxy.
- Stub health-score block to zeros (column doesn't exist yet) so the dashboard keeps rendering.
- Log every query's `error` on the server so the next silent-fallback regression surfaces immediately.
- Add `ANALYTICS_MIN_SEGMENT_SIZE` env var. Default 2 (prod privacy preserved). Dev / B2C-MVP-scale envs can set 1 without disabling suppression in prod.

No page schema changes — only the data wiring.

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] Hit `/api/admin/analytics` in dev — payload has non-zero `user_counts.total` and `user_counts.by_tier`
- [ ] Visit `/dashboard/admin/analytics` — Total Users matches Admin Overview, tier breakdown populates, MoM stops showing -100%
- [ ] Set `ANALYTICS_MIN_SEGMENT_SIZE=1` in dev — verify Top Categories / Top Merchants populate even when segments only have 1 user
- [ ] Confirm prod env stays on default (no env var set) → MIN_SEGMENT_SIZE=2

🤖 Generated with [Claude Code](https://claude.com/claude-code)