### PR TITLE
feat(compliance-centre): wire GOV.UK CMA + Find Case Law via canonical source router

### DIFF
--- a/docs/legal-data-api-research-2026-05-01.md
+++ b/docs/legal-data-api-research-2026-05-01.md
@@ -271,3 +271,137 @@ The gate is forward-compatible:
 
 When `feat/legal-data-freshness-pipeline` merges, the gate auto-
 upgrades — no code change required.
+
+
+## Phase 5 — Multi-source routing (2026-05-01)
+
+Phase 1–4 wired `legislation.gov.uk` as the primary canonical source
+and Perplexity as the fallback verifier. Two typed clients shipped at
+the same time but were ORPHANED — no caller imported them:
+
+- `src/lib/legal-data/gov-uk-content.ts` (CMA cases, regulator
+  decisions on gov.uk under `/cma-cases/` and
+  `/government/publications/`)
+- `src/lib/legal-data/find-case-law.ts` (TNA Find Case Law / BAILII /
+  Judiciary judgments)
+
+Phase 5 wires both into the verify route, the amendments-sweep cron,
+and the discover cron via a single canonical-source router.
+
+### Canonical source router
+
+`src/lib/legal-data/source-router.ts → pickCanonicalSource(ref)` is a
+pure synchronous classifier. It returns one of:
+
+| `CanonicalSourceKind` | Host / path matches |
+|---|---|
+| `'legislation'` | `(www\.)?legislation\.gov\.uk` |
+| `'gov-uk-content'` | `(www\.)?gov\.uk` AND path includes `/cma-cases/` OR `/government/publications/` |
+| `'find-case-law'` | `caselaw.nationalarchives.gov.uk`, `(www\.)?bailii\.org`, `(www\.)?judiciary\.uk` |
+| `'perplexity'` | everything else (FCA, Ofcom, Ofgem, FOS, ICO, generic gov.uk, …) |
+
+The router is pure — no env reads, no I/O. Licence enforcement for
+Find Case Law lives at the call site.
+
+### Per-source authority logic (verify route)
+
+For each canonical kind the verify route follows the same shape as
+the legislation.gov.uk path: fetch first-party, then run an
+authority-gate, then fall through to Perplexity if the authority
+gate fails. A canonical fetch is treated as authoritative when:
+
+- `legislation`: existing `isLegislationDocAuthoritative` check —
+  section-text + section-number match, or whole-Act fuzzy title
+  match.
+- `gov-uk-content`: doc returned from
+  `https://www.gov.uk/api/content/{base_path}` with a non-empty
+  title, a non-empty body, and a `base_path` that matches the ref's
+  source_url path. Otherwise: Perplexity fallback.
+- `find-case-law`: search the Atom feed for the ref's `law_name`,
+  prefer an exact URI match against `source_url`, fall back to fuzzy
+  title match. If no hit → Perplexity fallback.
+
+Same `legal_ref_corrections` queue, same founder-approval gate. The
+audit trail records `proposer ∈ {'legislation-gov-uk',
+'gov-uk-content', 'find-case-law', 'perplexity-sonar-pro'}` and
+`source_host ∈ {'legislation.gov.uk', 'gov-uk-content',
+'find-case-law', 'perplexity'}` so the admin UI can show provenance.
+
+### Amendments sweep (Phase 5 changes)
+
+`/api/cron/legal-refs-amendments-sweep` now buckets by canonical
+source. Each tick:
+
+1. Pull the 100 oldest-checked refs.
+2. Bucket via `pickCanonicalSource`.
+3. Sweep the `'legislation'` bucket (existing behaviour, unchanged
+   semantics — `hashLegislationDoc` fingerprint).
+4. Sweep the `'gov-uk-content'` bucket using
+   `hashGovUkContentDoc(doc) = SHA-256(base_path + title + body)`.
+   Drift queues a `legal_ref_corrections` row exactly like
+   legislation.
+5. **Skip** the `'find-case-law'` bucket. Case law is published, not
+   amended, so the weekly reverify cron is sufficient. We
+   reconsider this once the licence env-gate flips.
+6. Existing 100-cap and 5-parallel concurrency apply across both
+   sweeps independently.
+
+### Discover cron (Phase 5 changes)
+
+`/api/cron/discover-legal-refs` gains two alternate-source legs that
+bypass Perplexity entirely:
+
+- `?source=cma&query=<term>` — seeds candidates from
+  `searchByDocumentType('cma_case', query)`.
+- `?source=tna&query=<term>` — seeds candidates from the Find Case
+  Law Atom feed. **Licence-gated** — returns a no-op log line
+  unless `FIND_CASE_LAW_LICENCE_ACCEPTED=true`.
+
+Both write to the existing `legal_ref_candidates` table at status
+`'pending'` so the founder approves before anything reaches
+`legal_references`.
+
+**vercel.json**: the project is at the Vercel cron limit (60
+entries — already over the documented 40-cap and running on a
+custom workaround). We DID NOT add new scheduled cron entries for
+the alternate-source legs. Trade-off: founder runs them ad-hoc via
+the admin "Discover now" button (`POST /api/cron/discover-legal-refs?source=cma&query=...`)
+or, when the licence lands, `?source=tna&query=...`. If/when the
+cron count drops, add `0 5 * * 0` (weekly) for `?source=cma&query=energy`
+and similar.
+
+### B2B contract — `legal_basis_freshness.source` rename
+
+The optional response field's `source` union renamed `'cma-case'` →
+`'gov-uk-content'`. Reasons:
+
+- Aligns with the canonical-source router taxonomy.
+- The `/cma-cases/` and `/government/publications/` paths share the
+  same gov.uk Content API; a CMA-only literal was misleading.
+
+This is technically a breaking change in the union of allowed values.
+The field is 5 days old at rename time so no external integrator is
+expected to be discriminating on `'cma-case'`. Defensive integrators
+should prefer `source.startsWith('gov-uk') ||
+source === 'legislation.gov.uk'` rather than equality matching.
+
+### How the founder activates Find Case Law
+
+1. Apply for the licence:
+   `email caselawlicence@nationalarchives.gov.uk` — see
+   `https://caselaw.nationalarchives.gov.uk/licence-application-process`
+   (~10 working-day approval).
+2. When the licence is granted, set
+   `FIND_CASE_LAW_LICENCE_ACCEPTED=true` in Vercel env (production +
+   preview) and redeploy.
+3. Verify by hitting `POST /api/cron/discover-legal-refs?source=tna&query=PPI`
+   from the admin UI — should return a non-zero `candidates_found`
+   instead of `skipped: true, reason: 'licence-env-not-set'`.
+4. The verify route's find-case-law branch and the discover cron's
+   `?source=tna` leg light up automatically — no code change
+   required.
+
+Until that env is set the router still classifies `caselaw.*` URLs
+as `'find-case-law'` (so the admin chip shows the right family) but
+every call site short-circuits to a structured info log + Perplexity
+fallback.

--- a/src/app/api/admin/legal-refs/verify/route.ts
+++ b/src/app/api/admin/legal-refs/verify/route.ts
@@ -48,9 +48,20 @@ import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
 import {
   fetchStatuteByUri,
   isLegislationDocAuthoritative,
-  isLegislationGovUkUrl,
   type LegislationDoc,
 } from '@/lib/legal-data/legislation-gov-uk';
