### PR TITLE
fix(dashboards): consistent chrome, readable typography, mobile-safe tables across consumer + admin

### DIFF
--- a/src/app/dashboard/admin/analytics/page.tsx
+++ b/src/app/dashboard/admin/analytics/page.tsx
@@ -15,9 +15,9 @@
  */
 
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import AdminPage from '@/components/admin/AdminPage';
 import {
-  ArrowLeft, Loader2, RefreshCw, Users, TrendingDown, TrendingUp,
+  Loader2, RefreshCw, Users, TrendingDown, TrendingUp,
   Receipt, Wallet, Calendar, Scale, Layers, AlertTriangle,
   Plug, Sparkles, HeartPulse, Bot,
 } from 'lucide-react';
@@ -190,14 +190,11 @@ export default function AdminAnalyticsPage() {
 
   if (error) {
     return (
-      <div className="p-8 max-w-2xl mx-auto">
-        <Link href="/dashboard/admin" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900 mb-4">
-          <ArrowLeft className="h-4 w-4" /> Back to admin
-        </Link>
+      <AdminPage title="Platform Analytics">
         <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-sm text-red-700">
           {error}
         </div>
-      </div>
+      </AdminPage>
     );
   }
 
@@ -220,31 +217,19 @@ export default function AdminAnalyticsPage() {
   const startedSubtext = 'Month just started · transactions sync hourly';
 
   return (
-    <div className="p-4 md:p-8 max-w-7xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
-        <div>
-          <Link href="/dashboard/admin" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-900 mb-2">
-            <ArrowLeft className="h-4 w-4" /> Back to admin
-          </Link>
-          <h1 className="text-2xl md:text-3xl font-bold text-slate-900">Platform Analytics</h1>
-          <p className="text-sm text-slate-500 mt-1">
-            Generated {new Date(data.generated_at).toLocaleString('en-GB')} · {data.privacy_note}
-          </p>
-          {dayOne && (
-            <p className="text-sm text-amber-700 mt-1">
-              Day {daysIntoMonth} of month — figures partial.
-            </p>
-          )}
-        </div>
+    <AdminPage
+      title="Platform Analytics"
+      description={`Generated ${new Date(data.generated_at).toLocaleString('en-GB')} · ${data.privacy_note}${dayOne ? ` · Day ${daysIntoMonth} of month — figures partial.` : ''}`}
+      actions={
         <button
           onClick={() => load({ manual: true })}
           disabled={loading}
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-100 hover:bg-slate-200 text-sm text-slate-700 disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white border border-slate-200 hover:bg-slate-50 text-sm text-slate-700 disabled:opacity-50"
         >
           <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Refresh
         </button>
-      </div>
+      }
+    >
 
       {/* ─ USERS ─────────────────────────────────────────────────────── */}
       <Section icon={Users} title="Users" subtitle="Who's on the platform">
@@ -481,7 +466,7 @@ export default function AdminAnalyticsPage() {
           />
         )}
       </Section>
-    </div>
+    </AdminPage>
   );
 }
 

--- a/src/app/dashboard/admin/billing/page.tsx
+++ b/src/app/dashboard/admin/billing/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { headers } from 'next/headers';
-import AdminBackLink from '@/components/admin/AdminBackLink';
+import AdminPage from '@/components/admin/AdminPage';
 
 export const dynamic = 'force-dynamic';
 
