### PR TITLE
fix(managed-agents): unblock the 9 Claude managed agents — diagnose + fix

### DIFF
--- a/scripts/test-managed-agents.ts
+++ b/scripts/test-managed-agents.ts
@@ -1,0 +1,60 @@
+/**
+ * Test script: dispatch each Claude Managed Agent ONCE and print results.
+ *
+ * Run:
+ *   ANTHROPIC_AGENTS_API_KEY=... \
+ *   NEXT_PUBLIC_SUPABASE_URL=... \
+ *   SUPABASE_SERVICE_ROLE_KEY=... \
+ *     npx tsx scripts/test-managed-agents.ts
+ *
+ * Optional: pass an agent key to dispatch only that one:
+ *   npx tsx scripts/test-managed-agents.ts builder
+ *
+ * The script bypasses the cron route and calls createSession + sendTaskMessage
+ * directly, so it works locally without CRON_SECRET. It does NOT write to
+ * agent_messages — the production cron route does that.
+ *
+ * Use this to:
+ *   1. Verify ANTHROPIC_AGENTS_API_KEY (or ANTHROPIC_API_KEY) works.
+ *   2. Verify the platform.claude.com agents and memory stores are reachable.
+ *   3. See actual error responses if dispatch is failing.
+ */
+
+import { AGENTS, createSession, sendTaskMessage } from '../src/lib/managed-agents/config';
+
+async function main() {
+  const targetKey = process.argv[2];
+
+  const entries = targetKey
+    ? Object.entries(AGENTS).filter(([k]) => k === targetKey)
+    : Object.entries(AGENTS);
+
+  if (entries.length === 0) {
+    console.error(
+      `Unknown agent: ${targetKey}. Valid keys: ${Object.keys(AGENTS).join(', ')}`
+    );
+    process.exit(1);
+  }
+
+  console.log(`Dispatching ${entries.length} agent(s)...\n`);
+
+  for (const [key, config] of entries) {
+    process.stdout.write(`[${key}] (${config.name}) — `);
+    try {
+      const session = await createSession(config, `${config.name} — manual test`);
+      process.stdout.write(`session ${session.id} created — `);
+      await sendTaskMessage(session.id, config.taskPrompt);
+      console.log(`task sent ✓`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(`FAILED: ${msg}`);
+    }
+  }
+
+  console.log(`\nDone. Check platform.claude.com or query \`agent_messages\` to verify.`);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/src/app/api/cron/managed-agents/route.ts
+++ b/src/app/api/cron/managed-agents/route.ts
@@ -4,14 +4,24 @@
  * Triggers Claude Managed Agent sessions on schedule.
  *
  * Usage:
- *   POST /api/cron/managed-agents                — run ALL scheduled agents
- *   POST /api/cron/managed-agents?agent=builder   — run a specific agent by key
- *   POST /api/cron/managed-agents?agent=builder&task=Fix the login bug  — custom task
+ *   POST /api/cron/managed-agents                       — run ALL scheduled agents
+ *   POST /api/cron/managed-agents?agent=builder         — run a specific agent by key
+ *   POST /api/cron/managed-agents?agent=builder&task=X  — custom task
  *
  * Auth: Bearer CRON_SECRET (same as all other Vercel cron endpoints)
+ *
+ * Observability:
+ *   - Every session create/task send writes a row to `agent_messages` (status='ok'
+ *     or 'error'). The admin AI Team panel reads this to show "last fired" per agent.
+ *   - Failures additionally write to `business_log` (category='alert',
+ *     created_by='managed-agents-cron') so the digest cron surfaces them.
+ *   - We do NOT cost-log Anthropic spend here because the platform.claude.com
+ *     billing is per-session and not exposed via the create-session response.
+ *     Use the platform billing dashboard for spend visibility.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
 import {
   AGENTS,
   type AgentConfig,
@@ -22,66 +32,173 @@ import {
 
 export const maxDuration = 60;
 
-export async function POST(req: NextRequest) {
-  // Auth check
-  const authHeader = req.headers.get('authorization');
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+type DispatchResult = {
+  agent: string;
+  sessionId?: string;
+  status: 'ok' | 'error';
+  error?: string;
+};
 
+function getAdmin() {
+  return createClient(
+    (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim(),
+    (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim()
+  );
+}
+
+async function logAgentMessage(row: {
+  agentKey: string;
+  agentId?: string | null;
+  sessionId?: string | null;
+  eventType: 'session_created' | 'task_sent' | 'error';
+  triggeredBy: string;
+  status: 'ok' | 'error';
+  error?: string | null;
+  metadata?: Record<string, unknown> | null;
+}): Promise<void> {
+  try {
+    const admin = getAdmin();
+    const { error } = await admin.from('agent_messages').insert({
+      agent_key: row.agentKey,
+      agent_id: row.agentId ?? null,
+      session_id: row.sessionId ?? null,
+      event_type: row.eventType,
+      triggered_by: row.triggeredBy,
+      status: row.status,
+      error: row.error ?? null,
+      metadata: row.metadata ?? null,
+    });
+    if (error) {
+      console.warn('[managed-agents] agent_messages insert failed:', error.message);
+    }
+  } catch (err: unknown) {
+    console.warn(
+      '[managed-agents] agent_messages insert threw:',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+}
+
+async function logFailureToBusinessLog(
+  agentKey: string,
+  errorMsg: string
+): Promise<void> {
+  try {
+    const admin = getAdmin();
+    const { error } = await admin.from('business_log').insert({
+      category: 'alert',
+      title: `Managed agent failed: ${agentKey}`,
+      content: `The managed-agents cron failed to dispatch '${agentKey}'. Error: ${errorMsg}`,
+      created_by: 'managed-agents-cron',
+    });
+    if (error) {
+      console.warn('[managed-agents] business_log insert failed:', error.message);
+    }
+  } catch (err: unknown) {
+    console.warn(
+      '[managed-agents] business_log insert threw:',
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+}
+
+async function dispatchAgent(
+  key: string,
+  config: AgentConfig,
+  taskOverride: string | null,
+  triggeredBy: string
+): Promise<DispatchResult> {
+  const startedAt = Date.now();
+  try {
+    const session = await createSession(config);
+    await logAgentMessage({
+      agentKey: key,
+      agentId: config.id,
+      sessionId: session.id,
+      eventType: 'session_created',
+      triggeredBy,
+      status: 'ok',
+      metadata: { name: config.name, schedule: config.schedule },
+    });
+
+    const taskMessage = taskOverride || config.taskPrompt;
+    await sendTaskMessage(session.id, taskMessage);
+    await logAgentMessage({
+      agentKey: key,
+      agentId: config.id,
+      sessionId: session.id,
+      eventType: 'task_sent',
+      triggeredBy,
+      status: 'ok',
+      metadata: {
+        name: config.name,
+        custom_task: !!taskOverride,
+        elapsed_ms: Date.now() - startedAt,
+      },
+    });
+
+    return { agent: key, sessionId: session.id, status: 'ok' };
+  } catch (err: unknown) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    await logAgentMessage({
+      agentKey: key,
+      agentId: config.id,
+      eventType: 'error',
+      triggeredBy,
+      status: 'error',
+      error: errorMsg,
+      metadata: { name: config.name, elapsed_ms: Date.now() - startedAt },
+    });
+    await logFailureToBusinessLog(key, errorMsg);
+    return { agent: key, status: 'error', error: errorMsg };
+  }
+}
+
+function isAuthorized(req: NextRequest): boolean {
+  const authHeader = req.headers.get('authorization');
+  return authHeader === `Bearer ${process.env.CRON_SECRET}`;
+}
+
+async function runDispatch(
+  req: NextRequest,
+  triggeredBy: string,
+  forCron: boolean
+): Promise<NextResponse> {
   const { searchParams } = new URL(req.url);
   const agentKey = searchParams.get('agent');
   const customTask = searchParams.get('task');
 
-  // Determine which agents to run
   let agentsToRun: Array<[string, AgentConfig]>;
 
   if (agentKey) {
-    // Run a specific agent
     const config = AGENTS[agentKey];
     if (!config) {
       return NextResponse.json(
-        { error: `Unknown agent: ${agentKey}. Valid keys: ${Object.keys(AGENTS).join(', ')}` },
+        {
+          error: `Unknown agent: ${agentKey}. Valid keys: ${Object.keys(AGENTS).join(', ')}`,
+        },
         { status: 400 }
       );
     }
     agentsToRun = [[agentKey, config]];
+  } else if (forCron) {
+    // Vercel cron: only fire agents whose cron expression matches NOW (UTC).
+    const dueAgents = agentsDueAt(new Date());
+    agentsToRun = dueAgents.map((config) => {
+      const k = Object.entries(AGENTS).find(([, c]) => c === config)?.[0] ?? 'unknown';
+      return [k, config] as [string, AgentConfig];
+    });
   } else {
-    // Run all agents that have schedules (Vercel cron calls this)
-    agentsToRun = Object.entries(AGENTS).filter(([, config]) => config.schedule !== null);
+    // Manual POST without ?agent=: run every scheduled agent (operator override).
+    agentsToRun = Object.entries(AGENTS).filter(([, c]) => c.schedule !== null);
   }
 
-  const results: Array<{
-    agent: string;
-    sessionId?: string;
-    status?: string;
-    error?: string;
-  }> = [];
+  const results = await Promise.all(
+    agentsToRun.map(([k, c]) => dispatchAgent(k, c, customTask, triggeredBy))
+  );
 
-  // Create sessions in parallel (API allows 60/min)
-  const promises = agentsToRun.map(async ([key, config]) => {
-    try {
-      const session = await createSession(config);
-      const taskMessage = customTask || config.taskPrompt;
-      await sendTaskMessage(session.id, taskMessage);
-
-      results.push({
-        agent: key,
-        sessionId: session.id,
-        status: 'started',
-      });
-    } catch (err) {
-      results.push({
-        agent: key,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  });
-
-  await Promise.all(promises);
-
-  const succeeded = results.filter((r) => !r.error).length;
-  const failed = results.filter((r) => r.error).length;
+  const succeeded = results.filter((r) => r.status === 'ok').length;
+  const failed = results.filter((r) => r.status === 'error').length;
 
   return NextResponse.json({
     ok: failed === 0,
@@ -93,84 +210,16 @@ export async function POST(req: NextRequest) {
   });
 }
 
-// GET handler for Vercel cron (Vercel cron sends GET requests)
-export async function GET(req: NextRequest) {
-  // Auth check
-  const authHeader = req.headers.get('authorization');
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+export async function POST(req: NextRequest) {
+  if (!isAuthorized(req)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  return runDispatch(req, 'manual', false);
+}
 
-  // Determine which agent to run from the URL path or query
-  const { searchParams } = new URL(req.url);
-  const agentKey = searchParams.get('agent');
-
-  if (agentKey) {
-    // Run a specific agent
-    const config = AGENTS[agentKey];
-    if (!config) {
-      return NextResponse.json(
-        { error: `Unknown agent: ${agentKey}` },
-        { status: 400 }
-      );
-    }
-
-    try {
-      const session = await createSession(config);
-      await sendTaskMessage(session.id, config.taskPrompt);
-
-      return NextResponse.json({
-        ok: true,
-        agent: agentKey,
-        sessionId: session.id,
-        status: 'started',
-        timestamp: new Date().toISOString(),
-      });
-    } catch (err) {
-      return NextResponse.json(
-        {
-          ok: false,
-          agent: agentKey,
-          error: err instanceof Error ? err.message : String(err),
-        },
-        { status: 500 }
-      );
-    }
+export async function GET(req: NextRequest) {
+  if (!isAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-
-  // No specific agent — run only agents whose schedule matches NOW (UTC).
-  // The vercel.json entry hits this route every hour at :00; agentsDueAt filters to the
-  // subset whose cron expression matches the current minute+hour.
-  const dueAgents = agentsDueAt(new Date());
-  const agentsToRun = dueAgents.map((config) => {
-    const key = Object.entries(AGENTS).find(([, c]) => c === config)?.[0] ?? 'unknown';
-    return [key, config] as [string, AgentConfig];
-  });
-  const results: Array<{
-    agent: string;
-    sessionId?: string;
-    error?: string;
-  }> = [];
-
-  const promises = agentsToRun.map(async ([key, config]) => {
-    try {
-      const session = await createSession(config);
-      await sendTaskMessage(session.id, config.taskPrompt);
-      results.push({ agent: key, sessionId: session.id });
-    } catch (err) {
-      results.push({
-        agent: key,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  });
-
-  await Promise.all(promises);
-
-  return NextResponse.json({
-    ok: results.every((r) => !r.error),
-    triggered: results.length,
-    results,
-    timestamp: new Date().toISOString(),
-  });
+  return runDispatch(req, 'vercel-cron', true);
 }

--- a/supabase/migrations/20260502110000_managed_agents_messages.sql
+++ b/supabase/migrations/20260502110000_managed_agents_messages.sql
@@ -1,0 +1,30 @@
+-- Managed Agents observability table.
+--
+-- The 9 Claude Managed Agents (alert-tester, digest-compiler, support-triager,
+-- email-marketer, ux-auditor, feature-tester, finance-analyst, bug-triager,
+-- reviewer, builder) are dispatched by /api/cron/managed-agents hourly. Each
+-- session creation + initial task message is recorded here so the founder can
+-- see from SQL whether sessions are firing — independent of platform.claude.com.
+--
+-- The admin AI Team panel and CLAUDE.md both reference this table; this
+-- migration creates it for the first time. Strictly additive.
+
+CREATE TABLE IF NOT EXISTS agent_messages (
+  id BIGSERIAL PRIMARY KEY,
+  agent_key TEXT NOT NULL,             -- e.g. 'alert-tester'
+  agent_id TEXT,                        -- platform.claude.com agent id (agent_*)
+  session_id TEXT,                      -- platform.claude.com session id
+  event_type TEXT NOT NULL,             -- 'session_created' | 'task_sent' | 'error'
+  triggered_by TEXT,                    -- 'vercel-cron' | 'manual' | 'on-demand'
+  status TEXT,                          -- 'ok' | 'error'
+  error TEXT,                           -- non-null when status='error'
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_messages_recent
+  ON agent_messages(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_messages_agent
+  ON agent_messages(agent_key, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_messages_status
+  ON agent_messages(status, created_at DESC);


### PR DESCRIPTION
## Root cause

The Claude Managed Agents cron at `/api/cron/managed-agents` was **already scheduled** in `vercel.json` (`0 * * * *`) and the route was wired to dispatch agents. The earlier diagnosis (\"missing cron entry\") was wrong.

The actual failure modes were:

1. **No Supabase persistence whatsoever.** The route only called `platform.claude.com` APIs (`POST /v1/sessions` + `POST /v1/sessions/{id}/events`). Nothing was ever written to Supabase. The admin AI Team panel and `CLAUDE.md` data-model doc both reference an `agent_messages` table — but that migration was never written and the table doesn't exist.
2. **Failures swallowed silently.** Every `createSession` / `sendTaskMessage` error was captured into a `results` array and returned in the response body. Vercel cron discards response bodies. So if `ANTHROPIC_AGENTS_API_KEY` was unset / invalid / lacked managed-agents beta access, the founder had zero signal.
3. **Founder's diagnostic query (`select count(*) from agent_messages`) was always going to return 0** because the table didn't exist — independent of whether platform.claude.com sessions were firing.

## Changes

### 1. `supabase/migrations/20260502110000_managed_agents_messages.sql` (new)
Creates `agent_messages` (CREATE TABLE IF NOT EXISTS, fully additive). Columns: `agent_key`, `agent_id`, `session_id`, `event_type` (`session_created` | `task_sent` | `error`), `triggered_by`, `status`, `error`, `metadata`, `created_at`. Three indexes for the AI Team panel reads.

### 2. `src/app/api/cron/managed-agents/route.ts` (modified)
- Every dispatch writes ok/error rows to `agent_messages` so the founder can verify firing from SQL.
- Failures additionally append to `business_log` with `category='alert'` and `created_by='managed-agents-cron'` so the existing digest cron (07:00 / 12:30 / 19:00 UTC) surfaces broken agents to Telegram.
- GET (Vercel cron) still honours `agentsDueAt(now)` so only agents whose cron expression matches the current minute fire each hour. POST without `?agent=` now runs every scheduled agent (manual smoke-test override).
- DRYed GET/POST behind a shared `runDispatch` helper. `dispatchAgent` is the single execution path.

### 3. `scripts/test-managed-agents.ts` (new)
One-shot manual dispatcher. Bypasses CRON_SECRET / Vercel and calls `createSession` + `sendTaskMessage` directly so the founder can verify the API key works locally and see the actual error if dispatch fails. Defaults to all agents; pass an agent key to dispatch only one.

### Why we don't log to `api_cost_ledger` here
Managed Agents on `platform.claude.com` are billed per-session and the create-session response doesn't return token usage. Spend visibility lives in the platform billing dashboard. (The on-demand complaint_writer + dispute-agent paths still log to `api_cost_ledger` — they use the Messages API where token counts are returned.)

## How to verify it's firing

After one cron tick (next :00 UTC) or running the test script:
\`\`\`sql
-- recent dispatches
select agent_key, event_type, status, created_at
  from agent_messages
  order by created_at desc
  limit 30;

-- failures only
select agent_key, error, created_at
  from agent_messages
  where status = 'error'
  order by created_at desc;

-- broken-agent alerts the digest will surface
select * from business_log
  where created_by = 'managed-agents-cron'
  order by created_at desc;
\`\`\`

Manual smoke test:
\`\`\`bash
ANTHROPIC_AGENTS_API_KEY=... \
NEXT_PUBLIC_SUPABASE_URL=... \
SUPABASE_SERVICE_ROLE_KEY=... \
  npx tsx scripts/test-managed-agents.ts

# Or one agent:
npx tsx scripts/test-managed-agents.ts builder
\`\`\`

## Required env vars (already in CLAUDE.md)
- `ANTHROPIC_AGENTS_API_KEY` (preferred) or `ANTHROPIC_API_KEY` fallback
- `CRON_SECRET` (Vercel cron auth)
- `SUPABASE_SERVICE_ROLE_KEY` + `NEXT_PUBLIC_SUPABASE_URL` (observability writes)

If the cron is firing but `agent_messages` shows status='error', the most likely culprit is `ANTHROPIC_AGENTS_API_KEY` not being on the managed-agents beta — the error string from Anthropic is now persisted verbatim in `agent_messages.error` so the founder can see the exact 4xx body.

## Verification
\`\`\`
npx tsc --noEmit  # clean across touched files
\`\`\`

## Test plan
- [ ] Apply migration `20260502110000_managed_agents_messages.sql` to Supabase prod
- [ ] After deploy, wait one hour for the next cron tick at :00 UTC
- [ ] Run the verification SQL above — expect rows for any agents whose schedule matches the tick (e.g. at 06:00 UTC: alert-tester, support-triager, bug-triager, reviewer, dispute-agent crons; at 08:00 UTC: email-marketer)
- [ ] If status='error' rows appear, inspect the `error` column for the platform.claude.com response body and act accordingly (likely env var or beta access)
- [ ] Optionally run `npx tsx scripts/test-managed-agents.ts` locally to verify before next cron tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)