+import { fetchContent, type GovUkContent } from '@/lib/legal-data/gov-uk-content';
+import {
+  fetchAtomRaw,
+  parseAtomFeed,
+  isProductionEnabled as findCaseLawEnabled,
+  type CaseLawHit,
+} from '@/lib/legal-data/find-case-law';
+import {
+  pickCanonicalSource,
+  SOURCE_LABEL,
+  type CanonicalSourceKind,
+} from '@/lib/legal-data/source-router';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -306,6 +317,102 @@ function verdictFromLegislationDoc(
   };
 }
 
+/**
+ * Authority gate for gov.uk content (CMA cases / regulator pubs).
+ * Same pattern as `isLegislationDocAuthoritative` — non-empty title +
+ * a matching base_path/identifier check. We require the ref's
+ * source_url to share its base_path with the fetched doc, otherwise
+ * we're verifying against an unrelated page.
+ */
+function isGovUkContentDocAuthoritative(
+  doc: GovUkContent | null | undefined,
+  ref: { source_url: string; law_name: string },
+): { authoritative: boolean; reason: string } {
+  if (!doc) return { authoritative: false, reason: 'doc:null' };
+  if (!doc.title || !doc.title.trim()) {
+    return { authoritative: false, reason: 'doc:no-title' };
+  }
+  if (!doc.body || !doc.body.trim()) {
+    return { authoritative: false, reason: 'doc:no-body' };
+  }
+  let refPath = '';
+  try {
+    refPath = new URL(ref.source_url).pathname;
+  } catch {
+    return { authoritative: false, reason: 'ref-url:malformed' };
+  }
+  if (refPath.replace(/\/$/, '') !== doc.base_path.replace(/\/$/, '')) {
+    return {
+      authoritative: false,
+      reason: `doc:path-mismatch(ref='${refPath}',doc='${doc.base_path}')`,
+    };
+  }
+  return { authoritative: true, reason: 'doc:path+title-match' };
+}
+
+function verdictFromGovUkContentDoc(
+  ref: LegalRefRow,
+  doc: GovUkContent,
+): PerplexityVerdict {
+  const titleMatches =
+    doc.title.trim().toLowerCase() === ref.law_name.trim().toLowerCase();
+  return {
+    valid: true,
+    current_url: doc.web_url,
+    superseded_by: null,
+    confidence: titleMatches ? 'high' : 'medium',
+    notes: [
+      `Verified against gov.uk Content API (document_type='${doc.document_type}').`,
+      titleMatches ? null : `Title differs: canonical='${doc.title}', stored='${ref.law_name}'.`,
+      doc.public_updated_at ? `Last updated: ${doc.public_updated_at}.` : null,
+      `Source: gov.uk (Crown Copyright, OGL v3.0).`,
+    ].filter(Boolean).join(' '),
+  };
+}
+
+function pickFindCaseLawMatch(
+  hits: CaseLawHit[],
+  ref: { source_url: string; law_name: string },
+): CaseLawHit | null {
+  if (!hits || hits.length === 0) return null;
+  // Prefer a URI exact match against the stored source_url.
+  const stripSlash = (u: string) => u.replace(/\/$/, '').toLowerCase();
+  const refUrl = stripSlash(ref.source_url);
+  const byUri = hits.find((h) => stripSlash(h.uri) === refUrl);
+  if (byUri) return byUri;
+  // Fall back to a fuzzy title match.
+  const refTitle = ref.law_name.trim().toLowerCase();
+  return (
+    hits.find((h) => h.title.trim().toLowerCase() === refTitle) ||
+    hits.find((h) =>
+      h.title.toLowerCase().includes(refTitle) ||
+      refTitle.includes(h.title.toLowerCase()),
+    ) ||
+    null
+  );
+}
+
+function verdictFromFindCaseLawHit(
+  ref: LegalRefRow,
+  hit: CaseLawHit,
+): PerplexityVerdict {
+  const titleMatches =
+    hit.title.trim().toLowerCase() === ref.law_name.trim().toLowerCase();
+  return {
+    valid: true,
+    current_url: hit.uri,
+    superseded_by: null,
+    confidence: titleMatches ? 'high' : 'medium',
+    notes: [
+      `Verified against Find Case Law (TNA) Atom feed.`,
+      hit.court ? `Court: ${hit.court}.` : null,
+      hit.publishedAt ? `Published: ${hit.publishedAt}.` : null,
+      titleMatches ? null : `Title differs: canonical='${hit.title}', stored='${ref.law_name}'.`,
+      `Source: caselaw.nationalarchives.gov.uk (Crown Copyright, OGL v3.0).`,
+    ].filter(Boolean).join(' '),
+  };
+}
+
 async function verifyOne(id: string, userId: string | null): Promise<VerifyResult> {
   const admin = getAdmin();
   const { data: ref, error } = await admin
@@ -325,15 +432,22 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
   // try the canonical fetcher FIRST and only fall back to Perplexity
   // when the fetch fails or returns no body.
   let verdict: PerplexityVerdict | null = null;
-  let verifierLabel: 'legislation-gov-uk' | 'perplexity-sonar-pro' = 'perplexity-sonar-pro';
-  if (isLegislationGovUkUrl((ref as LegalRefRow).source_url)) {
+  let verifierLabel:
+    | 'legislation-gov-uk'
+    | 'gov-uk-content'
+    | 'find-case-law'
+    | 'perplexity-sonar-pro' = 'perplexity-sonar-pro';
+
+  // Phase 5: pick the canonical source via the router, then dispatch to
+  // the matching first-party fetcher. Fall through to Perplexity on
+  // any non-authoritative result so the existing P1-#415 safety net
+  // still applies for every source.
+  const canonicalKind: CanonicalSourceKind = pickCanonicalSource(
+    (ref as LegalRefRow).source_url,
+  );
+
+  if (canonicalKind === 'legislation') {
     const doc = await fetchStatuteByUri((ref as LegalRefRow).source_url);
-    // We must NOT treat the canonical fetch as authoritative just because
-    // the XML parsed and had a title. If the URL targets a section but the
-    // parser didn't find that section, OR the URL targets a whole Act but
-    // the title doesn't match the stored law_name, we have to fall through
-    // to Perplexity — otherwise an unmatched fetch silently masquerades as
-    // "no_change" and never gets re-grounded. (Codex P1 #415)
     const auth = isLegislationDocAuthoritative(doc, ref as LegalRefRow);
     if (doc && auth.authoritative) {
       verdict = verdictFromLegislationDoc(ref as LegalRefRow, doc);
@@ -343,6 +457,40 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
         '[legal-refs/verify] legislation.gov.uk fetch not authoritative; falling back to Perplexity',
         { ref_id: id, source_url: (ref as LegalRefRow).source_url, reason: auth.reason },
       );
+    }
+  } else if (canonicalKind === 'gov-uk-content') {
+    const doc = await fetchContent((ref as LegalRefRow).source_url);
+    const auth = isGovUkContentDocAuthoritative(doc, ref as LegalRefRow);
+    if (doc && auth.authoritative) {
+      verdict = verdictFromGovUkContentDoc(ref as LegalRefRow, doc);
+      verifierLabel = 'gov-uk-content';
+    } else {
+      console.warn(
+        '[legal-refs/verify] gov.uk content fetch not authoritative; falling back to Perplexity',
+        { ref_id: id, source_url: (ref as LegalRefRow).source_url, reason: auth.reason },
+      );
+    }
+  } else if (canonicalKind === 'find-case-law') {
+    if (!findCaseLawEnabled()) {
+      console.info(
+        '[legal-refs/verify] Find Case Law source skipped — licence env-gate not enabled (FIND_CASE_LAW_LICENCE_ACCEPTED)',
+        { ref_id: id, source_url: (ref as LegalRefRow).source_url },
+      );
+    } else {
+      // Use the ref's title as the search query — Find Case Law's
+      // atom feed returns hits scoring strongly on title match.
+      const xml = await fetchAtomRaw((ref as LegalRefRow).law_name);
+      const hits = xml ? parseAtomFeed(xml) : [];
+      const match = pickFindCaseLawMatch(hits, ref as LegalRefRow);
+      if (match) {
+        verdict = verdictFromFindCaseLawHit(ref as LegalRefRow, match);
+        verifierLabel = 'find-case-law';
+      } else {
+        console.warn(
+          '[legal-refs/verify] find-case-law fetch returned no matching hit; falling back to Perplexity',
+          { ref_id: id, source_url: (ref as LegalRefRow).source_url },
+        );
+      }
     }
   }
 
@@ -451,6 +599,15 @@ async function verifyOne(id: string, userId: string | null): Promise<VerifyResul
       confidence: verdict.confidence,
       cost_gbp: verifierLabel === 'perplexity-sonar-pro' ? COST_PER_CALL_GBP : 0,
       status: 'pending',
+      source_host: SOURCE_LABEL[
+        verifierLabel === 'legislation-gov-uk'
+          ? 'legislation'
+          : verifierLabel === 'gov-uk-content'
+          ? 'gov-uk-content'
+          : verifierLabel === 'find-case-law'
+          ? 'find-case-law'
+          : 'perplexity'
+      ],
     })
     .select('id')
     .limit(1);

