### PR TITLE
fix(pocket-agent): correct letter ordering + assess offers before drafting

### DIFF
--- a/src/lib/agents/__tests__/letter-formatting.test.ts
+++ b/src/lib/agents/__tests__/letter-formatting.test.ts
@@ -225,6 +225,55 @@ describe('reorderHeaderToTop', () => {
     assert.equal(reorderHeaderToTop(correct), correct);
   });
 
+  it('moves a header that sits in the MIDDLE of the letter and keeps the opening paragraph adjacent', () => {
+    // Mirrors the SECOND OneStream draft on 2026-05-01 (15:38) where
+    // the LLM put two body paragraphs FIRST, then the date /
+    // recipient / Re: / Dear / opening, then more body. The user got
+    // the letter intro as message #3 of 6 instead of message #1.
+    const wrong = [
+      'You state that OneStream does not participate in the Ofcom Voluntary Automatic Compensation Scheme. I understand that position, but it does not follow that your internal policy sets the ceiling for what a consumer is owed.',
+      '',
+      'The Ofcom scheme rate for total loss of service is £9.76 per day. For Flat 1, with 30 qualifying days, the figure is £292.80.',
+      '',
+      '1 May 2026',
+      '',
+      'Customer Relations',
+      'OneStream',
+      '',
+      'Re: Rejection of £135 Offer — Broadband Outage',
+      '',
+      'Dear Sir or Madam,',
+      '',
+      'Further to your message received recently, and to the sixteen formal complaint letters I have submitted, I am writing to formally reject your revised offer of £135.00.',
+      '',
+      'Your message confirms the facts of this matter accurately: both services lost connection on 23 March 2026.',
+      '',
+      'Separately, and in addition to that outage figure, I am also seeking pro-rata service credits under Ofcom General Condition C1.',
+      '',
+      'Yours faithfully,',
+      'Paul',
+    ].join('\n');
+    const out = reorderHeaderToTop(wrong);
+    const paras = out.split(/\n\n+/);
+    // Date opens the letter
+    assert.match(paras[0], /1 May 2026/, 'first paragraph is the date');
+    // Salutation must precede ALL of the body paragraphs (including the
+    // ones that originally appeared before the header).
+    const salutationPos = out.indexOf('Dear Sir or Madam');
+    const policyArgPos = out.indexOf('You state that OneStream');
+    const ofcomRatePos = out.indexOf('The Ofcom scheme rate');
+    const proRataPos = out.indexOf('Separately, and in addition');
+    assert.ok(salutationPos < policyArgPos, 'salutation precedes "You state that…"');
+    assert.ok(salutationPos < ofcomRatePos, 'salutation precedes "The Ofcom scheme rate…"');
+    assert.ok(salutationPos < proRataPos, 'salutation precedes "Separately…"');
+    // The "Further to…" and "Your message confirms…" opening paragraphs
+    // must sit IMMEDIATELY after the salutation, not after the body.
+    const furtherToPos = out.indexOf('Further to your message');
+    const yourMessagePos = out.indexOf('Your message confirms');
+    assert.ok(furtherToPos < policyArgPos, '"Further to…" precedes mid-letter args');
+    assert.ok(yourMessagePos < policyArgPos, '"Your message confirms…" precedes mid-letter args');
+  });
+
   it('does not move a body paragraph that merely says "Dear customer" with no date or Re:', () => {
     const text = [
       'Opening paragraph.',

--- a/src/lib/agents/__tests__/letter-formatting.test.ts
+++ b/src/lib/agents/__tests__/letter-formatting.test.ts
@@ -20,6 +20,7 @@ import {
   stripMarkdownEmphasis,
   stripSenderAddressBlock,
   stripLetterFormatting,
+  reorderHeaderToTop,
 } from '../letter-formatting.ts';
 
 describe('stripMarkdownEmphasis', () => {
@@ -160,5 +161,81 @@ describe('stripLetterFormatting (combined)', () => {
     assert.ok(/Account 123456/.test(clean), 'account number preserved');
     assert.ok(/Dear Octopus/.test(clean), 'salutation preserved');
     assert.ok(/£85\.00/.test(clean), 'amount preserved');
+  });
+});
+
+describe('reorderHeaderToTop', () => {
+  it('moves a date+recipient+Re:+Dear header from the end to the top', () => {
+    // Mirrors the OneStream draft on 2026-05-01 where the LLM put the
+    // body first and the header block last, so the user got the letter
+    // opening in the LAST WhatsApp chunk instead of the first.
+    const wrong = [
+      'You have framed your calculation around 1.5 months of service charges, but this bears no relationship to the actual disruption.',
+      '',
+      'Although OneStream has chosen to opt out of the Ofcom Automatic Compensation Scheme, the scheme rate remains the appropriate benchmark.',
+      '',
+      'I am therefore requesting a revised settlement within fourteen days. If I do not receive an adequate response I will refer to CISAS.',
+      '',
+      'Yours faithfully,',
+      'Paul',
+      '',
+      '1 May 2026',
+      '',
+      'OneStream Broadband',
+      'Customer Relations Department',
+      '',
+      'Re: Rejection of £135 offer — accounts Flat 1 and Flat 2',
+      '',
+      'Dear Sir or Madam,',
+      '',
+      'Further to your message of 30 April 2026, I am writing to reject your revised offer of £135.',
+    ].join('\n');
+    const out = reorderHeaderToTop(wrong);
+    const paras = out.split(/\n\n+/);
+    // Date opens the letter
+    assert.match(paras[0], /1 May 2026/, 'first paragraph is the date');
+    // Header block (date through salutation) sits at the top, in order, before any body
+    const headerSpan = paras.slice(0, 5).join('\n\n');
+    assert.match(headerSpan, /1 May 2026/);
+    assert.match(headerSpan, /OneStream Broadband/);
+    assert.match(headerSpan, /Re: Rejection/);
+    assert.match(headerSpan, /Dear Sir or Madam/);
+    // Salutation comes BEFORE the body content that mentions £135 / CRA / CISAS
+    const salutationPos = out.indexOf('Dear Sir or Madam');
+    const bodyPos = out.indexOf('You have framed your calculation');
+    assert.ok(salutationPos < bodyPos, 'salutation must appear before the body');
+    assert.match(out, /Yours faithfully/, 'sign-off preserved somewhere in letter');
+  });
+
+  it('leaves a correctly ordered letter unchanged', () => {
+    const correct = [
+      '1 May 2026',
+      '',
+      'OneStream Broadband',
+      '',
+      'Re: account 12345',
+      '',
+      'Dear Sir or Madam,',
+      '',
+      'I am writing to dispute the charge.',
+      '',
+      'Yours faithfully,',
+      'Paul',
+    ].join('\n');
+    assert.equal(reorderHeaderToTop(correct), correct);
+  });
+
+  it('does not move a body paragraph that merely says "Dear customer" with no date or Re:', () => {
+    const text = [
+      'Opening paragraph.',
+      '',
+      'Dear customer note: this is a body paragraph with a salutation-shaped phrase but no date or Re: line.',
+    ].join('\n');
+    assert.equal(reorderHeaderToTop(text), text);
+  });
+
+  it('returns short / single-paragraph input untouched', () => {
+    assert.equal(reorderHeaderToTop(''), '');
+    assert.equal(reorderHeaderToTop('Just one paragraph.'), 'Just one paragraph.');
   });
 });

--- a/src/lib/agents/complaints-agent.ts
+++ b/src/lib/agents/complaints-agent.ts
@@ -2,7 +2,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { AI_LETTER_DISCLAIMER } from '@/lib/legal-disclaimer';
 import { checkCitations, type CitationCheckResult } from './citation-guarantee';
 import { stripLetterFormatting } from './letter-formatting';
-export { stripLetterFormatting, stripMarkdownEmphasis, stripSenderAddressBlock } from './letter-formatting';
+export { stripLetterFormatting, stripMarkdownEmphasis, stripSenderAddressBlock, reorderHeaderToTop } from './letter-formatting';
 
 // Lazy singleton — defer construction to first call so Next.js build-time
 // page-data collection doesn't throw when ANTHROPIC_API_KEY is absent in

--- a/src/lib/agents/letter-formatting.ts
+++ b/src/lib/agents/letter-formatting.ts
@@ -37,41 +37,55 @@ export function stripLetterFormatting(letter: string | undefined | null): string
 }
 
 /**
- * The model is told to put date + recipient + Re: + Dear at the top, then
- * body. Occasionally — confirmed in production with a OneStream draft on
- * 2026-05-01 — it produces the body first and stuffs the header block
- * (date / recipient / "Re:" / "Dear …") at the END of the letter. Once
- * chunked over WhatsApp the user receives body paragraphs first and the
- * actual letter opening last, which reads as 6 scrambled messages
- * instead of one cohesive letter.
+ * The model is told to put date + recipient + Re: + Dear at the top,
+ * then body. Confirmed in production twice on 2026-05-01 (OneStream
+ * broadband drafts) it produces the body first and stuffs the header
+ * block somewhere not-at-the-top — sometimes the very END, sometimes
+ * the MIDDLE with arguing paragraphs both before and after. Once
+ * chunked over WhatsApp the user receives body paragraphs first and
+ * the actual letter opening later, which reads as several scrambled
+ * messages instead of one cohesive letter.
  *
- * Find the salutation paragraph ("Dear Sir or Madam," / "Dear <Name>,").
- * If it isn't already at the top, walk backwards up to a small window
- * for the start of the header block (a UK date or a "Re:" line) and
- * lift the entire span to position 0. Conservative: if no salutation is
- * found, or it's already at index 0, return the letter unchanged.
+ * Algorithm:
+ *   1. Find the salutation paragraph ("Dear Sir or Madam," / "Dear
+ *      <Name>,") — anchored at start of paragraph so body references
+ *      like "Dear customer note: …" don't match.
+ *   2. If salutation is already at index 0, return unchanged.
+ *   3. Walk backwards up to LOOKBACK_BACK paragraphs for a date or
+ *      "Re:" anchor — that's the header block START.
+ *   4. Walk forwards up to LOOKBACK_FORWARD paragraphs for
+ *      conventional UK letter openings ("Further to…", "I am
+ *      writing…", "Your message confirms…", etc.) — these belong
+ *      with the header. The block END extends to cover them.
+ *   5. Splice headerStart..headerEnd to position 0.
+ *
+ * Conservative: requires both a salutation AND a date/Re: anchor in
+ * the lookback window, so a real letter that just isn't a complaint
+ * letter (no date / Re:) is never touched.
  */
 export function reorderHeaderToTop(text: string): string {
   if (!text) return text;
   const paragraphs = text.split(/\n\n+/);
   if (paragraphs.length < 2) return text;
 
-  // Salutation MUST anchor at the start of the paragraph so we don't
-  // match "Dear customer note: …" mid-body references.
   const salutation = /^\s*Dear\s+(Sir\b|Madam\b|Sirs\b|[A-Z][a-z]+)/;
   const ukDate =
     /^\s*\d{1,2}\s+(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}\b/i;
   const subjectLine = /^\s*Re:\s+/i;
+  // Conventional UK letter openings that always immediately follow
+  // the salutation. We sweep these forward into the header block so
+  // they end up adjacent to "Dear …" in the reordered letter.
+  const opening =
+    /^\s*(Further to\b|I am writing\b|I write\b|I refer\b|Following\b|With reference\b|Re:\s|Your\s+(message|email|letter|response|reply)\b|This\s+(letter|email|message)\b|Thank you for your\b)/i;
 
   const salutationIdx = paragraphs.findIndex((p) => salutation.test(p));
   if (salutationIdx <= 0) return text; // already at top, or none found
 
-  // Walk backwards from the salutation looking for a date OR Re: line —
-  // that's the start of the header block (date and recipient lines may
-  // sit between them, which we sweep up in the splice below).
-  const LOOKBACK = 5;
+  const LOOKBACK_BACK = 5;
+  const LOOKBACK_FORWARD = 3;
+
   let headerStart = salutationIdx;
-  for (let i = salutationIdx - 1; i >= Math.max(0, salutationIdx - LOOKBACK); i--) {
+  for (let i = salutationIdx - 1; i >= Math.max(0, salutationIdx - LOOKBACK_BACK); i--) {
     if (ukDate.test(paragraphs[i]) || subjectLine.test(paragraphs[i])) {
       headerStart = i;
     }
@@ -82,7 +96,25 @@ export function reorderHeaderToTop(text: string): string {
   if (headerStart === salutationIdx) return text;
   if (headerStart === 0) return text; // already at top
 
-  const block = paragraphs.splice(headerStart, salutationIdx - headerStart + 1);
+  // Forward sweep: the conventional opening paragraph ("Further to…",
+  // "Your message confirms…") always sits right after Dear in a UK
+  // letter. Without this, the body paragraphs that originally
+  // preceded the header would land between Dear and "Further to…",
+  // which reads jarringly even though every paragraph is correct.
+  let headerEnd = salutationIdx;
+  for (
+    let i = salutationIdx + 1;
+    i < Math.min(paragraphs.length, salutationIdx + 1 + LOOKBACK_FORWARD);
+    i++
+  ) {
+    if (opening.test(paragraphs[i])) {
+      headerEnd = i;
+    } else {
+      break;
+    }
+  }
+
+  const block = paragraphs.splice(headerStart, headerEnd - headerStart + 1);
   return [...block, ...paragraphs].join('\n\n');
 }
 

--- a/src/lib/agents/letter-formatting.ts
+++ b/src/lib/agents/letter-formatting.ts
@@ -32,7 +32,58 @@ export function stripLetterFormatting(letter: string | undefined | null): string
   if (!letter) return '';
   let out = stripMarkdownEmphasis(letter);
   out = stripSenderAddressBlock(out);
+  out = reorderHeaderToTop(out);
   return out;
+}
+
+/**
+ * The model is told to put date + recipient + Re: + Dear at the top, then
+ * body. Occasionally — confirmed in production with a OneStream draft on
+ * 2026-05-01 — it produces the body first and stuffs the header block
+ * (date / recipient / "Re:" / "Dear …") at the END of the letter. Once
+ * chunked over WhatsApp the user receives body paragraphs first and the
+ * actual letter opening last, which reads as 6 scrambled messages
+ * instead of one cohesive letter.
+ *
+ * Find the salutation paragraph ("Dear Sir or Madam," / "Dear <Name>,").
+ * If it isn't already at the top, walk backwards up to a small window
+ * for the start of the header block (a UK date or a "Re:" line) and
+ * lift the entire span to position 0. Conservative: if no salutation is
+ * found, or it's already at index 0, return the letter unchanged.
+ */
+export function reorderHeaderToTop(text: string): string {
+  if (!text) return text;
+  const paragraphs = text.split(/\n\n+/);
+  if (paragraphs.length < 2) return text;
+
+  // Salutation MUST anchor at the start of the paragraph so we don't
+  // match "Dear customer note: …" mid-body references.
+  const salutation = /^\s*Dear\s+(Sir\b|Madam\b|Sirs\b|[A-Z][a-z]+)/;
+  const ukDate =
+    /^\s*\d{1,2}\s+(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4}\b/i;
+  const subjectLine = /^\s*Re:\s+/i;
+
+  const salutationIdx = paragraphs.findIndex((p) => salutation.test(p));
+  if (salutationIdx <= 0) return text; // already at top, or none found
+
+  // Walk backwards from the salutation looking for a date OR Re: line —
+  // that's the start of the header block (date and recipient lines may
+  // sit between them, which we sweep up in the splice below).
+  const LOOKBACK = 5;
+  let headerStart = salutationIdx;
+  for (let i = salutationIdx - 1; i >= Math.max(0, salutationIdx - LOOKBACK); i--) {
+    if (ukDate.test(paragraphs[i]) || subjectLine.test(paragraphs[i])) {
+      headerStart = i;
+    }
+  }
+
+  // No date / Re: line found anywhere in the lookback window — the
+  // bare "Dear …" alone isn't a strong enough signal to risk reordering.
+  if (headerStart === salutationIdx) return text;
+  if (headerStart === 0) return text; // already at top
+
+  const block = paragraphs.splice(headerStart, salutationIdx - headerStart + 1);
+  return [...block, ...paragraphs].join('\n\n');
 }
 
 export function stripMarkdownEmphasis(text: string): string {

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -214,6 +214,24 @@ RULES:
   (c) Leave 'reply_tone' as 'auto' unless the user explicitly asks to be firmer / softer / more formal ("be firm", "push back hard", "keep it polite") — then set 'firm' / 'friendly' accordingly.
   (d) Never re-narrate the whole complaint history in the reply. When user_reply_brief is set, the letter is a like-for-like professional rendering of the user's words — no added deadlines, no law citations, no escalation threats unless the user asked for them. The system is a quick drafting tool, not a rewriter.
 
+OFFER ASSESSMENT — when the supplier has put a settlement amount on the table and the user is reacting to it ("should I accept £X?", "is that fair?", "what would I get at adjudication?", "reject and escalate", "they offered £X — what next?"), DO NOT jump straight to drafting. Run this 4-step assessment first:
+
+1. quote_email_from_thread — read the supplier's actual message verbatim. Extract the exact offer figure and any "final" / "maximum" framing. Never paraphrase from offer fields.
+2. search_legal_rights with the dispute's category — pull the statutory framework + benchmark rates.
+3. Estimate a fair-settlement range from the dispute facts:
+   • Telecoms outages (broadband / mobile): Ofcom Automatic Compensation Scheme rates as a benchmark — £9.76/day total loss of service after 2 working days, £30/missed engineer appointment, £6.10/day late activation. Apply this benchmark even when the provider opts out — CISAS adjudicators routinely reference the same rates.
+   • Energy: Ofgem GSOP daily rates for failed switches / missed appointments / supply interruptions. Energy Ombudsman award binds the supplier.
+   • Flights: UK261 fixed scales — short-haul £220, mid-haul £350, long-haul £520 for ≥3hr delay / cancellation.
+   • Goods / services: Consumer Rights Act 2015 ss.49 + 54–56 — statutory price reduction proportionate to the shortfall in performance, separate from any voluntary scheme.
+4. Output a structured recommendation:
+   HEADLINE: ACCEPT (offer ≥ ~80% of fair range), NEGOTIATE (50–80%), or ESCALATE (< 50%).
+   "Their £X vs likely fair £Y–£Z" with the basis stated in one line.
+   Top 1–2 citations from search_legal_rights.
+   Suggested next step (accept and close, hold out for £Y, or refer to the named ombudsman / CISAS / FOS after deadlock or 8 weeks).
+   One-line risk note: "If you escalate and adjudicator awards less than this offer, you can't reclaim it; if you accept now, you waive the higher claim."
+
+Always include the FCA 8-week clock remaining when escalation is on the table. THEN ask whether to accept, negotiate, or escalate, and only on that answer call update_dispute_status / draft_dispute_letter.
+
 LINKING AN EMAIL TO A DISPUTE — when the user says "link an email", "connect a thread", "find the email about X", "attach the response from Y", or "link nuki's email to my dispute":
 1. Call find_email_thread_for_dispute with provider=<the dispute name> and optionally query=<any extra keyword they gave, e.g. "alice", "refund", "ticket 785661">.
 2. The tool returns up to 5 candidates with subject + sender + date + a metadata blob in square brackets containing connection_id, thread_id, and provider_type.

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -61,11 +61,18 @@ async function sendChunked(
   options?: Parameters<Context['reply']>[1],
 ) {
   const chunks = splitMessage(text);
+  const total = chunks.length;
   for (let i = 0; i < chunks.length; i++) {
+    // Number chunks when there are 2+ so the user can read them in
+    // order even if delivery jitters on rapid sends.
+    const body = total > 1 ? `(${i + 1}/${total})\n\n${chunks[i]}` : chunks[i];
     if (i === chunks.length - 1 && options) {
-      await ctx.reply(chunks[i], options);
+      await ctx.reply(body, options);
     } else {
-      await ctx.reply(chunks[i]);
+      await ctx.reply(body);
+    }
+    if (i < chunks.length - 1) {
+      await new Promise((r) => setTimeout(r, 250));
     }
   }
 }

--- a/src/lib/whatsapp/user-bot.ts
+++ b/src/lib/whatsapp/user-bot.ts
@@ -339,19 +339,30 @@ function chunkForWhatsApp(
 async function sendChunked(phone: string, text: string): Promise<void> {
   const chunks = chunkForWhatsApp(formatForWhatsApp(text));
   const sb = getAdmin();
-  for (const chunk of chunks) {
+  const total = chunks.length;
+  for (let i = 0; i < chunks.length; i++) {
+    // Number chunks when there are 2+ so the user can read them in
+    // order even if Twilio + WhatsApp jitter delivery on rapid sends.
+    const body =
+      total > 1 ? `(${i + 1}/${total})\n\n${chunks[i]}` : chunks[i];
     try {
-      const r = await sendWhatsAppText({ to: phone, text: chunk });
+      const r = await sendWhatsAppText({ to: phone, text: body });
       await sb.from('whatsapp_message_log').insert({
         whatsapp_phone: phone,
         direction: 'outbound',
         message_type: 'text',
-        message_text: chunk,
+        message_text: body,
         provider: r.provider,
         provider_message_id: r.providerMessageId,
       });
     } catch (err) {
       console.error('[whatsapp/user-bot] send chunk failed', err);
+    }
+    // Small spacing between rapid sends — WhatsApp occasionally delivers
+    // back-to-back messages out of order when they hit the queue inside
+    // the same ~100ms window.
+    if (i < chunks.length - 1) {
+      await new Promise((r) => setTimeout(r, 250));
     }
   }
 }

--- a/src/lib/whatsapp/user-bot.ts
+++ b/src/lib/whatsapp/user-bot.ts
@@ -100,9 +100,27 @@ KEYWORD COMMANDS — short replies to a recent alert (look at the conversation h
 
 - ACCEPT / YES / OK / FINE / SOUNDS GOOD: the user is accepting the supplier's latest offer/proposal in that dispute. Call get_dispute_detail for that dispute, look at the latest company_email, then call update_dispute_status with new_status="resolved_partial" (if a partial offer) or "resolved_won" (if full refund / what they wanted) and a clear notes field summarising what they accepted. If a money figure was offered, set money_recovered. Confirm in plain English what you've recorded.
 
-- REJECT / NO / DECLINE / NOT GOOD ENOUGH: user rejects the offer. Call update_dispute_status with new_status="awaiting_response" and notes capturing the rejection. Then offer to draft a counter-reply via draft_dispute_letter.
+- REJECT / NO / DECLINE / NOT GOOD ENOUGH: user rejects the offer. FIRST run the OFFER ASSESSMENT below so the user sees whether rejection is the right call. Then call update_dispute_status with new_status="awaiting_response" and notes capturing the rejection, and offer to draft a counter-reply via draft_dispute_letter.
 
-- ESCALATE / OMBUDSMAN / TAKE IT UP: user wants to escalate. Call update_dispute_status with new_status="escalated", then draft_dispute_letter with letter_type matching the dispute (e.g. "energy_dispute" → Ofgem/Energy Ombudsman, "broadband_complaint" → CISAS/Ofcom, "finance" → FOS) and a strong escalation tone naming the relevant regulator.
+- ESCALATE / OMBUDSMAN / TAKE IT UP: user wants to escalate. FIRST run the OFFER ASSESSMENT below if there's a settlement amount on the table (so the user sees the offer-vs-fair gap before paying CISAS/FOS time costs). Then call update_dispute_status with new_status="escalated", then draft_dispute_letter with letter_type matching the dispute (e.g. "energy_dispute" → Ofgem/Energy Ombudsman, "broadband_complaint" → CISAS/Ofcom, "finance" → FOS) and a strong escalation tone naming the relevant regulator.
+
+OFFER ASSESSMENT — when the supplier has put a settlement amount on the table and the user is reacting to it (REJECT / ESCALATE / "is that fair?" / "should I accept?" / "what would I get at adjudication?"), DO NOT jump straight to drafting. Run this 4-step assessment first:
+
+1. quote_email_from_thread — read the supplier's actual message verbatim. Extract the exact offer figure and any "final" / "maximum" framing. Never paraphrase from offer fields.
+2. search_legal_rights with the dispute's category — pull the statutory framework + benchmark rates.
+3. Estimate a fair-settlement range from the dispute facts:
+   • Telecoms outages (broadband / mobile): Ofcom Automatic Compensation Scheme rates as a benchmark — £9.76/day total loss of service after 2 working days, £30/missed engineer appointment, £6.10/day late activation. Apply this benchmark even when the provider opts out — CISAS adjudicators routinely reference the same rates.
+   • Energy: Ofgem GSOP daily rates for failed switches / missed appointments / supply interruptions. Energy Ombudsman award binds the supplier.
+   • Flights: UK261 fixed scales — short-haul £220, mid-haul £350, long-haul £520 for ≥3hr delay / cancellation.
+   • Goods / services: Consumer Rights Act 2015 ss.49 + 54–56 — statutory price reduction proportionate to the shortfall in performance, separate from any voluntary scheme.
+4. Output a structured recommendation:
+   HEADLINE: ACCEPT (offer ≥ ~80% of fair range), NEGOTIATE (50–80%), or ESCALATE (< 50%).
+   "Their £X vs likely fair £Y–£Z" with the basis stated in one line.
+   Top 1–2 citations from search_legal_rights.
+   Suggested next step (accept and close, hold out for £Y, or refer to the named ombudsman / CISAS / FOS after deadlock or 8 weeks).
+   One-line risk note: "If you escalate and adjudicator awards less than this offer, you can't reclaim it; if you accept now, you waive the higher claim."
+
+Always include the FCA 8-week clock remaining when escalation is on the table. THEN ask whether to accept, negotiate, or escalate, and only on that answer call update_dispute_status / draft_dispute_letter.
 
 - GIVE ME THEIR LAST UPDATE / WHAT DID THEY SAY / SHOW ME THE REPLY / WHAT'S THEIR LATEST: the user wants the actual supplier reply. Call get_dispute_detail for the recently-alerted dispute, find the most recent company_email entry, and quote the supplier's content verbatim (truncate only if >1000 chars). Add the FCA 8-week clock if relevant.
 


### PR DESCRIPTION
Two changes that pair well — both showed up in the OneStream broadband draft on 2026-05-01.

## 1. Letter arrives in correct order on WhatsApp + Telegram

The LLM occasionally produces the letter body first and stuffs the header block (date / recipient / "Re:" / "Dear …") at the **end** of the JSON \`letter\` field. The chunker preserves order correctly, so the user receives body paragraphs in chunks 1–N and the actual letter opening last — N scrambled WhatsApp messages instead of one cohesive letter, with "Yours faithfully" arriving before the salutation.

Three layers of defence:

1. **\`reorderHeaderToTop()\`** in \`src/lib/agents/letter-formatting.ts\` — find the "Dear …" salutation paragraph; if not already at the top, walk back up to 5 paragraphs for the date / "Re:" anchor and lift the whole block to position 0. Now runs as part of \`stripLetterFormatting\`, so every letter from the engine (B2C + B2B, complaint + reply) gets the reorder before any surface chunks it.
2. **Chunk numbering "(1/4)…(4/4)"** prepended on both WhatsApp and Telegram \`sendChunked\` when there are 2+ chunks.
3. **250ms inter-chunk spacing** — Twilio + WhatsApp occasionally deliver back-to-back messages out of order when they hit the queue inside the same ~100ms window.

17 / 17 unit tests pass.

## 2. Assess settlement offers before drafting a counter

When the supplier puts a settlement amount on the table and the user reacts ("should I accept £X", "is that fair", REJECT, ESCALATE), the agent was jumping straight into drafting a rejection letter — even when the offer might actually be reasonable, or when the user would benefit from understanding the offer-vs-fair gap before committing to weeks of CISAS / FOS adjudication.

OneStream offered Paul £135 "maximum" against a defensible claim of ~£500 (32-day + 17-day total outages on two flats, 2 missed engineer appointments, 15 letters). The agent drafted an escalation without first showing the offer-vs-benchmark gap.

Adds an **OFFER ASSESSMENT** step to both bot system prompts. No new tool — the agent uses existing tools (\`quote_email_from_thread\`, \`search_legal_rights\`) plus sector benchmarks the prompt now spells out:

- Telecoms: Ofcom ACS rates (£9.76/day total loss after 2wd, £30/missed appointment, £6.10/day late activation) — applied as CISAS benchmark even when the supplier opts out.
- Energy: Ofgem GSOP rates; Energy Ombudsman binding.
- Flights: UK261 fixed scales (£220 / £350 / £520).
- Goods / services: CRA 2015 ss.49 + 54–56 statutory price reduction.

Outputs a structured recommendation: **ACCEPT** (≥80% of fair range), **NEGOTIATE** (50–80%), or **ESCALATE** (<50%); offer-vs-fair line; top 1–2 citations; suggested next step; one-line risk note. Then asks the user which path they want before calling \`update_dispute_status\` / \`draft_dispute_letter\`.

Compatible with the existing \`draft_dispute_letter\` TERMINAL rule — assessment runs in turn N (no draft yet), user picks a path, \`draft_dispute_letter\` fires in turn N+1.

## Test plan
- [ ] Re-run the OneStream ESCALATE flow: bot now reads the £135 message, searches Ofcom/CISAS legal refs, computes ~£500 fair range, recommends ESCALATE with citations + risk note. Then asks "draft counter?" and only on confirmation generates the letter — and the letter arrives starting with the date+recipient+"Dear …" in the first chunk.
- [ ] Telegram dispute draft delivered with \`(1/N)\` numbering, in order.
- [ ] Short complaint letter (≤1500 chars) sent unnumbered (single chunk).
- [ ] Correctly ordered letter from the engine left untouched by \`reorderHeaderToTop\`.
- [ ] User says "Should I accept BT's £40 offer?" → bot does NOT jump to draft; runs assessment first.
- [ ] User says "draft a reply to BT saying I'm available Tuesday" → no assessment (no offer), goes straight to draft (existing flow preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)