### PR TITLE
fix(dispute-agent): full body to AI + override picker captures intent

### DIFF
--- a/src/app/api/cron/dispute-agent/route.ts
+++ b/src/app/api/cron/dispute-agent/route.ts
@@ -119,18 +119,24 @@ async function runAgent() {
       continue;
     }
 
-    // Load the last 30 days of correspondence.
+    // Load the last 30 days of inbound company correspondence.
     //
     // Read `correspondence` (the dispute thread, with full body in
     // `content`) NOT `dispute_correspondence` (the email-scanner index,
-    // which only stores a `summary` and loses offer figures). The state
-    // machine's company-reply filter matches the `correspondence.entry_type`
-    // values (company_email / company_letter / company_response).
+    // which only stores a `summary` and loses offer figures).
+    //
+    // Push the company-reply filter down to the query — the thread also
+    // contains user_note / ai_letter / sent_letter rows, and on a chatty
+    // dispute those would push the latest supplier reply out of the row
+    // limit, leaving `latestInbound` empty and silently skipping outcome
+    // classification. Mirror the entry_types in
+    // `state-machine.ts → isInboundFromCompany`.
     const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
     const { data: corrRows } = await sb
       .from('correspondence')
       .select('id,dispute_id,entry_type,entry_date,title,content,summary,created_at')
       .eq('dispute_id', d.id)
+      .in('entry_type', ['company_email', 'company_letter', 'company_response', 'reply_received'])
       .gte('created_at', since)
       .order('created_at', { ascending: false })
       .limit(20);

--- a/src/app/api/cron/dispute-agent/route.ts
+++ b/src/app/api/cron/dispute-agent/route.ts
@@ -120,10 +120,16 @@ async function runAgent() {
     }
 
     // Load the last 30 days of correspondence.
+    //
+    // Read `correspondence` (the dispute thread, with full body in
+    // `content`) NOT `dispute_correspondence` (the email-scanner index,
+    // which only stores a `summary` and loses offer figures). The state
+    // machine's company-reply filter matches the `correspondence.entry_type`
+    // values (company_email / company_letter / company_response).
     const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
     const { data: corrRows } = await sb
-      .from('dispute_correspondence')
-      .select('id,dispute_id,correspondence_type,email_date,subject,summary,created_at')
+      .from('correspondence')
+      .select('id,dispute_id,entry_type,entry_date,title,content,summary,created_at')
       .eq('dispute_id', d.id)
       .gte('created_at', since)
       .order('created_at', { ascending: false })

--- a/src/components/disputes/DisputeAgentBanner.tsx
+++ b/src/components/disputes/DisputeAgentBanner.tsx
@@ -58,12 +58,28 @@ const ACTION_LABELS: Record<string, string> = {
   wait: 'Wait for the next update',
 };
 
+// Order matches the natural escalation ladder so the picker reads top-
+// to-bottom in increasing severity. Keep `wait` last as the no-op.
+const OVERRIDE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: 'send_initial_letter', label: 'Review and send your letter' },
+  { value: 'send_followup', label: 'Send a followup' },
+  { value: 'accept_partial', label: 'Accept the partial offer' },
+  { value: 'mark_won', label: 'Mark this dispute as won' },
+  { value: 'escalate_ombudsman', label: 'Escalate to the ombudsman' },
+  { value: 'send_letter_before_action', label: 'Send a Letter Before Action' },
+  { value: 'small_claims', label: 'Open a small-claims case' },
+  { value: 'manual_review', label: 'Flag for manual review' },
+  { value: 'wait', label: 'Wait for the next update' },
+];
+
 export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
   const [data, setData] = useState<ApiResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [showLog, setShowLog] = useState(false);
+  const [overridePickerOpen, setOverridePickerOpen] = useState(false);
+  const [overrideTarget, setOverrideTarget] = useState<string>('');
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -89,19 +105,31 @@ export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
     void load();
   }, [load]);
 