--- a/src/app/api/cron/discover-legal-refs/route.ts
+++ b/src/app/api/cron/discover-legal-refs/route.ts
@@ -35,6 +35,11 @@ import { createClient } from '@supabase/supabase-js';
 import { authorizeAdminOrCron } from '@/lib/admin-auth';
 import { logPerplexityCall } from '@/lib/cost-ledger';
 import { checkUkLegalAuthority } from '@/lib/legal-refs-authority';
+import { searchByDocumentType } from '@/lib/legal-data/gov-uk-content';
+import {
+  searchByQuery as searchFindCaseLaw,
+  isProductionEnabled as findCaseLawEnabled,
+} from '@/lib/legal-data/find-case-law';
 
 const CITATION_SOURCE_RULE = [
   'CITATION SOURCE RULE (mandatory): Only return URLs from primary UK legal',
@@ -251,6 +256,18 @@ export async function GET(request: NextRequest) {
       ? 'category_coverage'
       : 'recent_updates';
 
+  // Phase 5: alternate non-Perplexity discovery sources. When
+  // `?source=cma` or `?source=tna` is set, seed candidates from the
+  // gov-uk-content / find-case-law clients respectively. These never
+  // call Perplexity so they sidestep the cost cap entirely and produce
+  // structurally-clean candidates that go straight to the founder
+  // review queue.
+  const sourceParam = (url.searchParams.get('source') || '').toLowerCase();
+  const sourceQuery = url.searchParams.get('query') || '';
+  if (sourceParam === 'cma' || sourceParam === 'tna') {
+    return discoverFromAlternateSource(sourceParam, sourceQuery);
+  }
+
   const queueSize = await pendingQueueSize();
   if (queueSize > MAX_PENDING_QUEUE) {
     const notes = `queue full — review pending first (${queueSize} pending)`;
@@ -393,6 +410,164 @@ export async function GET(request: NextRequest) {
     rejected_non_authority: rejectedNonAuthority,
     secondary: secondaryFlagged,
     cost_gbp: Number(costGbp.toFixed(6)),
+  });
+}
+
+/**
+ * Phase 5: alternate-source discovery (no Perplexity). Seeds
+ * `legal_ref_candidates` from gov.uk CMA cases (source=cma) or Find
+ * Case Law (source=tna). Find Case Law is licence-gated and returns a
+ * no-op when `FIND_CASE_LAW_LICENCE_ACCEPTED!=='true'`.
+ */
+async function discoverFromAlternateSource(
+  source: 'cma' | 'tna',
+  query: string,
+): Promise<NextResponse> {
+  const trimmedQuery = (query || '').trim();
+  if (!trimmedQuery) {
+    return NextResponse.json(
+      { ok: false, error: 'query parameter required for ?source=cma|tna' },
+      { status: 400 },
+    );
+  }
+
+  if (source === 'tna' && !findCaseLawEnabled()) {
+    console.info(
+      '[discover-legal-refs] Find Case Law source skipped — licence env-gate not enabled (FIND_CASE_LAW_LICENCE_ACCEPTED)',
+      { query: trimmedQuery },
+    );
+    await logRun({
+      leg: 'recent_updates',
+      found: 0,
+      added: 0,
+      skipped: 0,
+      costGbp: 0,
+      notes: `source=tna skipped: licence env-gate not enabled`,
+    });
+    return NextResponse.json({
+      ok: true,
+      source,
+      skipped: true,
+      reason: 'licence-env-not-set',
+      candidates_found: 0,
+      candidates_added: 0,
+      candidates_skipped_duplicate: 0,
+    });
+  }
+
+  const queueSize = await pendingQueueSize();
+  if (queueSize > MAX_PENDING_QUEUE) {
+    return NextResponse.json({
+      ok: true,
+      source,
+      skipped: true,
+      reason: 'queue-full',
+      candidates_found: 0,
+      candidates_added: 0,
+      candidates_skipped_duplicate: 0,
+    });
+  }
+
+  type Candidate = PerplexityCandidate;
+  const candidates: Candidate[] = [];
+
+  if (source === 'cma') {
+    const hits = await searchByDocumentType(trimmedQuery, {
+      documentType: 'cma_case',
+      limit: 15,
+    });
+    for (const h of hits) {
+      candidates.push({
+        title: h.title,
+        source_url: h.webUrl,
+        source_type: 'cma_case',
+        summary: h.description,
+        category: null,
+        jurisdiction: 'UK',
+        published_at: h.publicUpdatedAt,
+        confidence: 'high',
+      });
+    }
+  } else {
+    const hits = await searchFindCaseLaw(trimmedQuery);
+    for (const h of hits.slice(0, 15)) {
+      candidates.push({
+        title: h.title,
+        source_url: h.uri,
+        source_type: 'case_law',
+        summary: h.summary,
+        category: null,
+        jurisdiction: 'UK',
+        published_at: h.publishedAt,
+        confidence: 'high',
+      });
+    }
+  }
+
+  const runId = await logRun({
+    leg: 'recent_updates',
+    found: candidates.length,
+    added: 0,
+    skipped: 0,
+    costGbp: 0,
+    notes: `source=${source} query="${trimmedQuery.slice(0, 80)}"`,
+  });
+
+  const admin = getAdmin();
+  let added = 0;
+  let skipped = 0;
+  let rejectedNonAuthority = 0;
+
+  for (const item of candidates) {
+    if (await isDuplicate(item)) {
+      skipped++;
+      continue;
+    }
+    if (item.source_url) {
+      const authority = checkUkLegalAuthority(item.source_url);
+      if (!authority.ok) {
+        rejectedNonAuthority++;
+        skipped++;
+        continue;
+      }
+    }
+    const { error } = await admin.from('legal_ref_candidates').insert({
+      title: item.title.slice(0, 500),
+      source_url: item.source_url?.toString().slice(0, 1000) || null,
+      source_type: item.source_type?.toString().slice(0, 80) || null,
+      summary: item.summary?.toString().slice(0, 4000) || null,
+      category: item.category?.toString().slice(0, 80) || null,
+      jurisdiction: item.jurisdiction || 'UK',
+      confidence: item.confidence || 'high',
+      status: 'pending',
+      discovery_run_id: runId,
+    });
+    if (error) {
+      skipped++;
+      continue;
+    }
+    added++;
+  }
+
+  if (runId !== null) {
+    await admin
+      .from('legal_ref_discovery_runs')
+      .update({
+        candidates_added: added,
+        candidates_skipped_duplicate: skipped,
+      })
+      .eq('id', runId);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    source,
+    query: trimmedQuery,
+    candidates_found: candidates.length,
+    candidates_added: added,
+    candidates_skipped_duplicate: skipped,
+    rejected_non_authority: rejectedNonAuthority,
+    cost_gbp: 0,
   });
 }
 