@@ -62,27 +62,19 @@ export default async function AdminBillingPage() {
 
   if (!summary) {
     return (
-      <div className="p-8 text-white">
-        <AdminBackLink className="!text-slate-400 hover:!text-white" />
-        <h1 className="text-2xl font-bold">Billing</h1>
-        <p className="text-red-400 mt-4">{fetchErr || 'No data.'}</p>
-      </div>
+      <AdminPage title="API Billing">
+        <p className="text-rose-600">{fetchErr || 'No data.'}</p>
+      </AdminPage>
     );
   }
 
   const maxDaily = Math.max(0.01, ...summary.dailyTrend.map((d) => d.cost_gbp));
 
   return (
-    <div className="p-6 md:p-8 text-white space-y-8 max-w-6xl">
-      <AdminBackLink className="!text-slate-400 hover:!text-white !mb-0" />
-      <header>
-        <h1 className="text-2xl md:text-3xl font-bold">API Billing</h1>
-        <p className="text-sm text-slate-400 mt-1">
-          Internal cost ledger — actual paid third-party API spend across Anthropic, Perplexity, Resend, Stripe, TrueLayer.
-          Generated {new Date(summary.generatedAt).toLocaleString('en-GB')}.
-        </p>
-      </header>
-
+    <AdminPage
+      title="API Billing"
+      description={`Internal cost ledger — actual paid third-party API spend across Anthropic, Perplexity, Resend, Stripe, TrueLayer. Generated ${new Date(summary.generatedAt).toLocaleString('en-GB')}.`}
+    >
       <section className="grid md:grid-cols-3 gap-4">
         <Card label="This month so far" value={gbp(summary.monthSoFar.total_gbp)} />
         <Card label="Last 30 days" value={gbp(summary.last30Days.total_gbp)} />
@@ -149,31 +141,31 @@ export default async function AdminBillingPage() {
       </section>
 
       <section>
-        <h2 className="text-lg font-semibold mb-3">Daily cost trend (last 30 days)</h2>
-        <div className="space-y-1 bg-slate-900/40 border border-slate-700 rounded p-4">
+        <h2 className="text-lg font-semibold mb-3 text-slate-900">Daily cost trend (last 30 days)</h2>
+        <div className="space-y-1 bg-slate-50 border border-slate-200 rounded-lg p-4">
           {summary.dailyTrend.map((d) => (
             <div key={d.date} className="flex items-center gap-3 text-xs">
-              <span className="w-20 shrink-0 text-slate-400">{d.date}</span>
-              <div className="flex-1 bg-slate-800 rounded h-3 overflow-hidden">
+              <span className="w-20 shrink-0 text-slate-500">{d.date}</span>
+              <div className="flex-1 bg-slate-200 rounded h-3 overflow-hidden">
                 <div
                   className="h-full bg-amber-500"
                   style={{ width: `${Math.max(2, (d.cost_gbp / maxDaily) * 100)}%` }}
                 />
               </div>
-              <span className="w-20 text-right tabular-nums">{gbp(d.cost_gbp)}</span>
+              <span className="w-20 text-right tabular-nums text-slate-700">{gbp(d.cost_gbp)}</span>
             </div>
           ))}
         </div>
       </section>
-    </div>
+    </AdminPage>
   );
 }
 
 function Card({ label, value }: { label: string; value: string }) {
   return (
-    <div className="bg-slate-900/60 border border-slate-700 rounded-lg p-4">
-      <div className="text-xs uppercase tracking-wide text-slate-400">{label}</div>
-      <div className="text-2xl font-bold mt-1">{value}</div>
+    <div className="bg-white border border-slate-200 rounded-xl p-4">
+      <div className="text-xs uppercase tracking-wide text-slate-500 font-medium">{label}</div>
+      <div className="text-2xl font-bold mt-1 text-slate-900 tabular-nums">{value}</div>
     </div>
   );
 }
@@ -186,23 +178,23 @@ interface Col {
 
 function Table({ rows, cols }: { rows: Array<Record<string, unknown>>; cols: Col[] }) {
   if (!rows || rows.length === 0) {
-    return <p className="text-sm text-slate-400">No data.</p>;
+    return <p className="text-sm text-slate-500">No data.</p>;
   }
   return (
-    <div className="overflow-x-auto bg-slate-900/40 border border-slate-700 rounded">
+    <div className="overflow-x-auto -mx-1 bg-white border border-slate-200 rounded-lg">
       <table className="w-full text-sm">
-        <thead className="bg-slate-800/60 text-slate-300">
+        <thead className="bg-slate-50 text-slate-600">
           <tr>
             {cols.map((c) => (
-              <th key={c.key} className="text-left px-3 py-2 font-medium">{c.label}</th>
+              <th key={c.key} className="text-left px-4 py-3 font-medium uppercase tracking-wide text-xs">{c.label}</th>
             ))}
           </tr>
         </thead>
         <tbody>
           {rows.map((row, i) => (
-            <tr key={i} className="border-t border-slate-800">
+            <tr key={i} className="border-t border-slate-100">
               {cols.map((c) => (
-                <td key={c.key} className="px-3 py-2 text-slate-200 tabular-nums">
+                <td key={c.key} className="px-4 py-3 text-slate-700 tabular-nums">
                   {c.render ? c.render(row[c.key]) : String(row[c.key] ?? '')}
                 </td>
               ))}

--- a/src/app/dashboard/admin/crons/page.tsx
+++ b/src/app/dashboard/admin/crons/page.tsx
@@ -19,8 +19,8 @@
  */
 
 import { useEffect, useState, useCallback } from 'react';
-import Link from 'next/link';
-import { ArrowLeft, Clock, Loader2, Play, CheckCircle2, AlertCircle, RefreshCw } from 'lucide-react';
+import { Clock, Loader2, Play, CheckCircle2, AlertCircle, RefreshCw } from 'lucide-react';
+import AdminPage from '@/components/admin/AdminPage';
 
 interface CronRow {
   path: string;
@@ -133,28 +133,19 @@ export default function AdminCronsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 p-6">
-      <div className="max-w-5xl mx-auto">
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <Link href="/dashboard/admin" className="text-slate-500 text-sm inline-flex items-center gap-1 hover:text-slate-900 mb-2">
-              <ArrowLeft className="h-4 w-4" /> Admin
-            </Link>
-            <h1 className="text-2xl font-bold text-slate-900">Cron jobs</h1>
-            <p className="text-sm text-slate-500 mt-1">
-              Every Vercel cron registered in <code className="text-xs bg-slate-200 px-1 rounded">vercel.json</code>.
-              Tap <strong>Run now</strong> to invoke one manually — the call is proxied server-side with <code className="text-xs bg-slate-200 px-1 rounded">CRON_SECRET</code>, never in the browser.
-            </p>
-          </div>
-          <button
-            onClick={loadCrons}
-            disabled={loading}
-            className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-700 hover:bg-slate-100 disabled:opacity-50"
-          >
-            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Refresh
-          </button>
-        </div>
-
+    <AdminPage
+      title="Cron jobs"
+      description="Every Vercel cron registered in vercel.json. Tap Run now to invoke one manually — the call is proxied server-side with CRON_SECRET, never in the browser."
+      actions={
+        <button
+          onClick={loadCrons}
+          disabled={loading}
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-slate-200 bg-white text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+        >
+          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Refresh
+        </button>
+      }
+    >
         {runResult && (
           <div
             className={`mb-4 rounded-xl p-3 text-sm flex items-start gap-2 ${
@@ -249,7 +240,6 @@ export default function AdminCronsPage() {
         <p className="text-xs text-slate-500 mt-6">
           The &quot;Last run&quot; column reads from <code className="text-[11px] bg-slate-200 px-1 rounded">business_log</code> where <code className="text-[11px] bg-slate-200 px-1 rounded">category=&apos;cron_run&apos;</code>. Cron runs triggered by Vercel itself (on their schedule) need to opt in to this log by inserting a row in their handler — manual runs via this page always log. Vercel&apos;s built-in cron logs are still available in the Vercel dashboard.
         </p>
-      </div>
-    </div>
+    </AdminPage>
   );
 }

--- a/src/app/dashboard/admin/dispute-agent/page.tsx
+++ b/src/app/dashboard/admin/dispute-agent/page.tsx
@@ -11,7 +11,7 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { createClient as createServiceClient } from '@supabase/supabase-js';
 import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
+import AdminPage from '@/components/admin/AdminPage';
 
 export const dynamic = 'force-dynamic';
 const ADMIN_EMAIL = 'aireypaul@googlemail.com';
@@ -101,21 +101,19 @@ export default async function DisputeAgentAdminPage() {
   const firingNow = decs.filter((d) => Date.parse(d.decided_at) > cutoff);
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <div className="mx-auto max-w-6xl p-6">
-        <Link href="/dashboard/admin" className="inline-flex items-center gap-1 text-sm text-amber-400 hover:underline">
-          <ArrowLeft className="h-4 w-4" /> Back to admin
+    <AdminPage
+      title="Dispute Agent"
+      description="Autonomous state-machine driving every open dispute. Companion to Dispute Intelligence."
+    >
+      <div className="text-sm text-slate-600 -mt-4">
+        See also{' '}
+        <Link href="/dashboard/admin/dispute-intelligence" className="text-emerald-700 underline">
+          Dispute Intelligence
         </Link>
-        <h1 className="mt-2 text-2xl font-bold">Dispute Agent</h1>
-        <p className="mt-1 text-sm text-slate-400">
-          Autonomous state-machine driving every open dispute. Companion to{' '}
-          <Link href="/dashboard/admin/dispute-intelligence" className="text-amber-400 underline">
-            Dispute Intelligence
-          </Link>
-          .
-        </p>
+        .
+      </div>
 
-        <div className="mt-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           <Card label="Active managed disputes" value={String(totalActive)} hint={`${managedCount ?? 0} ever managed`} />
           <Card label="Decisions / dispute" value={decisionsPerDispute.toFixed(1)} />
           <Card label="Approve rate" value={`${(approveRate * 100).toFixed(0)}%`} hint={`${approveCount} of ${userActed.length} actioned`} />
@@ -126,10 +124,10 @@ export default async function DisputeAgentAdminPage() {
           <ul className="space-y-1 text-sm">
             {firingNow.length === 0 && <li className="text-slate-500">Nothing in the last hour.</li>}
             {firingNow.slice(0, 20).map((d) => (
-              <li key={d.id} className="text-slate-300">
+              <li key={d.id} className="text-slate-700">
                 <span className="text-slate-500">{new Date(d.decided_at).toLocaleString('en-GB')}</span>{' '}
-                <span className="text-amber-300">{d.recommended_action}</span> →{' '}
-                <span className="text-slate-400">dispute {d.dispute_id.slice(0, 8)}</span>
+                <span className="text-amber-700">{d.recommended_action}</span> →{' '}
+                <span className="text-slate-500">dispute {d.dispute_id.slice(0, 8)}</span>
               </li>
             ))}
           </ul>
@@ -137,12 +135,12 @@ export default async function DisputeAgentAdminPage() {
 
         <Section title="Recommendations by action type">
           <table className="w-full text-sm">
-            <thead><tr className="text-left text-slate-400"><th>Action</th><th>Count</th></tr></thead>
+            <thead><tr className="text-left text-slate-500"><th>Action</th><th>Count</th></tr></thead>
             <tbody>
               {actionRows.map(([action, count]) => (
-                <tr key={action} className="border-t border-slate-800">
-                  <td className="py-1 text-slate-200">{action}</td>
-                  <td className="py-1 text-slate-300">{count}</td>
+                <tr key={action} className="border-t border-slate-100">
+                  <td className="py-1 text-slate-700">{action}</td>
+                  <td className="py-1 text-slate-700">{count}</td>
                 </tr>
               ))}
             </tbody>
@@ -150,18 +148,18 @@ export default async function DisputeAgentAdminPage() {
         </Section>
 
         <Section title="Effectiveness by recommendation (key feedback signal)">
-          <p className="mb-2 text-xs text-slate-400">
+          <p className="mb-2 text-xs text-slate-500">
             Of disputes whose latest recommendation was X, what share ended <code>outcome=won</code>?
           </p>
           <table className="w-full text-sm">
-            <thead><tr className="text-left text-slate-400"><th>Action</th><th>Wins</th><th>Resolved</th><th>Win rate</th></tr></thead>
+            <thead><tr className="text-left text-slate-500"><th>Action</th><th>Wins</th><th>Resolved</th><th>Win rate</th></tr></thead>
             <tbody>
               {[...effectivenessAgg.entries()].sort((a, b) => b[1].total - a[1].total).map(([action, agg]) => (
-                <tr key={action} className="border-t border-slate-800">
-                  <td className="py-1 text-slate-200">{action}</td>
-                  <td className="py-1 text-slate-300">{agg.wins}</td>
-                  <td className="py-1 text-slate-300">{agg.total}</td>
-                  <td className="py-1 text-amber-300">{((agg.wins / Math.max(1, agg.total)) * 100).toFixed(0)}%</td>
+                <tr key={action} className="border-t border-slate-100">
+                  <td className="py-1 text-slate-700">{action}</td>
+                  <td className="py-1 text-slate-700">{agg.wins}</td>
+                  <td className="py-1 text-slate-700">{agg.total}</td>
+                  <td className="py-1 text-amber-700">{((agg.wins / Math.max(1, agg.total)) * 100).toFixed(0)}%</td>
                 </tr>
               ))}
               {effectivenessAgg.size === 0 && (
@@ -170,16 +168,15 @@ export default async function DisputeAgentAdminPage() {
             </tbody>
           </table>
         </Section>
-      </div>
-    </div>
+    </AdminPage>
   );
 }
 
 function Card({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
-      <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
-      <div className="mt-1 text-2xl font-semibold text-amber-300">{value}</div>
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="text-xs uppercase tracking-wide text-slate-500 font-medium">{label}</div>
+      <div className="mt-1 text-2xl font-semibold text-slate-900 tabular-nums">{value}</div>
       {hint && <div className="mt-1 text-xs text-slate-500">{hint}</div>}
     </div>
   );
@@ -187,8 +184,8 @@ function Card({ label, value, hint }: { label: string; value: string; hint?: str
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="mt-8 rounded-lg border border-slate-800 bg-slate-900/40 p-4">
-      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-300">{title}</h2>
+    <div className="rounded-xl border border-slate-200 bg-white p-4 overflow-x-auto">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-600">{title}</h2>
       {children}
     </div>
   );

--- a/src/app/dashboard/admin/dispute-intelligence/page.tsx
+++ b/src/app/dashboard/admin/dispute-intelligence/page.tsx
@@ -13,8 +13,7 @@
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { createClient as createServiceClient } from '@supabase/supabase-js';
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
+import AdminPage from '@/components/admin/AdminPage';
 
 export const dynamic = 'force-dynamic';
 
@@ -123,18 +122,12 @@ export default async function DisputeIntelligenceDashboard() {
     .from('disputes').select('id', { count: 'exact', head: true });
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white p-6">
-      <div className="max-w-7xl mx-auto">
-        <Link href="/dashboard/admin" className="text-sm text-gray-400 hover:text-white inline-flex items-center gap-1 mb-4">
-          <ArrowLeft size={14} /> Back to admin
-        </Link>
-        <h1 className="text-3xl font-bold mb-2">Dispute Intelligence</h1>
-        <p className="text-gray-400 mb-8 max-w-2xl">
-          The flywheel. Every tagged outcome trains the engine and compounds our moat.
-        </p>
-
+    <AdminPage
+      title="Dispute Intelligence"
+      description="The flywheel. Every tagged outcome trains the engine and compounds our moat."
+    >
         {/* Headline cards */}
-        <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
           <Card label="Total disputes" value={(totalDisputes ?? 0).toLocaleString('en-GB')} />
           <Card label="Total won" value={(overallStat?.won_count ?? 0).toLocaleString('en-GB')} />
           <Card label="Total recovered" value={gbp(overallStat?.total_recovered_gbp ?? null)} />
@@ -143,16 +136,16 @@ export default async function DisputeIntelligenceDashboard() {
         </div>
 
         {/* Dataset growth — fundraise narrative card */}
-        <div className="border-2 border-amber-500/40 bg-amber-500/5 rounded-lg p-6 mb-8">
-          <div className="text-amber-300 text-sm uppercase tracking-wider mb-1">Dataset growth</div>
+        <div className="border-2 border-amber-300 bg-amber-50 rounded-lg p-6 mb-8">
+          <div className="text-amber-700 text-sm uppercase tracking-wider mb-1">Dataset growth</div>
           <div className="text-2xl font-bold mb-1">
             {(overallStat?.total_count ?? 0).toLocaleString('en-GB')} tagged outcomes
             {' '}
-            <span className="text-gray-400 font-normal">
+            <span className="text-slate-500 font-normal">
               of {(totalDisputes ?? 0).toLocaleString('en-GB')} disputes
             </span>
           </div>
-          <div className="text-gray-300 text-sm">
+          <div className="text-slate-700 text-sm">
             Largest UK consumer dispute outcome dataset outside the Financial Ombudsman Service.
             Every confirmed outcome retrains the legal-basis selector against this merchant.
           </div>
@@ -167,11 +160,11 @@ export default async function DisputeIntelligenceDashboard() {
               .map((i) => (
                 <div key={i.scope_key} className="flex items-center gap-3 text-sm">
                   <div className="w-32 capitalize">{i.scope_key}</div>
-                  <div className="flex-1 bg-gray-800 rounded h-4 overflow-hidden">
+                  <div className="flex-1 bg-slate-200 rounded h-4 overflow-hidden">
                     <div className="h-full bg-emerald-500" style={{ width: `${(i.win_rate ?? 0) * 100}%` }} />
                   </div>
                   <div className="w-16 text-right">{pct(i.win_rate)}</div>
-                  <div className="w-20 text-right text-gray-400">n={i.total_count}</div>
+                  <div className="w-20 text-right text-slate-500">n={i.total_count}</div>
                 </div>
               ))}
             {byIndustry.length === 0 && <Empty />}
@@ -182,7 +175,7 @@ export default async function DisputeIntelligenceDashboard() {
         <Section title="Top merchants by case count">
           <Table headers={['Merchant', 'Cases', 'Win rate', 'Avg recovered']}>
             {topMerchants.map((m) => (
-              <tr key={m.scope_key} className="border-t border-gray-800">
+              <tr key={m.scope_key} className="border-t border-slate-100">
                 <td className="py-2 font-mono text-xs">{m.scope_key}</td>
                 <td className="py-2 text-right">{m.total_count}</td>
                 <td className="py-2 text-right">{pct(m.win_rate)}</td>
@@ -197,7 +190,7 @@ export default async function DisputeIntelligenceDashboard() {
         <Section title="Which legal arguments actually work? (min sample 5)">
           <Table headers={['Legal basis', 'Sample', 'Win rate', 'Avg recovered']}>
             {topLegal.map((l) => (
-              <tr key={l.scope_key} className="border-t border-gray-800">
+              <tr key={l.scope_key} className="border-t border-slate-100">
                 <td className="py-2 font-mono text-xs">{l.scope_key}</td>
                 <td className="py-2 text-right">{l.total_count}</td>
                 <td className="py-2 text-right">{pct(l.win_rate)}</td>
@@ -248,7 +241,7 @@ export default async function DisputeIntelligenceDashboard() {
         <Section title="By dispute type">
           <Table headers={['Type', 'Cases', 'Win rate', 'Avg recovered']}>
             {byType.sort((a, b) => b.total_count - a.total_count).map((t) => (
-              <tr key={t.scope_key} className="border-t border-gray-800">
+              <tr key={t.scope_key} className="border-t border-slate-100">
                 <td className="py-2 font-mono text-xs">{t.scope_key}</td>
                 <td className="py-2 text-right">{t.total_count}</td>
                 <td className="py-2 text-right">{pct(t.win_rate)}</td>
@@ -258,32 +251,31 @@ export default async function DisputeIntelligenceDashboard() {
             {byType.length === 0 && <tr><td colSpan={4}><Empty /></td></tr>}
           </Table>
         </Section>
-      </div>
-    </div>
+    </AdminPage>
   );
 }
 
 function Card({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
-      <div className="text-xs uppercase tracking-wider text-gray-400">{label}</div>
-      <div className="text-2xl font-bold mt-1">{value}</div>
+    <div className="bg-white border border-slate-200 rounded-xl p-4">
+      <div className="text-xs uppercase tracking-wider text-slate-500 font-medium">{label}</div>
+      <div className="text-2xl font-bold mt-1 text-slate-900 tabular-nums">{value}</div>
     </div>
   );
 }
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <section className="mb-8">
-      <h2 className="text-lg font-semibold mb-3">{title}</h2>
-      <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">{children}</div>
+    <section>
+      <h2 className="text-lg font-semibold mb-3 text-slate-900">{title}</h2>
+      <div className="bg-white border border-slate-200 rounded-xl p-4 overflow-x-auto">{children}</div>
     </section>
   );
 }
 function Table({ headers, children }: { headers: string[]; children: React.ReactNode }) {
   return (
     <table className="w-full text-sm">
-      <thead className="text-gray-400 text-left">
-        <tr>{headers.map((h, i) => <th key={h} className={i === 0 ? '' : 'text-right'}>{h}</th>)}</tr>
+      <thead className="text-slate-500 text-left">
+        <tr>{headers.map((h, i) => <th key={h} className={`pb-2 font-medium uppercase tracking-wide text-xs ${i === 0 ? '' : 'text-right'}`}>{h}</th>)}</tr>
       </thead>
       <tbody>{children}</tbody>
     </table>

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -805,7 +805,7 @@ export default function LegalRefsAdminPage() {
         : 'bg-white hover:border-emerald-500 text-slate-900 border-slate-200';
 
   return (
-    <div className="max-w-7xl">
+    <div className="max-w-7xl mx-auto w-full">
       {/* Compliance ops toast */}
       {opToast && (
         <div

--- a/src/app/dashboard/admin/whatsapp/page.tsx
+++ b/src/app/dashboard/admin/whatsapp/page.tsx
@@ -3,8 +3,8 @@
 export const dynamic = 'force-dynamic';
 
 import { useCallback, useEffect, useState } from 'react';
-import Link from 'next/link';
-import { ArrowLeft, RefreshCw, Loader2, CheckCircle, AlertTriangle, Clock } from 'lucide-react';
+import { RefreshCw, Loader2, CheckCircle, AlertTriangle, Clock } from 'lucide-react';
+import AdminPage from '@/components/admin/AdminPage';
 
 interface SidRow {
   template_name: string;
@@ -109,21 +109,15 @@ export default function WhatsAppTemplatesAdminPage() {
   const byName = new Map(rows.map((r) => [r.template_name, r]));
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100 p-6">
-      <div className="max-w-5xl mx-auto">
-        <Link href="/dashboard/admin" className="inline-flex items-center gap-2 text-sm text-slate-400 hover:text-slate-200 mb-4">
-          <ArrowLeft className="w-4 h-4" /> Back to admin
-        </Link>
-        <h1 className="text-2xl font-semibold mb-2">WhatsApp templates</h1>
-        <p className="text-sm text-slate-400 mb-6">
-          Server-side resubmit + daily Meta status poll. The dispatch path skips templates whose status is not <code>approved</code>.
-        </p>
-
-        <div className="flex flex-wrap gap-3 mb-6">
+    <AdminPage
+      title="WhatsApp templates"
+      description="Server-side resubmit + daily Meta status poll. The dispatch path skips templates whose status is not approved."
+      actions={
+        <>
           <button
             onClick={onResubmit}
             disabled={busy !== null}
-            className="inline-flex items-center gap-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 px-4 py-2 rounded-md text-sm"
+            className="inline-flex items-center gap-2 bg-emerald-600 text-white hover:bg-emerald-500 disabled:opacity-50 px-4 py-2 rounded-lg text-sm font-medium"
           >
             {busy === 'resubmit' ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
             Resubmit pending
@@ -131,54 +125,54 @@ export default function WhatsAppTemplatesAdminPage() {
           <button
             onClick={onRefresh}
             disabled={busy !== null}
-            className="inline-flex items-center gap-2 bg-slate-800 hover:bg-slate-700 disabled:opacity-50 px-4 py-2 rounded-md text-sm border border-slate-700"
+            className="inline-flex items-center gap-2 bg-white text-slate-700 hover:bg-slate-50 disabled:opacity-50 px-4 py-2 rounded-lg text-sm font-medium border border-slate-200"
           >
             {busy === 'refresh' ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
             Refresh status
           </button>
-        </div>
+        </>
+      }
+    >
+      {message && (
+        <div className="p-3 rounded-lg border border-slate-200 bg-slate-50 text-sm text-slate-700">{message}</div>
+      )}
 
-        {message && (
-          <div className="mb-4 p-3 rounded-md border border-slate-700 bg-slate-900 text-sm">{message}</div>
-        )}
-
-        <div className="border border-slate-800 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-slate-900 text-slate-400">
-              <tr>
-                <th className="text-left px-3 py-2">Template</th>
-                <th className="text-left px-3 py-2">Live SID</th>
-                <th className="text-left px-3 py-2">Status</th>
-                <th className="text-left px-3 py-2">Last check</th>
-              </tr>
-            </thead>
-            <tbody>
-              {loading && (
-                <tr><td colSpan={4} className="px-3 py-6 text-center text-slate-400">Loading…</td></tr>
-              )}
-              {!loading && registry.map((r) => {
-                const live = byName.get(r.name);
-                const sidDisplay = live?.sid ?? (r.is_pending_resubmission ? '— (pending resubmission)' : r.fallback_sid);
-                const status: SidRow['approval_status'] = live?.approval_status
-                  ?? (r.is_pending_resubmission ? 'pending' : 'approved');
-                return (
-                  <tr key={r.name} className="border-t border-slate-800">
-                    <td className="px-3 py-2 font-mono text-xs">{r.name}</td>
-                    <td className="px-3 py-2 font-mono text-xs text-slate-300">{sidDisplay}</td>
-                    <td className="px-3 py-2"><StatusPill status={status} /></td>
-                    <td className="px-3 py-2 text-xs text-slate-400">
-                      {live?.last_status_check_at ? new Date(live.last_status_check_at).toLocaleString('en-GB') : '—'}
-                      {live?.last_error && (
-                        <div className="text-rose-300 mt-1">{live.last_error}</div>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+      <div className="bg-white border border-slate-200 rounded-xl overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-slate-600">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium uppercase tracking-wide text-xs">Template</th>
+              <th className="text-left px-4 py-3 font-medium uppercase tracking-wide text-xs">Live SID</th>
+              <th className="text-left px-4 py-3 font-medium uppercase tracking-wide text-xs">Status</th>
+              <th className="text-left px-4 py-3 font-medium uppercase tracking-wide text-xs">Last check</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && (
+              <tr><td colSpan={4} className="px-4 py-6 text-center text-slate-500">Loading…</td></tr>
+            )}
+            {!loading && registry.map((r) => {
+              const live = byName.get(r.name);
+              const sidDisplay = live?.sid ?? (r.is_pending_resubmission ? '— (pending resubmission)' : r.fallback_sid);
+              const status: SidRow['approval_status'] = live?.approval_status
+                ?? (r.is_pending_resubmission ? 'pending' : 'approved');
+              return (
+                <tr key={r.name} className="border-t border-slate-100">
+                  <td className="px-4 py-3 font-mono text-xs text-slate-800">{r.name}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-600">{sidDisplay}</td>
+                  <td className="px-4 py-3"><StatusPill status={status} /></td>
+                  <td className="px-4 py-3 text-xs text-slate-500">
+                    {live?.last_status_check_at ? new Date(live.last_status_check_at).toLocaleString('en-GB') : '—'}
+                    {live?.last_error && (
+                      <div className="text-rose-600 mt-1">{live.last_error}</div>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
-    </div>
+    </AdminPage>
   );
 }

--- a/src/app/dashboard/deals/page.tsx
+++ b/src/app/dashboard/deals/page.tsx
@@ -655,7 +655,7 @@ export default function DealsPage() {
   const dealsCount = Object.values(DEALS).reduce((n, arr) => n + (arr?.length || 0), 0) + verifiedDeals.length;
 
   return (
-    <div className="max-w-7xl">
+    <div className="max-w-7xl mx-auto w-full">
       {/* Hero */}
       <div className="mb-8">
         <h1 className="text-3xl md:text-4xl font-bold text-slate-900 mb-2 font-[family-name:var(--font-heading)]">Find Better Deals</h1>

--- a/src/app/dashboard/money-hub/page.tsx
+++ b/src/app/dashboard/money-hub/page.tsx
@@ -724,7 +724,7 @@ export default function MoneyHubPage() {
 
  if (!data?.accounts?.length) {
  return (
- <div className="max-w-7xl">
+ <div className="max-w-7xl mx-auto w-full">
  <div className="text-center py-10 mb-8">
  <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-emerald-500/10 border border-emerald-200 mb-4">
  <Wallet className="h-8 w-8 text-emerald-600" />

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -786,7 +786,7 @@ export default function ProfilePage() {
   ];
 
   return (
-    <div className="max-w-5xl">
+    <div className="max-w-7xl mx-auto w-full">
       {/* Billing update message */}
       {billingMessage && (
         <div className="mb-6 bg-green-500/10 border border-green-500/30 rounded-xl p-4 text-green-400 text-sm font-medium flex items-center gap-2">

--- a/src/app/dashboard/rewards/page.tsx
+++ b/src/app/dashboard/rewards/page.tsx
@@ -262,7 +262,7 @@ export default function RewardsPage() {
     : 0;
 
   return (
-    <div className="max-w-6xl">
+    <div className="max-w-7xl mx-auto w-full">
       {/* Success banner */}
       {redeemSuccess && (
         <div className="mb-6 bg-green-500/10 border border-green-500/30 rounded-xl p-4 text-green-400 text-sm font-medium flex items-center gap-2 animate-pulse">

--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -415,3 +415,115 @@
 @media (max-width: 1100px) {
   .shell-v2 .compose-grid { grid-template-columns: 1fr; }
 }
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Dashboard chrome consistency pass (fix/dashboard-formatting-audit)
+
+   Founder reported: "all the dashboards are not readable, the formatting
+   is still a mess" — across consumer + admin surfaces. The root causes
+   were not bugs in any one page but inconsistent chrome between pages:
+     - admin sub-pages mixing dark (bg-slate-950) and light themes
+     - max-widths varying between max-w-2xl / 5xl / 6xl / 7xl on siblings
+     - <table> without overflow-x wrappers clipping on 390px viewport
+     - heading sizes diverging (text-2xl font-bold vs text-3xl font-bold
+       vs text-2xl font-semibold) across pages with the same role
+
+   These rules don't refactor any page — they normalise chrome at the
+   shell level so every page already inside `.shell-v2 .main-inner`
+   inherits a consistent baseline.
+   ───────────────────────────────────────────────────────────────────── */
+
+/* 1. Heading hierarchy.
+   Default any H1 inside .main-inner to the page-title size, any H2 to
+   a section size. Pages that already set explicit Tailwind sizes win
+   via specificity (Tailwind utilities are typically `font-size:1.5rem`
+   etc. and at the same specificity as these); this only acts as a floor
+   for pages that forgot. */
+.shell-v2 .main-inner h1:not([class*="text-"]) {
+  font-size: clamp(22px, 2.4vw, 30px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--text);
+}
+.shell-v2 .main-inner h2:not([class*="text-"]) {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+/* 2. Naked <table> overflow safety.
+   Several admin pages render <table> directly inside a card without
+   wrapping in overflow-x-auto, which clipped their widest column on
+   narrow viewports. Force the table itself to scroll horizontally
+   inside its parent if needed. The `display:block` keeps colgroup
+   layout intact while `overflow-x:auto` adds the scroll affordance. */
+.shell-v2 .main-inner table.w-full {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+}
+@media (min-width: 768px) {
+  /* On wider viewports give the natural table layout back so columns
+     proportion themselves. We keep the scroll fallback only where it's
+     actually needed (narrow phones). */
+  .shell-v2 .main-inner table.w-full {
+    display: table;
+    white-space: normal;
+  }
+}
+
+/* 3. Admin sub-page chrome.
+   Anchor admin sub-pages to the same paper background + spacing as the
+   rest of the shell. Replaces the dark `bg-slate-950 text-white` look
+   that several admin pages shipped with by setting a light surface for
+   pages wrapped in <AdminPage>. Pages not yet migrated to <AdminPage>
+   are unaffected — this targets the wrapper class only. */
+.shell-v2 .admin-page {
+  color: var(--text);
+}
+.shell-v2 .admin-page :where(h1, h2, h3) { color: var(--text); }
+.shell-v2 .admin-page-head { min-width: 0; }
+
+/* 4. Reusable card baseline class for admin pages.
+   Pages can opt in by adding `admin-card` to a <section> or <div>. */
+.shell-v2 .admin-card {
+  background: #fff;
+  border: 1px solid var(--divider);
+  border-radius: 14px;
+  padding: 18px;
+}
+
+/* 5. AdminTabStrip horizontal-scroll affordance.
+   PR #417 added flex-wrap to the strip but on very narrow phones (≤
+   360px) wrapping still produced 4 lines. Allow the strip to scroll-x
+   instead of growing tall. Only kick in below 480px so most phones
+   keep the wrapped layout. */
+@media (max-width: 480px) {
+  .shell-v2 .main-inner > .flex.flex-wrap.items-center.gap-2.mb-6 {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 6px;
+    margin-left: -4px;
+    padding-left: 4px;
+  }
+}
+
+/* 6. Mobile-safe break-words on admin headings + breadcrumb.
+   Some admin titles ("Per-tier cost (last 30d)") wrapped awkwardly on
+   390px because the parent flex column had min-width:auto. */
+.shell-v2 .admin-page h1,
+.shell-v2 .admin-page h2,
+.shell-v2 .admin-page h3 {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* 7. Mobile padding tightening for admin page wrapper.
+   The shell's .main-inner already drops to 18px 14px below 640px. We
+   want the admin-page to honour that without adding its own outer
+   padding (which would compound to ~32px on each side). */
+.shell-v2 .admin-page { padding-left: 0; padding-right: 0; }

--- a/src/app/dashboard/subscriptions/page.tsx
+++ b/src/app/dashboard/subscriptions/page.tsx
@@ -1284,7 +1284,7 @@ export default function SubscriptionsPage() {
   }
 
   return (
-    <div className="max-w-7xl">
+    <div className="max-w-7xl mx-auto w-full">
       {/* Share Win Modal */}
       <ShareWinModal
         open={shareModal.open}

--- a/src/components/admin/AdminPage.tsx
+++ b/src/components/admin/AdminPage.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react';
+import AdminBackLink from './AdminBackLink';
+
+interface AdminPageProps {
+  /** H1 page title rendered at the top. */
+  title: string;
+  /** Optional one-line subtitle/eyebrow under the H1. */
+  description?: string;
+  /** Right-side actions (buttons, CTAs) — rendered next to the title. */
+  actions?: ReactNode;
+  /** Override the back-link target. Defaults to /dashboard/admin. */
+  backHref?: string;
+  /** Override the back-link label. Defaults to "Back to Admin". */
+  backLabel?: string;
+  /** Hide the back link entirely (for the admin overview page itself). */
+  hideBack?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Shared chrome wrapper for every admin sub-page under /dashboard/admin/*.
+ *
+ * Before this existed each sub-page rolled its own root container —
+ * some were dark (`bg-slate-950 text-white`), some were light, and
+ * max-widths varied between `max-w-2xl`, `max-w-5xl`, `max-w-6xl` and
+ * `max-w-7xl`. The result was visual chaos when switching between
+ * tabs from the AdminTabStrip.
+ *
+ * This component normalises:
+ * - max-width to `max-w-7xl` so wide tables (cron jobs, analytics)
+ *   have room to breathe without dwarfing narrow pages
+ * - light theme matching the dashboard shell paper background
+ *   (`.shell-v2 .main-inner` is `var(--paper)` = #FAFAF7)
+ * - heading hierarchy: H1 = `text-2xl lg:text-3xl font-semibold`
+ * - consistent vertical rhythm via `space-y-6 lg:space-y-8`
+ * - a back-link to /dashboard/admin so the founder isn't relying on
+ *   browser back to navigate the admin tree
+ */
+export default function AdminPage({
+  title,
+  description,
+  actions,
+  backHref,
+  backLabel,
+  hideBack = false,
+  children,
+}: AdminPageProps) {
+  return (
+    <div className="admin-page max-w-7xl mx-auto w-full">
+      {!hideBack && <AdminBackLink href={backHref} label={backLabel} />}
+      <div className="admin-page-head flex flex-wrap items-start justify-between gap-3 mb-6">
+        <div className="min-w-0">
+          <h1 className="text-2xl lg:text-3xl font-semibold tracking-tight text-slate-900 break-words">
+            {title}
+          </h1>
+          {description && (
+            <p className="mt-1 text-sm lg:text-[15px] text-slate-600 max-w-2xl">
+              {description}
+            </p>
+          )}
+        </div>
+        {actions && (
+          <div className="flex flex-wrap items-center gap-2 shrink-0">{actions}</div>
+        )}
+      </div>
+      <div className="space-y-6 lg:space-y-8">{children}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Founder reported: *"all the dashboards are not readable, the formatting is still a mess"* across both consumer (`/dashboard/*`) and admin (`/dashboard/admin/*`) surfaces, even after PR #417 added the admin tab strip.

This is a chrome-only PR — no data flow changes, no route renames, no refactor of the disputes monolith. Cosmetic cleanup only.

## Per-page audit (BEFORE → AFTER)

| Page | BEFORE | AFTER |
|---|---|---|
| `/dashboard/admin/billing` | dark `bg-slate-950 text-white`, `max-w-6xl`, slate-900 cards | wrapped in shared `<AdminPage>`, light theme matching shell paper, `max-w-7xl`, scrollable tables |
| `/dashboard/admin/whatsapp` | dark `bg-slate-950 text-slate-100 p-6`, `max-w-5xl`, custom back link | `<AdminPage>` chrome, light, consistent buttons + table |
| `/dashboard/admin/dispute-intelligence` | dark `bg-gray-950 text-white`, dark cards (`bg-gray-900 border-gray-800`) | `<AdminPage>` light chrome, white cards w/ slate-200, amber-50 dataset-growth panel |
| `/dashboard/admin/dispute-agent` | dark `bg-slate-950 text-slate-100`, slate-800/900 cards | `<AdminPage>`, light theme |
| `/dashboard/admin/crons` | light but ad-hoc `max-w-5xl` + own header | `<AdminPage>` |
| `/dashboard/admin/analytics` | light but ad-hoc `max-w-7xl` + own header | `<AdminPage>` |
| `/dashboard/admin/legal-refs` | `max-w-7xl` (no `mx-auto`) | `max-w-7xl mx-auto w-full` |
| `/dashboard/profile` | `max-w-5xl` (narrower than siblings) | `max-w-7xl mx-auto w-full` |
| `/dashboard/rewards` | `max-w-6xl` | `max-w-7xl mx-auto w-full` |
| `/dashboard/deals`, `/money-hub`, `/subscriptions` | `max-w-7xl` w/o `mx-auto` (left-hugging on >1440 viewports) | added `mx-auto w-full` |
| `/dashboard` (overview), `/dashboard/disputes`, `/dashboard/contract-vault` | already use shell-v2 chrome (`page-title-row`, `page-title`) — left untouched | unchanged |

## Shared primitives

- **`<AdminPage>`** (`src/components/admin/AdminPage.tsx`) — single source for admin sub-page chrome:
  - `max-w-7xl mx-auto w-full`
  - light theme matching shell paper background
  - H1 `text-2xl lg:text-3xl font-semibold` (consistent with consumer page-title sizing)
  - description slot, actions slot, baked-in back link
- **`shell-v2.css` additions** (additive, scoped to `.shell-v2`):
  - heading floor for `h1`/`h2` inside `.main-inner` when no explicit `text-*` utility set
  - naked `<table className="w-full">` gets `display:block; overflow-x:auto` below 768px so wide tables (cron list, billing) scroll instead of clipping on a 390px viewport
  - reusable `.admin-card` class
  - AdminTabStrip horizontal-scroll affordance on viewports ≤480px (previously wrapped to 4 lines on narrow phones)
  - `overflow-wrap: anywhere` on admin headings so "Per-tier cost (last 30d)" no longer pushes the layout wider than the viewport

## What this does NOT touch

- `/dashboard/disputes` 3,190-line monolith — cosmetic only PR; refactor when feature work demands it (per memory).
- Data flow / API routes / auth.
- The in-flight gate-wiring/rebase PR #422, logo PR, or managed-agents work.
- B2B `/for-business/dashboard/*` — does not exist; B2B portal is `/dashboard/api-keys` which already uses shell-v2 chrome.

## Verification

- [x] `npx tsc --noEmit` clean
- [ ] Manual scan at 390px (iPhone) — admin tab strip scrolls, tables scroll, headings don't push layout
- [ ] Manual scan at 1440px desktop — every admin sub-page sits under the same width as consumer pages
- [ ] Light + dark mode contrast — admin sub-pages now match shell paper background (light)

🤖 Generated with [Claude Code](https://claude.com/claude-code)