### PR TITLE
fix(admin): match AdminTabStrip regardless of wrapper depth (Codex P2 #427)

### DIFF
--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -502,7 +502,7 @@
    instead of growing tall. Only kick in below 480px so most phones
    keep the wrapped layout. */
 @media (max-width: 480px) {
-  .shell-v2 .main-inner > .flex.flex-wrap.items-center.gap-2.mb-6 {
+  .shell-v2 .main-inner .flex.flex-wrap.items-center.gap-2.mb-6 {
     flex-wrap: nowrap;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## Summary
- Codex P2 follow-up to #427: the mobile (≤480px) horizontal-scroll affordance for the admin tab strip never activated because the CSS selector used a direct-child combinator (`.shell-v2 .main-inner > .flex.flex-wrap.items-center.gap-2.mb-6`), but `src/app/dashboard/admin/page.tsx` wraps its content in a `max-w-7xl` div before rendering `<AdminTabStrip>`.
- Switch to a descendant combinator so the rule matches regardless of wrapper depth, restoring the nowrap + overflow-x:auto behaviour on narrow phones.

## Test plan
- [ ] Vercel preview green
- [ ] On a ≤480px viewport, admin tab strip scrolls horizontally instead of wrapping to multiple lines
- [ ] No regression on >480px (rule is media-query gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)