### PR TITLE
fix(marketing): correct Onestream win copy + multi-channel framing + accurate pricing comparison

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -1015,7 +1015,7 @@ export default function HomepageV3PreviewPage() {
             </h2>
             <p>
               Two flats. 35 days and 17 days without broadband. The provider offered
-              roughly 1.5 months&rsquo; rental as &ldquo;goodwill&rdquo;. Paybacker
+              roughly 1.5 months&rsquo; service charges as &ldquo;goodwill&rdquo;. Paybacker
               cited the Ofcom Voluntary Automatic Compensation Scheme — £10.07 per
               calendar day from day three of an outage — plus £31.19 per missed
               engineer appointment. The gap is £398.50.
@@ -1027,8 +1027,8 @@ export default function HomepageV3PreviewPage() {
               <div className="real-win__label">What the supplier offered</div>
               <div className="real-win__amount">£106.96</div>
               <ul className="real-win__list">
-                <li>1 month rental on Flat 2 — £38.65</li>
-                <li>1.5 months rental on Flat 1 — £68.31</li>
+                <li>1 month of service charges on Flat 2 — £38.65</li>
+                <li>1.5 months of service charges on Flat 1 — £68.31</li>
                 <li>Framed as &ldquo;goodwill&rdquo;, not entitlement</li>
                 <li>No mention of Ofcom Auto-Comp Scheme</li>
                 <li>No allowance for missed engineer visits</li>
@@ -1281,6 +1281,7 @@ export default function HomepageV3PreviewPage() {
                 <li>Consumer Rights Act 2015, Ofcom, Ofgem, UK261, DVSA, HMRC</li>
                 <li>Energy, broadband, parking, flight delays, council tax</li>
                 <li>3 free letters / month. Unlimited on Essential and Pro.</li>
+                <li>Manage on the web at paybacker.co.uk or on the move via WhatsApp Pocket Agent (Pro) and Telegram Pocket Agent (free on every plan).</li>
               </ul>
               <div className="feature-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup">
@@ -1312,6 +1313,7 @@ export default function HomepageV3PreviewPage() {
                 <li>Transactions auto-categorised across 20+ spend buckets</li>
                 <li>Budgets, savings goals, income tracking, net worth</li>
                 <li>Daily sync on Essential. Unlimited accounts on Pro.</li>
+                <li>Manage on the web at paybacker.co.uk or on the move via WhatsApp Pocket Agent (Pro) and Telegram Pocket Agent (free on every plan) — ask &ldquo;did I get paid?&rdquo;, check balances, see recent transactions.</li>
               </ul>
               <div className="feature-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup">
@@ -1349,6 +1351,7 @@ export default function HomepageV3PreviewPage() {
                 <li>Auto-reply tracking — Watchdog picks up the provider&apos;s response from your inbox and progresses the dispute without you chasing</li>
                 <li>Renewal reminders 30, 14 and 7 days before charge</li>
                 <li>Contract end-date tracking for broadband, energy &amp; mobile</li>
+                <li>Manage on the web at paybacker.co.uk or on the move via WhatsApp Pocket Agent (Pro) and Telegram Pocket Agent (free on every plan).</li>
               </ul>
               <div className="feature-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup">
@@ -1453,7 +1456,7 @@ export default function HomepageV3PreviewPage() {
                 <li>UK banks via Yapily</li>
                 <li>Gmail / Outlook inbox scan</li>
                 <li>Manual subscription add</li>
-                <li>Telegram commands</li>
+                <li>WhatsApp + Telegram commands</li>
                 <li>Dispute form (web or chat)</li>
               </ul>
             </div>
@@ -1492,7 +1495,8 @@ export default function HomepageV3PreviewPage() {
               <div className="arch-label arch-label--mint">Outputs</div>
               <ul className="arch-list">
                 <li>Web app — Money Hub + Disputes</li>
-                <li>Telegram Pocket Agent</li>
+                <li>WhatsApp Pocket Agent (Pro)</li>
+                <li>Telegram Pocket Agent (free)</li>
                 <li>Complaint letters (copy/email/PDF)</li>
                 <li>Google Sheets live sync</li>
                 <li>Deep-links to cancel / switch</li>
@@ -1552,7 +1556,7 @@ export default function HomepageV3PreviewPage() {
                   <td className="us">5+ statutes</td>
                 </tr>
                 <tr>
-                  <td>Telegram / chat agent</td>
+                  <td>WhatsApp + Telegram Pocket Agent</td>
                   <td><span className="x">—</span></td>
                   <td><span className="x">—</span></td>
                   <td><span className="x">—</span></td>
@@ -1652,7 +1656,7 @@ export default function HomepageV3PreviewPage() {
                 <li>2 bank accounts · daily auto-sync</li>
                 <li>1 email inbox · Watchdog reply monitoring</li>
                 <li>Unlimited subscription tracker</li>
-                <li>Pocket Agent + AI chatbot</li>
+                <li>Telegram Pocket Agent + AI chatbot — free on every plan</li>
               </ul>
               <Link className="btn btn-ghost cta" href="/auth/signup" style={{ justifyContent: 'center' }}>
                 Start free →
@@ -1671,6 +1675,7 @@ export default function HomepageV3PreviewPage() {
                 <li>AI cancellation emails + renewal reminders</li>
                 <li>Full spending intelligence + budgets</li>
                 <li>Price-increase alerts by email</li>
+                <li>Telegram Pocket Agent included</li>
               </ul>
               <Link className="btn btn-mint cta" href="/auth/signup" style={{ justifyContent: 'center' }}>
                 Get Essential →
@@ -1684,7 +1689,18 @@ export default function HomepageV3PreviewPage() {
               <ul>
                 <li>Everything in Essential</li>
                 <li>Unlimited bank &amp; email connections</li>
-                <li>Price-increase alerts via Telegram (instant)</li>
+                <li><strong>WhatsApp Pocket Agent</strong> (Pro-only) — your caseworker on chat 24/7:
+                  <ul style={{ marginTop: 6 }}>
+                    <li>Better-deal alerts when a cheaper tariff is found</li>
+                    <li>Instant price-increase alerts</li>
+                    <li>Read &amp; reply to merchant correspondence on the move</li>
+                    <li>&ldquo;Did I get paid?&rdquo; balance &amp; transaction queries</li>
+                    <li>Money-received income alerts</li>
+                    <li>Bill-due reminders + FCA 8-week clock alerts on open disputes</li>
+                    <li>Dispute Agent next-step prompts (approve / override / snooze)</li>
+                    <li>Quick search across UK consumer-rights references</li>
+                  </ul>
+                </li>
                 <li>Money Hub top merchants + transaction analysis</li>
                 <li>Paybacker MCP (Claude Desktop)</li>
                 <li>CSV / PDF export · priority support</li>
@@ -1718,14 +1734,17 @@ export default function HomepageV3PreviewPage() {
       <section className="mcp-section section-ink" id="mcp">
         <div className="wrap">
           <Reveal className="section-head">
-            <span className="pill-pro">Pro plan</span>
-            <span className="eyebrow on-ink">Developer · MCP</span>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12, flexWrap: 'wrap', marginBottom: 16 }}>
+              <span className="pill-pro" style={{ marginBottom: 0 }}>Pro plan</span>
+              <span aria-hidden="true" style={{ color: 'rgba(255,255,255,0.4)', fontSize: 14 }}>·</span>
+              <span className="eyebrow on-ink" style={{ marginBottom: 0 }}>Developer tools — MCP server</span>
+            </div>
             <h2>
               Talk to your money
               <br />
               from Claude Desktop.
             </h2>
-            <p className="sub">
+            <p className="sub" style={{ color: 'var(--text-on-ink)' }}>
               The Paybacker MCP server gives Claude direct read-only access to your
               transactions, hikes, and savings opportunities. Available on Pro.
             </p>

--- a/src/app/pricing/PricingGrid.tsx
+++ b/src/app/pricing/PricingGrid.tsx
@@ -58,8 +58,10 @@ export default function PricingGrid() {
           <div className="founding" style={{ visibility: 'hidden' }}>—</div>
           <ul>
             <li>3 AI dispute letters / month</li>
+            <li>2 bank accounts · daily auto-sync</li>
             <li>Manual subscription tracker</li>
             <li>Public deals marketplace</li>
+            <li>Telegram Pocket Agent + AI chatbot</li>
           </ul>
           <PricingCTA
             plan="free"

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -137,27 +137,45 @@ function MarkFoot() {
 // "On a typical £216 refund" math table — figures pre-computed from the
 // percentage ranges so we don't claim anything stronger than the
 // 15–30% band that's already on the homepage.
+// Comparison: Paybacker vs lawyers vs claims management companies.
+// Numbers anchored to public norms — claims firms typically take 25–35% of
+// recovered amounts (FCA caps consumer-credit-claims management at 30% +
+// VAT under FG22/5); contingency-fee solicitors usually charge 25%+VAT
+// or £200–400/hr private-client rates.
+// TODO(founder): if there's a specific competitor we've benchmarked
+// against directly (DoNotPay, Resolver Plus, etc.), swap the generic
+// rows below for that named comparison.
 const MATH_ROWS: ReadonlyArray<{
   label: string;
   keep: string;
   note: string;
   highlight: boolean;
 }> = [
-  { label: 'Competitor A (30%)', keep: '£151.20', note: 'lost £64.80', highlight: false },
-  { label: 'Competitor B (25%)', keep: '£162.00', note: 'lost £54.00', highlight: false },
-  { label: 'Competitor C (15–20%)', keep: '£172–183', note: 'lost £32–43', highlight: false },
-  { label: 'Paybacker (0%)', keep: '£216.00', note: 'you keep £216', highlight: true },
+  { label: 'Solicitor (25% + VAT contingency)', keep: '£151.20', note: 'lost £64.80 + hourly fees risk', highlight: false },
+  { label: 'Claims management company (25–35%)', keep: '£140–162', note: 'lost £54–76 (FCA cap 30% + VAT)', highlight: false },
+  { label: 'Paybacker (0% success fee)', keep: '£216.00', note: 'you keep 100%', highlight: true },
 ];
 
+// Cells reflect src/lib/plan-limits.ts (PLAN_LIMITS) — copy follows reality,
+// not the other way round. Fix the table here if a limit changes.
 const COMPARE_ROWS: ReadonlyArray<readonly [string, string, string, string]> = [
   ['AI dispute letters', '3 / month', 'Unlimited', 'Unlimited'],
-  ['Bank sync (read-only, FCA via Yapily)', '—', '2 accounts', 'Unlimited'],
-  ['Email inbox scan', '—', '•', '•'],
-  ['Subscription tracker', 'Manual only', '•', '•'],
+  ['Bank sync (read-only, FCA via Yapily)', '2 accounts', '3 accounts', 'Unlimited'],
+  ['Email inbox scan + Watchdog reply polling', '1 inbox', '3 inboxes', 'Unlimited'],
+  ['Subscription tracker', '•', '•', '•'],
+  ['Money Hub (basic spending overview)', '•', '•', '•'],
+  ['Money Hub Budgets, Savings Goals, full categories', '—', '•', '•'],
+  ['Money Hub Top Merchants + transaction-level analysis', '—', '—', '•'],
+  ['AI cancellation emails + renewal reminders', '—', '•', '•'],
+  ['Price-increase alerts (email)', '—', '•', '•'],
   ['Public deals marketplace', '•', '•', '•'],
-  ['Pocket Agent in Telegram', '—', '•', '•'],
-  ['Deal alerts on bill changes', '—', '—', '•'],
-  ['Priority human review', '—', '—', '•'],
+  ['Telegram Pocket Agent + AI chatbot', '•', '•', '•'],
+  ['WhatsApp Pocket Agent', '—', '—', '•'],
+  ['Dispute Agent — autonomous next-step prompts', '—', '•', '•'],
+  ['Paybacker MCP (Claude Desktop)', '—', '—', '•'],
+  ['CSV / PDF export', '—', '—', '•'],
+  ['On-demand bank sync (manual refresh)', '—', '—', '•'],
+  ['Priority support', '—', '—', '•'],
   ['Success fee on refunds', '0%', '0%', '0%'],
 ];
 
@@ -263,10 +281,10 @@ export default function PricingPage() {
                   lineHeight: 1.05,
                 }}
               >
-                Three tiers. Zero success fees.
+                You keep 100% of what we recover.
               </h2>
               <p style={{ fontSize: 16.5, lineHeight: 1.6, color: 'var(--text-secondary)', margin: 0 }}>
-                Whichever tier you pick, we never take a cut of your refund. Competitors charge 15–30% on a successful dispute — on a typical £216 refund, that&apos;s up to £65 out of your pocket. Our revenue comes from the flat subscription, so the incentive stays clean: the more we help you, the longer you stay.
+                <strong>No success fee. Ever.</strong> Compare to claims-management companies (25–35% cut, capped by the FCA at 30% + VAT for consumer-credit claims) and contingency-fee solicitors (25% + VAT, or £200–400/hr private-client rates). Paybacker is a flat monthly subscription — every penny we recover stays in your pocket.
               </p>
             </div>
             <div


### PR DESCRIPTION
## Summary

Seven founder-flagged inaccuracies on the homepage + pricing page. Copy-only — no plan limits, feature gates, or pricing logic changed.

## Fixes

### 1. Onestream "real win" — service charges, not rental
**Before:** "1 month rental on Flat 2 — £38.65" / "1.5 months rental on Flat 1 — £68.31" / "1.5 months' rental as goodwill"
**After:** "1 month of service charges on Flat 2 — £38.65" / "1.5 months of service charges on Flat 1 — £68.31" / "1.5 months' service charges as goodwill"

(Maths untouched per founder's pragmatic call — Ofcom day-count interpretation can be revisited in a follow-up.)

### 2. Multi-channel reach across every dashboard tool
Added a one-liner to AI Disputes Centre, Money Hub, and Subscriptions sections:
> Manage on the web at paybacker.co.uk or on the move via WhatsApp Pocket Agent (Pro) and Telegram Pocket Agent (free on every plan).

### 3. Architecture + competitor matrix
- **Inputs row:** "Telegram commands" → "WhatsApp + Telegram commands"
- **Outputs row:** added "WhatsApp Pocket Agent (Pro)" alongside "Telegram Pocket Agent (free)"
- **Comparison table row:** "Telegram / chat agent" → "WhatsApp + Telegram Pocket Agent"

### 4. Founding-member pricing block
- **Free card:** "Pocket Agent + AI chatbot" → "Telegram Pocket Agent + AI chatbot — free on every plan"
- **Essential card:** added explicit "Telegram Pocket Agent included"
- **Pro card:** replaced single "Price-increase alerts via Telegram" line with the full WhatsApp Pocket Agent feature list:
  - Better-deal alerts when a cheaper tariff is found
  - Instant price-increase alerts
  - Read & reply to merchant correspondence on the move
  - "Did I get paid?" balance & transaction queries
  - Money-received income alerts
  - Bill-due reminders + FCA 8-week clock alerts on open disputes
  - Dispute Agent next-step prompts (approve / override / snooze)
  - Quick search across UK consumer-rights references

### 5. Pro Plan / Developer / MCP block
**Before:** "Pro plan" pill stacked on top of "Developer · MCP" eyebrow with no separator (formatting bug); body text rendered in `--text-on-ink-dim` (low contrast).
**After:** flex row with `Pro plan · Developer tools — MCP server` and proper spacing; body copy bumped to `var(--text-on-ink)` for readable contrast.

### 6. Pricing page "the math"
**Before:** "Three tiers. Zero success fees." with fake Competitor A (30%) / B (25%) / C (15–20%) rows.
**After:** "You keep 100% of what we recover. No success fee. Ever." with three real comparison rows:
- Solicitor (25% + VAT contingency) — keep £151.20
- Claims management company (25–35%, FCA cap 30% + VAT) — keep £140–162
- Paybacker (0% success fee) — keep £216 (100%)

`TODO(founder)` comment left in source for swapping in a named competitor benchmark if/when one is chosen.

### 7. Pricing page comparison table — matches `src/lib/plan-limits.ts`
- Free: now shows 2 banks (was —), 1 inbox, Telegram Pocket Agent ticked (was —)
- Essential: 3 banks, 3 inboxes, Money Hub Budgets/Goals, AI cancellation emails, renewal + price-increase alerts, Dispute Agent
- Pro: WhatsApp Pocket Agent, unlimited bank+email, Top Merchants + transaction analysis, MCP, CSV/PDF export, on-demand bank sync, priority support

## Test plan
- [ ] Visit `/` — re-read the Onestream block and confirm "service charges" copy lands
- [ ] Confirm AI Disputes Centre, Money Hub, Subscriptions all reference the multi-channel one-liner
- [ ] Confirm Architecture Outputs lists both Pocket Agents and competitor table row reads "WhatsApp + Telegram Pocket Agent"
- [ ] Re-read Founding Member Pro card — full WhatsApp Pocket Agent feature list visible and accurate
- [ ] MCP / Developer block — pill + eyebrow have a visible separator and body text is high-contrast
- [ ] Visit `/pricing` — "You keep 100%" headline + 3-row comparison renders
- [ ] Comparison table row counts match plan-limits.ts (Free 2 banks, Essential 3, Pro unlimited; WhatsApp Pro-only)
- [ ] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)