### PR TITLE
feat(iap): Apple StoreKit 2 IAP backend + native buttons + Twilio DSA voice

### DIFF
--- a/src/app/api/iap/verify/route.ts
+++ b/src/app/api/iap/verify/route.ts
@@ -1,0 +1,86 @@
+/**
+ * POST /api/iap/verify
+ *
+ * Called by the iOS app immediately after a successful StoreKit 2 purchase.
+ * Body: { transactionId: string }
+ *
+ * Flow:
+ *   1. Authenticate the caller via Supabase session (the app passes its
+ *      Supabase access token in Authorization: Bearer …).
+ *   2. Fetch the latest signed transaction info from Apple's App Store
+ *      Server API for that transactionId.
+ *   3. Verify the JWS signature.
+ *   4. Sync the result to the database via syncAppleSubscription().
+ *      This is what links the originalTransactionId to this Supabase user
+ *      so future ASN v2 webhooks can find them.
+ *
+ * Idempotent — calling this multiple times with the same transactionId
+ * is a no-op after the first one (upsert keyed on originalTransactionId).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { fetchTransactionInfo, verifyAppleJws, type JwsTransactionPayload } from '@/lib/iap/apple';
+import { syncAppleSubscription } from '@/lib/iap/sync';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+async function getUserFromAuthHeader(req: NextRequest): Promise<string | null> {
+  const auth = req.headers.get('authorization') || req.headers.get('Authorization');
+  if (!auth || !auth.toLowerCase().startsWith('bearer ')) return null;
+  const token = auth.slice(7).trim();
+  if (!token) return null;
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false } },
+  );
+
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data?.user) return null;
+  return data.user.id;
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'invalid json' }, { status: 400 });
+  }
+
+  const transactionId = (body as { transactionId?: unknown })?.transactionId;
+  if (typeof transactionId !== 'string' || !transactionId) {
+    return NextResponse.json({ ok: false, error: 'transactionId required' }, { status: 400 });
+  }
+
+  const userId = await getUserFromAuthHeader(req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  let payload: JwsTransactionPayload;
+  try {
+    const jws = await fetchTransactionInfo(transactionId);
+    payload = await verifyAppleJws<JwsTransactionPayload>(jws);
+  } catch (err) {
+    console.error('[iap/verify] Apple lookup/verify failed', err);
+    return NextResponse.json(
+      { ok: false, error: 'apple verification failed', detail: (err as Error).message },
+      { status: 502 },
+    );
+  }
+
+  const expectedBundle = process.env.APPLE_BUNDLE_ID;
+  if (expectedBundle && payload.bundleId && payload.bundleId !== expectedBundle) {
+    return NextResponse.json(
+      { ok: false, error: 'bundleId mismatch', expected: expectedBundle, got: payload.bundleId },
+      { status: 400 },
+    );
+  }
+
+  const result = await syncAppleSubscription(payload, userId);
+  return NextResponse.json(result, { status: result.ok ? 200 : 422 });
+}

--- a/src/app/api/iap/webhook/apple/route.ts
+++ b/src/app/api/iap/webhook/apple/route.ts
@@ -1,0 +1,117 @@
+/**
+ * POST /api/iap/webhook/apple
+ *
+ * App Store Server Notifications v2 endpoint. Apple POSTs here for
+ * SUBSCRIBED, DID_RENEW, REFUND, EXPIRED, GRACE_PERIOD_EXPIRED,
+ * REVOKE, and ~15 others.
+ *
+ * Configure URL in App Store Connect → Your App → App Information →
+ * App Store Server Notifications → Production Server URL:
+ *   https://paybacker.co.uk/api/iap/webhook/apple
+ *
+ * Apple retries non-2xx responses for up to 5 days. We always return 200
+ * unless the body is malformed at the JSON-parsing level — that way Apple
+ * stops retrying for permanent errors.
+ *
+ * Idempotency:
+ *   - Dedupe by notificationUUID via iap_processed_notifications table.
+ *   - syncAppleSubscription is itself idempotent.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyAsnV2, verifyAppleJws, type JwsTransactionPayload } from '@/lib/iap/apple';
+import { syncAppleSubscription } from '@/lib/iap/sync';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  let body: { signedPayload?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'invalid json' }, { status: 400 });
+  }
+
+  if (!body.signedPayload) {
+    return NextResponse.json({ ok: false, error: 'signedPayload required' }, { status: 400 });
+  }
+
+  let envelope;
+  try {
+    envelope = await verifyAsnV2(body.signedPayload);
+  } catch (err) {
+    console.error('[iap/webhook/apple] outer JWS verify failed', err);
+    return NextResponse.json({ ok: false, error: 'invalid jws' });
+  }
+
+  const admin = getAdmin();
+  try {
+    const { error: insertErr } = await admin
+      .from('iap_processed_notifications')
+      .insert({
+        source: 'apple_iap',
+        notification_uuid: envelope.notificationUUID,
+        notification_type: envelope.notificationType,
+        payload: envelope as unknown,
+      });
+    if (insertErr && /duplicate|unique/.test(insertErr.message)) {
+      return NextResponse.json({ ok: true, deduped: true, notificationUUID: envelope.notificationUUID });
+    }
+    if (insertErr) {
+      console.warn('[iap/webhook/apple] dedupe insert failed (continuing)', insertErr);
+    }
+  } catch (err) {
+    console.warn('[iap/webhook/apple] dedupe insert threw (continuing)', err);
+  }
+
+  if (!envelope.data?.signedTransactionInfo) {
+    return NextResponse.json({ ok: true, skipped: 'no signedTransactionInfo', type: envelope.notificationType });
+  }
+
+  let txPayload: JwsTransactionPayload;
+  try {
+    txPayload = await verifyAppleJws<JwsTransactionPayload>(envelope.data.signedTransactionInfo);
+  } catch (err) {
+    console.error('[iap/webhook/apple] inner JWS verify failed', err);
+    return NextResponse.json({ ok: false, error: 'invalid inner jws' });
+  }
+
+  const expectedBundle = process.env.APPLE_BUNDLE_ID;
+  if (expectedBundle && txPayload.bundleId && txPayload.bundleId !== expectedBundle) {
+    console.warn('[iap/webhook/apple] bundleId mismatch — ignoring', {
+      expected: expectedBundle,
+      got: txPayload.bundleId,
+    });
+    return NextResponse.json({ ok: true, skipped: 'bundleId mismatch' });
+  }
+
+  const result = await syncAppleSubscription(txPayload);
+
+  if (result.userId) {
+    try {
+      await admin
+        .from('iap_processed_notifications')
+        .update({ user_id: result.userId })
+        .eq('source', 'apple_iap')
+        .eq('notification_uuid', envelope.notificationUUID);
+    } catch {
+      // best-effort
+    }
+  }
+
+  return NextResponse.json({
+    ok: true,
+    notificationType: envelope.notificationType,
+    syncResult: result,
+  });
+}

--- a/src/app/api/subscription/active/route.ts
+++ b/src/app/api/subscription/active/route.ts
@@ -1,0 +1,115 @@
+/**
+ * GET /api/subscription/active
+ *
+ * Returns all active subscription rows for the authenticated user across
+ * billing sources, plus the resolved effective tier.
+ *
+ * Used by:
+ *   - iOS app: BEFORE showing IAP upgrade buttons, call this. If any
+ *     non-IAP active sub exists (e.g. Stripe), show "Manage on web"
+ *     instead. Prevents users double-paying via Apple when they already
+ *     pay via Stripe.
+ *   - Web UpgradePrompt: BEFORE showing Stripe checkout, call this.
+ *     If any IAP active sub exists, show "Manage in App Store" instead.
+ *
+ * Response shape:
+ *   {
+ *     userId: string,
+ *     effectiveTier: 'free' | 'essential' | 'pro',
+ *     primarySource: 'stripe' | 'apple_iap' | 'google_play_billing' | null,
+ *     trialActive: boolean,
+ *     subscriptions: [{ source, tier, billingPeriod, productId, status,
+ *                       expiresAt, autoRenew }, ...]
+ *   }
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+async function getUserFromAuthHeader(req: NextRequest): Promise<string | null> {
+  const auth = req.headers.get('authorization') || req.headers.get('Authorization');
+  if (!auth || !auth.toLowerCase().startsWith('bearer ')) return null;
+  const token = auth.slice(7).trim();
+  if (!token) return null;
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: false } },
+  );
+
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data?.user) return null;
+  return data.user.id;
+}
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } },
+  );
+}
+
+export async function GET(req: NextRequest) {
+  const userId = await getUserFromAuthHeader(req);
+  if (!userId) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+
+  const [profileRes, subsRes] = await Promise.all([
+    admin
+      .from('profiles')
+      .select('subscription_tier, subscription_source, trial_ends_at, trial_converted_at, trial_expired_at')
+      .eq('id', userId)
+      .single(),
+    admin
+      .from('subscriptions')
+      .select('source, tier, billing_period, product_id, status, expires_at, auto_renew')
+      .eq('user_id', userId)
+      .in('status', ['active', 'trialing']),
+  ]);
+
+  const now = Date.now();
+  const activeSubs = (subsRes.data ?? []).filter(
+    (s: { expires_at: string | null }) => !s.expires_at || new Date(s.expires_at).getTime() > now,
+  );
+
+  let effectiveTier = (profileRes.data?.subscription_tier as string) ?? 'free';
+  const trialActive =
+    !!profileRes.data?.trial_ends_at &&
+    new Date(profileRes.data.trial_ends_at) > new Date() &&
+    !profileRes.data?.trial_converted_at &&
+    !profileRes.data?.trial_expired_at;
+  if (trialActive) effectiveTier = 'pro';
+
+  return NextResponse.json({
+    ok: true,
+    userId,
+    effectiveTier,
+    primarySource: profileRes.data?.subscription_source ?? null,
+    trialActive,
+    subscriptions: activeSubs.map((s: {
+      source: string;
+      tier: string;
+      billing_period: string;
+      product_id: string | null;
+      status: string;
+      expires_at: string | null;
+      auto_renew: boolean | null;
+    }) => ({
+      source: s.source,
+      tier: s.tier,
+      billingPeriod: s.billing_period,
+      productId: s.product_id,
+      status: s.status,
+      expiresAt: s.expires_at,
+      autoRenew: s.auto_renew,
+    })),
+  });
+}

--- a/src/app/api/twilio/voice/route.ts
+++ b/src/app/api/twilio/voice/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Twilio Voice webhook for the DSA trader-contact line (+447488895049).
+ *
+ * Twilio POSTs here when someone calls the number. We respond with TwiML
+ * that:
+ *   1. Plays a polite greeting steering callers to email
+ *   2. Records up to 2 minutes of voicemail with auto-transcription
+ *   3. Pings /api/twilio/voicemail when the transcription is ready
+ *
+ * Why this exists: the EU Digital Services Act requires Apple to display
+ * a working trader phone number on every Paybacker App Store listing in
+ * the EU. We don't want to staff a live line for a solo-founder SaaS,
+ * so the voicemail-to-email pattern is the right shape — DSA compliant,
+ * EU-user-friendly, and the founder still sees every message.
+ *
+ * Configured at provision time:
+ *   VoiceUrl    = https://paybacker.co.uk/api/twilio/voice
+ *   VoiceMethod = POST
+ *
+ * No env vars required for this route — TwiML is static. Signature
+ * validation isn't strictly required here (the worst an attacker can
+ * do is trigger our static TwiML response), but we add it anyway for
+ * defence in depth.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { validateTwilioSignature } from '@/lib/twilio/verify';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const TRANSCRIBE_CALLBACK = 'https://paybacker.co.uk/api/twilio/voicemail';
+
+const TWIML = `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Say voice="Polly.Amy-Neural" language="en-GB">Thanks for calling Paybacker. The fastest way to reach our support team is by email at hello at paybacker dot co dot uk. If your message is urgent, please leave a voicemail after the tone, and we will respond within one business day.</Say>
+  <Record maxLength="120" timeout="5" playBeep="true" transcribe="true" transcribeCallback="${TRANSCRIBE_CALLBACK}" finishOnKey="#" />
+  <Say voice="Polly.Amy-Neural" language="en-GB">We did not record a message. Please email hello at paybacker dot co dot uk. Goodbye.</Say>
+</Response>`;
+
+export async function POST(req: NextRequest) {
+  // Signature check — fails open in dev (when TWILIO_AUTH_TOKEN absent)
+  // because we'd rather a misconfigured deploy still answer the phone
+  // than reject the call and 500 to a real EU user.
+  if (process.env.TWILIO_AUTH_TOKEN) {
+    const ok = await validateTwilioSignature(req);
+    if (!ok) {
+      console.warn('[twilio/voice] signature validation failed');
+      return new NextResponse('Forbidden', { status: 403 });
+    }
+  }
+
+  return new NextResponse(TWIML, {
+    status: 200,
+    headers: { 'Content-Type': 'text/xml; charset=utf-8' },
+  });
+}
+
+// Twilio sometimes pre-flights with GET — answer politely so console
+// "Test it" works.
+export async function GET() {
+  return new NextResponse(TWIML, {
+    status: 200,
+    headers: { 'Content-Type': 'text/xml; charset=utf-8' },
+  });
+}

--- a/src/app/api/twilio/voicemail/route.ts
+++ b/src/app/api/twilio/voicemail/route.ts
@@ -1,0 +1,88 @@
+/**
+ * Twilio Voicemail transcription callback.
+ *
+ * Twilio POSTs here once the inbound voicemail has been transcribed
+ * (usually 30-90 seconds after the call ends). We:
+ *   1. Validate the request actually came from Twilio
+ *   2. Email the transcription + recording link to hello@paybacker.co.uk
+ *      via Resend (already wired)
+ *
+ * Body (form-encoded) from Twilio includes:
+ *   From, To, CallSid, RecordingSid, RecordingUrl, RecordingDuration,
+ *   TranscriptionText, TranscriptionStatus, TranscriptionUrl
+ *
+ * For details see https://www.twilio.com/docs/voice/twiml/record#transcribe
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { resend, FROM_EMAIL } from '@/lib/resend';
+import { validateTwilioSignature } from '@/lib/twilio/verify';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NOTIFY_TO = process.env.TWILIO_VOICEMAIL_NOTIFY_TO || 'hello@paybacker.co.uk';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export async function POST(req: NextRequest) {
+  // Defence: fail closed unless the request really is from Twilio.
+  if (process.env.TWILIO_AUTH_TOKEN) {
+    const ok = await validateTwilioSignature(req);
+    if (!ok) {
+      console.warn('[twilio/voicemail] signature validation failed');
+      return new NextResponse('Forbidden', { status: 403 });
+    }
+  } else {
+    console.warn('[twilio/voicemail] TWILIO_AUTH_TOKEN not set — skipping signature check (dev mode)');
+  }
+
+  const form = await req.formData();
+  const data: Record<string, string> = {};
+  for (const [k, v] of form.entries()) {
+    data[k] = typeof v === 'string' ? v : '';
+  }
+
+  const from = data.From || '(unknown)';
+  const callSid = data.CallSid || '';
+  const recordingUrl = data.RecordingUrl || '';
+  const recordingDuration = data.RecordingDuration || '';
+  const transcriptionText = data.TranscriptionText || '(no transcription text — likely silent or below audio threshold)';
+  const transcriptionStatus = data.TranscriptionStatus || '';
+
+  // Twilio's RecordingUrl is the audio resource — append .mp3 for direct playback.
+  const playableUrl = recordingUrl ? `${recordingUrl}.mp3` : '';
+
+  const subject = `📞 Paybacker voicemail from ${from}`;
+  const html = `
+    <div style="font-family: -apple-system, system-ui, sans-serif; max-width: 600px; margin: 0 auto; background: #0f172a; color: #e2e8f0; padding: 32px; border-radius: 16px;">
+      <h2 style="color: #34d399; font-size: 22px; margin: 0 0 16px;">New voicemail on +447488895049</h2>
+      <p style="color: #94a3b8; font-size: 14px; margin: 0 0 8px;">From <strong style="color: #e2e8f0;">${escapeHtml(from)}</strong> — ${escapeHtml(recordingDuration)}s</p>
+      <div style="background: #1e293b; border-radius: 12px; padding: 20px; margin: 20px 0;">
+        <div style="color: #94a3b8; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px;">Transcription (${escapeHtml(transcriptionStatus)})</div>
+        <div style="color: #e2e8f0; font-size: 15px; line-height: 1.6; white-space: pre-wrap;">${escapeHtml(transcriptionText)}</div>
+      </div>
+      ${playableUrl ? `<p style="margin: 16px 0;"><a href="${escapeHtml(playableUrl)}" style="color: #34d399; text-decoration: none; font-weight: 600;">▶ Listen to recording</a></p>` : ''}
+      <p style="color: #64748b; font-size: 11px; margin-top: 24px; padding-top: 16px; border-top: 1px solid #1e293b;">CallSid: ${escapeHtml(callSid)}</p>
+    </div>`;
+
+  try {
+    await resend.emails.send({
+      from: FROM_EMAIL,
+      to: NOTIFY_TO,
+      subject,
+      html,
+    });
+  } catch (err) {
+    console.error('[twilio/voicemail] resend send failed', err);
+    // Still return 200 so Twilio doesn't retry — we've already logged.
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/NativeIapButtons.tsx
+++ b/src/components/NativeIapButtons.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+/**
+ * Native IAP upgrade buttons rendered inside the Capacitor app shell.
+ *
+ * Replaces the web Stripe/Pricing link with Apple-IAP-compliant native
+ * purchase buttons. Cross-source check (CRITICAL): before rendering
+ * buttons, fetches /api/subscription/active. If the user already has
+ * an active non-IAP subscription (Stripe/web), shows a "manage on web"
+ * panel instead — prevents the user from being charged twice.
+ */
+
+import { useEffect, useState } from 'react';
+import { ExternalLink, Loader2, Sparkles } from 'lucide-react';
+import { isNativeShell, nativeBridge, type NativePurchaseResult } from '@/lib/native-shell';
+import { createClient } from '@supabase/supabase-js';
+
+interface ActiveSub {
+  source: 'stripe' | 'apple_iap' | 'google_play_billing';
+  tier: 'free' | 'essential' | 'pro';
+  billingPeriod: 'monthly' | 'annual';
+  productId: string | null;
+  status: string;
+  expiresAt: string | null;
+  autoRenew: boolean | null;
+}
+
+interface ActiveSubsResponse {
+  ok: boolean;
+  effectiveTier: 'free' | 'essential' | 'pro';
+  primarySource: ActiveSub['source'] | null;
+  trialActive: boolean;
+  subscriptions: ActiveSub[];
+}
+
+const PRODUCTS = [
+  { id: 'paybacker.essential.monthly', tier: 'essential', period: 'monthly', priceLabel: '£4.99/mo' },
+  { id: 'paybacker.essential.annual',  tier: 'essential', period: 'annual',  priceLabel: '£44.99/yr' },
+  { id: 'paybacker.pro.monthly',       tier: 'pro',       period: 'monthly', priceLabel: '£9.99/mo' },
+  { id: 'paybacker.pro.annual',        tier: 'pro',       period: 'annual',  priceLabel: '£94.99/yr' },
+] as const;
+
+export default function NativeIapButtons({ onClose }: { onClose?: () => void }) {
+  const [active, setActive] = useState<ActiveSubsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [purchasing, setPurchasing] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const supabase = createClient(
+          process.env.NEXT_PUBLIC_SUPABASE_URL!,
+          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        );
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session?.access_token) {
+          if (!cancelled) {
+            setError('Not signed in');
+            setLoading(false);
+          }
+          return;
+        }
+        const res = await fetch('/api/subscription/active', {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        const data = (await res.json()) as ActiveSubsResponse;
+        if (!cancelled) {
+          setActive(data);
+          setLoading(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message || 'Could not check subscription state');
+          setLoading(false);
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  async function handlePurchase(productId: string) {
+    if (!isNativeShell()) {
+      setError('Not in native shell — cannot purchase');
+      return;
+    }
+    setError(null);
+    setPurchasing(productId);
+    try {
+      const bridge = nativeBridge();
+      if (!bridge.startPurchase) {
+        throw new Error('Native bridge does not support purchase');
+      }
+      const result: NativePurchaseResult = await bridge.startPurchase(productId);
+      if (result.ok) {
+        location.reload();
+      } else if (result.error === 'cancelled') {
+        // silent
+      } else {
+        setError(result.message || `Purchase ${result.error}`);
+      }
+    } catch (err) {
+      setError((err as Error).message || 'Purchase failed');
+    } finally {
+      setPurchasing(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-mint-400" />
+      </div>
+    );
+  }
+
+  const externalSub = active?.subscriptions.find((s) => s.source !== 'apple_iap' && s.source !== 'google_play_billing');
+  if (externalSub) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-xl p-6 text-center">
+        <Sparkles className="h-8 w-8 text-mint-400 mx-auto mb-3" />
+        <h3 className="text-lg font-bold text-slate-900 mb-2">You&apos;re subscribed via the web</h3>
+        <p className="text-sm text-slate-500 mb-4">
+          Your <strong>{externalSub.tier}</strong> plan is managed on paybacker.co.uk.
+          To change or cancel it, sign in there from a browser.
+        </p>
+        <a
+          href="https://paybacker.co.uk/dashboard/billing"
+          className="inline-flex items-center gap-2 text-mint-400 font-semibold text-sm"
+        >
+          Open paybacker.co.uk <ExternalLink className="h-4 w-4" />
+        </a>
+      </div>
+    );
+  }
+
+  const iapSub = active?.subscriptions.find((s) => s.source === 'apple_iap' || s.source === 'google_play_billing');
+  if (iapSub) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-xl p-6 text-center">
+        <Sparkles className="h-8 w-8 text-mint-400 mx-auto mb-3" />
+        <h3 className="text-lg font-bold text-slate-900 mb-2">
+          You&apos;re on {iapSub.tier} ({iapSub.billingPeriod})
+        </h3>
+        <p className="text-sm text-slate-500 mb-4">
+          Manage or cancel your subscription in the App Store / Play Store.
+        </p>
+        <button
+          onClick={() => isNativeShell() && nativeBridge().openManageSubscriptions?.()}
+          className="inline-flex items-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold text-sm px-4 py-2 rounded-lg"
+        >
+          Manage subscription <ExternalLink className="h-4 w-4" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-6">
+      <div className="text-center mb-5">
+        <Sparkles className="h-8 w-8 text-mint-400 mx-auto mb-2" />
+        <h3 className="text-lg font-bold text-slate-900">Choose your plan</h3>
+        <p className="text-xs text-slate-500 mt-1">Cancel anytime in App Store settings</p>
+      </div>
+
+      <div className="grid gap-3">
+        {PRODUCTS.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => handlePurchase(p.id)}
+            disabled={purchasing !== null}
+            className={`
+              w-full flex items-center justify-between gap-4 p-4 rounded-xl border transition-all
+              ${p.tier === 'pro'
+                ? 'border-mint-400 bg-mint-400/5 hover:bg-mint-400/10'
+                : 'border-slate-200 hover:bg-slate-50'}
+              disabled:opacity-50 disabled:cursor-not-allowed
+            `}
+          >
+            <div className="text-left">
+              <p className="text-sm font-bold text-slate-900 capitalize">{p.tier}</p>
+              <p className="text-xs text-slate-500 capitalize">{p.period} billing</p>
+            </div>
+            <div className="text-right">
+              {purchasing === p.id ? (
+                <Loader2 className="h-5 w-5 animate-spin text-mint-400 ml-auto" />
+              ) : (
+                <p className="text-sm font-semibold text-slate-900">{p.priceLabel}</p>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="mt-4 text-xs text-red-600 text-center">{error}</div>
+      )}
+
+      {onClose && (
+        <button
+          onClick={onClose}
+          className="mt-4 w-full text-slate-500 hover:text-slate-900 text-sm transition-colors"
+        >
+          Maybe later
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/NativeIapButtons.tsx
+++ b/src/components/NativeIapButtons.tsx
@@ -9,6 +9,7 @@ import {
   type IapProductId,
   type IapPurchaseResult,
 } from '@/lib/native-shell';
+import { createClient } from '@/lib/supabase/client';
 
 /**
  * Native IAP buttons — rendered inside the Capacitor shell only.
@@ -25,9 +26,27 @@ import {
  * notice instead of risking a double-charge.
  */
 
+/**
+ * Subset of /api/subscription/active's response that the guard cares
+ * about. Full shape is documented at the route handler — keep these
+ * field names in sync if the API shape changes.
+ */
+type SubscriptionActiveResponse = {
+  ok: boolean;
+  effectiveTier?: 'free' | 'essential' | 'pro';
+  primarySource?: 'stripe' | 'apple_iap' | 'google_play_billing' | null;
+  trialActive?: boolean;
+  subscriptions?: Array<{
+    source: string;
+    tier: string;
+    status: string;
+    expiresAt: string | null;
+  }>;
+};
+
 type CrossSourceCheck = {
   hasActive: boolean;
-  source?: 'stripe' | 'apple_iap' | 'google_iap';
+  source?: 'stripe' | 'apple_iap' | 'google_play_billing';
   tier?: 'free' | 'essential' | 'pro';
 };
 
@@ -60,16 +79,64 @@ export default function NativeIapButtons() {
       }
 
       try {
+        // /api/subscription/active requires Bearer auth (it's the same
+        // endpoint the iOS app calls, and that path uses Supabase
+        // access tokens, not cookies). Without the header we'd hit 401
+        // and the guard would silently fail-open — meaning a user with
+        // an active Stripe subscription could buy again on iOS and be
+        // double-charged. Pull the access token from the browser
+        // Supabase session before the fetch.
+        const supabase = createClient();
+        const sessionRes = await supabase.auth.getSession();
+        const accessToken = sessionRes.data.session?.access_token;
+
+        const guardFetch = (async (): Promise<CrossSourceCheck> => {
+          if (!accessToken) {
+            // Logged-out / unknown user — IAP shouldn't surface here
+            // anyway (the page is gated upstream), but be conservative
+            // and treat as "no active sub elsewhere" rather than
+            // blocking purchase.
+            return { hasActive: false };
+          }
+          try {
+            const r = await fetch('/api/subscription/active', {
+              headers: { Authorization: `Bearer ${accessToken}` },
+            });
+            if (!r.ok) return { hasActive: false };
+            const data = (await r.json()) as SubscriptionActiveResponse;
+            const subs = Array.isArray(data.subscriptions) ? data.subscriptions : [];
+            // We only block IAP when the user already has a NON-IAP
+            // active subscription — i.e. Stripe-on-web. An existing
+            // apple_iap/google_play sub means "tap Restore", not
+            // "you'll be double-charged".
+            const blocking = subs.find(
+              (s) =>
+                s.status !== 'expired' &&
+                s.source !== 'apple_iap' &&
+                s.source !== 'google_play_billing',
+            );
+            if (!blocking) return { hasActive: false };
+            return {
+              hasActive: true,
+              source: blocking.source as CrossSourceCheck['source'],
+              tier: data.effectiveTier ?? (blocking.tier as CrossSourceCheck['tier']),
+            };
+          } catch {
+            // Conservative default: don't block purchase on a network
+            // hiccup. The /verify call after a successful purchase
+            // catches double-pay server-side via iap_source_tracking.
+            return { hasActive: false };
+          }
+        })();
+
         // Fire both lookups in parallel
         const [productsResp, crossResp] = await Promise.all([
           plugin.getProducts(),
-          fetch('/api/subscription/active', { credentials: 'include' })
-            .then((r) => (r.ok ? r.json() : { hasActive: false }))
-            .catch(() => ({ hasActive: false })),
+          guardFetch,
         ]);
         if (cancelled) return;
         setProducts(productsResp.products);
-        setCrossSource(crossResp as CrossSourceCheck);
+        setCrossSource(crossResp);
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load products');
       } finally {
@@ -95,7 +162,7 @@ export default function NativeIapButtons() {
           // Refresh the cross-source state so the UI re-renders the upgraded tier
           setCrossSource({
             hasActive: true,
-            source: getPlatform() === 'ios' ? 'apple_iap' : 'google_iap',
+            source: getPlatform() === 'ios' ? 'apple_iap' : 'google_play_billing',
             tier: TIER_DISPLAY[productId].tier,
           });
           // Trigger any parent listener (e.g. close the modal)
@@ -182,7 +249,7 @@ export default function NativeIapButtons() {
   }
 
   // Already subscribed via the same store — show manage instead
-  if (crossSource?.hasActive && (crossSource.source === 'apple_iap' || crossSource.source === 'google_iap')) {
+  if (crossSource?.hasActive && (crossSource.source === 'apple_iap' || crossSource.source === 'google_play_billing')) {
     return (
       <div className="space-y-3">
         <div className="bg-mint-400/10 border border-mint-400/20 rounded-xl p-4 text-sm text-slate-900">

--- a/src/components/NativeIapButtons.tsx
+++ b/src/components/NativeIapButtons.tsx
@@ -1,210 +1,277 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import { Sparkles, Loader2, AlertCircle } from 'lucide-react';
+import {
+  getIapPlugin,
+  getPlatform,
+  type IapProduct,
+  type IapProductId,
+  type IapPurchaseResult,
+} from '@/lib/native-shell';
+
 /**
- * Native IAP upgrade buttons rendered inside the Capacitor app shell.
+ * Native IAP buttons — rendered inside the Capacitor shell only.
  *
- * Replaces the web Stripe/Pricing link with Apple-IAP-compliant native
- * purchase buttons. Cross-source check (CRITICAL): before rendering
- * buttons, fetches /api/subscription/active. If the user already has
- * an active non-IAP subscription (Stripe/web), shows a "manage on web"
- * panel instead — prevents the user from being charged twice.
+ * Loads the 4 subscription products from the device store (Apple or Google)
+ * and exposes Buy / Restore / Manage Subscriptions buttons. Each purchase
+ * triggers Apple's native Face ID / Touch ID sheet (or Google Play sheet
+ * on Android), and on success the plugin POSTs the JWS receipt to
+ * /api/iap/verify before resolving.
+ *
+ * Cross-source guard: before showing a purchase button we hit
+ * /api/subscription/active to check whether the user already has an active
+ * subscription via Stripe (web) — if so, we render an "Already subscribed"
+ * notice instead of risking a double-charge.
  */
 
-import { useEffect, useState } from 'react';
-import { ExternalLink, Loader2, Sparkles } from 'lucide-react';
-import { isNativeShell, nativeBridge, type NativePurchaseResult } from '@/lib/native-shell';
-import { createClient } from '@supabase/supabase-js';
+type CrossSourceCheck = {
+  hasActive: boolean;
+  source?: 'stripe' | 'apple_iap' | 'google_iap';
+  tier?: 'free' | 'essential' | 'pro';
+};
 
-interface ActiveSub {
-  source: 'stripe' | 'apple_iap' | 'google_play_billing';
-  tier: 'free' | 'essential' | 'pro';
-  billingPeriod: 'monthly' | 'annual';
-  productId: string | null;
-  status: string;
-  expiresAt: string | null;
-  autoRenew: boolean | null;
-}
+const TIER_DISPLAY: Record<IapProductId, { tier: 'essential' | 'pro'; period: 'month' | 'year' }> = {
+  'paybacker.essential.monthly': { tier: 'essential', period: 'month' },
+  'paybacker.essential.annual': { tier: 'essential', period: 'year' },
+  'paybacker.pro.monthly': { tier: 'pro', period: 'month' },
+  'paybacker.pro.annual': { tier: 'pro', period: 'year' },
+};
 
-interface ActiveSubsResponse {
-  ok: boolean;
-  effectiveTier: 'free' | 'essential' | 'pro';
-  primarySource: ActiveSub['source'] | null;
-  trialActive: boolean;
-  subscriptions: ActiveSub[];
-}
-
-const PRODUCTS = [
-  { id: 'paybacker.essential.monthly', tier: 'essential', period: 'monthly', priceLabel: '£4.99/mo' },
-  { id: 'paybacker.essential.annual',  tier: 'essential', period: 'annual',  priceLabel: '£44.99/yr' },
-  { id: 'paybacker.pro.monthly',       tier: 'pro',       period: 'monthly', priceLabel: '£9.99/mo' },
-  { id: 'paybacker.pro.annual',        tier: 'pro',       period: 'annual',  priceLabel: '£94.99/yr' },
-] as const;
-
-export default function NativeIapButtons({ onClose }: { onClose?: () => void }) {
-  const [active, setActive] = useState<ActiveSubsResponse | null>(null);
+export default function NativeIapButtons() {
+  const [products, setProducts] = useState<IapProduct[]>([]);
   const [loading, setLoading] = useState(true);
-  const [purchasing, setPurchasing] = useState<string | null>(null);
+  const [purchasingId, setPurchasingId] = useState<IapProductId | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [crossSource, setCrossSource] = useState<CrossSourceCheck | null>(null);
+  const [restoring, setRestoring] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
+      const plugin = getIapPlugin();
+      if (!plugin) {
+        if (!cancelled) {
+          setError('Native IAP plugin not available on this platform.');
+          setLoading(false);
+        }
+        return;
+      }
+
       try {
-        const supabase = createClient(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-        );
-        const { data: { session } } = await supabase.auth.getSession();
-        if (!session?.access_token) {
-          if (!cancelled) {
-            setError('Not signed in');
-            setLoading(false);
-          }
-          return;
-        }
-        const res = await fetch('/api/subscription/active', {
-          headers: { Authorization: `Bearer ${session.access_token}` },
-        });
-        const data = (await res.json()) as ActiveSubsResponse;
-        if (!cancelled) {
-          setActive(data);
-          setLoading(false);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError((err as Error).message || 'Could not check subscription state');
-          setLoading(false);
-        }
+        // Fire both lookups in parallel
+        const [productsResp, crossResp] = await Promise.all([
+          plugin.getProducts(),
+          fetch('/api/subscription/active', { credentials: 'include' })
+            .then((r) => (r.ok ? r.json() : { hasActive: false }))
+            .catch(() => ({ hasActive: false })),
+        ]);
+        if (cancelled) return;
+        setProducts(productsResp.products);
+        setCrossSource(crossResp as CrossSourceCheck);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load products');
+      } finally {
+        if (!cancelled) setLoading(false);
       }
     })();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  async function handlePurchase(productId: string) {
-    if (!isNativeShell()) {
-      setError('Not in native shell — cannot purchase');
-      return;
-    }
+  async function handlePurchase(productId: IapProductId) {
+    const plugin = getIapPlugin();
+    if (!plugin) return;
     setError(null);
-    setPurchasing(productId);
+    setSuccessMessage(null);
+    setPurchasingId(productId);
     try {
-      const bridge = nativeBridge();
-      if (!bridge.startPurchase) {
-        throw new Error('Native bridge does not support purchase');
+      const result: IapPurchaseResult = await plugin.purchase({ productId });
+      switch (result.state) {
+        case 'success':
+          setSuccessMessage('Subscription active. Welcome to ' + TIER_DISPLAY[productId].tier + '.');
+          // Refresh the cross-source state so the UI re-renders the upgraded tier
+          setCrossSource({
+            hasActive: true,
+            source: getPlatform() === 'ios' ? 'apple_iap' : 'google_iap',
+            tier: TIER_DISPLAY[productId].tier,
+          });
+          // Trigger any parent listener (e.g. close the modal)
+          window.dispatchEvent(new CustomEvent('paybacker:iap-purchased', { detail: { productId } }));
+          break;
+        case 'pending_server_verify':
+          setError(
+            "Purchase succeeded but we couldn't confirm with our servers. We'll retry automatically — check back in a minute."
+          );
+          break;
+        case 'pending':
+          setSuccessMessage('Purchase awaiting approval (Family Sharing or bank verification).');
+          break;
+        case 'cancelled':
+          // Silent — user dismissed the sheet
+          break;
       }
-      const result: NativePurchaseResult = await bridge.startPurchase(productId);
-      if (result.ok) {
-        location.reload();
-      } else if (result.error === 'cancelled') {
-        // silent
-      } else {
-        setError(result.message || `Purchase ${result.error}`);
-      }
-    } catch (err) {
-      setError((err as Error).message || 'Purchase failed');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Purchase failed');
     } finally {
-      setPurchasing(null);
+      setPurchasingId(null);
+    }
+  }
+
+  async function handleRestore() {
+    const plugin = getIapPlugin();
+    if (!plugin) return;
+    setError(null);
+    setSuccessMessage(null);
+    setRestoring(true);
+    try {
+      const { restored } = await plugin.restorePurchases();
+      if (restored.length === 0) {
+        setError('No previous purchases found on this Apple ID.');
+      } else {
+        setSuccessMessage(`Restored ${restored.length} purchase${restored.length > 1 ? 's' : ''}.`);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Restore failed');
+    } finally {
+      setRestoring(false);
+    }
+  }
+
+  async function handleManage() {
+    const plugin = getIapPlugin();
+    if (!plugin) return;
+    try {
+      await plugin.openManageSubscriptions();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to open subscription management');
     }
   }
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
+      <div className="flex items-center justify-center py-8">
         <Loader2 className="h-6 w-6 animate-spin text-mint-400" />
       </div>
     );
   }
 
-  const externalSub = active?.subscriptions.find((s) => s.source !== 'apple_iap' && s.source !== 'google_play_billing');
-  if (externalSub) {
+  if (error && products.length === 0) {
     return (
-      <div className="bg-white border border-slate-200 rounded-xl p-6 text-center">
-        <Sparkles className="h-8 w-8 text-mint-400 mx-auto mb-3" />
-        <h3 className="text-lg font-bold text-slate-900 mb-2">You&apos;re subscribed via the web</h3>
-        <p className="text-sm text-slate-500 mb-4">
-          Your <strong>{externalSub.tier}</strong> plan is managed on paybacker.co.uk.
-          To change or cancel it, sign in there from a browser.
-        </p>
-        <a
-          href="https://paybacker.co.uk/dashboard/billing"
-          className="inline-flex items-center gap-2 text-mint-400 font-semibold text-sm"
-        >
-          Open paybacker.co.uk <ExternalLink className="h-4 w-4" />
-        </a>
+      <div className="bg-rose-500/10 border border-rose-500/20 rounded-xl p-4 text-sm text-rose-700">
+        <AlertCircle className="h-4 w-4 inline mr-2" />
+        {error}
       </div>
     );
   }
 
-  const iapSub = active?.subscriptions.find((s) => s.source === 'apple_iap' || s.source === 'google_play_billing');
-  if (iapSub) {
+  // Cross-source guard: user already paying via Stripe
+  if (crossSource?.hasActive && crossSource.source === 'stripe') {
     return (
-      <div className="bg-white border border-slate-200 rounded-xl p-6 text-center">
-        <Sparkles className="h-8 w-8 text-mint-400 mx-auto mb-3" />
-        <h3 className="text-lg font-bold text-slate-900 mb-2">
-          You&apos;re on {iapSub.tier} ({iapSub.billingPeriod})
-        </h3>
-        <p className="text-sm text-slate-500 mb-4">
-          Manage or cancel your subscription in the App Store / Play Store.
+      <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-4 text-sm text-amber-900">
+        <p className="font-semibold mb-1">You&apos;re already subscribed via the web</p>
+        <p>
+          You currently have an active {crossSource.tier} subscription paid through paybacker.co.uk. To
+          avoid being charged twice, please cancel your web subscription before subscribing through the
+          App Store.
         </p>
+      </div>
+    );
+  }
+
+  // Already subscribed via the same store — show manage instead
+  if (crossSource?.hasActive && (crossSource.source === 'apple_iap' || crossSource.source === 'google_iap')) {
+    return (
+      <div className="space-y-3">
+        <div className="bg-mint-400/10 border border-mint-400/20 rounded-xl p-4 text-sm text-slate-900">
+          <p className="font-semibold mb-1">
+            You&apos;re subscribed to {crossSource.tier === 'pro' ? 'Pro' : 'Essential'}
+          </p>
+          <p className="text-slate-600">Manage or cancel your subscription via the App Store.</p>
+        </div>
         <button
-          onClick={() => isNativeShell() && nativeBridge().openManageSubscriptions?.()}
-          className="inline-flex items-center gap-2 bg-mint-400 hover:bg-mint-500 text-navy-950 font-semibold text-sm px-4 py-2 rounded-lg"
+          onClick={handleManage}
+          className="w-full py-3 bg-slate-100 hover:bg-slate-200 text-slate-900 font-semibold rounded-xl transition-all"
         >
-          Manage subscription <ExternalLink className="h-4 w-4" />
+          Manage subscription
         </button>
       </div>
     );
   }
+
+  // Order: Pro Annual, Pro Monthly, Essential Annual, Essential Monthly
+  const sortedProducts = [...products].sort((a, b) => {
+    const order: IapProductId[] = [
+      'paybacker.pro.annual',
+      'paybacker.pro.monthly',
+      'paybacker.essential.annual',
+      'paybacker.essential.monthly',
+    ];
+    return order.indexOf(a.id as IapProductId) - order.indexOf(b.id as IapProductId);
+  });
 
   return (
-    <div className="bg-white border border-slate-200 rounded-xl p-6">
-      <div className="text-center mb-5">
-        <Sparkles className="h-8 w-8 text-mint-400 mx-auto mb-2" />
-        <h3 className="text-lg font-bold text-slate-900">Choose your plan</h3>
-        <p className="text-xs text-slate-500 mt-1">Cancel anytime in App Store settings</p>
-      </div>
-
-      <div className="grid gap-3">
-        {PRODUCTS.map((p) => (
-          <button
-            key={p.id}
-            onClick={() => handlePurchase(p.id)}
-            disabled={purchasing !== null}
-            className={`
-              w-full flex items-center justify-between gap-4 p-4 rounded-xl border transition-all
-              ${p.tier === 'pro'
-                ? 'border-mint-400 bg-mint-400/5 hover:bg-mint-400/10'
-                : 'border-slate-200 hover:bg-slate-50'}
-              disabled:opacity-50 disabled:cursor-not-allowed
-            `}
-          >
-            <div className="text-left">
-              <p className="text-sm font-bold text-slate-900 capitalize">{p.tier}</p>
-              <p className="text-xs text-slate-500 capitalize">{p.period} billing</p>
-            </div>
-            <div className="text-right">
-              {purchasing === p.id ? (
-                <Loader2 className="h-5 w-5 animate-spin text-mint-400 ml-auto" />
-              ) : (
-                <p className="text-sm font-semibold text-slate-900">{p.priceLabel}</p>
-              )}
-            </div>
-          </button>
-        ))}
-      </div>
-
+    <div className="space-y-3">
+      {successMessage && (
+        <div className="bg-mint-400/10 border border-mint-400/20 rounded-xl p-3 text-sm text-slate-900">
+          {successMessage}
+        </div>
+      )}
       {error && (
-        <div className="mt-4 text-xs text-red-600 text-center">{error}</div>
+        <div className="bg-rose-500/10 border border-rose-500/20 rounded-xl p-3 text-sm text-rose-700">
+          <AlertCircle className="h-4 w-4 inline mr-2" />
+          {error}
+        </div>
       )}
+      {sortedProducts.map((product) => {
+        const meta = TIER_DISPLAY[product.id as IapProductId];
+        if (!meta) return null;
+        const isPurchasing = purchasingId === product.id;
+        const isPro = meta.tier === 'pro';
+        return (
+          <button
+            key={product.id}
+            onClick={() => handlePurchase(product.id as IapProductId)}
+            disabled={isPurchasing}
+            className={`w-full py-4 px-4 rounded-xl font-bold transition-all text-left flex items-center justify-between ${
+              isPro
+                ? 'bg-mint-400 hover:bg-mint-500 text-navy-950 disabled:bg-mint-400/50'
+                : 'bg-white hover:bg-slate-50 text-slate-900 border border-slate-200 disabled:bg-slate-100'
+            }`}
+          >
+            <span className="flex items-center gap-2">
+              {isPro && <Sparkles className="h-4 w-4" />}
+              <span className="flex flex-col items-start">
+                <span>{product.displayName}</span>
+                <span className="text-xs font-normal opacity-70">
+                  {meta.period === 'year' ? 'Best value — billed annually' : 'Billed monthly'}
+                </span>
+              </span>
+            </span>
+            <span className="flex items-center gap-2">
+              <span>{product.displayPrice}</span>
+              {isPurchasing && <Loader2 className="h-4 w-4 animate-spin" />}
+            </span>
+          </button>
+        );
+      })}
 
-      {onClose && (
+      <div className="pt-2 flex flex-col gap-2 border-t border-slate-200">
         <button
-          onClick={onClose}
-          className="mt-4 w-full text-slate-500 hover:text-slate-900 text-sm transition-colors"
+          onClick={handleRestore}
+          disabled={restoring}
+          className="text-sm text-slate-500 hover:text-slate-900 transition-colors py-2"
         >
-          Maybe later
+          {restoring ? 'Restoring…' : 'Restore previous purchases'}
         </button>
-      )}
+      </div>
+
+      <p className="text-xs text-slate-400 text-center pt-2">
+        Subscriptions auto-renew unless cancelled at least 24 hours before the period ends. Manage or
+        cancel anytime via the App Store.
+      </p>
     </div>
   );
 }

--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { X, Sparkles, ArrowRight } from 'lucide-react';
+import { isNativeShell } from '@/lib/native-shell';
+import NativeIapButtons from './NativeIapButtons';
 
 interface UpgradePromptProps {
   variant: 'banner' | 'modal' | 'inline';
@@ -11,6 +13,15 @@ interface UpgradePromptProps {
 
 export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) {
   const [dismissed, setDismissed] = useState(false);
+  const [native, setNative] = useState(false);
+
+  // Inside the iOS/Android Capacitor shell the web Stripe link would
+  // violate Apple Guideline 3.1.1 / Google Play's billing policy — render
+  // the native IAP buttons instead. Cross-source double-charge prevention
+  // happens inside NativeIapButtons via /api/subscription/active.
+  useEffect(() => {
+    setNative(isNativeShell());
+  }, []);
 
   const handleClose = () => {
     setDismissed(true);
@@ -18,6 +29,20 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
   };
 
   if (dismissed) return null;
+
+  if (native && variant === 'modal') {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={handleClose} />
+        <div className="relative max-w-md w-full">
+          <NativeIapButtons onClose={handleClose} />
+        </div>
+      </div>
+    );
+  }
+  if (native) {
+    return <NativeIapButtons onClose={onClose} />;
+  }
 
   if (variant === 'banner') {
     return (

--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { X, Sparkles, ArrowRight } from 'lucide-react';
 import { isNativeShell } from '@/lib/native-shell';
@@ -13,15 +13,19 @@ interface UpgradePromptProps {
 
 export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) {
   const [dismissed, setDismissed] = useState(false);
-  const [native, setNative] = useState(false);
+  const [isNative, setIsNative] = useState(false);
 
-  // Inside the iOS/Android Capacitor shell the web Stripe link would
-  // violate Apple Guideline 3.1.1 / Google Play's billing policy — render
-  // the native IAP buttons instead. Cross-source double-charge prevention
-  // happens inside NativeIapButtons via /api/subscription/active.
   useEffect(() => {
-    setNative(isNativeShell());
-  }, []);
+    setIsNative(isNativeShell());
+    // Listen for successful native purchases — auto-dismiss the modal so
+    // the user lands back on the freshly-upgraded experience.
+    const onPurchased = () => {
+      setDismissed(true);
+      onClose?.();
+    };
+    window.addEventListener('paybacker:iap-purchased', onPurchased);
+    return () => window.removeEventListener('paybacker:iap-purchased', onPurchased);
+  }, [onClose]);
 
   const handleClose = () => {
     setDismissed(true);
@@ -29,20 +33,6 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
   };
 
   if (dismissed) return null;
-
-  if (native && variant === 'modal') {
-    return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={handleClose} />
-        <div className="relative max-w-md w-full">
-          <NativeIapButtons onClose={handleClose} />
-        </div>
-      </div>
-    );
-  }
-  if (native) {
-    return <NativeIapButtons onClose={onClose} />;
-  }
 
   if (variant === 'banner') {
     return (
@@ -90,12 +80,23 @@ export default function UpgradePrompt({ variant, onClose }: UpgradePromptProps) 
               <li className="flex items-center gap-2"><span className="text-mint-400">✓</span> Price-increase alerts by email</li>
             </ul>
           </div>
-          <div className="flex flex-col gap-3">
-            <Link href="/pricing" className="w-full py-3 bg-mint-400 hover:bg-mint-500 text-navy-950 font-bold rounded-xl transition-all text-center">
-              Upgrade — from £4.99/mo
-            </Link>
-            <button onClick={handleClose} className="text-slate-500 hover:text-slate-900 text-sm transition-colors">Maybe later</button>
-          </div>
+          {isNative ? (
+            // In-app: native StoreKit 2 / Play Billing buttons
+            <NativeIapButtons />
+          ) : (
+            // Web: Stripe checkout link
+            <div className="flex flex-col gap-3">
+              <Link href="/pricing" className="w-full py-3 bg-mint-400 hover:bg-mint-500 text-navy-950 font-bold rounded-xl transition-all text-center">
+                Upgrade — from £4.99/mo
+              </Link>
+              <button onClick={handleClose} className="text-slate-500 hover:text-slate-900 text-sm transition-colors">Maybe later</button>
+            </div>
+          )}
+          {isNative && (
+            <button onClick={handleClose} className="w-full text-slate-500 hover:text-slate-900 text-sm transition-colors mt-4">
+              Maybe later
+            </button>
+          )}
         </div>
       </div>
     );

--- a/src/lib/iap/__tests__/apple-chain.test.ts
+++ b/src/lib/iap/__tests__/apple-chain.test.ts
@@ -1,0 +1,92 @@
+// src/lib/iap/__tests__/apple-chain.test.ts
+//
+// Validates that verifyJwsChain rejects a self-signed / unsigned chain
+// even when individual certs in x5c are well-formed. Catches the
+// security regression Codex flagged on PR #433 where verifyJwsChain
+// was a no-op and any attacker with a self-issued ECC cert could
+// produce JWS payloads we'd treat as Apple's.
+//
+// Run:
+//   node --experimental-strip-types --test \
+//     src/lib/iap/__tests__/apple-chain.test.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { X509Certificate } from 'node:crypto';
+import { verifyJwsChain } from '../apple-chain.ts';
+import { APPLE_ROOT_CA_G3_PEM } from '../apple-root-ca.ts';
+
+describe('verifyJwsChain', () => {
+  it('rejects a chain shorter than 2 certs', () => {
+    assert.throws(() => verifyJwsChain([]), /chain too short/);
+    // Even a single Apple-root cert should fail — there's no leaf to verify.
+    const rootB64 = APPLE_ROOT_CA_G3_PEM
+      .replace(/-----BEGIN CERTIFICATE-----/g, '')
+      .replace(/-----END CERTIFICATE-----/g, '')
+      .replace(/\s+/g, '');
+    assert.throws(() => verifyJwsChain([rootB64]), /chain too short/);
+  });
+
+  it('rejects a chain whose terminator is NOT a pinned Apple root', () => {
+    // A 2-element chain made up of two unrelated roots — the second
+    // one is NOT the Apple root, so termination check fails before any
+    // cryptographic concern. This is the OneStream-class attack the
+    // P0 finding flagged: attacker sends [self_signed_leaf, self_signed_root].
+    //
+    // We synthesise the "fake root" by reusing the Apple G3 cert with one
+    // byte flipped — it's still a valid cert (parses fine), but its
+    // fingerprint won't match the pinned constant.
+    const realRootDer = APPLE_ROOT_CA_G3_PEM
+      .replace(/-----BEGIN CERTIFICATE-----/g, '')
+      .replace(/-----END CERTIFICATE-----/g, '')
+      .replace(/\s+/g, '');
+
+    // Decoding + flipping a byte breaks the X.509 parser, so instead
+    // construct a clearly-different cert: use a cert from a different
+    // public CA. Actually simplest — generate a self-signed cert using
+    // a tiny helper. Node 19+ doesn't expose a cert builder, so we
+    // assemble two real different certs by base64-encoding totally
+    // different DER bytes:
+    //
+    //   - leaf: real Apple G3 (will parse fine but wrong role)
+    //   - root: also real Apple G3 (same fingerprint!)
+    //
+    // That isn't a useful test — let's instead just confirm the
+    // SAME chain (real apple root duplicated) ALSO fails because
+    // root cert can't sign itself for our chain link rule (i → i+1).
+    //
+    // The strongest test we can write without cert-builder deps:
+    // assert that a chain made from [leaf=real_apple_root,
+    // root=real_apple_root] fails the signature link OR the "leaf isn't
+    // a real Apple-issued leaf" — either way, throws.
+    assert.throws(
+      () => verifyJwsChain([realRootDer, realRootDer]),
+      /leaf cert is itself a pinned Apple root/,
+    );
+  });
+
+  it('rejects a chain whose links do not actually sign each other', () => {
+    // Pull the Apple root cert as-is, base64 the DER, and pair it with
+    // a totally synthetic / random base64 string. The random one will
+    // fail to parse as X.509 — exercises the parse-error branch.
+    const realRootDer = APPLE_ROOT_CA_G3_PEM
+      .replace(/-----BEGIN CERTIFICATE-----/g, '')
+      .replace(/-----END CERTIFICATE-----/g, '')
+      .replace(/\s+/g, '');
+    const garbageDer = Buffer.from('not a real cert, just bytes').toString('base64');
+    assert.throws(
+      () => verifyJwsChain([garbageDer, realRootDer]),
+      /not a valid X\.509 certificate/,
+    );
+  });
+
+  it('pinned Apple root parses + has a stable SHA-256 fingerprint', () => {
+    const cert = new X509Certificate(APPLE_ROOT_CA_G3_PEM);
+    // Fingerprint published by Apple at apple.com/certificateauthority/AppleRootCA-G3.cer
+    // and verified locally via `openssl x509 -fingerprint -sha256` on 2026-05-01.
+    assert.equal(
+      cert.fingerprint256,
+      '63:34:3A:BF:B8:9A:6A:03:EB:B5:7E:9B:3F:5F:A7:BE:7C:4F:5C:75:6F:30:17:B3:A8:C4:88:C3:65:3E:91:79',
+    );
+  });
+});

--- a/src/lib/iap/apple-chain.ts
+++ b/src/lib/iap/apple-chain.ts
@@ -1,0 +1,85 @@
+/**
+ * Apple JWS x5c chain validation. Split out from apple.ts so it can
+ * be unit-tested under `node --experimental-strip-types --test`
+ * without dragging in the jose / @supabase / Anthropic SDK imports.
+ *
+ * Used by both surfaces:
+ *   - /api/iap/verify        (client-callable JWS round-trip)
+ *   - /api/iap/webhook/apple (ASN v2 server notifications)
+ *
+ * What we assert:
+ *   1. x5c has at least 2 entries (a leaf and at least one issuer)
+ *   2. Every cert parses as X.509 and is currently within its
+ *      validity window
+ *   3. Each cert (except the last) is signed by the next cert's
+ *      public key — i.e. the chain hangs together
+ *   4. The terminating cert matches one of TRUSTED_APPLE_ROOT_PEMS
+ *      by SHA-256 fingerprint — defeats a malicious chain that
+ *      appends its own self-signed "root"
+ *
+ * Throws on any failure. Caller passes `decodedHeader.x5c` from
+ * jose.decodeProtectedHeader().
+ */
+
+import { X509Certificate } from 'node:crypto';
+import { TRUSTED_APPLE_ROOT_PEMS } from './apple-root-ca.ts';
+
+export function verifyJwsChain(x5c: string[]): void {
+  if (x5c.length < 2) {
+    throw new Error(
+      `JWS x5c chain too short (${x5c.length}) — expected leaf + intermediate(s) + root`,
+    );
+  }
+
+  const certs = x5c.map((b64, i) => {
+    try {
+      return new X509Certificate(Buffer.from(b64, 'base64'));
+    } catch (err) {
+      throw new Error(
+        `JWS x5c[${i}] is not a valid X.509 certificate: ${(err as Error).message}`,
+      );
+    }
+  });
+
+  const trustedFingerprints = TRUSTED_APPLE_ROOT_PEMS.map(
+    (pem) => new X509Certificate(pem).fingerprint256,
+  );
+
+  // Leaf cannot itself be a pinned root — would let an attacker bypass
+  // signature verification by submitting [apple_root, apple_root].
+  // (Self-signed roots verify against themselves; the JWS signature
+  // check would still catch this in practice because they don't have
+  // Apple's private key, but rejecting up-front is clearer.)
+  if (trustedFingerprints.includes(certs[0].fingerprint256)) {
+    throw new Error(
+      'JWS x5c leaf cert is itself a pinned Apple root — refusing to treat as a valid leaf',
+    );
+  }
+
+  const now = new Date();
+  for (let i = 0; i < certs.length; i++) {
+    const cert = certs[i];
+    if (new Date(cert.validFrom) > now || new Date(cert.validTo) < now) {
+      throw new Error(
+        `JWS x5c[${i}] is outside its validity window (${cert.validFrom} → ${cert.validTo})`,
+      );
+    }
+  }
+
+  // Each cert must be signed by the next cert in the chain.
+  for (let i = 0; i < certs.length - 1; i++) {
+    if (!certs[i].verify(certs[i + 1].publicKey)) {
+      throw new Error(`JWS x5c chain link ${i} → ${i + 1} failed signature verification`);
+    }
+  }
+
+  // Terminator must be a pinned Apple root by SHA-256 fingerprint.
+  // We compare against a pinned constant rather than trusting any
+  // self-styled "Apple Root" the chain might present.
+  const terminatorFingerprint = certs[certs.length - 1].fingerprint256;
+  if (!trustedFingerprints.includes(terminatorFingerprint)) {
+    throw new Error(
+      `JWS x5c chain does not terminate at a pinned Apple root — terminator fingerprint ${terminatorFingerprint} is not trusted`,
+    );
+  }
+}

--- a/src/lib/iap/apple-root-ca.ts
+++ b/src/lib/iap/apple-root-ca.ts
@@ -1,0 +1,43 @@
+/**
+ * Apple Root CA - G3 — pinned root for App Store JWS chain validation.
+ *
+ * Apple signs every StoreKit 2 JWSTransaction and every App Store Server
+ * Notification V2 (ASN v2) with a leaf cert that chains up to one of
+ * Apple's published roots. For our IAP flow we pin Apple Root CA - G3
+ * (issued 2014-04-30, valid till 2039-04-30) — the root every current
+ * App Store Server signing chain ultimately terminates at.
+ *
+ * Source: https://www.apple.com/certificateauthority/AppleRootCA-G3.cer
+ *
+ * SHA-256 fingerprint (published by Apple at the same URL):
+ *   63:34:3A:BF:B8:9A:6A:03:EB:B5:7E:9B:3F:5F:A7:BE:7C:4F:5C:75:6F:30:17:B3:A8:C4:88:C3:65:3E:91:79
+ *
+ * Verified against the freshly downloaded .cer on 2026-05-01. Matches.
+ *
+ * If Apple ever rotates IAP signing onto a new root (G6 etc.) we add
+ * the new PEM here and have `verifyJwsChain` accept any pinned root.
+ */
+export const APPLE_ROOT_CA_G3_PEM = `-----BEGIN CERTIFICATE-----
+MIICQzCCAcmgAwIBAgIILcX8iNLFS5UwCgYIKoZIzj0EAwMwZzEbMBkGA1UEAwwS
+QXBwbGUgUm9vdCBDQSAtIEczMSYwJAYDVQQLDB1BcHBsZSBDZXJ0aWZpY2F0aW9u
+IEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcN
+MTQwNDMwMTgxOTA2WhcNMzkwNDMwMTgxOTA2WjBnMRswGQYDVQQDDBJBcHBsZSBS
+b290IENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9y
+aXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzB2MBAGByqGSM49
+AgEGBSuBBAAiA2IABJjpLz1AcqTtkyJygRMc3RCV8cWjTnHcFBbZDuWmBSp3ZHtf
+TjjTuxxEtX/1H7YyYl3J6YRbTzBPEVoA/VhYDKX1DyxNB0cTddqXl5dvMVztK517
+IDvYuVTZXpmkOlEKMaNCMEAwHQYDVR0OBBYEFLuw3qFYM4iapIqZ3r6966/ayySr
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMDA2gA
+MGUCMQCD6cHEFl4aXTQY2e3v9GwOAEZLuN+yRhHFD/3meoyhpmvOwgPUnPWTxnS4
+at+qIxUCMG1mihDK1A3UT82NQz60imOlM27jbdoXt2QfyFMm+YhidDkLF1vLUagM
+6BgD56KyKA==
+-----END CERTIFICATE-----
+`;
+
+/**
+ * Trusted Apple roots for IAP JWS chain termination. Add new roots
+ * here when Apple rotates; chain validation accepts any of them.
+ */
+export const TRUSTED_APPLE_ROOT_PEMS: readonly string[] = Object.freeze([
+  APPLE_ROOT_CA_G3_PEM,
+]);

--- a/src/lib/iap/apple.ts
+++ b/src/lib/iap/apple.ts
@@ -1,0 +1,154 @@
+/**
+ * Apple App Store Server API + JWS verification.
+ *
+ * StoreKit 2 (iOS 15+, our minimum) issues `JWSTransaction` strings
+ * to the client app. The client sends us a transactionId; we look it
+ * up against Apple's App Store Server API to fetch the most recent JWS
+ * and verify it.
+ *
+ * Two distinct verification surfaces:
+ *
+ *   1. /api/iap/verify       — client-callable: app sends transactionId,
+ *                              we fetch+verify+sync subscription state.
+ *
+ *   2. /api/iap/webhook/apple — Apple-callable: ASN v2 sends signed
+ *                              notifications (DID_RENEW, REFUND, etc.)
+ *                              with the JWS embedded; we verify+sync.
+ *
+ * Env vars required:
+ *   APPLE_BUNDLE_ID            — co.uk.paybacker.app
+ *   APPLE_TEAM_ID
+ *   APPLE_ISSUER_ID            — App Store Connect API issuer id
+ *   APPLE_KEY_ID               — App Store Connect API key id
+ *   APPLE_PRIVATE_KEY          — App Store Connect API private key (.p8)
+ *   APPLE_USE_SANDBOX          — '1' for sandbox testing, otherwise prod
+ */
+
+import * as jose from 'jose';
+
+const PROD_BASE = 'https://api.storekit.itunes.apple.com';
+const SANDBOX_BASE = 'https://api.storekit-sandbox.itunes.apple.com';
+
+function isSandbox(): boolean {
+  return process.env.APPLE_USE_SANDBOX === '1' || process.env.NODE_ENV !== 'production';
+}
+
+function apiBase(): string {
+  return isSandbox() ? SANDBOX_BASE : PROD_BASE;
+}
+
+export interface JwsTransactionPayload {
+  transactionId: string;
+  originalTransactionId: string;
+  bundleId: string;
+  productId: string;
+  subscriptionGroupIdentifier?: string;
+  purchaseDate: number;
+  originalPurchaseDate: number;
+  expiresDate?: number;
+  type: 'Auto-Renewable Subscription' | 'Non-Consumable' | 'Consumable' | 'Non-Renewing Subscription';
+  inAppOwnershipType: 'PURCHASED' | 'FAMILY_SHARED';
+  signedDate: number;
+  environment: 'Sandbox' | 'Production';
+  revocationDate?: number;
+  revocationReason?: number;
+}
+
+/**
+ * Decode + verify a JWS string from Apple. Returns the decoded payload
+ * if the leaf cert signature checks out.
+ *
+ * TODO before public launch: full x5c chain validation up to
+ * AppleRootCA-G3 in verifyJwsChain() (currently no-op). For sandbox
+ * testing this is acceptable — leaf-cert verification still rejects
+ * unsigned/wrong-key tokens.
+ */
+export async function verifyAppleJws<T = JwsTransactionPayload>(
+  jws: string,
+): Promise<T> {
+  const decodedHeader = jose.decodeProtectedHeader(jws);
+  const x5c = decodedHeader.x5c;
+  if (!Array.isArray(x5c) || x5c.length === 0) {
+    throw new Error('JWS missing x5c header — refusing to verify');
+  }
+
+  const leafCertPem = `-----BEGIN CERTIFICATE-----\n${x5c[0]}\n-----END CERTIFICATE-----`;
+  const leafKey = await jose.importX509(leafCertPem, 'ES256');
+
+  const { payload } = await jose.jwtVerify(jws, leafKey, {
+    algorithms: ['ES256'],
+  });
+
+  await verifyJwsChain(x5c);
+
+  return payload as unknown as T;
+}
+
+async function verifyJwsChain(_x5c: string[]): Promise<void> {
+  // TODO: walk x5c chain up to AppleRootCA-G3 before public launch
+  return;
+}
+
+async function generateApiJwt(): Promise<string> {
+  const issuerId = process.env.APPLE_ISSUER_ID;
+  const keyId = process.env.APPLE_KEY_ID;
+  const bundleId = process.env.APPLE_BUNDLE_ID;
+  const privateKeyPem = process.env.APPLE_PRIVATE_KEY;
+
+  if (!issuerId || !keyId || !bundleId || !privateKeyPem) {
+    throw new Error(
+      'Missing Apple env: APPLE_ISSUER_ID, APPLE_KEY_ID, APPLE_BUNDLE_ID, APPLE_PRIVATE_KEY',
+    );
+  }
+
+  const privateKey = await jose.importPKCS8(privateKeyPem, 'ES256');
+
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = await new jose.SignJWT({ bid: bundleId })
+    .setProtectedHeader({ alg: 'ES256', kid: keyId, typ: 'JWT' })
+    .setIssuer(issuerId)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 60 * 20)
+    .setAudience('appstoreconnect-v1')
+    .sign(privateKey);
+
+  return jwt;
+}
+
+export async function fetchTransactionInfo(transactionId: string): Promise<string> {
+  const token = await generateApiJwt();
+  const url = `${apiBase()}/inApps/v1/transactions/${encodeURIComponent(transactionId)}`;
+
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`App Store Server API ${res.status}: ${body.slice(0, 300)}`);
+  }
+
+  const data = await res.json();
+  if (!data?.signedTransactionInfo) {
+    throw new Error('App Store Server API returned no signedTransactionInfo');
+  }
+  return data.signedTransactionInfo as string;
+}
+
+export interface AsnV2Payload {
+  notificationType: string;
+  subtype?: string;
+  notificationUUID: string;
+  data: {
+    bundleId: string;
+    environment: 'Sandbox' | 'Production';
+    signedTransactionInfo?: string;
+    signedRenewalInfo?: string;
+  };
+  version: string;
+  signedDate: number;
+}
+
+export async function verifyAsnV2(signedPayload: string): Promise<AsnV2Payload> {
+  return verifyAppleJws<AsnV2Payload>(signedPayload);
+}

--- a/src/lib/iap/apple.ts
+++ b/src/lib/iap/apple.ts
@@ -25,6 +25,9 @@
  */
 
 import * as jose from 'jose';
+import { verifyJwsChain } from './apple-chain';
+
+export { verifyJwsChain };
 
 const PROD_BASE = 'https://api.storekit.itunes.apple.com';
 const SANDBOX_BASE = 'https://api.storekit-sandbox.itunes.apple.com';
@@ -56,12 +59,11 @@ export interface JwsTransactionPayload {
 
 /**
  * Decode + verify a JWS string from Apple. Returns the decoded payload
- * if the leaf cert signature checks out.
- *
- * TODO before public launch: full x5c chain validation up to
- * AppleRootCA-G3 in verifyJwsChain() (currently no-op). For sandbox
- * testing this is acceptable — leaf-cert verification still rejects
- * unsigned/wrong-key tokens.
+ * only when:
+ *   1. The leaf cert in `x5c[0]` signs the JWS (jose.jwtVerify)
+ *   2. The full x5c chain validates and terminates at a pinned Apple
+ *      root (verifyJwsChain) — without this, anyone with a self-signed
+ *      cert can mint payloads we'd otherwise accept as Apple's.
  */
 export async function verifyAppleJws<T = JwsTransactionPayload>(
   jws: string,
@@ -72,6 +74,10 @@ export async function verifyAppleJws<T = JwsTransactionPayload>(
     throw new Error('JWS missing x5c header — refusing to verify');
   }
 
+  // Chain validation FIRST. If we don't trust the leaf, jose.jwtVerify's
+  // signature check is meaningless because the attacker controls the key.
+  verifyJwsChain(x5c);
+
   const leafCertPem = `-----BEGIN CERTIFICATE-----\n${x5c[0]}\n-----END CERTIFICATE-----`;
   const leafKey = await jose.importX509(leafCertPem, 'ES256');
 
@@ -79,15 +85,9 @@ export async function verifyAppleJws<T = JwsTransactionPayload>(
     algorithms: ['ES256'],
   });
 
-  await verifyJwsChain(x5c);
-
   return payload as unknown as T;
 }
 
-async function verifyJwsChain(_x5c: string[]): Promise<void> {
-  // TODO: walk x5c chain up to AppleRootCA-G3 before public launch
-  return;
-}
 
 async function generateApiJwt(): Promise<string> {
   const issuerId = process.env.APPLE_ISSUER_ID;

--- a/src/lib/iap/products.ts
+++ b/src/lib/iap/products.ts
@@ -1,0 +1,62 @@
+/**
+ * IAP product ID mapping.
+ *
+ * Apple App Store Connect and Google Play Console both let us define our
+ * own product identifiers. We use the same identifier scheme on both so
+ * the verify/sync logic doesn't have to special-case per platform.
+ *
+ * Convention: <app>.<tier>.<period>
+ *
+ *   paybacker.essential.monthly  → Essential, monthly billing
+ *   paybacker.essential.annual   → Essential, annual billing
+ *   paybacker.pro.monthly        → Pro, monthly billing
+ *   paybacker.pro.annual         → Pro, annual billing
+ *
+ * These IDs need to be created in App Store Connect (task #50) and Play
+ * Console (task #53) BEFORE we can test in sandbox. Prices match
+ * src/lib/plan-limits.ts so the in-app display stays consistent with the
+ * web pricing page.
+ */
+
+export type IapTier = 'essential' | 'pro';
+export type IapPeriod = 'monthly' | 'annual';
+
+export interface IapProduct {
+  productId: string;
+  tier: IapTier;
+  period: IapPeriod;
+  priceGbp: number;
+}
+
+export const IAP_PRODUCTS: readonly IapProduct[] = [
+  { productId: 'paybacker.essential.monthly', tier: 'essential', period: 'monthly', priceGbp: 4.99 },
+  { productId: 'paybacker.essential.annual',  tier: 'essential', period: 'annual',  priceGbp: 44.99 },
+  { productId: 'paybacker.pro.monthly',       tier: 'pro',       period: 'monthly', priceGbp: 9.99 },
+  { productId: 'paybacker.pro.annual',        tier: 'pro',       period: 'annual',  priceGbp: 94.99 },
+] as const;
+
+const PRODUCT_BY_ID: Record<string, IapProduct> = Object.fromEntries(
+  IAP_PRODUCTS.map((p) => [p.productId, p]),
+);
+
+export function getIapProduct(productId: string): IapProduct | null {
+  return PRODUCT_BY_ID[productId] ?? null;
+}
+
+const TIER_RANK: Record<string, number> = {
+  free: 0,
+  essential: 1,
+  pro: 2,
+};
+
+export function tierRank(tier: string | null | undefined): number {
+  return TIER_RANK[tier ?? 'free'] ?? 0;
+}
+
+export function maxTier(...tiers: Array<string | null | undefined>): string {
+  let best = 'free';
+  for (const t of tiers) {
+    if (tierRank(t) > tierRank(best)) best = t ?? 'free';
+  }
+  return best;
+}

--- a/src/lib/iap/sync.ts
+++ b/src/lib/iap/sync.ts
@@ -1,0 +1,201 @@
+/**
+ * IAP → database sync logic.
+ *
+ * Single entry point — `syncAppleSubscription()` — that takes a verified
+ * Apple JWS payload and updates both the `subscriptions` row AND
+ * `profiles.subscription_tier` if appropriate.
+ *
+ * Why both: legacy code reads `profiles.subscription_tier` everywhere
+ * (see CLAUDE.md — "getEffectiveTier trusts profile.subscription_tier
+ * as source of truth"). We keep that pattern. The `subscriptions`
+ * table grows the source-of-record for what each billing system says,
+ * and profile.subscription_tier reflects the MAX tier across sources.
+ *
+ * Idempotent: same Apple originalTransactionId processed twice writes
+ * the same row state both times. Safe to call from webhook retries.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { getIapProduct, type IapTier, type IapPeriod, maxTier } from './products';
+import type { JwsTransactionPayload } from './apple';
+
+function getAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export interface SyncResult {
+  ok: boolean;
+  userId?: string;
+  productId: string;
+  tier: IapTier;
+  period: IapPeriod;
+  status: 'active' | 'expired' | 'refunded';
+  effectiveTierBefore: string;
+  effectiveTierAfter: string;
+  reason?: string;
+}
+
+async function resolveUserId(
+  originalTransactionId: string,
+  fallbackUserId?: string,
+): Promise<string | null> {
+  if (fallbackUserId) return fallbackUserId;
+
+  const admin = getAdmin();
+  const { data } = await admin
+    .from('subscriptions')
+    .select('user_id')
+    .eq('apple_original_transaction_id', originalTransactionId)
+    .maybeSingle();
+
+  return (data?.user_id as string) ?? null;
+}
+
+export async function syncAppleSubscription(
+  payload: JwsTransactionPayload,
+  userId?: string,
+): Promise<SyncResult> {
+  const product = getIapProduct(payload.productId);
+  if (!product) {
+    return {
+      ok: false,
+      productId: payload.productId,
+      tier: 'essential',
+      period: 'monthly',
+      status: 'active',
+      effectiveTierBefore: 'free',
+      effectiveTierAfter: 'free',
+      reason: `unknown productId: ${payload.productId}`,
+    };
+  }
+
+  const resolvedUserId = await resolveUserId(payload.originalTransactionId, userId);
+  if (!resolvedUserId) {
+    return {
+      ok: false,
+      productId: payload.productId,
+      tier: product.tier,
+      period: product.period,
+      status: 'active',
+      effectiveTierBefore: 'free',
+      effectiveTierAfter: 'free',
+      reason: `no user linked to originalTransactionId ${payload.originalTransactionId} — verify must run first`,
+    };
+  }
+
+  const admin = getAdmin();
+
+  const now = Date.now();
+  const expired = payload.expiresDate != null && payload.expiresDate < now;
+  const refunded = payload.revocationDate != null;
+  const status: 'active' | 'expired' | 'refunded' = refunded
+    ? 'refunded'
+    : expired
+      ? 'expired'
+      : 'active';
+
+  const { data: beforeProfile } = await admin
+    .from('profiles')
+    .select('subscription_tier, subscription_source')
+    .eq('id', resolvedUserId)
+    .single();
+  const effectiveTierBefore = (beforeProfile?.subscription_tier as string) ?? 'free';
+
+  const subRow = {
+    user_id: resolvedUserId,
+    source: 'apple_iap' as const,
+    product_id: payload.productId,
+    apple_original_transaction_id: payload.originalTransactionId,
+    expires_at: payload.expiresDate ? new Date(payload.expiresDate).toISOString() : null,
+    auto_renew: !refunded && !expired,
+    status,
+    tier: product.tier,
+    billing_period: product.period,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error: upsertErr } = await admin
+    .from('subscriptions')
+    .upsert(subRow, { onConflict: 'apple_original_transaction_id' });
+
+  if (upsertErr) {
+    return {
+      ok: false,
+      userId: resolvedUserId,
+      productId: payload.productId,
+      tier: product.tier,
+      period: product.period,
+      status,
+      effectiveTierBefore,
+      effectiveTierAfter: effectiveTierBefore,
+      reason: `subscriptions upsert failed: ${upsertErr.message}`,
+    };
+  }
+
+  const { data: activeRows } = await admin
+    .from('subscriptions')
+    .select('tier, source, status, expires_at')
+    .eq('user_id', resolvedUserId)
+    .in('status', ['active', 'trialing']);
+
+  const tiersFromActive = (activeRows ?? [])
+    .filter((r: { expires_at: string | null }) => !r.expires_at || new Date(r.expires_at) > new Date())
+    .map((r: { tier: string }) => r.tier);
+
+  const newEffective = maxTier(...tiersFromActive);
+
+  let effectiveTierAfter = effectiveTierBefore;
+  if (newEffective !== effectiveTierBefore) {
+    const winningSource = (activeRows ?? []).find(
+      (r: { tier: string; source: string }) => r.tier === newEffective,
+    )?.source ?? 'apple_iap';
+
+    const { error: profErr } = await admin
+      .from('profiles')
+      .update({
+        subscription_tier: newEffective,
+        subscription_source: winningSource,
+      })
+      .eq('id', resolvedUserId);
+
+    if (!profErr) {
+      effectiveTierAfter = newEffective;
+    }
+  }
+
+  // Cross-source overlap log for support visibility
+  const sources = new Set((activeRows ?? []).map((r: { source: string }) => r.source));
+  if (sources.size > 1) {
+    try {
+      await admin.from('business_log').insert({
+        category: 'iap_overlap',
+        title: 'User has active subs on multiple sources',
+        content: JSON.stringify({
+          userId: resolvedUserId,
+          sources: Array.from(sources),
+          tiers: tiersFromActive,
+          effectiveTier: effectiveTierAfter,
+        }),
+        created_by: 'iap-sync',
+      });
+    } catch {
+      // business_log may not be present in dev — fail open
+    }
+  }
+
+  return {
+    ok: true,
+    userId: resolvedUserId,
+    productId: payload.productId,
+    tier: product.tier,
+    period: product.period,
+    status,
+    effectiveTierBefore,
+    effectiveTierAfter,
+  };
+}

--- a/src/lib/iap/sync.ts
+++ b/src/lib/iap/sync.ts
@@ -40,20 +40,56 @@ export interface SyncResult {
   reason?: string;
 }
 
+/**
+ * Resolve which user owns an `apple_original_transaction_id`.
+ *
+ * Apple `originalTransactionId` is the immutable identity of an Apple
+ * subscription chain — once an Apple ID owns one, it owns it forever
+ * across renewals/upgrades. We treat it the same way: the FIRST user
+ * to link a transaction id is the only user that can update it.
+ *
+ * Returns one of:
+ *   { ok: true,  userId }                 — caller should sync this user
+ *   { ok: false, reason: 'unlinked' }     — caller (verify) supplied an
+ *                                           authenticated userId for a
+ *                                           transaction id we've never
+ *                                           seen — fine, link it now
+ *   { ok: false, reason: 'conflict' }     — transaction id is owned by
+ *                                           a DIFFERENT user. Refuse to
+ *                                           proceed; the caller must
+ *                                           surface this as an error,
+ *                                           NOT silently reassign.
+ *
+ * Without this guard, anyone who learned a real `originalTransactionId`
+ * (logs, support screenshots) could authenticate as their own account
+ * and call /api/iap/verify to claim that subscription's entitlement —
+ * upsert(onConflict='apple_original_transaction_id') would then move
+ * `user_id` to them.
+ */
 async function resolveUserId(
   originalTransactionId: string,
   fallbackUserId?: string,
-): Promise<string | null> {
-  if (fallbackUserId) return fallbackUserId;
-
+): Promise<
+  | { ok: true; userId: string }
+  | { ok: false; reason: 'unlinked' | 'conflict'; conflictUserId?: string }
+> {
   const admin = getAdmin();
   const { data } = await admin
     .from('subscriptions')
     .select('user_id')
     .eq('apple_original_transaction_id', originalTransactionId)
     .maybeSingle();
+  const linkedUserId = (data?.user_id as string | undefined) ?? null;
 
-  return (data?.user_id as string) ?? null;
+  if (fallbackUserId) {
+    if (linkedUserId && linkedUserId !== fallbackUserId) {
+      return { ok: false, reason: 'conflict', conflictUserId: linkedUserId };
+    }
+    return { ok: true, userId: fallbackUserId };
+  }
+
+  if (linkedUserId) return { ok: true, userId: linkedUserId };
+  return { ok: false, reason: 'unlinked' };
 }
 
 export async function syncAppleSubscription(
@@ -74,8 +110,20 @@ export async function syncAppleSubscription(
     };
   }
 
-  const resolvedUserId = await resolveUserId(payload.originalTransactionId, userId);
-  if (!resolvedUserId) {
+  const resolved = await resolveUserId(payload.originalTransactionId, userId);
+  if (!resolved.ok) {
+    if (resolved.reason === 'conflict') {
+      return {
+        ok: false,
+        productId: payload.productId,
+        tier: product.tier,
+        period: product.period,
+        status: 'active',
+        effectiveTierBefore: 'free',
+        effectiveTierAfter: 'free',
+        reason: `originalTransactionId ${payload.originalTransactionId} is already owned by another user — refusing to reassign`,
+      };
+    }
     return {
       ok: false,
       productId: payload.productId,
@@ -87,6 +135,7 @@ export async function syncAppleSubscription(
       reason: `no user linked to originalTransactionId ${payload.originalTransactionId} — verify must run first`,
     };
   }
+  const resolvedUserId = resolved.userId;
 
   const admin = getAdmin();
 

--- a/src/lib/native-shell.ts
+++ b/src/lib/native-shell.ts
@@ -1,0 +1,55 @@
+/**
+ * Native shell bridge — detects whether the React app is running inside
+ * the paybacker-mobile Capacitor WebView, and provides a typed window
+ * surface for invoking native StoreKit 2 / Play Billing actions.
+ *
+ * The native shell injects `window.PaybackerNative` on app boot via a
+ * Capacitor WebViewClient script. If that surface exists, we're in the
+ * iOS or Android app; otherwise we're on the web at paybacker.co.uk.
+ *
+ * Why this matters for IAP: Apple's anti-steering rules (Guideline 3.1.1)
+ * forbid showing "Subscribe on paybacker.co.uk for £4.99" buttons inside
+ * the iOS app. We MUST render Apple IAP buttons there. Without this
+ * detection the app shell would render the web upgrade UI and Apple
+ * would reject the build.
+ */
+
+'use client';
+
+export type NativePlatform = 'ios' | 'android';
+
+export interface PaybackerNativeBridge {
+  platform: NativePlatform;
+  appVersion?: string;
+
+  startPurchase?: (productId: string) => Promise<NativePurchaseResult>;
+  restorePurchases?: () => Promise<NativePurchaseResult[]>;
+  openManageSubscriptions?: () => void;
+}
+
+export type NativePurchaseResult =
+  | { ok: true; productId: string; transactionId: string; tier: string }
+  | { ok: false; error: 'cancelled' | 'pending' | 'failed'; message?: string };
+
+declare global {
+  interface Window {
+    PaybackerNative?: PaybackerNativeBridge;
+  }
+}
+
+export function isNativeShell(): boolean {
+  if (typeof window === 'undefined') return false;
+  return !!window.PaybackerNative;
+}
+
+export function getNativePlatform(): NativePlatform | null {
+  if (typeof window === 'undefined') return null;
+  return window.PaybackerNative?.platform ?? null;
+}
+
+export function nativeBridge(): PaybackerNativeBridge {
+  if (typeof window === 'undefined' || !window.PaybackerNative) {
+    throw new Error('PaybackerNative bridge not available — not in native shell');
+  }
+  return window.PaybackerNative;
+}

--- a/src/lib/native-shell.ts
+++ b/src/lib/native-shell.ts
@@ -1,55 +1,128 @@
 /**
- * Native shell bridge — detects whether the React app is running inside
- * the paybacker-mobile Capacitor WebView, and provides a typed window
- * surface for invoking native StoreKit 2 / Play Billing actions.
+ * Native shell bridge — Capacitor plugin wrappers.
  *
- * The native shell injects `window.PaybackerNative` on app boot via a
- * Capacitor WebViewClient script. If that surface exists, we're in the
- * iOS or Android app; otherwise we're on the web at paybacker.co.uk.
+ * The Paybacker mobile apps are Capacitor wrappers around paybacker.co.uk.
+ * When the same web pages render inside the iOS or Android shell, this
+ * module exposes typed wrappers around the native plugins (StoreKit 2 on
+ * iOS, Google Play Billing on Android).
  *
- * Why this matters for IAP: Apple's anti-steering rules (Guideline 3.1.1)
- * forbid showing "Subscribe on paybacker.co.uk for £4.99" buttons inside
- * the iOS app. We MUST render Apple IAP buttons there. Without this
- * detection the app shell would render the web upgrade UI and Apple
- * would reject the build.
+ * On the desktop or mobile web (paybacker.co.uk in a browser),
+ * `isNativeShell()` returns false and the IAP helpers throw — callers must
+ * fall back to the Stripe checkout flow.
  */
 
-'use client';
-
-export type NativePlatform = 'ios' | 'android';
-
-export interface PaybackerNativeBridge {
-  platform: NativePlatform;
-  appVersion?: string;
-
-  startPurchase?: (productId: string) => Promise<NativePurchaseResult>;
-  restorePurchases?: () => Promise<NativePurchaseResult[]>;
-  openManageSubscriptions?: () => void;
-}
-
-export type NativePurchaseResult =
-  | { ok: true; productId: string; transactionId: string; tier: string }
-  | { ok: false; error: 'cancelled' | 'pending' | 'failed'; message?: string };
+// Capacitor's global. We avoid a hard import on `@capacitor/core` so the
+// web bundle doesn't have to ship Capacitor — the native shell injects the
+// global before any web code runs.
+type CapGlobal = {
+  isNativePlatform?: () => boolean;
+  getPlatform?: () => 'ios' | 'android' | 'web';
+  Plugins?: Record<string, unknown>;
+  registerPlugin?: <T = unknown>(name: string) => T;
+};
 
 declare global {
   interface Window {
-    PaybackerNative?: PaybackerNativeBridge;
+    Capacitor?: CapGlobal;
   }
 }
 
 export function isNativeShell(): boolean {
   if (typeof window === 'undefined') return false;
-  return !!window.PaybackerNative;
+  return Boolean(window.Capacitor?.isNativePlatform?.());
 }
 
-export function getNativePlatform(): NativePlatform | null {
+export function getPlatform(): 'ios' | 'android' | 'web' {
+  if (typeof window === 'undefined') return 'web';
+  return window.Capacitor?.getPlatform?.() ?? 'web';
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// IAP plugin types
+// ──────────────────────────────────────────────────────────────────────
+
+export type IapProductId =
+  | 'paybacker.essential.monthly'
+  | 'paybacker.essential.annual'
+  | 'paybacker.pro.monthly'
+  | 'paybacker.pro.annual';
+
+export type IapProduct = {
+  id: IapProductId;
+  displayName: string;
+  description: string;
+  price: string;            // raw decimal as string, e.g. "9.99"
+  displayPrice: string;     // localized, e.g. "£9.99"
+  currencyCode: string;     // "GBP"
+  period: string;           // "1_month", "1_year"
+  type: string;
+};
+
+export type IapPurchaseResult =
+  | {
+      state: 'success';
+      productId: IapProductId;
+      originalTransactionId: string;
+      transactionId: string;
+      jws: string;
+    }
+  | {
+      state: 'pending_server_verify';
+      productId: IapProductId;
+      originalTransactionId: string;
+      error: string;
+    }
+  | { state: 'pending' }
+  | { state: 'cancelled' };
+
+export type IapEntitlement = {
+  productId: IapProductId;
+  originalTransactionId: string;
+  purchaseDate: number;
+  expiresAt: number | null;
+  isUpgraded: boolean;
+};
+
+export type IapPlugin = {
+  getProducts(opts?: { productIds?: IapProductId[] }): Promise<{ products: IapProduct[] }>;
+  purchase(opts: { productId: IapProductId }): Promise<IapPurchaseResult>;
+  restorePurchases(): Promise<{
+    restored: Array<{
+      productId: IapProductId;
+      originalTransactionId: string;
+      expiresAt: number | null;
+      jws: string;
+    }>;
+  }>;
+  openManageSubscriptions(): Promise<void>;
+  getEntitlements(): Promise<{ entitlements: IapEntitlement[] }>;
+};
+
+let cachedPlugin: IapPlugin | null = null;
+
+/**
+ * Returns the native IAP plugin, or null if not running inside the native
+ * shell. Callers must check for null and fall back to the web Stripe flow.
+ */
+export function getIapPlugin(): IapPlugin | null {
+  if (cachedPlugin) return cachedPlugin;
+  if (!isNativeShell()) return null;
   if (typeof window === 'undefined') return null;
-  return window.PaybackerNative?.platform ?? null;
-}
 
-export function nativeBridge(): PaybackerNativeBridge {
-  if (typeof window === 'undefined' || !window.PaybackerNative) {
-    throw new Error('PaybackerNative bridge not available — not in native shell');
+  // iOS: ObjC macro registration auto-exposes Capacitor.Plugins.PaybackerIAP
+  // Android: Java/Kotlin annotation-based registration does the same
+  const fromGlobal = window.Capacitor?.Plugins?.['PaybackerIAP'] as IapPlugin | undefined;
+  if (fromGlobal) {
+    cachedPlugin = fromGlobal;
+    return cachedPlugin;
   }
-  return window.PaybackerNative;
+
+  // Fallback: dynamic registerPlugin() if the global wasn't pre-mounted
+  const reg = window.Capacitor?.registerPlugin;
+  if (reg) {
+    cachedPlugin = reg<IapPlugin>('PaybackerIAP');
+    return cachedPlugin;
+  }
+
+  return null;
 }

--- a/src/lib/twilio/verify.ts
+++ b/src/lib/twilio/verify.ts
@@ -1,0 +1,62 @@
+/**
+ * Twilio request signature verification.
+ *
+ * Twilio signs every webhook request with HMAC-SHA1 using your account
+ * Auth Token. The signature is computed from:
+ *   1. The full URL Twilio called (including query string)
+ *   2. The form-encoded body parameters, sorted alphabetically by key,
+ *      concatenated as key+value
+ *
+ * Result is base64-encoded and sent as the `X-Twilio-Signature` header.
+ *
+ * Reference: https://www.twilio.com/docs/usage/webhooks/webhooks-security
+ */
+import crypto from 'node:crypto';
+import type { NextRequest } from 'next/server';
+
+export async function validateTwilioSignature(req: NextRequest): Promise<boolean> {
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  if (!authToken) return false;
+
+  const sig = req.headers.get('x-twilio-signature');
+  if (!sig) return false;
+
+  // Twilio signs the URL it actually called. We must reconstruct it
+  // exactly — Vercel terminates TLS so the request scheme arrives as
+  // "http", but Twilio will have called https://. Use the X-Forwarded
+  // headers when present, otherwise the request URL.
+  const proto = req.headers.get('x-forwarded-proto') || 'https';
+  const host = req.headers.get('host') || req.headers.get('x-forwarded-host') || '';
+  const url = new URL(req.url);
+  const reconstructed = `${proto}://${host}${url.pathname}${url.search}`;
+
+  // Twilio sends form-encoded body for webhooks. Read it without
+  // consuming the request stream — we clone first because the route
+  // handler needs to read it again for the actual payload.
+  const cloned = req.clone();
+  const params: Record<string, string> = {};
+  try {
+    const form = await cloned.formData();
+    for (const [k, v] of form.entries()) {
+      params[k] = typeof v === 'string' ? v : '';
+    }
+  } catch {
+    // Not form-encoded — JSON or empty. Fall through with empty params.
+  }
+
+  const sortedKeys = Object.keys(params).sort();
+  const concatenated = sortedKeys.reduce((acc, k) => acc + k + params[k], reconstructed);
+
+  const expected = crypto
+    .createHmac('sha1', authToken)
+    .update(concatenated)
+    .digest('base64');
+
+  // Constant-time comparison to avoid timing attacks
+  if (sig.length !== expected.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- **Apple IAP backend** — `/api/iap/verify` + `/api/iap/webhook/apple` for App Store Server Notifications V2; subscription source tracking via `iap_source_tracking` migration (already applied to Supabase cloud).
- **StoreKit 2 web bridge** — `src/lib/native-shell.ts` adds typed `getIapPlugin()` that resolves the native `PaybackerIAP` plugin via `Capacitor.Plugins`, with `registerPlugin()` fallback. `NativeIapButtons.tsx` renders Buy / Restore / Manage Subscriptions (App Review requires all three for auto-renewable subs).
- **Cross-source guard** — `/api/subscription/active` prevents double-pay when a user already has a Stripe sub and tries to buy via IAP.
- **`UpgradePrompt` branching** — modal variant renders `<NativeIapButtons />` inside the native shell, Stripe link on web. Listens for `paybacker:iap-purchased` to auto-dismiss on success.
- **Twilio DSA voice number** — `/api/twilio/voice` + `/api/twilio/voicemail` so the Digital Services Act voice contact requirement is satisfied; verify-by-call helper in `src/lib/twilio/verify.ts`.

Cherry-picked from `feature/yapily-hosted-pages` 23a50e39 onto a clean branch off master so this can deploy independently of the Yapily import-error blocker.

## Env / infra
- All 5 `APPLE_*` env vars set in Vercel. `APPLE_KEY_ID` + `APPLE_PRIVATE_KEY` were rotated after the original `.p8` was exposed in chat.
- Migration `iap_source_tracking` already applied to Supabase cloud directly.

## Test plan
- [ ] StoreKit sandbox: `getProducts()` returns the 4 IAP product IDs
- [ ] Buy flow → `/api/iap/verify` records the receipt and entitlement
- [ ] App Store Server Notifications V2 → `/api/iap/webhook/apple` updates entitlement on RENEWAL / EXPIRED / REFUND
- [ ] User with active Stripe sub: `NativeIapButtons` blocks purchase via `/api/subscription/active` cross-source guard
- [ ] Restore Purchases re-syncs entitlement for fresh device
- [ ] Manage Subscriptions deep-links to App Store subscription management
- [ ] Twilio voice: inbound call → menu → voicemail recording stored
- [ ] Web shell still uses Stripe link (no native plugin call attempted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)