### PR TITLE
feat(legal): public methodology + ethics code pages for TNA licence application

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -106,6 +106,8 @@ function MarkFoot() {
             <h5>Legal</h5>
             <Link href="/privacy-policy">Privacy</Link>
             <Link href="/terms-of-service">Terms</Link>
+            <Link href="/legal/methodology">Methodology</Link>
+            <Link href="/legal/ethics-code">Ethics Code</Link>
             <Link href="/cookie-policy">Cookies</Link>
           </div>
           <div className="footer-col">

--- a/src/app/blog/_shared.tsx
+++ b/src/app/blog/_shared.tsx
@@ -69,6 +69,8 @@ export function MarkFoot() {
             <h5>Legal</h5>
             <Link href="/privacy-policy">Privacy</Link>
             <Link href="/terms-of-service">Terms</Link>
+            <Link href="/legal/methodology">Methodology</Link>
+            <Link href="/legal/ethics-code">Ethics Code</Link>
             <Link href="/cookie-policy">Cookies</Link>
             <Link href="/ico-notice">ICO notice</Link>
           </div>

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -115,6 +115,8 @@ function MarkFoot() {
             <h5>Legal</h5>
             <Link href="/privacy-policy">Privacy</Link>
             <Link href="/terms-of-service">Terms</Link>
+            <Link href="/legal/methodology">Methodology</Link>
+            <Link href="/legal/ethics-code">Ethics Code</Link>
             <Link href="/cookie-policy">Cookies</Link>
             <Link href="/ico-notice">ICO notice</Link>
           </div>

--- a/src/app/legal/ethics-code/page.tsx
+++ b/src/app/legal/ethics-code/page.tsx
@@ -1,0 +1,157 @@
+import type { Metadata } from "next";
+import { PostShell, SIGNUP_HREF } from "../../blog/_shared";
+import "../../blog/styles.css";
+
+export const metadata: Metadata = {
+  title: "Code of Ethics — Paybacker LTD",
+  description:
+    "The de facto code of ethics governing Paybacker's AI-drafted consumer complaint letters: human-in-loop, source attribution, plain English, no terminal automation, GDPR posture, transparency and bias monitoring.",
+  alternates: { canonical: "https://paybacker.co.uk/legal/ethics-code" },
+};
+
+const TOC = [
+  { id: "overview", label: "1. Overview" },
+  { id: "human-in-loop", label: "2. Human-in-loop" },
+  { id: "source-attribution", label: "3. Source attribution" },
+  { id: "no-republishing", label: "4. No republishing of judgment text" },
+  { id: "plain-english", label: "5. Plain-English explanation" },
+  { id: "no-terminal-outcomes", label: "6. No automated terminal outcomes" },
+  { id: "corrections-queue", label: "7. Founder-reviewed corrections queue" },
+  { id: "gdpr", label: "8. GDPR posture" },
+  { id: "ai-transparency", label: "9. AI transparency" },
+  { id: "bias-monitoring", label: "10. Bias monitoring" },
+  { id: "contact", label: "11. Contact" },
+];
+
+export default function LegalEthicsCodePage() {
+  return (
+    <PostShell
+      category="Legal"
+      title="Code of Ethics"
+      dek="The principles that govern how Paybacker uses generative AI, primary UK legal sources, and user data when drafting consumer complaint and dispute letters."
+      dateLabel="Last updated 1 May 2026"
+      toc={TOC}
+      aside={{
+        eyebrow: "Questions?",
+        title: "Raise an ethics concern",
+        description:
+          "Email hello@paybacker.co.uk and we will respond within 5 working days.",
+        ctaLabel: "Start free",
+        ctaHref: SIGNUP_HREF,
+      }}
+    >
+      <h2 id="overview">1. Overview</h2>
+      <p>
+        Paybacker drafts UK consumer complaint and dispute letters using
+        generative AI grounded in primary legal sources. This document is the
+        de facto code of ethics already operating inside the product — it
+        describes commitments enforced in code, in process, or in published
+        product behaviour, not aspirations. It corresponds to question 19 of
+        the Find Case Law (TNA) Computational Analysis Agreement application.
+      </p>
+
+      <h2 id="human-in-loop">2. Human-in-loop</h2>
+      <p>
+        AI proposes, the user approves. Paybacker never auto-sends a complaint
+        letter, escalation request, cancellation email, or small-claims draft.
+        The autonomous Dispute Agent surfaces recommended next actions but
+        always requires a user click before any outbound communication is
+        generated or sent. Human approval is the load-bearing safeguard
+        against AI error.
+      </p>
+
+      <h2 id="source-attribution">3. Source attribution</h2>
+      <p>
+        Every citation in a Paybacker letter links back to the original
+        primary source — caselaw.nationalarchives.gov.uk for judgments,
+        legislation.gov.uk for statutes, the regulator&apos;s own domain for
+        guidance. The user, and any recipient of the drafted letter, can
+        always verify a citation against the canonical record.
+      </p>
+
+      <h2 id="no-republishing">4. No republishing of judgment text</h2>
+      <p>
+        Paybacker does not republish the full text of any Find Case Law
+        judgment. Drafted letters quote only the neutral citation, the court,
+        and a short plain-English ratio summary, with a back-link to the
+        original record. Aggregate citation lists or extracted-data feeds are
+        not published.
+      </p>
+
+      <h2 id="plain-english">5. Plain-English explanation</h2>
+      <p>
+        Every formal legal reference in a Paybacker letter is paired with a
+        plain-English explanation of what it means for the consumer&apos;s
+        specific dispute. This is a deliberate accessibility choice:
+        consumers should be able to read their own letter and understand it
+        without legal training.
+      </p>
+
+      <h2 id="no-terminal-outcomes">6. No automated terminal outcomes</h2>
+      <p>
+        Paybacker&apos;s AI never decides whether a dispute is &ldquo;won&rdquo;
+        or &ldquo;lost&rdquo;. The dispute outcome dataset captures
+        won / partial / lost / withdrawn / timeout / still-open states only
+        when the user (or in some cases an AI proposal that the user
+        confirms) explicitly records them. The engine surfaces a suggested
+        outcome with an evidence excerpt; the user has to click Confirm.
+        Terminal outcomes are never auto-written.
+      </p>
+
+      <h2 id="corrections-queue">7. Founder-reviewed corrections queue</h2>
+      <p>
+        Citations drift — statutes are amended, regulator guidance is
+        republished, judgments are superseded. Paybacker runs a daily
+        compliance-sync pipeline that flags any citation whose source
+        appears to have changed. Every proposed change is queued for
+        founder review before the canonical record is updated. Semantic
+        changes (section numbers, year changes, act renames, jurisdiction
+        changes) always require founder approval; only same-host redirect
+        fixes within the authority allowlist may auto-apply.
+      </p>
+
+      <h2 id="gdpr">8. GDPR posture</h2>
+      <p>
+        User data — account information, dispute facts, uploaded
+        correspondence — is held under the UK GDPR. Paybacker LTD is the
+        data controller. We do not extract, store or republish personal
+        data from Find Case Law judgments. Citations reference cases by
+        neutral citation, court and ratio only — names of parties, judges
+        and witnesses appearing in the public record are not used as
+        analytical inputs and are not stored beyond the citation itself.
+        Full details of how we handle user data, including UK GDPR rights,
+        are set out in our{" "}
+        <a href="/privacy-policy">Privacy Policy</a>.
+      </p>
+
+      <h2 id="ai-transparency">9. AI transparency</h2>
+      <p>
+        Paybacker&apos;s use of generative AI is disclosed explicitly in
+        marketing pages and in the onboarding flow. Inside the product,
+        every AI-drafted letter is presented to the user as an AI-assisted
+        draft requiring their review before sending. The AI provider
+        (Anthropic Claude) and the human-in-loop review step are described
+        in our <a href="/legal/methodology">Methodology</a> page.
+      </p>
+
+      <h2 id="bias-monitoring">10. Bias monitoring</h2>
+      <p>
+        We run a monthly sample audit of cited authorities to check that
+        the engine is not over-relying on a narrow set of citations or
+        skewing dispute outcomes by demographic factors. A quarterly
+        summary records the audit findings, any corrections applied, and
+        any changes to the relevance-scoring policy. Findings that would
+        affect cited authorities feed directly into the corrections queue
+        described in section 7.
+      </p>
+
+      <h2 id="contact">11. Contact</h2>
+      <p>
+        Ethics questions, concerns, or proposed corrections:{" "}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>.
+        Paybacker LTD is registered in England &amp; Wales (company no.
+        15289174).
+      </p>
+    </PostShell>
+  );
+}

--- a/src/app/legal/methodology/page.tsx
+++ b/src/app/legal/methodology/page.tsx
@@ -1,0 +1,204 @@
+import type { Metadata } from "next";
+import { PostShell, SIGNUP_HREF } from "../../blog/_shared";
+import "../../blog/styles.css";
+
+export const metadata: Metadata = {
+  title: "Methodology — Paybacker LTD",
+  description:
+    "How Paybacker uses Find Case Law (TNA) records and other primary UK legal sources to ground AI-drafted complaint and dispute letters.",
+  alternates: { canonical: "https://paybacker.co.uk/legal/methodology" },
+};
+
+const TOC = [
+  { id: "overview", label: "1. Overview" },
+  { id: "find-case-law", label: "2. How we use Find Case Law (TNA)" },
+  { id: "citation-pipeline", label: "3. Citation pipeline" },
+  { id: "relevance-scoring", label: "4. Relevance scoring" },
+  { id: "ai-provider", label: "5. AI provider and data flow" },
+  { id: "human-in-loop", label: "6. Human-in-loop review" },
+  { id: "coverage-limits", label: "7. Find Case Law coverage limits" },
+  { id: "verification", label: "8. Verification cadence" },
+  { id: "auditability", label: "9. Auditability and corrections" },
+  { id: "contact", label: "10. Contact" },
+];
+
+export default function LegalMethodologyPage() {
+  return (
+    <PostShell
+      category="Legal"
+      title="Methodology"
+      dek="How Paybacker retrieves, scores, cites and verifies primary UK legal sources — including Find Case Law (TNA) records — when drafting consumer complaint and dispute letters."
+      dateLabel="Last updated 1 May 2026"
+      toc={TOC}
+      aside={{
+        eyebrow: "Questions?",
+        title: "Contact us about methodology",
+        description:
+          "Email hello@paybacker.co.uk with any methodology question — we respond within 5 working days.",
+        ctaLabel: "Start free",
+        ctaHref: SIGNUP_HREF,
+      }}
+    >
+      <h2 id="overview">1. Overview</h2>
+      <p>
+        Paybacker drafts pre-litigation complaint letters, escalation requests,
+        cancellation emails and small-claims correspondence on behalf of UK
+        consumers. Every drafted letter is grounded in primary UK legal sources —
+        legislation, regulator guidance and reported case law — and every
+        citation links back to the original record so the user (and any
+        recipient of the letter) can verify it in full. This page explains how
+        that pipeline works, in line with question 23 and question 27 of our
+        Find Case Law (TNA) Computational Analysis Agreement application.
+      </p>
+
+      <h2 id="find-case-law">2. How we use Find Case Law (TNA)</h2>
+      <p>
+        Find Case Law records are retrieved via the public Atom feed at{" "}
+        <a href="https://caselaw.nationalarchives.gov.uk">
+          caselaw.nationalarchives.gov.uk
+        </a>
+        . Inside Paybacker, Find Case Law is treated as one canonical source
+        through our internal source-router, alongside{" "}
+        <a href="https://www.legislation.gov.uk">legislation.gov.uk</a> and
+        published regulator guidance (Ofcom, Ofgem, FCA, CMA, ICO). We do not
+        republish full judgment text. We extract the neutral citation, the
+        court, the date, and a short ratio summary that describes the principle
+        the judgment establishes for use in consumer disputes. The full record
+        is always reachable via a back-link to the original judgment URL on
+        caselaw.nationalarchives.gov.uk.
+      </p>
+
+      <h2 id="citation-pipeline">3. Citation pipeline</h2>
+      <p>
+        Every citation that appears in a Paybacker-drafted letter contains four
+        elements:
+      </p>
+      <ul>
+        <li>The neutral citation (e.g. <em>[2023] UKSC 1</em>) or statutory reference (e.g. <em>Consumer Rights Act 2015, s.49</em>).</li>
+        <li>The court (for case law) or the issuing body (for legislation and regulator guidance).</li>
+        <li>A short plain-English statement of the ratio or the relevant section.</li>
+        <li>A back-link to the original record — caselaw.nationalarchives.gov.uk for judgments, legislation.gov.uk for statutes, the regulator&apos;s own domain for guidance.</li>
+      </ul>
+      <p>
+        No citation is ever inserted into a draft without a verified
+        back-link. The pre-send guardrail blocks any letter containing a
+        citation that cannot be traced to an authority-listed source.
+      </p>
+
+      <h2 id="relevance-scoring">4. Relevance scoring</h2>
+      <p>
+        For each user dispute we identify the dispute type (e.g. broadband
+        outage, energy overcharge, parking charge, flight delay, debt dispute)
+        and match it to entries in our internal <code>legal_references</code>{" "}
+        table. Candidates are then ranked using two signals:
+      </p>
+      <ul>
+        <li>
+          <strong>Primary-authority preference.</strong> Legislation outranks
+          regulator guidance, which outranks reported case law, which outranks
+          secondary commentary. Find Case Law records are surfaced when a
+          decided case is the clearest authority for the consumer&apos;s claim
+          (for example a Supreme Court decision on penalty clauses) or when
+          legislation alone is ambiguous.
+        </li>
+        <li>
+          <strong>Historical win rate.</strong> When we have at least five
+          recorded outcomes for a given merchant × legal-reference pair, we
+          weight that pair by its recovered-amount and resolved-in-user&apos;s-favour
+          rate. With fewer than five outcomes, this signal is suppressed and
+          ranking falls back to authority preference alone. The model still
+          chooses based on the case facts — historical win rate is provided as
+          context, not as an instruction.
+        </li>
+      </ul>
+
+      <h2 id="ai-provider">5. AI provider and data flow</h2>
+      <p>
+        Drafting and analysis are performed by Anthropic Claude via{" "}
+        <a href="https://api.anthropic.com">api.anthropic.com</a>. Paybacker
+        LTD is the data controller. The prompt sent to Anthropic includes the
+        user&apos;s dispute facts and the structured citation metadata (neutral
+        citation, court, ratio summary, back-link). We do not pass full
+        judgment text back to Anthropic, and the API is invoked under
+        Anthropic&apos;s zero-retention commercial terms — no Paybacker traffic
+        is used for model training.
+      </p>
+
+      <h2 id="human-in-loop">6. Human-in-loop review</h2>
+      <p>
+        Paybacker&apos;s AI proposes; the user approves before any letter is
+        sent. The product never auto-sends a complaint, escalation or
+        cancellation letter on a user&apos;s behalf. The autonomous Dispute
+        Agent surfaces recommended next actions (escalate, await response,
+        send follow-up) but a human click is required before any outbound
+        communication is generated or transmitted. The AI also never writes
+        the terminal canonical fields of a citation — corrections to a
+        citation&apos;s name, source URL or status pass through a founder-reviewed
+        corrections queue (see <a href="#auditability">section 9</a>).
+      </p>
+
+      <h2 id="coverage-limits">7. Find Case Law coverage limits</h2>
+      <p>
+        Find Case Law&apos;s coverage is limited to judgments published from
+        April 2003 onwards. Not all judgments are included — historic case
+        law, much of the lower-court output, and most unreported decisions
+        are outside the collection. Where the relevant authority for a
+        consumer&apos;s dispute predates 2003, sits in a court not currently
+        published, or is otherwise outside Find Case Law&apos;s scope,
+        Paybacker drafts the citation from an alternate primary source —
+        legislation.gov.uk, regulator guidance (Ofcom General Conditions,
+        Ofgem Standard Licence Conditions, FCA CONC, ICO guidance) or the
+        relevant court&apos;s own published rules — and the drafted letter
+        notes the alternate source explicitly. The user sees this caveat
+        where it applies.
+      </p>
+
+      <h2 id="verification">8. Verification cadence</h2>
+      <p>
+        Citations are reverified on a rolling schedule:
+      </p>
+      <ul>
+        <li>
+          <strong>legislation.gov.uk references</strong> are checked daily for
+          amendments, supersessions and repeal status.
+        </li>
+        <li>
+          <strong>Non-legislation references</strong> (Find Case Law records,
+          regulator guidance) are reverified weekly. A daily compliance-sync
+          pipeline runs URL-liveness checks, authority-allowlist audits, and
+          discovery of newly-published judgments and guidance.
+        </li>
+        <li>
+          Any proposed change to a citation&apos;s name, URL or status is
+          queued in <code>legal_ref_corrections</code> and reviewed by the
+          founder before it touches the canonical record. Same-host redirect
+          fixes within the authority allowlist may auto-apply (e.g.{" "}
+          legislation.gov.uk/x/y → legislation.gov.uk/x/y/contents); semantic
+          changes — section numbers, year changes, act renames — always
+          require founder approval.
+        </li>
+      </ul>
+
+      <h2 id="auditability">9. Auditability and corrections</h2>
+      <p>
+        Every decision the engine makes is preserved. The corrections queue
+        records every proposed change to a citation, the source text that
+        triggered it, the verifier that proposed it, and the founder&apos;s
+        accept/reject click. A freshness-audit table records every
+        verification check and its outcome. Together these tables form the
+        audit trail behind any citation we serve. If you believe a citation
+        in a Paybacker letter is incorrect or out of date, email{" "}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a> and
+        we will queue a correction within one working day.
+      </p>
+
+      <h2 id="contact">10. Contact</h2>
+      <p>
+        Methodology questions:{" "}
+        <a href="mailto:hello@paybacker.co.uk">hello@paybacker.co.uk</a>.
+        Paybacker LTD is registered in England &amp; Wales (company no.
+        15289174).
+      </p>
+    </PostShell>
+  );
+}

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -1830,6 +1830,8 @@ export default function HomepageV3PreviewPage() {
               <h5>Legal</h5>
               <Link href="/privacy-policy">Privacy</Link>
               <Link href="/terms-of-service">Terms</Link>
+              <Link href="/legal/methodology">Methodology</Link>
+              <Link href="/legal/ethics-code">Ethics Code</Link>
               <Link href="/cookie-policy">Cookies</Link>
               <Link href="/ico-notice">ICO notice</Link>
             </div>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -111,6 +111,8 @@ function MarkFoot() {
             <h5>Legal</h5>
             <Link href="/privacy-policy">Privacy</Link>
             <Link href="/terms-of-service">Terms</Link>
+            <Link href="/legal/methodology">Methodology</Link>
+            <Link href="/legal/ethics-code">Ethics Code</Link>
             <Link href="/cookie-policy">Cookies</Link>
           </div>
           <div className="footer-col">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -115,5 +115,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${baseUrl}/terms-of-service`, lastModified: now, changeFrequency: 'monthly', priority: 0.2 },
     { url: `${baseUrl}/cookie-policy`, lastModified: now, changeFrequency: 'monthly', priority: 0.2 },
     { url: `${baseUrl}/ico-notice`, lastModified: now, changeFrequency: 'monthly', priority: 0.2 },
+    { url: `${baseUrl}/legal/methodology`, lastModified: now, changeFrequency: 'monthly', priority: 0.3 },
+    { url: `${baseUrl}/legal/ethics-code`, lastModified: now, changeFrequency: 'monthly', priority: 0.3 },
   ];
 }


### PR DESCRIPTION
## Summary

Adds two indexable public pages required by the Find Case Law (TNA) Computational Analysis Agreement application. URLs are referenced verbatim in `docs/find-case-law-licence-application.md` and must be live before the founder submits.

- **`/legal/methodology`** — backs Q23 + Q27.
- **`/legal/ethics-code`** — backs Q19.

Pages reuse the existing `PostShell` chrome (same pattern as `/privacy-policy`) so nav, footer and typography match the rest of the legal surface. Footer "Legal" groups across all five hand-coded marketing footers (homepage preview, about, careers, pricing, blog `_shared`) updated to include Methodology + Ethics Code. Sitemap entries added; no `noindex` (TNA may verify the pages are publicly visible).

## Methodology page — claims it must back (Q23, Q27)

- [x] Find Case Law records retrieved via the public Atom feed at caselaw.nationalarchives.gov.uk
- [x] Treated as a canonical source via the source-router; full judgment text never republished
- [x] Citations: neutral citation + court + ratio + back-link to original judgment URL
- [x] Relevance scoring: dispute type → `legal_references` table → ranked by historical win-rate (≥5 outcomes per merchant×legal_ref) and primary-authority preference (legislation > regulator guidance > case law > secondary)
- [x] AI provider: Anthropic Claude (api.anthropic.com); Paybacker is data controller; no full judgment text passed to Anthropic for training
- [x] Human-in-loop: AI proposes, user approves before send; AI never auto-sends, never auto-writes terminal canonical changes
- [x] Find Case Law coverage limits: April 2003 onwards; alternate sources (legislation.gov.uk, regulator guidance) used and disclosed where authority sits outside coverage
- [x] Verification cadence: legislation.gov.uk daily, non-legislation weekly; corrections queued via `legal_ref_corrections` and reviewed by founder
- [x] Auditability: corrections queue + freshness audit table preserve every decision
- [x] Last-updated 1 May 2026

## Ethics code page — claims it must back (Q19)

- [x] Human-in-loop: AI proposes, user approves before any letter is sent
- [x] Source attribution: every citation links to the original judgment / statute URL
- [x] No republishing of full judgment text
- [x] Plain-English explanation alongside formal legal language
- [x] No automated terminal outcomes (AI never decides won / lost)
- [x] Founder-reviewed corrections queue for any cited authority that drifts
- [x] GDPR posture: user data held under UK GDPR; founder is data controller; no personal data extracted from judgments
- [x] AI transparency: marketing + onboarding explicitly state generative AI is used
- [x] Bias monitoring: monthly sample-audit of cited authorities; quarterly summary
- [x] Last-updated 1 May 2026

## Test plan

- [ ] Vercel preview renders `/legal/methodology` with all 10 sections + TOC
- [ ] Vercel preview renders `/legal/ethics-code` with all 11 sections + TOC
- [ ] Homepage footer shows new Methodology + Ethics Code links under Legal
- [ ] Pricing / About / Careers / Blog footers all updated identically
- [ ] `/sitemap.xml` includes both new URLs
- [ ] Pages do NOT carry a `noindex` meta tag
- [ ] `npx tsc --noEmit` clean for the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)