-  async function act(action: 'approve' | 'override' | 'snooze') {
+  async function act(action: 'approve' | 'override' | 'snooze', overrideAction?: string) {
     if (!data?.latest) return;
+    // Override needs an explicit target — without it the engine learns
+    // "user disagreed" but not what they wanted, which is most of the
+    // signal we care about.
+    if (action === 'override' && !overrideAction) {
+      setOverridePickerOpen(true);
+      return;
+    }
     setBusy(true);
     try {
       const body: Record<string, unknown> = { decision_id: data.latest.id, action };
       if (action === 'snooze') {
         body.snooze_until = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
       }
+      if (action === 'override' && overrideAction) {
+        body.override_target_action = overrideAction;
+      }
       await fetch(`/api/disputes/${disputeId}/agent-decision`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
+      setOverridePickerOpen(false);
+      setOverrideTarget('');
       await load();
     } finally {
       setBusy(false);
@@ -187,10 +215,10 @@ export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
         <button
           type="button"
           disabled={busy}
-          onClick={() => act('override')}
+          onClick={() => setOverridePickerOpen((v) => !v)}
           className="rounded-md border border-slate-600 bg-slate-800 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-700 disabled:opacity-50"
         >
-          Override
+          {overridePickerOpen ? 'Cancel override' : 'Override'}
         </button>
         <button
           type="button"
@@ -201,6 +229,42 @@ export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
           Snooze 7d
         </button>
       </div>
+      {overridePickerOpen && (
+        <div className="mt-3 rounded-md border border-slate-600 bg-slate-900/60 p-3">
+          <div className="text-xs uppercase tracking-wide text-amber-400">
+            What would you do instead?
+          </div>
+          <p className="mt-1 text-xs text-slate-400">
+            Tells the agent which action you actually wanted — not just that you disagreed —
+            so future recommendations against {merchant} learn from it.
+          </p>
+          <select
+            value={overrideTarget}
+            onChange={(e) => setOverrideTarget(e.target.value)}
+            disabled={busy}
+            className="mt-2 w-full rounded-md border border-slate-600 bg-slate-800 px-2 py-1.5 text-sm text-slate-100 disabled:opacity-50"
+          >
+            <option value="">Pick an action…</option>
+            {OVERRIDE_OPTIONS
+              .filter((o) => o.value !== latest.recommended_action)
+              .map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+          </select>
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              disabled={busy || !overrideTarget}
+              onClick={() => act('override', overrideTarget)}
+              className="rounded-md bg-amber-500 px-3 py-1.5 text-sm font-semibold text-slate-900 hover:bg-amber-400 disabled:opacity-50"
+            >
+              Confirm override
+            </button>
+          </div>
+        </div>
+      )}
       {history.length > 1 && (
         <button
           type="button"

--- a/src/lib/dispute-agent/state-machine.ts
+++ b/src/lib/dispute-agent/state-machine.ts
@@ -73,12 +73,20 @@ export interface DisputeRow {
   archived_at: string | null;
 }
 
+/**
+ * Mirrors the `correspondence` table (NOT `dispute_correspondence`).
+ * `correspondence` stores the full body in `content` — that's what the
+ * AI extractor needs to spot offer figures and "final / maximum"
+ * framing. `dispute_correspondence` is a separate scanner-side table
+ * that only carries a `summary`, which loses the figures we care about.
+ */
 export interface CorrespondenceRow {
   id: string;
   dispute_id: string;
-  correspondence_type: string | null;
-  email_date: string | null;
-  subject: string | null;
+  entry_type: string | null;
+  entry_date: string | null;
+  title: string | null;
+  content: string | null;
   summary: string | null;
   created_at: string;
 }
@@ -116,7 +124,7 @@ function plus(days: number): Date {
 
 /** True when AI-extracted outcome on the latest inbound is present and reliable. */
 function isInboundFromCompany(c: CorrespondenceRow): boolean {
-  const t = (c.correspondence_type ?? '').toLowerCase();
+  const t = (c.entry_type ?? '').toLowerCase();
   return (
     t === 'company_email' ||
     t === 'company_letter' ||
@@ -129,8 +137,8 @@ function latestInbound(correspondence: CorrespondenceRow[]): CorrespondenceRow |
   const inbound = correspondence
     .filter(isInboundFromCompany)
     .sort((a, b) => {
-      const ad = Date.parse(a.email_date ?? a.created_at);
-      const bd = Date.parse(b.email_date ?? b.created_at);
+      const ad = Date.parse(a.entry_date ?? a.created_at);
+      const bd = Date.parse(b.entry_date ?? b.created_at);
       return bd - ad;
     });
   return inbound[0] ?? null;
@@ -282,7 +290,14 @@ export async function decideNextAction(
   const inbound = latestInbound(recentCorrespondence);
   if (state === 'responded' || inbound) {
     if (inbound) {
-      const inboundText = `${inbound.subject ?? ''}\n\n${inbound.summary ?? ''}`;
+      // Prefer the full body. Summary is a Haiku-generated paraphrase
+      // that strips offer figures + "final / maximum" framing — the
+      // exact signals the outcome extractor needs. Fall back only when
+      // body genuinely missing (legacy phone-call entries, manual notes
+      // captured before content was required).
+      const body = (inbound.content ?? '').trim();
+      const fallback = (inbound.summary ?? '').trim();
+      const inboundText = `${inbound.title ?? ''}\n\n${body || fallback}`;
       const inferred = await inferOutcomeFromCorrespondence(
         dispute.id,
         inboundText,


### PR DESCRIPTION
## Summary
- **Gap 2 (AI quality):** cron loaded rows from `dispute_correspondence` (scanner-side, summary-only) and fed Haiku `subject + summary`. Summaries strip offer figures and "final / maximum" framing — the exact signal the outcome extractor uses to flip `still_open` → `partial`/`lost`. Now reads `correspondence` (the dispute thread, with the real `content` body) and feeds `title + content`, with a summary fallback for legacy rows.
- **Gap 3 (flywheel signal):** `DisputeAgentBanner` Override button recorded "user disagreed" without saying which action they'd have taken. The endpoint already accepted `override_target_action` — the UI just never sent it. Inline picker now appears under the action row, lists every AgentAction except the current recommendation, with a Confirm step.

## Why this matters for the flywheel

The agent's training signal is per-merchant: "when we recommended X against Stripe, what did the user actually want?" Without override targets we capture half the signal. Combined with Gap 2 (Haiku now sees real body text), the next 30 days of agent decisions should be materially better — especially around partial-offer detection, which OneStream-class disputes were missing.

## Test plan

- [ ] On a dispute with company replies, confirm `/api/cron/dispute-agent` reads from `correspondence` and Haiku sees the body (Anthropic logs)
- [ ] Click Override on a DisputeAgentBanner — picker opens with current recommendation hidden
- [ ] Pick a target, Confirm — `dispute_agent_decisions.recommended_action` should be the new target and `user_action='overrode'`
- [ ] Cancel override — picker closes, no API call fires
- [ ] Existing approve / snooze flows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)