--- a/src/app/api/cron/legal-refs-amendments-sweep/route.ts
+++ b/src/app/api/cron/legal-refs-amendments-sweep/route.ts
@@ -33,9 +33,17 @@ import { createClient as createAdminClient } from '@supabase/supabase-js';
 import {
   fetchStatuteByUri,
   hashLegislationDoc,
-  isLegislationGovUkUrl,
   type LegislationDoc,
 } from '@/lib/legal-data/legislation-gov-uk';
+import {
+  fetchContent,
+  hashGovUkContentDoc,
+  type GovUkContent,
+} from '@/lib/legal-data/gov-uk-content';
+import {
+  pickCanonicalSource,
+  type CanonicalSourceKind,
+} from '@/lib/legal-data/source-router';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -252,6 +260,152 @@ async function processRef(
 }
 
 /**
+ * Phase 5: gov.uk content (CMA cases / regulator pubs) drift detector.
+ * Same shape as `processRef` but uses gov-uk-content's typed fetcher
+ * + hash function. Drift queues a `legal_ref_corrections` row exactly
+ * like the legislation.gov.uk path; the founder approves before any
+ * canonical write.
+ */
+async function processGovUkContentRef(
+  admin: ReturnType<typeof getAdmin>,
+  ref: LegalRefRow,
+): Promise<Partial<SweepCounts>> {
+  const nowIso = new Date().toISOString();
+
+  let doc: GovUkContent | null = null;
+  try {
+    doc = await fetchContent(ref.source_url);
+  } catch {
+    doc = null;
+  }
+  if (!doc) {
+    return { fetch_failed: 1 };
+  }
+
+  let newHash: string;
+  try {
+    newHash = await hashGovUkContentDoc(doc);
+  } catch {
+    return { errors: 1 };
+  }
+
+  if (!ref.source_xml_hash) {
+    await admin
+      .from('legal_references')
+      .update({
+        source_xml_hash: newHash,
+        last_freshness_check_at: nowIso,
+      })
+      .eq('id', ref.id);
+    return { hashed_first_time: 1 };
+  }
+
+  if (newHash === ref.source_xml_hash) {
+    await admin
+      .from('legal_references')
+      .update({ last_freshness_check_at: nowIso })
+      .eq('id', ref.id);
+    return { unchanged: 1 };
+  }
+
+  // Drift detected — propose a correction.
+  const proposedTitle = doc.title || ref.law_name;
+  const proposedUrl = doc.web_url;
+
+  const reasoningParts = [
+    `gov.uk content has changed since last sweep (document_type='${doc.document_type}').`,
+    `Old hash: ${ref.source_xml_hash.slice(0, 12)}…`,
+    `New hash: ${newHash.slice(0, 12)}…`,
+    doc.public_updated_at ? `Last updated: ${doc.public_updated_at}.` : null,
+    'Source: gov.uk (Crown Copyright, OGL v3.0).',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const { data: insertedRows, error: insErr } = await admin
+    .from('legal_ref_corrections')
+    .insert({
+      ref_id: ref.id,
+      proposer: 'gov-uk-content-amendments-sweep',
+      before_law_name: ref.law_name,
+      before_source_url: ref.source_url,
+      before_status: ref.verification_status,
+      proposed_law_name:
+        proposedTitle.trim().toLowerCase() === ref.law_name.trim().toLowerCase()
+          ? null
+          : proposedTitle,
+      proposed_source_url:
+        proposedUrl.replace(/\/$/, '').toLowerCase() ===
+        (ref.source_url || '').replace(/\/$/, '').toLowerCase()
+          ? null
+          : proposedUrl,
+      proposed_status: 'updated',
+      superseded_by: null,
+      reasoning: reasoningParts,
+      raw_response: {
+        body_excerpt: (doc.body || '').slice(0, 4000),
+        public_updated_at: doc.public_updated_at,
+        first_published_at: doc.first_published_at,
+        document_type: doc.document_type,
+        web_url: doc.web_url,
+      },
+      confidence: 'high',
+      cost_gbp: 0,
+      status: 'pending',
+      source_xml_hash: newHash,
+      source_host: 'gov-uk-content',
+    })
+    .select('id')
+    .limit(1);
+
+  if (insErr) {
+    return { errors: 1 };
+  }
+
+  const newCorrectionId = insertedRows?.[0]?.id ?? null;
+  if (newCorrectionId) {
+    await admin
+      .from('legal_ref_corrections')
+      .update({
+        status: 'superseded_by_newer',
+        reviewed_at: nowIso,
+        reviewed_by: 'amendments-sweep-new-proposal',
+      })
+      .eq('ref_id', ref.id)
+      .eq('status', 'pending')
+      .neq('id', newCorrectionId);
+  }
+
+  await admin
+    .from('legal_references')
+    .update({
+      is_stale: true,
+      last_freshness_check_at: nowIso,
+    })
+    .eq('id', ref.id);
+
+  void admin.from('legal_ref_verifications').insert({
+    ref_id: ref.id,
+    verifier: 'gov-uk-content-amendments-sweep',
+    triggered_by: 'cron',
+    before_status: ref.verification_status,
+    after_status: 'pending-correction-queued',
+    before_url: ref.source_url,
+    after_url: proposedUrl,
+    changes: {
+      queued_correction: true,
+      correction_id: insertedRows?.[0]?.id ?? null,
+      old_hash: ref.source_xml_hash,
+      new_hash: newHash,
+    },
+    cost_gbp: 0,
+    notes: reasoningParts,
+  });
+
+  return { drift_queued: 1 };
+}
+
+/**
  * Pool runner — caps concurrency to N. Returns when every task settles.
  * Used to keep the legislation.gov.uk fetch fan-out polite (≤5 in-flight)
  * while still finishing 100 rows in a reasonable cron window.
@@ -290,15 +444,15 @@ export async function GET(request: NextRequest) {
 
   const admin = getAdmin();
 
-  // Order: never-checked first (NULLs), then oldest last_freshness_check_at.
-  // Filter to legislation.gov.uk hosts only — non-legislation refs fall
-  // under the weekly reverify cron.
+  // Phase 5: bucket by canonical source. Sweep legislation.gov.uk
+  // (existing) AND gov-uk-content refs (new). Skip find-case-law here
+  // — case law is published, not amended, so the weekly reverify cron
+  // is enough.
   const { data, error } = await admin
     .from('legal_references')
     .select(
       'id, law_name, section, source_url, source_type, category, verification_status, source_xml_hash, last_freshness_check_at, is_stale, unapplied_effects',
     )
-    .ilike('source_url', '%legislation.gov.uk%')
     .order('last_freshness_check_at', { ascending: true, nullsFirst: true })
     .limit(HARD_CAP);
 
@@ -309,9 +463,15 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const queue = (data || []).filter((r): r is LegalRefRow =>
-    isLegislationGovUkUrl((r as { source_url?: string }).source_url),
-  );
+  const allRefs = (data || []) as LegalRefRow[];
+  const legQueue: LegalRefRow[] = [];
+  const govQueue: LegalRefRow[] = [];
+  for (const r of allRefs) {
+    const kind: CanonicalSourceKind = pickCanonicalSource(r.source_url);
+    if (kind === 'legislation') legQueue.push(r);
+    else if (kind === 'gov-uk-content') govQueue.push(r);
+    // find-case-law + perplexity refs deliberately skipped here.
+  }
 
   const counts: SweepCounts = {
     scanned: 0,
@@ -323,13 +483,16 @@ export async function GET(request: NextRequest) {
     errors: 0,
   };
 
-  await runWithConcurrency(queue, CONCURRENCY, async (ref) => {
+  const tally = (delta: Partial<SweepCounts>) => {
+    for (const k of Object.keys(delta) as Array<keyof SweepCounts>) {
+      counts[k] += delta[k] ?? 0;
+    }
+  };
+
+  await runWithConcurrency(legQueue, CONCURRENCY, async (ref) => {
     counts.scanned += 1;
     try {
-      const delta = await processRef(admin, ref);
-      for (const k of Object.keys(delta) as Array<keyof SweepCounts>) {
-        counts[k] += delta[k] ?? 0;
-      }
+      tally(await processRef(admin, ref));
     } catch (err) {
       counts.errors += 1;
       console.warn(
@@ -340,5 +503,27 @@ export async function GET(request: NextRequest) {
     }
   });
 
-  return NextResponse.json({ ok: true, queue: queue.length, counts });
+  await runWithConcurrency(govQueue, CONCURRENCY, async (ref) => {
+    counts.scanned += 1;
+    try {
+      tally(await processGovUkContentRef(admin, ref));
+    } catch (err) {
+      counts.errors += 1;
+      console.warn(
+        '[amendments-sweep] processGovUkContentRef threw',
+        ref.id,
+        (err as Error)?.message,
+      );
+    }
+  });
+
+  return NextResponse.json({
+    ok: true,
+    queue: legQueue.length + govQueue.length,
+    queue_breakdown: {
+      legislation: legQueue.length,
+      'gov-uk-content': govQueue.length,
+    },
+    counts,
+  });
 }

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -11,6 +11,31 @@ import {
 import Link from 'next/link';
 import { AutoAppliedPanel } from './AutoAppliedPanel';
 import PendingCorrectionsSection from './PendingCorrectionsSection';
+import { pickCanonicalSource, SOURCE_LABEL } from '@/lib/legal-data/source-router';
+
+/**
+ * Phase 5 (2026-05-01): canonical-source chip. Lets the founder
+ * eyeball at a glance which fetcher will be tried first for each ref
+ * (legislation.gov.uk, gov-uk-content, find-case-law, perplexity).
+ */
+function SourceKindChip({ url }: { url: string | null | undefined }) {
+  const kind = pickCanonicalSource(url ?? '');
+  const palette: Record<string, string> = {
+    legislation: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    'gov-uk-content': 'bg-sky-50 text-sky-700 border-sky-200',
+    'find-case-law': 'bg-violet-50 text-violet-700 border-violet-200',
+    perplexity: 'bg-slate-100 text-slate-600 border-slate-200',
+  };
+  const label = SOURCE_LABEL[kind];
+  return (
+    <span
+      className={`inline-flex items-center text-[10px] font-medium px-1.5 py-0.5 rounded border ${palette[kind]}`}
+      title={`Canonical source: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}
 
 const ADMIN_EMAIL = 'aireypaul@googlemail.com';
 
@@ -1613,7 +1638,10 @@ export default function LegalRefsAdminPage() {
                         <tr key={ref.id} className="border-b border-slate-200 hover:bg-slate-50 transition-colors">
                           <td className="px-5 py-4">
                             <p className="text-slate-900 text-sm font-medium">{ref.law_name}</p>
-                            <p className="text-slate-600 text-xs mt-0.5">{ref.source_type || '—'}{ref.section ? ` · ${ref.section}` : ''}</p>
+                            <p className="text-slate-600 text-xs mt-0.5 flex flex-wrap items-center gap-1.5">
+                              <span>{ref.source_type || '—'}{ref.section ? ` · ${ref.section}` : ''}</span>
+                              <SourceKindChip url={ref.source_url} />
+                            </p>
                           </td>
                           <td className="px-5 py-4 text-slate-700 text-sm hidden md:table-cell">{year}</td>
                           <td className="px-5 py-4 hidden md:table-cell">

--- a/src/lib/b2b/disputes.ts
+++ b/src/lib/b2b/disputes.ts
@@ -222,7 +222,24 @@ export interface DisputeResponse {
   legal_basis_freshness?: Array<{
     ref_id: string;
     last_verified_at: string | null;
-    source: 'legislation.gov.uk' | 'perplexity' | 'find-case-law' | 'cma-case' | 'other';
+    /**
+     * Phase 5 (2026-05-01): the `'cma-case'` literal is RENAMED to
+     * `'gov-uk-content'` to align with the canonical-source router
+     * taxonomy (`src/lib/legal-data/source-router.ts`). gov.uk pages
+     * under `/cma-cases/` AND `/government/publications/` both map to
+     * the `'gov-uk-content'` family, so a CMA-case-only literal was
+     * misleading. This is technically a breaking change in the union;
+     * the field is 5 days old at rename time so no external integrator
+     * is expected to be discriminating on `'cma-case'` yet. If you
+     * need to be defensive: `source.startsWith('gov-uk') ||
+     * source === 'legislation.gov.uk'`.
+     */
+    source:
+      | 'legislation.gov.uk'
+      | 'perplexity'
+      | 'find-case-law'
+      | 'gov-uk-content'
+      | 'other';
     is_stale: boolean;
   }>;
   agent_recommendation?: {

--- a/src/lib/legal-data/__tests__/find-case-law-hash.test.ts
+++ b/src/lib/legal-data/__tests__/find-case-law-hash.test.ts
@@ -1,0 +1,69 @@
+// Phase 5 — unit tests for find-case-law drift-detection hash + the
+// licence-gate behaviour of `searchByQuery`.
+// Run with:
+//   node --experimental-strip-types --test src/lib/legal-data/__tests__/find-case-law-hash.test.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  hashFindCaseLawDoc,
+  searchByQuery,
+  isProductionEnabled,
+} from '../find-case-law.ts';
+
+describe('hashFindCaseLawDoc', () => {
+  const baseDoc = {
+    uri: 'https://caselaw.nationalarchives.gov.uk/uksc/2024/15',
+    title: 'Smith v Acme Ltd [2024] UKSC 15',
+    court: 'UKSC',
+    summary: 'Consumer rights — implied terms — fitness for purpose.',
+  };
+
+  it('returns a 64-character lowercase hex SHA-256', async () => {
+    const h = await hashFindCaseLawDoc(baseDoc);
+    assert.match(h, /^[0-9a-f]{64}$/);
+  });
+
+  it('is stable for identical input', async () => {
+    assert.equal(
+      await hashFindCaseLawDoc(baseDoc),
+      await hashFindCaseLawDoc(baseDoc),
+    );
+  });
+
+  it('changes when the title changes', async () => {
+    const a = await hashFindCaseLawDoc(baseDoc);
+    const b = await hashFindCaseLawDoc({ ...baseDoc, title: 'Different' });
+    assert.notEqual(a, b);
+  });
+});
+
+describe('searchByQuery licence gate', () => {
+  it('returns [] (no fetch) when FIND_CASE_LAW_LICENCE_ACCEPTED is unset', async () => {
+    delete process.env.FIND_CASE_LAW_LICENCE_ACCEPTED;
+    assert.equal(isProductionEnabled(), false);
+    const r = await searchByQuery('test');
+    assert.deepEqual(r, []);
+  });
+
+  it('returns [] (no fetch) when FIND_CASE_LAW_LICENCE_ACCEPTED is "false"', async () => {
+    process.env.FIND_CASE_LAW_LICENCE_ACCEPTED = 'false';
+    assert.equal(isProductionEnabled(), false);
+    const r = await searchByQuery('test');
+    assert.deepEqual(r, []);
+  });
+
+  it('returns [] when FIND_CASE_LAW_LICENCE_ACCEPTED is "1" (strict literal "true")', async () => {
+    process.env.FIND_CASE_LAW_LICENCE_ACCEPTED = '1';
+    assert.equal(isProductionEnabled(), false);
+    const r = await searchByQuery('test');
+    assert.deepEqual(r, []);
+  });
+
+  it('flips isProductionEnabled to true when env is exactly "true"', () => {
+    process.env.FIND_CASE_LAW_LICENCE_ACCEPTED = 'true';
+    assert.equal(isProductionEnabled(), true);
+    delete process.env.FIND_CASE_LAW_LICENCE_ACCEPTED;
+  });
+});

--- a/src/lib/legal-data/__tests__/freshness-gate.test.ts
+++ b/src/lib/legal-data/__tests__/freshness-gate.test.ts
@@ -27,8 +27,12 @@ describe('classifySource', () => {
   it('detects find-case-law', () => {
     assert.equal(classifySource('https://caselaw.nationalarchives.gov.uk/id/uksc/2024/15'), 'find-case-law');
   });
-  it('detects cma-case', () => {
-    assert.equal(classifySource('https://www.gov.uk/cma-cases/abc'), 'cma-case');
+  it('detects gov-uk-content (renamed from cma-case in Phase 5)', () => {
+    assert.equal(classifySource('https://www.gov.uk/cma-cases/abc'), 'gov-uk-content');
+    assert.equal(
+      classifySource('https://www.gov.uk/government/publications/example'),
+      'gov-uk-content',
+    );
   });
   it('falls back to other', () => {
     assert.equal(classifySource('https://example.com/x'), 'other');

--- a/src/lib/legal-data/__tests__/gov-uk-content-hash.test.ts
+++ b/src/lib/legal-data/__tests__/gov-uk-content-hash.test.ts
@@ -1,0 +1,48 @@
+// Phase 5 — unit tests for the gov-uk-content drift-detection hash.
+// Run with:
+//   node --experimental-strip-types --test src/lib/legal-data/__tests__/gov-uk-content-hash.test.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { hashGovUkContentDoc } from '../gov-uk-content.ts';
+
+describe('hashGovUkContentDoc', () => {
+  const baseDoc = {
+    base_path: '/cma-cases/example-case',
+    title: 'Example CMA case',
+    body: 'The CMA opened an investigation into pricing practices.',
+    description: 'Decision page',
+  };
+
+  it('returns a 64-character lowercase hex SHA-256', async () => {
+    const h = await hashGovUkContentDoc(baseDoc);
+    assert.match(h, /^[0-9a-f]{64}$/);
+  });
+
+  it('is stable across calls for identical input', async () => {
+    const a = await hashGovUkContentDoc(baseDoc);
+    const b = await hashGovUkContentDoc(baseDoc);
+    assert.equal(a, b);
+  });
+
+  it('changes when the body changes', async () => {
+    const a = await hashGovUkContentDoc(baseDoc);
+    const b = await hashGovUkContentDoc({
+      ...baseDoc,
+      body: 'The CMA opened an investigation into pricing practices and fined the firm.',
+    });
+    assert.notEqual(a, b);
+  });
+
+  it('changes when the title changes', async () => {
+    const a = await hashGovUkContentDoc(baseDoc);
+    const b = await hashGovUkContentDoc({ ...baseDoc, title: 'Different title' });
+    assert.notEqual(a, b);
+  });
+
+  it('falls back to description when body is null', async () => {
+    const h = await hashGovUkContentDoc({ ...baseDoc, body: null });
+    assert.match(h, /^[0-9a-f]{64}$/);
+  });
+});

--- a/src/lib/legal-data/__tests__/source-router.test.ts
+++ b/src/lib/legal-data/__tests__/source-router.test.ts
@@ -1,0 +1,124 @@
+// Unit tests for the canonical source router.
+// Run with:
+//   node --experimental-strip-types --test src/lib/legal-data/__tests__/source-router.test.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  pickCanonicalSource,
+  SOURCE_LABEL,
+  type CanonicalSourceKind,
+} from '../source-router.ts';
+
+describe('pickCanonicalSource', () => {
+  it('routes legislation.gov.uk hosts to legislation', () => {
+    assert.equal(
+      pickCanonicalSource('https://www.legislation.gov.uk/ukpga/2015/15'),
+      'legislation',
+    );
+    assert.equal(
+      pickCanonicalSource('https://legislation.gov.uk/ukpga/2015/15/section/9'),
+      'legislation',
+    );
+  });
+
+  it('routes gov.uk /cma-cases/ paths to gov-uk-content', () => {
+    assert.equal(
+      pickCanonicalSource('https://www.gov.uk/cma-cases/example-case-2024'),
+      'gov-uk-content',
+    );
+  });
+
+  it('routes gov.uk /government/publications/ paths to gov-uk-content', () => {
+    assert.equal(
+      pickCanonicalSource(
+        'https://www.gov.uk/government/publications/example-decision',
+      ),
+      'gov-uk-content',
+    );
+  });
+
+  it('falls through to perplexity for unrelated gov.uk paths', () => {
+    // /guidance/... is plain content — not a regulator decision page.
+    assert.equal(
+      pickCanonicalSource('https://www.gov.uk/guidance/consumer-rights'),
+      'perplexity',
+    );
+    assert.equal(
+      pickCanonicalSource('https://www.gov.uk/contact'),
+      'perplexity',
+    );
+  });
+
+  it('routes caselaw.nationalarchives.gov.uk to find-case-law', () => {
+    assert.equal(
+      pickCanonicalSource(
+        'https://caselaw.nationalarchives.gov.uk/uksc/2024/15',
+      ),
+      'find-case-law',
+    );
+  });
+
+  it('routes bailii.org and judiciary.uk to find-case-law', () => {
+    assert.equal(
+      pickCanonicalSource('https://www.bailii.org/ew/cases/EWCA/Civ/2023/1.html'),
+      'find-case-law',
+    );
+    assert.equal(
+      pickCanonicalSource('https://judiciary.uk/judgments/some-case'),
+      'find-case-law',
+    );
+  });
+
+  it('falls through to perplexity for everything else (FCA, Ofcom, Ofgem, FOS, ICO)', () => {
+    assert.equal(
+      pickCanonicalSource('https://www.fca.org.uk/handbook/CONC.7'),
+      'perplexity',
+    );
+    assert.equal(
+      pickCanonicalSource('https://www.ofcom.org.uk/some-rule'),
+      'perplexity',
+    );
+    assert.equal(
+      pickCanonicalSource('https://financial-ombudsman.org.uk/businesses/decisions'),
+      'perplexity',
+    );
+  });
+
+  it('handles missing / malformed / null inputs by defaulting to perplexity', () => {
+    assert.equal(pickCanonicalSource(null), 'perplexity');
+    assert.equal(pickCanonicalSource(undefined), 'perplexity');
+    assert.equal(pickCanonicalSource(''), 'perplexity');
+    assert.equal(pickCanonicalSource('not-a-url'), 'perplexity');
+    assert.equal(pickCanonicalSource({ source_url: null }), 'perplexity');
+    assert.equal(
+      pickCanonicalSource({ source_url: 'https://example.com/x' }),
+      'perplexity',
+    );
+  });
+
+  it('accepts a row-shaped object via source_url or url', () => {
+    assert.equal(
+      pickCanonicalSource({ source_url: 'https://www.legislation.gov.uk/ukpga/2015/15' }),
+      'legislation',
+    );
+    assert.equal(
+      pickCanonicalSource({ url: 'https://caselaw.nationalarchives.gov.uk/x' }),
+      'find-case-law',
+    );
+  });
+
+  it('SOURCE_LABEL covers every CanonicalSourceKind', () => {
+    const kinds: CanonicalSourceKind[] = [
+      'legislation',
+      'gov-uk-content',
+      'find-case-law',
+      'perplexity',
+    ];
+    for (const k of kinds) {
+      assert.equal(typeof SOURCE_LABEL[k], 'string');
+      assert.ok(SOURCE_LABEL[k].length > 0);
+    }
+  });
+});

--- a/src/lib/legal-data/find-case-law.ts
+++ b/src/lib/legal-data/find-case-law.ts
@@ -195,3 +195,49 @@ export function isFindCaseLawUrl(url: string | null | undefined): boolean {
     return false;
   }
 }
+
+/**
+ * Backward-compat alias for the discovery cron — searches the Atom
+ * feed by query string. Wraps `searchAtom` and so respects the same
+ * licence env-gate.
+ */
+export async function searchByQuery(
+  query: string,
+  opts: { signal?: AbortSignal; bypassLicenceGate?: boolean } = {},
+): Promise<CaseLawHit[]> {
+  return searchAtom(query, opts);
+}
+
+/**
+ * Hash a Find Case Law judgment (or atom-feed hit) for drift
+ * detection. Includes the canonical URI, title, court, and any
+ * summary excerpt. The Atom feed itself is the only stable
+ * fingerprint surface — the full HTML pages get republished with
+ * navigation chrome changes that we don't want to false-positive on.
+ * SHA-256 lowercase hex.
+ */
+export async function hashFindCaseLawDoc(
+  doc: Pick<CaseLawHit, 'uri' | 'title' | 'court' | 'summary'>,
+): Promise<string> {
+  const summary = (doc.summary || '').replace(/\s+/g, ' ').trim();
+  const payload = [
+    `uri:${doc.uri}`,
+    `title:${(doc.title || '').trim()}`,
+    `court:${doc.court || ''}`,
+    `summary:${summary}`,
+  ].join('\n');
+  return sha256Hex(payload);
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const subtle = (globalThis as { crypto?: Crypto }).crypto?.subtle;
+  if (subtle) {
+    const buf = await subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  const nodeCrypto: typeof import('node:crypto') = await import('node:crypto');
+  return nodeCrypto.createHash('sha256').update(data).digest('hex');
+}

--- a/src/lib/legal-data/freshness-gate.ts
+++ b/src/lib/legal-data/freshness-gate.ts
@@ -94,7 +94,12 @@ export interface FreshnessGateResult {
   provenance: Array<{
     ref_id: string;
     last_verified_at: string | null;
-    source: 'legislation.gov.uk' | 'perplexity' | 'find-case-law' | 'cma-case' | 'other';
+    source:
+      | 'legislation.gov.uk'
+      | 'perplexity'
+      | 'find-case-law'
+      | 'gov-uk-content'
+      | 'other';
     is_stale: boolean;
   }>;
 }
@@ -114,7 +119,10 @@ export function classifySource(url: string | null | undefined): FreshnessGateRes
   const u = url.toLowerCase();
   if (u.includes('legislation.gov.uk')) return 'legislation.gov.uk';
   if (u.includes('caselaw.nationalarchives.gov.uk') || u.includes('find-case-law')) return 'find-case-law';
-  if (u.includes('gov.uk/cma-cases') || u.includes('cma-cases')) return 'cma-case';
+  // Phase 5 (2026-05-01): rename `'cma-case'` → `'gov-uk-content'`. The
+  // `/cma-cases/` and `/government/publications/` paths share the same
+  // gov.uk Content API surface and now classify under one family.
+  if (u.includes('gov.uk/cma-cases') || u.includes('cma-cases') || u.includes('gov.uk/government/publications')) return 'gov-uk-content';
   if (u.includes('perplexity')) return 'perplexity';
   return 'other';
 }

--- a/src/lib/legal-data/gov-uk-content.ts
+++ b/src/lib/legal-data/gov-uk-content.ts
@@ -251,3 +251,38 @@ export function isGovUkUrl(url: string | null | undefined): boolean {
     return false;
   }
 }
+
+/**
+ * Hash a GovUkContent doc for drift detection (Phase 5 amendments
+ * sweep). The fingerprint includes the stable identifier (base_path),
+ * the title, and the body — but NOT `public_updated_at`, which the
+ * publishing platform sometimes ticks on republish without a real
+ * content change. SHA-256 lowercase hex.
+ *
+ * Same hashing pattern as `hashLegislationDoc` so the amendments
+ * sweep can compare new vs stored hashes uniformly across sources.
+ */
+export async function hashGovUkContentDoc(
+  doc: Pick<GovUkContent, 'base_path' | 'title' | 'body' | 'description'>,
+): Promise<string> {
+  const body = (doc.body ?? doc.description ?? '').replace(/\s+/g, ' ').trim();
+  const payload = [
+    `base_path:${doc.base_path}`,
+    `title:${(doc.title || '').trim()}`,
+    `body:${body}`,
+  ].join('\n');
+  return sha256Hex(payload);
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const subtle = (globalThis as { crypto?: Crypto }).crypto?.subtle;
+  if (subtle) {
+    const buf = await subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  const nodeCrypto: typeof import('node:crypto') = await import('node:crypto');
+  return nodeCrypto.createHash('sha256').update(data).digest('hex');
+}

--- a/src/lib/legal-data/source-router.ts
+++ b/src/lib/legal-data/source-router.ts
@@ -1,0 +1,109 @@
+/**
+ * src/lib/legal-data/source-router.ts
+ *
+ * Canonical source router for the Compliance Centre's verify /
+ * amendments-sweep / discover pipelines.
+ *
+ * Given a `legal_references` row (or anything with a `source_url`),
+ * decide WHICH first-party fetcher should be tried first BEFORE we
+ * fall back to Perplexity. This is what wires the previously-orphaned
+ * `gov-uk-content.ts` (CMA cases, regulator decisions) and
+ * `find-case-law.ts` (Find Case Law / TNA) modules into production.
+ *
+ * Per `docs/legal-data-api-research-2026-05-01.md` Phase 5:
+ *   - legislation.gov.uk → primary statutes (existing, unchanged)
+ *   - gov.uk content API → CMA cases + regulator decision pages
+ *     under `/cma-cases/` and `/government/publications/`
+ *   - Find Case Law (TNA) → caselaw.nationalarchives.gov.uk +
+ *     bailii.org + judiciary.uk hosts. **Licence-gated** by
+ *     `FIND_CASE_LAW_LICENCE_ACCEPTED=true`; the gate is enforced at
+ *     the call site, not here. The router will still RETURN
+ *     `'find-case-law'` for these hosts so callers can log skipped
+ *     decisions consistently.
+ *   - Everything else → fall through to Perplexity.
+ *
+ * COMPLIANCE PRINCIPLE: this module is pure — no I/O, no env reads.
+ * It just classifies. The licence env-gate lives at the call site
+ * (verify route, crons) so unit tests don't need to mutate process.env
+ * to exercise the dispatch matrix.
+ */
+
+export type CanonicalSourceKind =
+  | 'legislation'
+  | 'gov-uk-content'
+  | 'find-case-law'
+  | 'perplexity';
+
+interface RoutableRef {
+  source_url?: string | null;
+  url?: string | null;
+}
+
+/**
+ * Decide which canonical fetcher to try for a given citation.
+ *
+ * Pure synchronous classifier — no env reads, no network. Defaults to
+ * `'perplexity'` whenever the URL is missing, malformed, or doesn't
+ * match a recognised authority host.
+ */
+export function pickCanonicalSource(
+  ref: RoutableRef | string | null | undefined,
+): CanonicalSourceKind {
+  const raw =
+    typeof ref === 'string'
+      ? ref
+      : ref?.source_url ?? ref?.url ?? '';
+  if (!raw || typeof raw !== 'string') return 'perplexity';
+
+  let host = '';
+  let path = '';
+  try {
+    const u = new URL(raw);
+    host = u.hostname.toLowerCase();
+    path = u.pathname.toLowerCase();
+  } catch {
+    return 'perplexity';
+  }
+
+  // 1. legislation.gov.uk (and www. variant)
+  if (/^(www\.)?legislation\.gov\.uk$/.test(host)) {
+    return 'legislation';
+  }
+
+  // 2. gov.uk content API — CMA cases + government publications.
+  //    Other gov.uk paths (guidance, news, contact pages) fall through
+  //    to Perplexity because they don't have stable, citation-grade
+  //    JSON shape under /api/content.
+  if (/^(www\.)?gov\.uk$/.test(host)) {
+    if (
+      path.includes('/cma-cases/') ||
+      path.includes('/government/publications/')
+    ) {
+      return 'gov-uk-content';
+    }
+    return 'perplexity';
+  }
+
+  // 3. Find Case Law (TNA) family — caselaw.nationalarchives.gov.uk,
+  //    bailii.org, judiciary.uk. Licence enforcement is at the call
+  //    site, not here.
+  if (host === 'caselaw.nationalarchives.gov.uk') return 'find-case-law';
+  if (/^(www\.)?bailii\.org$/.test(host)) return 'find-case-law';
+  if (/^(www\.)?judiciary\.uk$/.test(host)) return 'find-case-law';
+
+  // 4. Anything else → Perplexity (commentary, regulator subdomains
+  //    we don't have a typed client for, etc.)
+  return 'perplexity';
+}
+
+/**
+ * Mapping from `CanonicalSourceKind` to the audit-trail string used in
+ * `legal_ref_corrections.proposer` / `legal_ref_verifications.verifier`.
+ * The B2B `legal_basis_freshness.source` field uses these same labels.
+ */
+export const SOURCE_LABEL: Record<CanonicalSourceKind, string> = {
+  legislation: 'legislation.gov.uk',
+  'gov-uk-content': 'gov-uk-content',
+  'find-case-law': 'find-case-law',
+  perplexity: 'perplexity',
+};


### PR DESCRIPTION
## Summary

Phase 5 of the legal-data API roadmap. Wires the previously-orphaned `gov-uk-content.ts` (CMA cases + regulator decisions) and `find-case-law.ts` (TNA / BAILII / Judiciary) clients into production via a single pure canonical-source router.

## Source-routing matrix

| Host / path | Canonical fetcher | Notes |
|---|---|---|
| `(www.)?legislation.gov.uk` | `legislation` | Existing; unchanged |
| `(www.)?gov.uk` AND path includes `/cma-cases/` OR `/government/publications/` | `gov-uk-content` | NEW — CMA cases + regulator publications |
| `caselaw.nationalarchives.gov.uk`, `(www.)?bailii.org`, `(www.)?judiciary.uk` | `find-case-law` | NEW — licence-gated; see below |
| Everything else (FCA, Ofcom, Ofgem, FOS, ICO, generic gov.uk, …) | `perplexity` | Unchanged fallback |

`pickCanonicalSource()` is pure (no env reads, no I/O) — covered by 10 unit tests.

## What changed

- New `src/lib/legal-data/source-router.ts`.
- Verify route (`/api/admin/legal-refs/verify`) dispatches via the router. Each source has its own authority gate; mismatch falls back to Perplexity (preserves P1-#415 safety net). Same `legal_ref_corrections` queue, founder-approval still required for any canonical write.
- Amendments sweep buckets refs by canonical source. Sweeps both legislation.gov.uk (existing) and gov-uk-content (new) — case-law refs are skipped (judgments are published, not amended; weekly reverify is sufficient).
- Discover cron gains `?source=cma&query=…` and `?source=tna&query=…` legs that bypass Perplexity entirely.
- New `hashGovUkContentDoc(doc)` and `hashFindCaseLawDoc(doc)` for drift detection.
- Admin UI: small canonical-source chip on each ref row.
- B2B `legal_basis_freshness.source` rename `'cma-case'` → `'gov-uk-content'`.
- Docs: Phase 5 section appended to `docs/legal-data-api-research-2026-05-01.md`.

## Breaking-change call-out

The `'cma-case'` → `'gov-uk-content'` rename in `DisputeResponse.legal_basis_freshness.source` is technically a breaking change in the union of allowed values. The field is 5 days old at rename time and no external integrator is expected to be discriminating on the `'cma-case'` literal yet. Defensive integrators should prefer `source.startsWith('gov-uk') || source === 'legislation.gov.uk'` rather than equality matching against the previous literal.

## Activating Find Case Law (founder)

1. Apply for the TNA transactional licence (`caselawlicence@nationalarchives.gov.uk`, ~10 working days).
2. When granted, set `FIND_CASE_LAW_LICENCE_ACCEPTED=true` in Vercel env (production + preview) and redeploy.
3. Verify with `POST /api/cron/discover-legal-refs?source=tna&query=PPI` — should return non-zero `candidates_found` instead of `skipped: true, reason: 'licence-env-not-set'`.

No code change required to flip the gate — the verify route, sweep, and discover legs all read the env var at call time.

## Vercel cron count trade-off

The project is currently at 60 cron entries (already over the documented 40-cap). I did NOT add new scheduled cron entries for the alternate-source legs. The founder runs them ad-hoc via the admin "Discover now" button. When the cron count drops we can add e.g. `0 5 * * 0` for `?source=cma&query=energy`.

## Test plan

- [x] `npx tsc --noEmit` clean (zero errors in touched files; 89 legal-data tests pass).
- [x] `node --experimental-strip-types --test src/lib/legal-data/__tests__/*.ts` — 89 tests, all green.
- [x] Source-router 10 branches covered (legislation, gov-uk-content cma/publications, find-case-law triple, malformed/null, fallthrough).
- [x] Hash tests for both new sources (stability + diff detection).
- [x] Find Case Law licence-gate strictness (`'true'` literal only — `'1'`, `'false'`, unset all return `[]`).
- [ ] Smoke: amendments-sweep run on staging over a mixed legislation + gov-uk-content seed bucket.
- [ ] Smoke: verify route on a known CMA case URL (`/cma-cases/...`) — confirm `proposer='gov-uk-content'`.
- [ ] Smoke: discover cron `?source=cma&query=energy` — confirm candidates land in `legal_ref_candidates`.
- [ ] Once licence is approved: smoke-test `?source=tna&query=PPI` end-to-end.