### PR TITLE
feat(legal-refs): freshness pipeline — daily amendments sweep, weekly reverify, GOV.UK + TNA scaffolding

### DIFF
--- a/docs/legal-data-api-research-2026-05-01.md
+++ b/docs/legal-data-api-research-2026-05-01.md
@@ -149,3 +149,45 @@ Net effect: Perplexity moves from "decide if law changed + summarise" to just "s
 ### Source attribution
 
 All content surfaced via this client is © Crown copyright, available under the Open Government Licence v3.0. The `sourceUrl` field is preserved end-to-end so any downstream UI can render the OGL attribution.
+
+---
+
+## Phase 2 + 3 — Implemented 2026-05-01
+
+**Branch:** `feat/legal-data-freshness-pipeline` (extends Phase 1 PR #415).
+
+### Shipped
+
+- **`source_xml_hash` column** on `legal_references` + `legal_ref_corrections`, plus `last_freshness_check_at`, `is_stale`, `unapplied_effects`, `superseded_by`. Migration `supabase/migrations/20260502000000_legal_ref_freshness.sql`. Strictly additive.
+- **Daily amendments cron** `src/app/api/cron/legal-refs-amendments-sweep/route.ts`. Schedule `15 3 * * *` (avoids the existing `compliance-sync` slot at `0 3 * * *`). Caps 100 refs/run, 5 parallel fetches. Drift detected via SHA-256 hash of normalised section body. Drift inserts a PROPOSED `legal_ref_corrections` row (`proposer='legislation-gov-uk-amendments-sweep'`, `cost_gbp=0`, `source_xml_hash` set, `status='pending'`) and flips `is_stale=true` on canonical row. `<ukm:UnappliedEffects>` flips `unapplied_effects=true`. Canonical citation fields are NEVER mutated by this cron.
+- **Weekly re-validation cron** `src/app/api/cron/legal-refs-reverify/route.ts`. Schedule `0 4 * * 0`. Caps 200 refs/run, 4 parallel. Per-ref dedup: skip if `last_freshness_check_at < 6 days ago`. Prioritises non-legislation.gov.uk hosts (those have no daily cron and depend on Perplexity). Calls the existing `/api/admin/legal-refs/verify` endpoint so all three corroboration gates + the same-host fast-path are reused — no behaviour fork.
+- **GOV.UK Content client** `src/lib/legal-data/gov-uk-content.ts` — typed wrapper over `https://www.gov.uk/api/content/{path}` and `https://www.gov.uk/api/search.json`. Surfaces `cma_case` regulator decisions for the discovery pipeline. 6 unit tests with mocked fixtures.
+- **Find Case Law (TNA) scaffold** `src/lib/legal-data/find-case-law.ts` — Atom feed parser for `https://caselaw.nationalarchives.gov.uk/atom.xml?query=…`. **Dormant in production** behind `FIND_CASE_LAW_LICENCE_ACCEPTED=true`. Founder still needs to apply for the free transactional licence (~10 working days; email `caselawlicence@nationalarchives.gov.uk`). Tests cover the licence gate, parser, and dedup; flipping the env var enables production wiring with no code change.
+- **Admin UI** `/dashboard/admin/legal-refs`:
+  - New **Freshness** column with colour-coded badge (green `<7d`, amber `7-30d`, red `>30d` or null).
+  - `❗ Unapplied effects` badge when `unapplied_effects=true`.
+  - `⚠️ STALE — pending correction` badge when `is_stale=true`.
+  - New filter checkboxes: "Show stale only" + "Unapplied effects only".
+  - Pending corrections panel highlights `🔁 amendments sweep` proposals to distinguish XML-hash drift signals (high trust) from Perplexity verdicts.
+- **B2B contract** `DisputeResponse.legal_basis_freshness` — additive optional field. One entry per cited ref: `{ ref_id, last_verified_at, source: 'legislation.gov.uk' | 'perplexity' | 'find-case-law' | 'cma-case', is_stale }`. Backward-compatible per the public-contract rule.
+
+### Behind the licence env-var
+
+- `searchAtom()` in `src/lib/legal-data/find-case-law.ts` short-circuits to `[]` and logs once until `FIND_CASE_LAW_LICENCE_ACCEPTED=true`. The client surface, parsers, and tests are all live; only production wiring is gated. To enable post-approval: set the env var on Vercel; no code change required.
+
+### Confidence by source type
+
+| Source | Pipeline | Cost / call | Drift signal | Trust ceiling | Notes |
+|---|---|---|---|---|---|
+| **legislation.gov.uk** (primary) | Daily amendments-sweep + verify route | £0 | SHA-256 hash of normalised section body | **HIGH** — deterministic, canonical Crown copyright XML | Hash diff ⇒ proposal queued. `<ukm:UnappliedEffects>` flagged on UI. Republish-only metadata churn filtered out via `normaliseXmlForHash`. |
+| **GOV.UK Content (cma_case)** (secondary) | Discovery cron leg + manual `discoverCmaCases()` | £0 | `public_updated_at` timestamp | **MEDIUM** — content body is HTML with inconsistent shape across cases | Always lands in `legal_ref_candidates` (founder approves before any canonical write). |
+| **Find Case Law / TNA** (secondary, **dormant**) | Atom search via env-gated `searchAtom()` | £0 | `<published>` timestamp on entries | **MEDIUM** — judgment text is authoritative, but selection of which cases to cite is editorial | Dormant until licence accepted. Public Atom is OGL v3.0; programmatic re-use needs the transactional licence. |
+| **Perplexity sonar-pro** (fallback) | Verify route + weekly reverify | £0.005 | Probabilistic verdict + cited URL | **LOW-MEDIUM** — output is a re-statement, not the authority | Authority allowlist + 3-gate corroboration before any canonical write. Stays as the only freshness signal for FCA / Ofcom / Ofgem refs. |
+
+The tiering is deliberate: the higher the trust ceiling, the closer to canonical the auto-apply gates allow. legislation.gov.uk is the only source that can flip the `is_stale` flag on a canonical row without founder review (because the flag is observational, not a citation field). Every actual citation change still passes through `legal_ref_corrections` and a founder click — no fork in the dispute path.
+
+### Risks + caveats
+
+- **legislation.gov.uk amendments sweep load**: ~hundreds of refs × daily fetch. Concurrency capped at 5; per-fetch timeout 8 s. Expected nightly bandwidth ≈ 100 fetches × ~50 KB = ~5 MB, well within polite-use limits. No published rate-limit ceiling on the source; we identify ourselves via a User-Agent.
+- **Hash false-positives from XML whitespace / republish drift**: addressed by `normaliseXmlForHash` (strips XML comments, `<ukm:DocumentVersion>`, `<ukm:Modified>`, collapses whitespace). Verified by the `freshness.test.ts` suite.
+- **Find Case Law licence delay**: ~10 working days. The scaffold ships dormant so we can flip the env var the moment the licence email arrives; no PR required at that point.

--- a/src/app/api/cron/legal-refs-amendments-sweep/route.ts
+++ b/src/app/api/cron/legal-refs-amendments-sweep/route.ts
@@ -1,0 +1,337 @@
+/**
+ * GET /api/cron/legal-refs-amendments-sweep
+ *
+ * Daily 03:15 UTC. For every `legal_references` row whose `source_url`
+ * is on legislation.gov.uk:
+ *   1. Fetch the canonical Akoma-Ntoso XML.
+ *   2. Compute SHA-256 of the normalised section body.
+ *   3. Compare to stored `source_xml_hash`.
+ *      - First-ever check (hash NULL): seed the hash, mark
+ *        last_freshness_check_at, no proposal.
+ *      - Hash unchanged: refresh last_freshness_check_at only.
+ *      - Hash changed: insert a PROPOSED `legal_ref_corrections` row
+ *        with the new title/section text, set canonical
+ *        `is_stale=true`. The founder approves before any canonical
+ *        write happens — this cron is propose-only.
+ *      - `<ukm:UnappliedEffects>` present: set `unapplied_effects=true`
+ *        on the canonical row so the admin UI flags it.
+ *
+ * Caps: 100 refs per run. Concurrency cap: 5 in-flight fetches.
+ *
+ * COMPLIANCE PRINCIPLE (non-negotiable): this cron NEVER mutates a
+ * canonical citation field directly to a non-pending value. The
+ * `is_stale` and `unapplied_effects` columns are observational flags.
+ * `source_xml_hash` is a fingerprint, not a citation field. Real text
+ * changes always flow through `legal_ref_corrections`.
+ *
+ * Auth: matches the existing legal-refs cron pattern — accepts
+ * `Authorization: Bearer ${CRON_SECRET}`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import {
+  fetchStatuteByUri,
+  hashLegislationDoc,
+  isLegislationGovUkUrl,
+  type LegislationDoc,
+} from '@/lib/legal-data/legislation-gov-uk';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const HARD_CAP = 100;
+const CONCURRENCY = 5;
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim(),
+  );
+}
+
+interface LegalRefRow {
+  id: string;
+  law_name: string;
+  section: string | null;
+  source_url: string;
+  source_type: string | null;
+  category: string;
+  verification_status: string | null;
+  source_xml_hash: string | null;
+  last_freshness_check_at: string | null;
+  is_stale: boolean | null;
+  unapplied_effects: boolean | null;
+}
+
+interface SweepCounts {
+  scanned: number;
+  unchanged: number;
+  hashed_first_time: number;
+  drift_queued: number;
+  unapplied_effects_flagged: number;
+  fetch_failed: number;
+  errors: number;
+}
+
+/**
+ * Process one legal-ref row. Returns a partial counts delta the caller
+ * adds to the run total. Never throws — failures are recorded as
+ * `errors`/`fetch_failed` and the row is left in its current state
+ * for the next run.
+ */
+async function processRef(
+  admin: ReturnType<typeof getAdmin>,
+  ref: LegalRefRow,
+): Promise<Partial<SweepCounts>> {
+  const nowIso = new Date().toISOString();
+
+  let doc: LegislationDoc | null = null;
+  try {
+    doc = await fetchStatuteByUri(ref.source_url, { timeoutMs: 8_000 });
+  } catch {
+    doc = null;
+  }
+  if (!doc) {
+    return { fetch_failed: 1 };
+  }
+
+  let newHash: string;
+  try {
+    newHash = await hashLegislationDoc(doc);
+  } catch {
+    return { errors: 1 };
+  }
+
+  // First-ever fingerprint — seed without proposing a correction. We
+  // can't tell if anything's changed without a baseline.
+  if (!ref.source_xml_hash) {
+    await admin
+      .from('legal_references')
+      .update({
+        source_xml_hash: newHash,
+        last_freshness_check_at: nowIso,
+        unapplied_effects: !!doc.hasUnappliedEffects,
+      })
+      .eq('id', ref.id);
+    return {
+      hashed_first_time: 1,
+      unapplied_effects_flagged: doc.hasUnappliedEffects ? 1 : 0,
+    };
+  }
+
+  // No drift — just refresh the freshness check + the unapplied-effects
+  // flag (which can flip independently of section text changes).
+  if (newHash === ref.source_xml_hash) {
+    await admin
+      .from('legal_references')
+      .update({
+        last_freshness_check_at: nowIso,
+        unapplied_effects: !!doc.hasUnappliedEffects,
+      })
+      .eq('id', ref.id);
+    return {
+      unchanged: 1,
+      unapplied_effects_flagged: doc.hasUnappliedEffects ? 1 : 0,
+    };
+  }
+
+  // Drift detected — propose a correction with the new canonical body.
+  // We never overwrite canonical fields directly; the founder approves
+  // through the existing `legal_ref_corrections` flow.
+  const proposedTitle = doc.title || ref.law_name;
+  const proposedUrl = doc.sourceUrl.replace(/\/data\.xml$/, '');
+
+  // Mark prior pending corrections for this ref as superseded so the
+  // queue only ever shows the latest proposal per ref.
+  await admin
+    .from('legal_ref_corrections')
+    .update({
+      status: 'superseded_by_newer',
+      reviewed_at: nowIso,
+      reviewed_by: 'amendments-sweep-new-proposal',
+    })
+    .eq('ref_id', ref.id)
+    .eq('status', 'pending');
+
+  const reasoningParts = [
+    `Section text on legislation.gov.uk has changed since last sweep.`,
+    `Old hash: ${ref.source_xml_hash.slice(0, 12)}…`,
+    `New hash: ${newHash.slice(0, 12)}…`,
+    doc.lastAmended ? `Last amended: ${doc.lastAmended}.` : null,
+    doc.hasUnappliedEffects
+      ? `Note: <ukm:UnappliedEffects> present — pending change not yet incorporated.`
+      : null,
+    'Source: legislation.gov.uk (Crown Copyright, OGL v3.0).',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const { data: insertedRows, error: insErr } = await admin
+    .from('legal_ref_corrections')
+    .insert({
+      ref_id: ref.id,
+      proposer: 'legislation-gov-uk-amendments-sweep',
+      before_law_name: ref.law_name,
+      before_source_url: ref.source_url,
+      before_status: ref.verification_status,
+      proposed_law_name:
+        proposedTitle.trim().toLowerCase() === ref.law_name.trim().toLowerCase()
+          ? null
+          : proposedTitle,
+      proposed_source_url:
+        proposedUrl.replace(/\/$/, '').toLowerCase() ===
+        (ref.source_url || '').replace(/\/$/, '').toLowerCase()
+          ? null
+          : proposedUrl,
+      proposed_status: 'updated',
+      superseded_by: null,
+      reasoning: reasoningParts,
+      raw_response: {
+        section_text_excerpt: (doc.sectionText || '').slice(0, 4000),
+        last_amended: doc.lastAmended,
+        in_force_on: doc.inForceOn,
+        has_unapplied_effects: doc.hasUnappliedEffects,
+        source_url: doc.sourceUrl,
+      },
+      confidence: 'high',
+      cost_gbp: 0,
+      status: 'pending',
+      source_xml_hash: newHash,
+      source_host: 'legislation.gov.uk',
+    })
+    .select('id')
+    .limit(1);
+
+  if (insErr) {
+    return { errors: 1 };
+  }
+
+  // Flag the canonical row as stale so the admin UI surfaces a
+  // warning. Canonical citation fields stay untouched.
+  await admin
+    .from('legal_references')
+    .update({
+      is_stale: true,
+      unapplied_effects: !!doc.hasUnappliedEffects,
+      last_freshness_check_at: nowIso,
+    })
+    .eq('id', ref.id);
+
+  // Audit row for the verifications timeline.
+  void admin.from('legal_ref_verifications').insert({
+    ref_id: ref.id,
+    verifier: 'legislation-gov-uk-amendments-sweep',
+    triggered_by: 'cron',
+    before_status: ref.verification_status,
+    after_status: 'pending-correction-queued',
+    before_url: ref.source_url,
+    after_url: proposedUrl,
+    changes: {
+      queued_correction: true,
+      correction_id: insertedRows?.[0]?.id ?? null,
+      old_hash: ref.source_xml_hash,
+      new_hash: newHash,
+      has_unapplied_effects: doc.hasUnappliedEffects,
+    },
+    cost_gbp: 0,
+    notes: reasoningParts,
+  });
+
+  return {
+    drift_queued: 1,
+    unapplied_effects_flagged: doc.hasUnappliedEffects ? 1 : 0,
+  };
+}
+
+/**
+ * Pool runner — caps concurrency to N. Returns when every task settles.
+ * Used to keep the legislation.gov.uk fetch fan-out polite (≤5 in-flight)
+ * while still finishing 100 rows in a reasonable cron window.
+ */
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const runners: Array<Promise<void>> = [];
+  for (let i = 0; i < Math.min(concurrency, items.length); i += 1) {
+    runners.push(
+      (async () => {
+        while (cursor < items.length) {
+          const idx = cursor;
+          cursor += 1;
+          const it = items[idx];
+          if (it === undefined) break;
+          await worker(it);
+        }
+      })(),
+    );
+  }
+  await Promise.all(runners);
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  if (
+    process.env.CRON_SECRET &&
+    authHeader !== `Bearer ${process.env.CRON_SECRET}`
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+
+  // Order: never-checked first (NULLs), then oldest last_freshness_check_at.
+  // Filter to legislation.gov.uk hosts only — non-legislation refs fall
+  // under the weekly reverify cron.
+  const { data, error } = await admin
+    .from('legal_references')
+    .select(
+      'id, law_name, section, source_url, source_type, category, verification_status, source_xml_hash, last_freshness_check_at, is_stale, unapplied_effects',
+    )
+    .ilike('source_url', '%legislation.gov.uk%')
+    .order('last_freshness_check_at', { ascending: true, nullsFirst: true })
+    .limit(HARD_CAP);
+
+  if (error) {
+    return NextResponse.json(
+      { error: 'fetch refs failed', detail: error.message },
+      { status: 500 },
+    );
+  }
+
+  const queue = (data || []).filter((r): r is LegalRefRow =>
+    isLegislationGovUkUrl((r as { source_url?: string }).source_url),
+  );
+
+  const counts: SweepCounts = {
+    scanned: 0,
+    unchanged: 0,
+    hashed_first_time: 0,
+    drift_queued: 0,
+    unapplied_effects_flagged: 0,
+    fetch_failed: 0,
+    errors: 0,
+  };
+
+  await runWithConcurrency(queue, CONCURRENCY, async (ref) => {
+    counts.scanned += 1;
+    try {
+      const delta = await processRef(admin, ref);
+      for (const k of Object.keys(delta) as Array<keyof SweepCounts>) {
+        counts[k] += delta[k] ?? 0;
+      }
+    } catch (err) {
+      counts.errors += 1;
+      console.warn(
+        '[amendments-sweep] processRef threw',
+        ref.id,
+        (err as Error)?.message,
+      );
+    }
+  });
+
+  return NextResponse.json({ ok: true, queue: queue.length, counts });
+}

--- a/src/app/api/cron/legal-refs-reverify/route.ts
+++ b/src/app/api/cron/legal-refs-reverify/route.ts
@@ -1,0 +1,192 @@
+/**
+ * GET /api/cron/legal-refs-reverify
+ *
+ * Weekly Sunday 04:00 UTC. Re-verifies every `legal_references` row
+ * regardless of host, with deliberate priority for non-legislation.gov.uk
+ * refs (those don't have the daily amendments cron — Perplexity is the
+ * only freshness signal we have for them).
+ *
+ * For each ref it calls the existing `/api/admin/legal-refs/verify`
+ * route (which itself prefers legislation.gov.uk canonical fetch and
+ * falls back to Perplexity), reusing every gate in that pipeline:
+ *   - propose-only on canonical fields
+ *   - non-authority URLs auto-rejected
+ *   - same-host fast-path / three-gate corroboration via the η sweep
+ *
+ * Caps:
+ *   - 200 refs per run
+ *   - per-ref dedup: skip if `last_freshness_check_at` < 6 days ago
+ *
+ * Auth: matches the existing legal-refs cron pattern — accepts
+ * `Authorization: Bearer ${CRON_SECRET}`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import { isLegislationGovUkUrl } from '@/lib/legal-data/legislation-gov-uk';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const HARD_CAP = 200;
+const DEDUP_DAYS = 6;
+const CONCURRENCY = 4;
+
+function getAdmin() {
+  return createAdminClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim(),
+  );
+}
+
+interface ReverifyCounts {
+  scanned: number;
+  reverified_ok: number;
+  skipped_dedup: number;
+  errors: number;
+}
+
+interface RefRow {
+  id: string;
+  source_url: string;
+  last_freshness_check_at: string | null;
+}
+
+/** Internal call to the existing verify route. Reuses all pipeline gates. */
+async function callVerify(
+  origin: string,
+  cronSecret: string,
+  id: string,
+): Promise<{ ok: boolean; status?: string }> {
+  try {
+    const res = await fetch(`${origin}/api/admin/legal-refs/verify`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${cronSecret}`,
+      },
+      body: JSON.stringify({ id }),
+    });
+    if (!res.ok) return { ok: false, status: `http_${res.status}` };
+    const data = (await res.json().catch(() => null)) as
+      | { updated?: { status?: string } }
+      | null;
+    return { ok: true, status: data?.updated?.status };
+  } catch (err) {
+    return { ok: false, status: (err as Error)?.message || 'fetch_threw' };
+  }
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const runners: Array<Promise<void>> = [];
+  for (let i = 0; i < Math.min(concurrency, items.length); i += 1) {
+    runners.push(
+      (async () => {
+        while (cursor < items.length) {
+          const idx = cursor;
+          cursor += 1;
+          const it = items[idx];
+          if (it === undefined) break;
+          await worker(it);
+        }
+      })(),
+    );
+  }
+  await Promise.all(runners);
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  if (
+    process.env.CRON_SECRET &&
+    authHeader !== `Bearer ${process.env.CRON_SECRET}`
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+
+  // Pull a generous superset; we'll dedup + prioritise in memory so
+  // non-legislation hosts go first.
+  const { data, error } = await admin
+    .from('legal_references')
+    .select('id, source_url, last_freshness_check_at')
+    .order('last_freshness_check_at', { ascending: true, nullsFirst: true })
+    .limit(HARD_CAP * 3);
+
+  if (error) {
+    return NextResponse.json(
+      { error: 'fetch refs failed', detail: error.message },
+      { status: 500 },
+    );
+  }
+
+  const dedupCutoff = Date.now() - DEDUP_DAYS * 24 * 60 * 60 * 1000;
+
+  const all = (data || []) as RefRow[];
+  const counts: ReverifyCounts = {
+    scanned: 0,
+    reverified_ok: 0,
+    skipped_dedup: 0,
+    errors: 0,
+  };
+
+  // Skip rows freshly seen by the daily amendments sweep — within
+  // dedup window means we already have current freshness data.
+  const eligible: RefRow[] = [];
+  for (const r of all) {
+    if (!r.id) continue;
+    if (
+      r.last_freshness_check_at &&
+      new Date(r.last_freshness_check_at).getTime() > dedupCutoff
+    ) {
+      counts.skipped_dedup += 1;
+      continue;
+    }
+    eligible.push(r);
+  }
+
+  // Prioritise non-legislation.gov.uk hosts — those have no daily cron
+  // and Perplexity is their only freshness signal.
+  eligible.sort((a, b) => {
+    const aLeg = isLegislationGovUkUrl(a.source_url) ? 1 : 0;
+    const bLeg = isLegislationGovUkUrl(b.source_url) ? 1 : 0;
+    return aLeg - bLeg; // non-leg (0) first
+  });
+
+  const queue = eligible.slice(0, HARD_CAP);
+
+  const cronSecret = process.env.CRON_SECRET || '';
+  const origin =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    `https://${request.headers.get('host') || 'paybacker.co.uk'}`;
+
+  await runWithConcurrency(queue, CONCURRENCY, async (ref) => {
+    counts.scanned += 1;
+    const result = await callVerify(origin, cronSecret, ref.id);
+    if (result.ok) {
+      counts.reverified_ok += 1;
+      // Touch the freshness check stamp so the next sweep can dedup
+      // even when /verify itself didn't update freshness columns.
+      await admin
+        .from('legal_references')
+        .update({ last_freshness_check_at: new Date().toISOString() })
+        .eq('id', ref.id);
+    } else {
+      counts.errors += 1;
+    }
+  });
+
+  return NextResponse.json({
+    ok: true,
+    eligible: eligible.length,
+    queue: queue.length,
+    counts,
+  });
+}

--- a/src/app/dashboard/admin/legal-refs/PendingCorrectionsSection.tsx
+++ b/src/app/dashboard/admin/legal-refs/PendingCorrectionsSection.tsx
@@ -227,6 +227,15 @@ export default function PendingCorrectionsSection() {
                       proposed by {c.proposer} · {new Date(c.proposed_at).toLocaleString('en-GB')}
                       {c.cost_gbp != null && ` · £${c.cost_gbp.toFixed(4)}`}
                     </p>
+                    {/* Amendments-sweep proposals are XML-hash drift signals
+                        (high trust, deterministic) — distinguish them from
+                        Perplexity-verdict proposals so the founder knows
+                        what they're approving. Added 2026-05-01. */}
+                    {c.proposer && c.proposer.includes('amendments-sweep') && (
+                      <span className="inline-flex items-center gap-1 mt-1 text-[11px] font-semibold px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 border border-blue-300">
+                        🔁 amendments sweep
+                      </span>
+                    )}
                   </div>
                   <span
                     className={`inline-flex text-xs font-medium px-2.5 py-1 rounded-full border ${CONFIDENCE_CLASS[c.confidence]}`}

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -31,8 +31,37 @@ interface LegalRef {
   verification_notes: string | null;
   verified_url: string | null;
   auto_corrected?: boolean | null;
+  // Freshness pipeline columns (added 2026-05-01 — see migration
+  // 20260502000000_legal_ref_freshness.sql). Optional in the typed
+  // surface so older snapshot data still parses.
+  source_xml_hash?: string | null;
+  last_freshness_check_at?: string | null;
+  is_stale?: boolean | null;
+  unapplied_effects?: boolean | null;
+  superseded_by?: string | null;
   created_at: string;
 }
+
+/**
+ * Freshness badge tier for a ref. Green when last freshness check was
+ * within 7 days, amber 7-30, red >30 days or never checked. The check
+ * stamp is independent of `verification_status` — it tracks how
+ * recently we re-fetched the canonical source, not whether the citation
+ * passed verification.
+ */
+function freshnessTier(checkedAt: string | null | undefined): 'green' | 'amber' | 'red' {
+  if (!checkedAt) return 'red';
+  const ageDays = (Date.now() - new Date(checkedAt).getTime()) / (1000 * 60 * 60 * 24);
+  if (ageDays < 7) return 'green';
+  if (ageDays < 30) return 'amber';
+  return 'red';
+}
+
+const FRESHNESS_BADGE: Record<'green' | 'amber' | 'red', string> = {
+  green: 'bg-green-500/10 text-green-700 border-green-300',
+  amber: 'bg-amber-500/10 text-amber-700 border-amber-300',
+  red: 'bg-red-500/10 text-red-700 border-red-300',
+};
 
 const PERPLEXITY_COST_PER_ROW_GBP = 0.005 * 0.79; // sonar-pro flat rate × USD→GBP
 
@@ -174,6 +203,9 @@ export default function LegalRefsAdminPage() {
   const [lastSyncRun, setLastSyncRun] = useState<{ at: string; ok: boolean; failedPhases: string[] } | null>(null);
   const [allRefsExpanded, setAllRefsExpanded] = useState<boolean>(false);
   const [expandedNotes, setExpandedNotes] = useState<Set<string>>(new Set());
+  // Freshness pipeline filters (added 2026-05-01).
+  const [filterStaleOnly, setFilterStaleOnly] = useState<boolean>(false);
+  const [filterUnappliedOnly, setFilterUnappliedOnly] = useState<boolean>(false);
 
   useEffect(() => {
     if (!opToast) return;
@@ -663,6 +695,8 @@ export default function LegalRefsAdminPage() {
       if (!needsReview(r)) return false;
     } else if (filterStatus !== 'all' && r.verification_status !== filterStatus) return false;
     if (filterCategory !== 'all' && r.category !== filterCategory) return false;
+    if (filterStaleOnly && !r.is_stale) return false;
+    if (filterUnappliedOnly && !r.unapplied_effects) return false;
     if (search) {
       const q = search.toLowerCase();
       return (
@@ -1186,9 +1220,27 @@ export default function LegalRefsAdminPage() {
             <option key={cat} value={cat}>{CATEGORY_LABELS[cat] || cat}</option>
           ))}
         </select>
-        {(search || filterStatus !== 'all' || filterCategory !== 'all') && (
+        <label className="flex items-center gap-2 px-3 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={filterStaleOnly}
+            onChange={(e) => setFilterStaleOnly(e.target.checked)}
+            className="h-4 w-4"
+          />
+          Show stale only
+        </label>
+        <label className="flex items-center gap-2 px-3 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-700 text-sm cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={filterUnappliedOnly}
+            onChange={(e) => setFilterUnappliedOnly(e.target.checked)}
+            className="h-4 w-4"
+          />
+          Unapplied effects only
+        </label>
+        {(search || filterStatus !== 'all' || filterCategory !== 'all' || filterStaleOnly || filterUnappliedOnly) && (
           <button
-            onClick={() => { setSearch(''); setFilterStatus('all'); setFilterCategory('all'); }}
+            onClick={() => { setSearch(''); setFilterStatus('all'); setFilterCategory('all'); setFilterStaleOnly(false); setFilterUnappliedOnly(false); }}
             className="px-4 py-2.5 bg-white border border-slate-200 rounded-xl text-slate-600 hover:text-slate-900 text-sm transition-colors"
           >
             Clear
@@ -1207,6 +1259,7 @@ export default function LegalRefsAdminPage() {
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Law / Section</th>
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Category</th>
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide">Status</th>
+                <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide" title="How recently the canonical source was re-fetched. Green <7d, amber 7-30d, red >30d or never.">Freshness</th>
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden lg:table-cell">Last verified</th>
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden xl:table-cell">Strength</th>
                 <th className="text-left px-5 py-3 text-xs font-semibold text-slate-600 uppercase tracking-wide hidden xl:table-cell" title="How many B2C letters / B2B disputes are currently citing this ref. Wired in PR γ.">Block effect</th>
@@ -1281,6 +1334,38 @@ export default function LegalRefsAdminPage() {
                           ⚠ Auto-corrected — verify
                         </div>
                       )}
+                    </td>
+                    <td className="px-5 py-4">
+                      {(() => {
+                        const tier = freshnessTier(ref.last_freshness_check_at);
+                        return (
+                          <div className="flex flex-col gap-1">
+                            <span
+                              className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border ${FRESHNESS_BADGE[tier]}`}
+                              title={ref.last_freshness_check_at ? `Last freshness check: ${formatDate(ref.last_freshness_check_at)}` : 'Never checked'}
+                            >
+                              <Clock className="h-3 w-3" />
+                              {relativeTime(ref.last_freshness_check_at ?? null)}
+                            </span>
+                            {ref.unapplied_effects && (
+                              <span
+                                className="inline-flex items-center gap-1 text-[11px] font-bold px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 border border-amber-300"
+                                title="<ukm:UnappliedEffects> on legislation.gov.uk — pending change not yet incorporated."
+                              >
+                                ❗ Unapplied effects
+                              </span>
+                            )}
+                            {ref.is_stale && (
+                              <span
+                                className="inline-flex items-center gap-1 text-[11px] font-bold px-2 py-0.5 rounded-full bg-red-100 text-red-800 border border-red-300"
+                                title="Drift detected by amendments sweep — pending correction queued for review."
+                              >
+                                ⚠️ STALE — pending correction
+                              </span>
+                            )}
+                          </div>
+                        );
+                      })()}
                     </td>
                     <td className="px-5 py-4 hidden lg:table-cell">
                       <div className="flex items-center gap-1.5 text-slate-600 text-xs">

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -228,6 +228,26 @@ export interface DisputeResponse {
     data_grounded: boolean;
     historical_signal?: { merchant_win_rate: number; sample_size: number };
   } | null;
+  /**
+   * Per-citation freshness metadata. One entry per cited
+   * `legal_references` row, surfacing how recently we re-verified the
+   * citation and which authoritative source provided the verdict.
+   *
+   * Additive optional field — never required, never breaking. The
+   * dispute-engine omits the field entirely on responses that pre-date
+   * the freshness pipeline rather than emitting an empty array, so
+   * back-compat is preserved for callers that gate on `in` checks.
+   *
+   * Shipped 2026-05-01 alongside the legal-refs freshness pipeline
+   * (daily legislation.gov.uk amendments sweep + weekly Perplexity /
+   * GOV.UK / Find Case Law reverify).
+   */
+  legal_basis_freshness?: Array<{
+    ref_id: string;
+    last_verified_at: string | null;
+    source: 'legislation.gov.uk' | 'perplexity' | 'find-case-law' | 'cma-case';
+    is_stale: boolean;
+  }>;
 }
 
 export interface PreflightResult {
@@ -478,7 +498,7 @@ async function fetchVerifiedRefs(scenario: string): Promise<any[]> {
   // /coverage page and the consumer engine's ground truth.
   const { data } = await supabase
     .from('legal_references')
-    .select('law_name, section, summary, full_text, source_url, category')
+    .select('id, law_name, section, summary, full_text, source_url, category, is_stale, last_freshness_check_at, last_verified')
     .in('verification_status', CITATION_ELIGIBLE_STATUSES as unknown as string[])
     .limit(500);
   if (!data || data.length === 0) return [];
@@ -948,6 +968,35 @@ export async function resolveDispute(req: DisputeRequest): Promise<DisputeRespon
       }));
     if (matched.length > 0) {
       void supabase.from('legal_ref_usages').insert(matched);
+    }
+    // Populate legal_basis_freshness — additive optional field. One
+    // entry per cited ref so callers that care about citation
+    // freshness can surface "verified Xd ago" in their CRM. Best-effort:
+    // empty/missing freshness columns just produce nulls.
+    if (matched.length > 0) {
+      const freshness: NonNullable<DisputeResponse['legal_basis_freshness']> = [];
+      for (const r of verifiedRefs as Array<Record<string, unknown>>) {
+        if (!r?.id) continue;
+        const sourceUrl = typeof r.source_url === 'string' ? r.source_url : '';
+        const isStale = !!(r.is_stale as boolean | undefined);
+        const lastVerified =
+          (r.last_freshness_check_at as string | null | undefined) ??
+          (r.last_verified as string | null | undefined) ??
+          null;
+        let source: 'legislation.gov.uk' | 'perplexity' | 'find-case-law' | 'cma-case' = 'perplexity';
+        if (sourceUrl.includes('legislation.gov.uk')) source = 'legislation.gov.uk';
+        else if (sourceUrl.includes('caselaw.nationalarchives.gov.uk')) source = 'find-case-law';
+        else if (sourceUrl.includes('gov.uk/cma-cases')) source = 'cma-case';
+        freshness.push({
+          ref_id: String(r.id),
+          last_verified_at: lastVerified,
+          source,
+          is_stale: isStale,
+        });
+      }
+      if (freshness.length > 0) {
+        response.legal_basis_freshness = freshness;
+      }
     }
   } catch (e) {
     console.warn('[legal_ref_usages] B2B insert failed (non-fatal):', e);

--- a/src/lib/legal-data/__tests__/find-case-law.test.ts
+++ b/src/lib/legal-data/__tests__/find-case-law.test.ts
@@ -1,0 +1,131 @@
+// src/lib/legal-data/__tests__/find-case-law.test.ts
+//
+// Run with:
+//   node --experimental-strip-types --test src/lib/legal-data/__tests__/find-case-law.test.ts
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  fetchAtomRaw,
+  isFindCaseLawUrl,
+  isProductionEnabled,
+  parseAtomFeed,
+  searchAtom,
+  searchUrl,
+} from '../find-case-law.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE = readFileSync(
+  join(__dirname, 'fixtures', 'find-case-law-atom.xml'),
+  'utf8',
+);
+
+describe('searchUrl', () => {
+  it('appends query', () => {
+    assert.equal(
+      searchUrl('PPI'),
+      'https://caselaw.nationalarchives.gov.uk/atom.xml?query=PPI',
+    );
+  });
+  it('falls through to bare atom feed when no query', () => {
+    assert.equal(
+      searchUrl(''),
+      'https://caselaw.nationalarchives.gov.uk/atom.xml',
+    );
+  });
+});
+
+describe('parseAtomFeed', () => {
+  it('parses TNA atom entries with court + summary', () => {
+    const hits = parseAtomFeed(FIXTURE);
+    assert.equal(hits.length, 2);
+    assert.equal(hits[0].title, 'Smith v Example Bank plc [2026] EWCA Civ 123');
+    assert.equal(
+      hits[0].uri,
+      'https://caselaw.nationalarchives.gov.uk/ewca/civ/2026/123',
+    );
+    assert.equal(hits[0].court, 'EWCA-Civil');
+    assert.match(hits[0].summary ?? '', /PPI/);
+  });
+
+  it('returns [] on empty input', () => {
+    assert.deepEqual(parseAtomFeed(''), []);
+  });
+});
+
+describe('isFindCaseLawUrl', () => {
+  it('matches TNA host', () => {
+    assert.equal(
+      isFindCaseLawUrl('https://caselaw.nationalarchives.gov.uk/x'),
+      true,
+    );
+    assert.equal(isFindCaseLawUrl('https://example.com/x'), false);
+    assert.equal(isFindCaseLawUrl(null), false);
+  });
+});
+
+describe('isProductionEnabled / searchAtom (gated)', () => {
+  const realFetch = globalThis.fetch;
+  before(() => {
+    delete process.env.FIND_CASE_LAW_LICENCE_ACCEPTED;
+    // @ts-expect-error — augment for test
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      text: async () => FIXTURE,
+    });
+  });
+  after(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.FIND_CASE_LAW_LICENCE_ACCEPTED;
+  });
+
+  it('returns [] while the licence env var is unset (dormant)', async () => {
+    assert.equal(isProductionEnabled(), false);
+    const hits = await searchAtom('PPI');
+    assert.deepEqual(hits, []);
+  });
+
+  it('returns parsed hits when the gate is bypassed (test path)', async () => {
+    const hits = await searchAtom('PPI', { bypassLicenceGate: true });
+    assert.equal(hits.length, 2);
+  });
+
+  it('flips on when the env var is "true"', async () => {
+    process.env.FIND_CASE_LAW_LICENCE_ACCEPTED = 'true';
+    assert.equal(isProductionEnabled(), true);
+    const hits = await searchAtom('PPI');
+    assert.equal(hits.length, 2);
+    delete process.env.FIND_CASE_LAW_LICENCE_ACCEPTED;
+  });
+
+  it('rejects truthy-looking values that are not literal "true"', async () => {
+    process.env.FIND_CASE_LAW_LICENCE_ACCEPTED = '1';
+    assert.equal(isProductionEnabled(), false);
+    process.env.FIND_CASE_LAW_LICENCE_ACCEPTED = 'yes';
+    assert.equal(isProductionEnabled(), false);
+    delete process.env.FIND_CASE_LAW_LICENCE_ACCEPTED;
+  });
+});
+
+describe('fetchAtomRaw', () => {
+  const realFetch = globalThis.fetch;
+  after(() => {
+    globalThis.fetch = realFetch;
+  });
+  it('returns null on non-ok response', async () => {
+    // @ts-expect-error — augment for test
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 503,
+      text: async () => '',
+    });
+    const xml = await fetchAtomRaw('PPI');
+    assert.equal(xml, null);
+  });
+});

--- a/src/lib/legal-data/__tests__/fixtures/cma-case.json
+++ b/src/lib/legal-data/__tests__/fixtures/cma-case.json
@@ -1,0 +1,12 @@
+{
+  "base_path": "/cma-cases/example-merger-investigation",
+  "title": "Example Co / Other Co merger inquiry",
+  "description": "CMA Phase 1 decision on the anticipated acquisition.",
+  "document_type": "cma_case",
+  "public_updated_at": "2026-04-15T10:00:00Z",
+  "first_published_at": "2026-01-10T09:30:00Z",
+  "details": {
+    "body": "<p>The CMA has decided not to refer the merger for a Phase 2 investigation.</p>"
+  },
+  "links": {}
+}

--- a/src/lib/legal-data/__tests__/fixtures/cma-search.json
+++ b/src/lib/legal-data/__tests__/fixtures/cma-search.json
@@ -1,0 +1,20 @@
+{
+  "results": [
+    {
+      "title": "Example Co / Other Co merger inquiry",
+      "link": "/cma-cases/example-merger-investigation",
+      "format": "cma_case",
+      "public_timestamp": "2026-04-15T10:00:00Z",
+      "description": "CMA Phase 1 decision on the anticipated acquisition.",
+      "organisations": [{ "title": "Competition and Markets Authority" }]
+    },
+    {
+      "title": "Another Co market study",
+      "link": "/cma-cases/another-market-study",
+      "format": "cma_case",
+      "public_timestamp": "2026-03-20T09:00:00Z",
+      "description": null,
+      "organisations": []
+    }
+  ]
+}

--- a/src/lib/legal-data/__tests__/fixtures/find-case-law-atom.xml
+++ b/src/lib/legal-data/__tests__/fixtures/find-case-law-atom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:tna="https://caselaw.nationalarchives.gov.uk/schema">
+  <title>Find Case Law — recent judgments</title>
+  <updated>2026-04-30T12:00:00Z</updated>
+  <entry>
+    <id>https://caselaw.nationalarchives.gov.uk/ewca/civ/2026/123</id>
+    <title>Smith v Example Bank plc [2026] EWCA Civ 123</title>
+    <link rel="alternate" href="https://caselaw.nationalarchives.gov.uk/ewca/civ/2026/123" />
+    <updated>2026-04-29T15:30:00Z</updated>
+    <published>2026-04-29T15:30:00Z</published>
+    <tna:court>EWCA-Civil</tna:court>
+    <summary>Appeal allowed in part; consumer credit dispute over PPI charges remitted.</summary>
+  </entry>
+  <entry>
+    <id>https://caselaw.nationalarchives.gov.uk/ukut/aac/2026/45</id>
+    <title>Doe v HMRC [2026] UKUT 45 (AAC)</title>
+    <link rel="alternate" href="https://caselaw.nationalarchives.gov.uk/ukut/aac/2026/45" />
+    <updated>2026-04-20T09:15:00Z</updated>
+    <published>2026-04-20T09:15:00Z</published>
+    <tna:court>UKUT-AAC</tna:court>
+    <summary>Tax credit overpayment; appeal dismissed.</summary>
+  </entry>
+</feed>

--- a/src/lib/legal-data/__tests__/freshness.test.ts
+++ b/src/lib/legal-data/__tests__/freshness.test.ts
@@ -1,0 +1,176 @@
+// src/lib/legal-data/__tests__/freshness.test.ts
+//
+// Tests for the freshness-pipeline primitives:
+//   - normaliseXmlForHash
+//   - hashLegislationDoc
+//   - amendments-sweep correction-shape (logical: hash diff ⇒ insert)
+//   - reverify dedup window (skip if last_freshness_check_at < 6 days ago)
+//
+// We test the pure logic — wiring through Next route handlers + Supabase
+// is covered separately by integration smoke (out of scope here).
+//
+// Run with:
+//   node --experimental-strip-types --test src/lib/legal-data/__tests__/freshness.test.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  hashLegislationDoc,
+  normaliseXmlForHash,
+  parseLegislationXml,
+  type LegislationDoc,
+} from '../legislation-gov-uk.ts';
+
+const SAMPLE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Legislation xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ukm="http://www.legislation.gov.uk/namespaces/metadata">
+  <ukm:Metadata>
+    <dc:title>Consumer Rights Act 2015</dc:title>
+    <ukm:DocumentVersion date="2026-04-01"/>
+    <ukm:Modified Date="2026-04-01T12:00:00Z"/>
+  </ukm:Metadata>
+  <Section>
+    <Number>9</Number>
+    <Text>Goods to be of satisfactory quality.</Text>
+  </Section>
+</Legislation>`;
+
+const SAMPLE_XML_WITH_REPUBLISHED_TIMESTAMP = SAMPLE_XML
+  .replace('2026-04-01"/>', '2026-04-15"/>')
+  .replace('2026-04-01T12:00:00Z"', '2026-04-15T09:00:00Z"');
+
+const SAMPLE_XML_WITH_REAL_AMENDMENT = SAMPLE_XML.replace(
+  'Goods to be of satisfactory quality.',
+  'Goods to be of satisfactory quality and free from defects.',
+);
+
+describe('normaliseXmlForHash', () => {
+  it('strips XML comments', () => {
+    const out = normaliseXmlForHash('<a>hi <!-- comment --> there</a>');
+    assert.ok(!out.includes('comment'));
+  });
+
+  it('collapses whitespace between tags', () => {
+    const out = normaliseXmlForHash('<a>   <b>x</b>\n\n   </a>');
+    assert.equal(out, '<a><b>x</b></a>');
+  });
+
+  it('drops volatile <ukm:DocumentVersion> + <ukm:Modified> stamps', () => {
+    const a = normaliseXmlForHash(SAMPLE_XML);
+    const b = normaliseXmlForHash(SAMPLE_XML_WITH_REPUBLISHED_TIMESTAMP);
+    assert.equal(
+      a,
+      b,
+      'a republish that only changes the metadata stamp should hash identically',
+    );
+  });
+});
+
+describe('hashLegislationDoc', () => {
+  it('produces deterministic sha256 hex of section text', async () => {
+    const doc = parseLegislationXml(
+      SAMPLE_XML,
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml',
+    );
+    const h1 = await hashLegislationDoc(doc);
+    const h2 = await hashLegislationDoc(doc);
+    assert.equal(h1, h2);
+    assert.match(h1, /^[a-f0-9]{64}$/);
+  });
+
+  it('flips the hash on a real text amendment', async () => {
+    const before = parseLegislationXml(
+      SAMPLE_XML,
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml',
+    );
+    const after = parseLegislationXml(
+      SAMPLE_XML_WITH_REAL_AMENDMENT,
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml',
+    );
+    const hBefore = await hashLegislationDoc(before);
+    const hAfter = await hashLegislationDoc(after);
+    assert.notEqual(
+      hBefore,
+      hAfter,
+      'real text change should produce a different hash',
+    );
+  });
+
+  it('does NOT flip the hash on a republish-only metadata change', async () => {
+    // We hash sectionText preferentially — but this also doubles as a
+    // safety net if a future ref lands without a section number, where
+    // we fall back to normaliseXmlForHash(raw).
+    const synthA: LegislationDoc = {
+      title: 't',
+      fullCitation: 't',
+      sectionText: null,
+      sectionNumber: null,
+      inForceOn: null,
+      lastAmended: null,
+      sourceUrl: 'x',
+      hasUnappliedEffects: false,
+      raw: SAMPLE_XML,
+    };
+    const synthB: LegislationDoc = { ...synthA, raw: SAMPLE_XML_WITH_REPUBLISHED_TIMESTAMP };
+    const hA = await hashLegislationDoc(synthA);
+    const hB = await hashLegislationDoc(synthB);
+    assert.equal(hA, hB);
+  });
+});
+
+describe('amendments-sweep correction shape (logical)', () => {
+  it('hash diff produces a proposal payload with proposer + source_xml_hash + status=pending', async () => {
+    // Synthesise the row + verdict shape the cron will INSERT.
+    const before = parseLegislationXml(
+      SAMPLE_XML,
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml',
+    );
+    const after = parseLegislationXml(
+      SAMPLE_XML_WITH_REAL_AMENDMENT,
+      'https://www.legislation.gov.uk/ukpga/2015/15/section/9/data.xml',
+    );
+    const oldHash = await hashLegislationDoc(before);
+    const newHash = await hashLegislationDoc(after);
+    assert.notEqual(oldHash, newHash);
+
+    const proposal = {
+      proposer: 'legislation-gov-uk-amendments-sweep',
+      source_xml_hash: newHash,
+      source_host: 'legislation.gov.uk',
+      status: 'pending',
+      proposed_status: 'updated',
+      cost_gbp: 0,
+      confidence: 'high' as const,
+    };
+    assert.equal(proposal.status, 'pending');
+    assert.equal(proposal.cost_gbp, 0);
+    assert.equal(proposal.confidence, 'high');
+    assert.match(proposal.source_xml_hash, /^[a-f0-9]{64}$/);
+    assert.equal(proposal.source_host, 'legislation.gov.uk');
+  });
+});
+
+describe('reverify dedup window', () => {
+  // Mirror the inline predicate used by /api/cron/legal-refs-reverify:
+  //   skip if last_freshness_check_at > Date.now() - 6 days
+  function shouldSkip(checkedAt: string | null): boolean {
+    if (!checkedAt) return false;
+    const dedupCutoff = Date.now() - 6 * 24 * 60 * 60 * 1000;
+    return new Date(checkedAt).getTime() > dedupCutoff;
+  }
+
+  it('skips refs checked 1 day ago', () => {
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    assert.equal(shouldSkip(oneDayAgo), true);
+  });
+
+  it('keeps refs checked 7 days ago', () => {
+    const sevenDaysAgo = new Date(
+      Date.now() - 7 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    assert.equal(shouldSkip(sevenDaysAgo), false);
+  });
+
+  it('keeps refs that were never checked', () => {
+    assert.equal(shouldSkip(null), false);
+  });
+});

--- a/src/lib/legal-data/__tests__/gov-uk-content.test.ts
+++ b/src/lib/legal-data/__tests__/gov-uk-content.test.ts
@@ -1,0 +1,115 @@
+// src/lib/legal-data/__tests__/gov-uk-content.test.ts
+//
+// Mirrors legislation-gov-uk.test.ts: node:test, no jest/vitest. Run with:
+//   node --experimental-strip-types --test src/lib/legal-data/__tests__/gov-uk-content.test.ts
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  fetchContent,
+  isGovUkUrl,
+  searchByDocumentType,
+  discoverCmaCases,
+} from '../gov-uk-content.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SEARCH_FIXTURE = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures', 'cma-search.json'), 'utf8'),
+);
+const CONTENT_FIXTURE = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures', 'cma-case.json'), 'utf8'),
+);
+
+const realFetch = globalThis.fetch;
+
+function mockFetch(handler: (url: string) => { ok: boolean; body: unknown }) {
+  // @ts-expect-error — augment for test
+  globalThis.fetch = async (input: string) => {
+    const url = typeof input === 'string' ? input : String(input);
+    const { ok, body } = handler(url);
+    return {
+      ok,
+      status: ok ? 200 : 500,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    } as unknown as Response;
+  };
+}
+
+describe('isGovUkUrl', () => {
+  it('accepts gov.uk and www.gov.uk', () => {
+    assert.equal(isGovUkUrl('https://www.gov.uk/cma-cases/x'), true);
+    assert.equal(isGovUkUrl('https://gov.uk/cma-cases/x'), true);
+  });
+  it('rejects non-gov hosts', () => {
+    assert.equal(isGovUkUrl('https://example.com'), false);
+    assert.equal(isGovUkUrl(null), false);
+    assert.equal(isGovUkUrl(''), false);
+  });
+});
+
+describe('searchByDocumentType', () => {
+  before(() => mockFetch(() => ({ ok: true, body: SEARCH_FIXTURE })));
+  after(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('parses search hits with web_url + organisations', async () => {
+    const hits = await searchByDocumentType('merger', {
+      documentType: 'cma_case',
+      limit: 10,
+    });
+    assert.equal(hits.length, 2);
+    assert.equal(hits[0].title, 'Example Co / Other Co merger inquiry');
+    assert.equal(
+      hits[0].webUrl,
+      'https://www.gov.uk/cma-cases/example-merger-investigation',
+    );
+    assert.deepEqual(hits[0].organisations, ['Competition and Markets Authority']);
+  });
+});
+
+describe('fetchContent', () => {
+  before(() => mockFetch(() => ({ ok: true, body: CONTENT_FIXTURE })));
+  after(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('returns typed content with web_url and body', async () => {
+    const c = await fetchContent('/cma-cases/example-merger-investigation');
+    assert.ok(c, 'expected content');
+    assert.equal(c?.document_type, 'cma_case');
+    assert.equal(c?.title, 'Example Co / Other Co merger inquiry');
+    assert.match(c?.web_url ?? '', /^https:\/\/www\.gov\.uk/);
+    assert.match(c?.body ?? '', /Phase 2 investigation/);
+  });
+
+  it('rejects non-gov hosts', async () => {
+    const c = await fetchContent('https://example.com/x');
+    assert.equal(c, null);
+  });
+});
+
+describe('discoverCmaCases', () => {
+  before(() =>
+    mockFetch((url) => ({
+      ok: true,
+      body: url.includes('/api/search.json') ? SEARCH_FIXTURE : CONTENT_FIXTURE,
+    })),
+  );
+  after(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('returns hydrated hits up to limit', async () => {
+    const out = await discoverCmaCases('merger', { limit: 1 });
+    assert.equal(out.length, 1);
+    assert.ok(out[0].content, 'expected hydrated content');
+    assert.equal(out[0].content?.document_type, 'cma_case');
+  });
+});

--- a/src/lib/legal-data/find-case-law.ts
+++ b/src/lib/legal-data/find-case-law.ts
@@ -1,0 +1,197 @@
+/**
+ * src/lib/legal-data/find-case-law.ts
+ *
+ * Typed client for The National Archives' Find Case Law service.
+ * Public Atom feed: https://caselaw.nationalarchives.gov.uk/atom.xml
+ * Programmatic re-use is governed by a free transactional licence
+ * (5-yr term, ~10 working-day approval). The licence governs
+ * COMPUTATIONAL re-use, not copyright (the data itself is OGL v3.0).
+ *
+ * IMPORTANT — DORMANT UNTIL LICENCE IS APPROVED:
+ *   The founder has not yet completed the Find Case Law transactional
+ *   licence application. Until that licence is granted AND the env
+ *   var `FIND_CASE_LAW_LICENCE_ACCEPTED=true` is set, the production
+ *   wiring (discovery cron leg, dispute-engine grounding) MUST NOT
+ *   call this client. The `isProductionEnabled()` guard below is the
+ *   single source of truth for that gate.
+ *
+ *   The client itself, the parsers, and the tests are built so that
+ *   the moment the licence lands, flipping the env var enables the
+ *   pipeline without a redeploy of new code.
+ *
+ * To apply for the licence:
+ *   email caselawlicence@nationalarchives.gov.uk
+ *   https://caselaw.nationalarchives.gov.uk/licence-application-process
+ *
+ * Output rights:
+ *   Judgments and decisions are © Crown copyright, OGL v3.0. Always
+ *   retain the canonical `uri` for citation use.
+ */
+
+const ATOM_HOST = 'https://caselaw.nationalarchives.gov.uk';
+const ATOM_PATH = '/atom.xml';
+
+const USER_AGENT = 'paybacker-compliance-bot/1.0 (+https://paybacker.co.uk)';
+
+export interface CaseLawHit {
+  /** Canonical URI on caselaw.nationalarchives.gov.uk. */
+  uri: string;
+  /** Plain-language title (court + parties). */
+  title: string;
+  /** Court / tribunal label, e.g. "EWCA-Civil". */
+  court: string | null;
+  /** Date judgment was handed down (ISO). */
+  publishedAt: string | null;
+  /** Short summary / catchword block where present. */
+  summary: string | null;
+}
+
+/**
+ * Production gate. `false` whenever the env var is unset OR set to
+ * anything other than the literal string "true". This is intentionally
+ * strict so a misconfiguration ("yes" / "1") fails closed.
+ *
+ * Callers in production (cron legs, dispute engine) MUST guard every
+ * call to this client with `isProductionEnabled()`. Test callers can
+ * use the parsers + low-level fetcher freely — only the public
+ * `searchAtom` wrapper enforces the gate.
+ */
+export function isProductionEnabled(): boolean {
+  return process.env.FIND_CASE_LAW_LICENCE_ACCEPTED === 'true';
+}
+
+/**
+ * Build the Atom search URL for a given query.
+ * Example: searchUrl('PPI mis-selling') →
+ *   https://caselaw.nationalarchives.gov.uk/atom.xml?query=PPI+mis-selling
+ */
+export function searchUrl(query: string): string {
+  const params = new URLSearchParams();
+  if (query && query.trim().length > 0) params.set('query', query.trim());
+  const qs = params.toString();
+  return qs ? `${ATOM_HOST}${ATOM_PATH}?${qs}` : `${ATOM_HOST}${ATOM_PATH}`;
+}
+
+/**
+ * Parse an Atom feed from Find Case Law. Exported for tests.
+ * Tolerant to the slight schema differences between the global
+ * "recent judgments" feed and the per-query search feeds.
+ */
+export function parseAtomFeed(xml: string): CaseLawHit[] {
+  if (!xml) return [];
+  const out: CaseLawHit[] = [];
+  const entryRe = /<entry\b[^>]*>([\s\S]*?)<\/entry>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = entryRe.exec(xml))) {
+    const block = m[1];
+    const title = firstTagText(block, 'title') || '';
+    // <link rel="alternate" href="..." /> takes precedence; fall back
+    // to <id> which on Find Case Law is the same canonical URI.
+    const link =
+      firstAttr(block, 'link', 'href') || firstTagText(block, 'id') || '';
+    if (!title || !link) continue;
+    const published =
+      firstTagText(block, 'published') || firstTagText(block, 'updated');
+    const court =
+      firstTagText(block, 'tna:court') ||
+      firstAttr(block, 'category', 'term') ||
+      null;
+    const summary =
+      firstTagText(block, 'summary') || firstTagText(block, 'content') || null;
+    out.push({
+      uri: link,
+      title: title.trim(),
+      court,
+      publishedAt: published || null,
+      summary: summary ? summary.replace(/\s+/g, ' ').trim() : null,
+    });
+  }
+  return out;
+}
+
+function firstTagText(xml: string, tag: string): string | null {
+  const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'i');
+  const mm = xml.match(re);
+  if (!mm) return null;
+  return mm[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim() || null;
+}
+
+function firstAttr(xml: string, tag: string, attr: string): string | null {
+  const re = new RegExp(
+    `<${tag}\\b[^>]*\\b${attr}=("([^"]*)"|'([^']*)')`,
+    'i',
+  );
+  const mm = xml.match(re);
+  if (!mm) return null;
+  return (mm[2] ?? mm[3] ?? null) || null;
+}
+
+/**
+ * Public search wrapper.
+ *
+ * GUARDED by the licence env var. Returns an empty array — and logs a
+ * single info-level note — whenever the licence has not been accepted.
+ * That keeps the calling cron/dispute-engine paths green during the
+ * 10-day approval window without requiring caller code changes.
+ *
+ * For tests, call `fetchAtomRaw` + `parseAtomFeed` directly.
+ */
+export async function searchAtom(
+  query: string,
+  opts: { signal?: AbortSignal; bypassLicenceGate?: boolean } = {},
+): Promise<CaseLawHit[]> {
+  if (!opts.bypassLicenceGate && !isProductionEnabled()) {
+    console.info(
+      '[find-case-law] dormant — FIND_CASE_LAW_LICENCE_ACCEPTED is not "true". ' +
+        'Apply via caselawlicence@nationalarchives.gov.uk; expect ~10 working days.',
+    );
+    return [];
+  }
+  const xml = await fetchAtomRaw(query, opts.signal);
+  if (!xml) return [];
+  return parseAtomFeed(xml);
+}
+
+/**
+ * Low-level fetcher exposed for tests + tooling. Returns the raw Atom
+ * XML or `null` on network/HTTP error. Does NOT enforce the licence
+ * gate — `searchAtom` is the gated public wrapper.
+ */
+export async function fetchAtomRaw(
+  query: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  try {
+    const res = await fetch(searchUrl(query), {
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/atom+xml, application/xml',
+      },
+      signal,
+    });
+    if (!res.ok) return null;
+    const xml = await res.text();
+    return xml || null;
+  } catch (err) {
+    console.warn(
+      '[find-case-law] fetch failed',
+      query,
+      (err as Error)?.message,
+    );
+    return null;
+  }
+}
+
+/**
+ * Returns true if the URL is hosted on caselaw.nationalarchives.gov.uk.
+ * Useful for the discovery pipeline's source-typing branch.
+ */
+export function isFindCaseLawUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const u = new URL(url);
+    return u.hostname === 'caselaw.nationalarchives.gov.uk';
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/legal-data/gov-uk-content.ts
+++ b/src/lib/legal-data/gov-uk-content.ts
@@ -1,0 +1,253 @@
+/**
+ * src/lib/legal-data/gov-uk-content.ts
+ *
+ * Typed client for the GOV.UK Content API.
+ * Docs: https://content-api.publishing.service.gov.uk/reference.html
+ *
+ * Why: regulator decisions surfaced by the CMA (and OIM/SAU) live on
+ * gov.uk under the `cma_case` document type. There is no first-party
+ * legislation feed for these — but each case has a stable JSON
+ * representation at `https://www.gov.uk/api/content/{slug}` that we
+ * can ingest into the discovery pipeline as candidate
+ * `legal_references` rows tagged with `source_type='cma_case'`.
+ *
+ * Per `docs/legal-data-api-research-2026-05-01.md` §3, this is a
+ * SECONDARY source — the primary engine is legislation.gov.uk for
+ * statutes. We use this to enrich the regulator-decisions corner of
+ * the dataset, not to replace anything.
+ *
+ * Output rights: gov.uk content is Crown Copyright, available under
+ * the Open Government Licence v3.0. Callers MUST retain `web_url` for
+ * attribution.
+ *
+ * Compliance: all results from this client flow through
+ * `legal_ref_candidates` (discovery) — never auto-applied. The founder
+ * approves before anything reaches `legal_references`.
+ */
+
+const HOST = 'https://www.gov.uk';
+const SEARCH_HOST = 'https://www.gov.uk/api/search.json';
+const CONTENT_HOST = 'https://www.gov.uk/api/content';
+
+const USER_AGENT = 'paybacker-compliance-bot/1.0 (+https://paybacker.co.uk)';
+
+/** Document type filter — see https://docs.publishing.service.gov.uk/document-types.html */
+export type GovUkDocumentType =
+  | 'cma_case'
+  | 'cma_decision'
+  | 'fca_handbook'
+  | 'guidance'
+  | 'detailed_guide';
+
+export interface GovUkSearchHit {
+  title: string;
+  /** Slug-only path, e.g. "/cma-cases/example-case". */
+  link: string;
+  /** Full canonical URL on gov.uk. */
+  webUrl: string;
+  documentType: string | null;
+  publicUpdatedAt: string | null;
+  description: string | null;
+  organisations: string[];
+}
+
+export interface GovUkContent {
+  base_path: string;
+  title: string;
+  description: string | null;
+  document_type: string;
+  public_updated_at: string | null;
+  first_published_at: string | null;
+  /** Full URL `https://www.gov.uk{base_path}` for citation use. */
+  web_url: string;
+  /** Body text where present (gov.uk content has heterogeneous shapes). */
+  body: string | null;
+  /** Raw payload for callers needing fields the typed surface omits. */
+  raw: unknown;
+}
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<T | null> {
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/json',
+      },
+      signal,
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn('[gov-uk-content] fetch failed', url, (err as Error)?.message);
+    return null;
+  }
+}
+
+/**
+ * Search gov.uk for documents of the given type matching `query`.
+ *
+ * @example
+ *   await searchByDocumentType('payment protection insurance', {
+ *     documentType: 'cma_case',
+ *     limit: 20,
+ *   });
+ */
+export async function searchByDocumentType(
+  query: string,
+  opts: {
+    documentType: GovUkDocumentType;
+    limit?: number;
+    signal?: AbortSignal;
+  },
+): Promise<GovUkSearchHit[]> {
+  const limit = Math.max(1, Math.min(opts.limit ?? 20, 100));
+  const params = new URLSearchParams({
+    q: query.trim(),
+    count: String(limit),
+    filter_document_type: opts.documentType,
+    order: '-public_timestamp',
+  });
+  const url = `${SEARCH_HOST}?${params.toString()}`;
+  const json = await getJson<{
+    results?: Array<Record<string, unknown>>;
+  }>(url, opts.signal);
+  if (!json?.results) return [];
+  return json.results
+    .map((r): GovUkSearchHit | null => {
+      const link = typeof r.link === 'string' ? r.link : null;
+      const title = typeof r.title === 'string' ? r.title : null;
+      if (!link || !title) return null;
+      return {
+        title,
+        link,
+        webUrl: link.startsWith('http') ? link : `${HOST}${link}`,
+        documentType:
+          typeof r.format === 'string'
+            ? r.format
+            : typeof r.document_type === 'string'
+            ? r.document_type
+            : null,
+        publicUpdatedAt:
+          typeof r.public_timestamp === 'string' ? r.public_timestamp : null,
+        description:
+          typeof r.description === 'string' ? r.description : null,
+        organisations: Array.isArray(r.organisations)
+          ? r.organisations
+              .map((o: unknown) =>
+                o && typeof o === 'object' && 'title' in o
+                  ? String((o as { title?: unknown }).title ?? '')
+                  : '',
+              )
+              .filter(Boolean)
+          : [],
+      };
+    })
+    .filter((x): x is GovUkSearchHit => x !== null);
+}
+
+/**
+ * Fetch a specific gov.uk content item by base_path. Accepts a slug
+ * ("/cma-cases/example") or a full URL — both yield the same lookup.
+ */
+export async function fetchContent(
+  basePathOrUrl: string,
+  opts: { signal?: AbortSignal } = {},
+): Promise<GovUkContent | null> {
+  if (!basePathOrUrl) return null;
+  let basePath = basePathOrUrl;
+  try {
+    if (basePath.startsWith('http')) {
+      const u = new URL(basePath);
+      if (!u.hostname.endsWith('gov.uk')) return null;
+      basePath = u.pathname;
+    }
+  } catch {
+    return null;
+  }
+  if (!basePath.startsWith('/')) basePath = `/${basePath}`;
+  const url = `${CONTENT_HOST}${basePath}`;
+  const json = await getJson<Record<string, unknown>>(url, opts.signal);
+  if (!json) return null;
+
+  const documentType =
+    typeof json.document_type === 'string' ? json.document_type : '';
+  const title = typeof json.title === 'string' ? json.title : '';
+  if (!documentType || !title) return null;
+
+  const description =
+    typeof json.description === 'string' ? json.description : null;
+  const publicUpdatedAt =
+    typeof json.public_updated_at === 'string'
+      ? json.public_updated_at
+      : null;
+  const firstPublishedAt =
+    typeof json.first_published_at === 'string'
+      ? json.first_published_at
+      : null;
+
+  // Detail body lives at details.body (HTML) for most document types.
+  const details = (json.details as Record<string, unknown> | undefined) ?? {};
+  const body =
+    typeof details.body === 'string'
+      ? details.body
+      : Array.isArray(details.body)
+      ? (details.body
+          .map((b) =>
+            typeof b === 'object' && b && 'content' in b
+              ? String((b as { content?: unknown }).content ?? '')
+              : '',
+          )
+          .filter(Boolean)
+          .join('\n') || null)
+      : null;
+
+  return {
+    base_path: basePath,
+    title,
+    description,
+    document_type: documentType,
+    public_updated_at: publicUpdatedAt,
+    first_published_at: firstPublishedAt,
+    web_url: `${HOST}${basePath}`,
+    body,
+    raw: json,
+  };
+}
+
+/**
+ * Discovery convenience: returns CMA cases matching `query`, hydrated
+ * to full content. Caps the network fan-out at `limit` so the cron
+ * leg stays cheap even when the search returns hundreds of hits.
+ */
+export async function discoverCmaCases(
+  query: string,
+  opts: { limit?: number; signal?: AbortSignal } = {},
+): Promise<Array<GovUkSearchHit & { content: GovUkContent | null }>> {
+  const limit = Math.max(1, Math.min(opts.limit ?? 5, 25));
+  const hits = await searchByDocumentType(query, {
+    documentType: 'cma_case',
+    limit,
+    signal: opts.signal,
+  });
+  // Hydrate sequentially — gov.uk is generous but we don't want to
+  // burst with 25 parallel calls from a Vercel function. Truncate
+  // again to `limit` here in case the upstream search returns more
+  // than the requested count (rare, but the API is permissive).
+  const out: Array<GovUkSearchHit & { content: GovUkContent | null }> = [];
+  for (const hit of hits.slice(0, limit)) {
+    const content = await fetchContent(hit.link, { signal: opts.signal });
+    out.push({ ...hit, content });
+  }
+  return out;
+}
+
+/** True when the given URL is on gov.uk (any subpath). */
+export function isGovUkUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const u = new URL(url);
+    return u.hostname === 'www.gov.uk' || u.hostname === 'gov.uk';
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/legal-data/legislation-gov-uk.ts
+++ b/src/lib/legal-data/legislation-gov-uk.ts
@@ -440,6 +440,75 @@ export function fuzzyTitleMatch(a: string, b: string): boolean {
 }
 
 /**
+ * Normalise an Akoma-Ntoso XML document for hashing. We deliberately
+ * collapse whitespace, strip XML comments, and drop volatile metadata
+ * envelopes that change between fetches without reflecting a real
+ * legal-text amendment (e.g. `<ukm:DocumentVersion>` timestamps that
+ * tick on every republish). The remaining body is what we want to
+ * fingerprint section-by-section for the daily amendments sweep.
+ *
+ * Risks this addresses:
+ *   - Legislation.gov.uk republishes the same canonical text with a
+ *     fresh `<ukm:Modified>` stamp on infra rebuilds — hashing the raw
+ *     document would yield false-positive drifts. We strip those.
+ *   - XML comments and inter-tag whitespace also vary on republish.
+ *   - We DO retain element + attribute structure so a real change to
+ *     a `<Section>` body (e.g. text amendment, repeal) does flip the
+ *     hash.
+ */
+export function normaliseXmlForHash(xml: string): string {
+  if (!xml) return '';
+  return (
+    xml
+      // Strip XML comments outright.
+      .replace(/<!--[\s\S]*?-->/g, '')
+      // Strip volatile metadata blocks — these change without a legal
+      // amendment occurring (republish noise).
+      .replace(/<ukm:DocumentVersion\b[^>]*\/?>/gi, '')
+      .replace(/<ukm:Modified\b[^>]*\/?>/gi, '')
+      .replace(/<ukm:DataMigration\b[\s\S]*?<\/ukm:DataMigration>/gi, '')
+      .replace(/<ukm:Statistics\b[\s\S]*?<\/ukm:Statistics>/gi, '')
+      .replace(/<ukm:Stats\b[\s\S]*?<\/ukm:Stats>/gi, '')
+      // Collapse whitespace between tags and inside text nodes.
+      .replace(/>\s+</g, '><')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+/**
+ * SHA-256 hash of normalised section content. Uses Web Crypto where
+ * available (Edge / Node 20+), falling back to `node:crypto` in
+ * old-node test runs. Returns lowercase hex.
+ */
+export async function sha256Hex(input: string): Promise<string> {
+  const data = typeof input === 'string' ? new TextEncoder().encode(input) : input;
+  // Prefer the standard subtle API.
+  const subtle = (globalThis as { crypto?: Crypto }).crypto?.subtle;
+  if (subtle) {
+    const buf = await subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  // Fallback: node:crypto.
+  const nodeCrypto: typeof import('node:crypto') = await import('node:crypto');
+  return nodeCrypto.createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Hash the canonical body of a LegislationDoc for drift detection.
+ * Prefers the section text when a section was addressed; falls back
+ * to the full normalised XML when the doc represents a whole Act.
+ */
+export async function hashLegislationDoc(doc: LegislationDoc): Promise<string> {
+  const body = doc.sectionText && doc.sectionText.length > 0
+    ? doc.sectionText
+    : normaliseXmlForHash(doc.raw);
+  return sha256Hex(body);
+}
+
+/**
  * Convenience: returns true if the given URL is hosted by legislation.gov.uk.
  * Use this to gate the "primary statute fetcher" branch in the enrichment
  * pipeline — anything else falls through to Perplexity.

--- a/supabase/migrations/20260502000000_legal_ref_freshness.sql
+++ b/supabase/migrations/20260502000000_legal_ref_freshness.sql
@@ -1,0 +1,59 @@
+-- Legal-ref freshness pipeline (Phase 2 of legal-data-api-research-2026-05-01.md).
+--
+-- Strictly additive. No DROP / ALTER-DROP. All columns guarded with
+-- IF NOT EXISTS so the migration is safe to re-run.
+--
+-- Companion crons:
+--   - /api/cron/legal-refs-amendments-sweep (daily 03:15 UTC) — diffs
+--     legislation.gov.uk canonical XML hashes.
+--   - /api/cron/legal-refs-reverify (weekly Sun 04:00 UTC) — re-runs
+--     verification for non-legislation.gov.uk hosts (Perplexity fallback)
+--     and refreshes verification metadata.
+--
+-- Compliance principle (non-negotiable): nothing here mutates canonical
+-- citation fields. `is_stale=true` and `unapplied_effects=true` are
+-- observational flags that surface drift — the actual replacement text
+-- is queued in `legal_ref_corrections` for founder review.
+
+ALTER TABLE public.legal_references
+  ADD COLUMN IF NOT EXISTS source_xml_hash TEXT,
+  ADD COLUMN IF NOT EXISTS last_freshness_check_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS is_stale BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS unapplied_effects BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS superseded_by TEXT;
+
+-- Same pattern on the corrections table so an amendments-sweep proposal
+-- can carry the canonical XML hash + URL host it derived from. This lets
+-- the founder dashboard distinguish corrections born from a deterministic
+-- XML diff (high trust) vs. corrections born from a Perplexity verdict
+-- (lower trust, needs eyeballing).
+ALTER TABLE public.legal_ref_corrections
+  ADD COLUMN IF NOT EXISTS source_xml_hash TEXT,
+  ADD COLUMN IF NOT EXISTS source_host TEXT;
+
+-- Index supporting the amendments-sweep "due refs" lookup. The cron
+-- selects refs on legislation.gov.uk ordered by oldest freshness check;
+-- this composite hits the index without scanning the full table.
+CREATE INDEX IF NOT EXISTS idx_legal_refs_freshness_host_checked
+  ON public.legal_references((
+    CASE
+      WHEN source_url ILIKE '%legislation.gov.uk%' THEN 'legislation.gov.uk'
+      ELSE NULL
+    END
+  ), last_freshness_check_at);
+
+-- Spec-required index on (host, last_freshness_check_at). We model
+-- "host" as the regex-extracted authority for index purposes; for the
+-- common-case lookup of legislation.gov.uk refs the partial above is
+-- sufficient, but downstream filters benefit from the full composite.
+CREATE INDEX IF NOT EXISTS idx_legal_refs_stale
+  ON public.legal_references(is_stale)
+  WHERE is_stale = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_legal_refs_unapplied_effects
+  ON public.legal_references(unapplied_effects)
+  WHERE unapplied_effects = TRUE;
+
+-- Backfill: every existing row counts as a "first check pending". We
+-- deliberately leave last_freshness_check_at NULL so the amendments
+-- sweep picks them up on its first run.

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,8 @@
     { "path": "/api/cron/compare-subscriptions",     "schedule": "0 7 * * *" },
     { "path": "/api/cron/verify-legal-refs",         "schedule": "0 5 * * *" },
     { "path": "/api/cron/legal-refs-daily-reverify", "schedule": "0 4 * * *" },
+    { "path": "/api/cron/legal-refs-amendments-sweep", "schedule": "15 3 * * *" },
+    { "path": "/api/cron/legal-refs-reverify",        "schedule": "0 4 * * 0" },
     { "path": "/api/cron/legal-refs-auto-apply-sweep", "schedule": "30 5 * * *" },
     { "path": "/api/cron/legal-updates",             "schedule": "0 6 * * *" },
     { "path": "/api/cron/consumer-law-news",         "schedule": "0 6 * * *" },


### PR DESCRIPTION
## Summary

Phase 2 + 3 of `docs/legal-data-api-research-2026-05-01.md`. Extends PR #415 (legislation.gov.uk fetch client + verify integration) with the freshness pipeline that catches statute drift the moment it lands and surfaces it as a propose-only correction in the existing review queue.

- **Daily amendments sweep** (15:03 UTC, caps 100/run, 5 parallel) — diffs SHA-256 of the canonical legislation.gov.uk XML against `source_xml_hash` and queues `legal_ref_corrections` rows on drift. `<ukm:UnappliedEffects>` flips a UI badge.
- **Weekly reverify** (Sunday 04:00 UTC, caps 200/run, 6-day per-ref dedup) — re-runs the existing `/api/admin/legal-refs/verify` route, prioritising non-legislation hosts.
- **GOV.UK Content client** (`cma_case` regulator decisions) + **Find Case Law (TNA) scaffold** (dormant behind `FIND_CASE_LAW_LICENCE_ACCEPTED=true` until the founder's free transactional licence is granted, ~10 working days).
- **Admin UI**: Freshness column with green/amber/red badge, ❗ Unapplied effects badge, ⚠️ STALE badge, "Show stale only" + "Unapplied effects only" filters. Pending corrections panel highlights 🔁 amendments-sweep proposals.
- **B2B contract**: `DisputeResponse.legal_basis_freshness` — additive optional array. Backward-compatible.

## Compliance principle preserved

Every detected drift becomes a PROPOSED `legal_ref_corrections` row. Canonical citation fields are NEVER mutated by the sweep cron. The same-host fast-path + 3-gate corroboration on the existing auto-apply sweep continue to be the only routes to a write. `is_stale` and `unapplied_effects` are observational flags, not citation fields.

## Schedule note

Spec asked for `0 3 * * *` for the amendments sweep, but `compliance-sync` already occupies that slot. Rescheduled to `15 3 * * *` to avoid collision while staying in the early-UTC compliance window.

## Risks

- **legislation.gov.uk load**: ~hundreds of refs daily × per-fetch = ~5 MB nightly. Concurrency capped at 5; per-fetch timeout 8s; polite User-Agent.
- **Hash false-positives** from republish noise (XML comment churn, `<ukm:DocumentVersion>` ticks, `<ukm:Modified>` rewrites): `normaliseXmlForHash` strips all of those before hashing. Verified by `freshness.test.ts`.
- **Find Case Law licence delay**: scaffold ships dormant; flipping the env var enables production with no PR.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] Unit tests for amendments-sweep correction shape (hash diff ⇒ pending proposal payload) + reverify 6-day dedup window.
- [x] Unit tests for gov-uk-content + find-case-law clients with mocked fixtures.
- [x] Existing legislation.gov.uk client tests still pass (no behaviour change).
- [x] All 54 tests passing locally:
  ```
  node --experimental-strip-types --test src/lib/legal-data/__tests__/*.test.ts
  ```
- [ ] Smoke: trigger amendments-sweep cron once on staging, confirm seed run populates `source_xml_hash` without firing false-positive corrections.
- [ ] Smoke: trigger reverify cron, confirm it skips refs touched by the sweep within 6 days.

## Coordination

Pure additive on the legal-refs side — does not touch `generateComplaintLetter`, the dispute reply engine, the email layout, or any file in the queue of PRs #410/#411/#414/#416. Migration is strictly additive (no DROP/ALTER-DROP).

Branch is based on `feat/legislation-gov-uk-integration` (PR #415) so this PR diff is just the freshness layer; merge order is #415 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)