### PR TITLE
fix(blog/legal): correct early-post images + move legal pages out of blog chrome + footer Legal column

### DIFF
--- a/src/app/blog/_shared.tsx
+++ b/src/app/blog/_shared.tsx
@@ -130,6 +130,13 @@ export type PostShellProps = {
   children: ReactNode;
   /** Optional JSON-LD block to place at the top of the root. */
   jsonLd?: Record<string, unknown>;
+  /**
+   * Which top-level section this page belongs to. Drives the breadcrumb
+   * and which nav item is highlighted. Defaults to 'blog' so the existing
+   * post pages keep their Blog / Category breadcrumb. Standalone legal
+   * pages pass 'legal' so they don't appear nested under Blog.
+   */
+  section?: 'blog' | 'legal';
 };
 
 export function PostShell({
@@ -142,6 +149,7 @@ export function PostShell({
   aside,
   children,
   jsonLd,
+  section = 'blog',
 }: PostShellProps) {
   const defaultAside: PostAsideCTAProps = {
     eyebrow: 'Try Paybacker',
@@ -160,14 +168,24 @@ export function PostShell({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
       ) : null}
-      <MarkNav active="Blog" />
+      <MarkNav active={section === 'blog' ? 'Blog' : undefined} />
       <main>
         <section className="section-light" style={{ paddingTop: 64 }}>
           <div className="wrap">
             <div className="post-breadcrumb">
-              <Link href="/blog">Blog</Link>
-              <span>/</span>
-              {category ? <span className="cat">{category}</span> : <span>{title.length > 48 ? title.slice(0, 48) + '…' : title}</span>}
+              {section === 'blog' ? (
+                <>
+                  <Link href="/blog">Blog</Link>
+                  <span>/</span>
+                  {category ? (
+                    <span className="cat">{category}</span>
+                  ) : (
+                    <span>{title.length > 48 ? title.slice(0, 48) + '…' : title}</span>
+                  )}
+                </>
+              ) : (
+                <span className="cat">{category ?? 'Legal'}</span>
+              )}
             </div>
             <h1 className="post-headline">{title}</h1>
             {dek ? <p className="post-dek">{dek}</p> : null}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -65,7 +65,12 @@ const GRADIENTS = [
 ];
 
 // Hand-coded SEO posts that already exist as live pages under /blog/*.
-const STATIC_POSTS: ReadonlyArray<Omit<Post, 'gradient' | 'emoji'>> = [
+// Each post pins its own gradient + emoji so the icon stays on-topic
+// regardless of how many dynamic posts precede it. Without this the
+// (dynamicPosts.length + i) % GRADIENTS.length cycle handed flight an
+// energy/radio mast icon and energy a plane icon — the founder spotted
+// the mismatch on /blog after the dynamic feed grew.
+const STATIC_POSTS: ReadonlyArray<Post> = [
   {
     title: 'How to Claim Flight Delay Compensation UK — Up to £520',
     excerpt:
@@ -73,6 +78,8 @@ const STATIC_POSTS: ReadonlyArray<Omit<Post, 'gradient' | 'emoji'>> = [
     href: '/blog/how-to-claim-flight-delay-compensation-uk',
     date: '25 March 2026',
     cat: 'Guides',
+    gradient: 'linear-gradient(135deg, #3B82F6, #2563EB)',
+    emoji: '✈',
   },
   {
     title: 'Are You Overpaying on Energy in 2026? Here\'s How to Find Out',
@@ -81,6 +88,8 @@ const STATIC_POSTS: ReadonlyArray<Omit<Post, 'gradient' | 'emoji'>> = [
     href: '/blog/are-you-overpaying-on-energy',
     date: '23 March 2026',
     cat: 'Guides',
+    gradient: 'linear-gradient(135deg, #F59E0B, #D97706)',
+    emoji: '⚡',
   },
   {
     title: 'Your Broadband Contract Has Ended — You\'re Probably Being Overcharged',
@@ -89,6 +98,8 @@ const STATIC_POSTS: ReadonlyArray<Omit<Post, 'gradient' | 'emoji'>> = [
     href: '/blog/broadband-contract-ended',
     date: '23 March 2026',
     cat: 'Guides',
+    gradient: 'linear-gradient(135deg, #14B8A6, #0F766E)',
+    emoji: '📡',
   },
 ];
 
@@ -145,11 +156,7 @@ async function fetchDynamicPosts(): Promise<Post[]> {
 
 export default async function BlogIndexPage() {
   const dynamicPosts = await fetchDynamicPosts();
-  const staticWithArt: Post[] = STATIC_POSTS.map((p, i) => {
-    const g = GRADIENTS[(dynamicPosts.length + i) % GRADIENTS.length];
-    return { ...p, gradient: g.bg, emoji: g.emoji };
-  });
-  const allPosts: Post[] = [...dynamicPosts, ...staticWithArt];
+  const allPosts: Post[] = [...dynamicPosts, ...STATIC_POSTS];
   const [featured, ...rest] = allPosts;
 
   return (

--- a/src/app/legal/ethics-code/page.tsx
+++ b/src/app/legal/ethics-code/page.tsx
@@ -26,6 +26,7 @@ const TOC = [
 export default function LegalEthicsCodePage() {
   return (
     <PostShell
+      section="legal"
       category="Legal"
       title="Code of Ethics"
       dek="The principles that govern how Paybacker uses generative AI, primary UK legal sources, and user data when drafting consumer complaint and dispute letters."

--- a/src/app/legal/methodology/page.tsx
+++ b/src/app/legal/methodology/page.tsx
@@ -25,6 +25,7 @@ const TOC = [
 export default function LegalMethodologyPage() {
   return (
     <PostShell
+      section="legal"
       category="Legal"
       title="Methodology"
       dek="How Paybacker retrieves, scores, cites and verifies primary UK legal sources — including Find Case Law (TNA) records — when drafting consumer complaint and dispute letters."

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -169,6 +169,8 @@ export default function NotFound() {
         <Link href="/about" style={{ color: '#6B7280', textDecoration: 'none' }}>About</Link>
         <Link href="/privacy-policy" style={{ color: '#6B7280', textDecoration: 'none' }}>Privacy</Link>
         <Link href="/terms-of-service" style={{ color: '#6B7280', textDecoration: 'none' }}>Terms</Link>
+        <Link href="/legal/methodology" style={{ color: '#6B7280', textDecoration: 'none' }}>Methodology</Link>
+        <Link href="/legal/ethics-code" style={{ color: '#6B7280', textDecoration: 'none' }}>Ethics Code</Link>
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary

Two founder-flagged issues in one PR:

**1. Wrong icons on the three earliest /blog posts**
- Flight delay post was rendering a 📡 (radio mast)
- Energy post was rendering ✈ (plane)
- Broadband post was generic

Root cause: `/blog/page.tsx` cycled the GRADIENTS array by `(dynamicPosts.length + i) % 5` for the static posts, so the icon assigned to each post drifted as the dynamic Supabase feed grew. Fix pins an explicit gradient + emoji per static post:
- Flight → ✈ blue
- Energy → ⚡ amber
- Broadband → 📡 teal

**2. /legal/methodology and /legal/ethics-code rendering under "Blog / Legal" chrome**
PR #431 reused `PostShell` for the two new TNA legal pages, which hardcoded a `<Link href="/blog">Blog</Link> / Legal` breadcrumb and highlighted Blog in the nav. Founder wants legal pages to stand alone.

`PostShell` now takes an optional `section: 'blog' | 'legal'` prop (default `'blog'`, so existing post pages and other legal pages already on PostShell are untouched). Methodology + Ethics Code pass `section='legal'`:
- Breadcrumb shows just "Legal" (no Blog link)
- Nav no longer highlights Blog

**3. Footer Legal column consistency**
`not-found.tsx` was the one public footer that hadn't picked up Methodology + Ethics Code from PR #431. Added them. The other 5 public footers (about, careers, pricing, preview/homepage, blog `_shared`) already ship the full set.

Body content of methodology and ethics-code pages is unchanged — chrome only, per scope.

## Test plan

- [ ] /blog renders flight=✈, energy=⚡, broadband=📡 in the post grid
- [ ] /legal/methodology shows "Legal" breadcrumb (no "Blog /" prefix), Blog nav item not highlighted
- [ ] /legal/ethics-code same
- [ ] Footer on /, /pricing, /about, /blog, /404 all show Privacy / Terms / Methodology / Ethics Code
- [ ] `npx tsc --noEmit` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)