### PR TITLE
fix(email): migrate marketing + weekly digest to canonical layout

### DIFF
--- a/src/lib/email/churn-prevention.ts
+++ b/src/lib/email/churn-prevention.ts
@@ -38,11 +38,11 @@ function buildEmail(type: ChurnEmailType, name: string, data: Record<string, any
 
     body = `
       <h1 style="color:#0B1220;font-size:24px;font-weight:700;margin:0 0 16px;line-height:1.3;">We have been keeping an eye on things, ${name}</h1>
-      <p style="color:#E5E7EB;font-size:15px;line-height:1.75;margin:0 0 16px;">While you have been away, Paybacker has been monitoring your finances. Here is what we found:</p>
+      <p style="color:#374151;font-size:15px;line-height:1.75;margin:0 0 16px;">While you have been away, Paybacker has been monitoring your finances. Here is what we found:</p>
 
       <div style="background:#F9FAFB;border-radius:12px;padding:20px 24px;margin:20px 0;border-left:3px solid #059669;">
         <p style="color:#059669;font-weight:700;margin:0 0 12px;font-size:13px;text-transform:uppercase;letter-spacing:0.5px;">Your snapshot</p>
-        <p style="color:#E5E7EB;margin:0 0 8px;font-size:14px;"><strong>${subCount}</strong> active subscriptions costing <strong>${monthlySpend}/month</strong></p>
+        <p style="color:#374151;margin:0 0 8px;font-size:14px;"><strong>${subCount}</strong> active subscriptions costing <strong>${monthlySpend}/month</strong></p>
         ${expiringCount > 0 ? `<p style="color:#059669;margin:0 0 8px;font-size:14px;font-weight:600;">${expiringCount} contract${expiringCount > 1 ? 's' : ''} expiring soon. Review before they auto-renew at a higher rate.</p>` : ''}
         <p style="color:#6B7280;margin:0;font-size:14px;">Log in to see if any of your providers have cheaper deals available.</p>
       </div>
@@ -55,16 +55,16 @@ function buildEmail(type: ChurnEmailType, name: string, data: Record<string, any
   if (type === 'inactive_14d') {
     body = `
       <h1 style="color:#0B1220;font-size:24px;font-weight:700;margin:0 0 16px;line-height:1.3;">It has been a while, ${name}</h1>
-      <p style="color:#E5E7EB;font-size:15px;line-height:1.75;margin:0 0 16px;">We have noticed you haven't logged in for two weeks. Here are three quick things you can do in under 2 minutes:</p>
+      <p style="color:#374151;font-size:15px;line-height:1.75;margin:0 0 16px;">We have noticed you haven't logged in for two weeks. Here are three quick things you can do in under 2 minutes:</p>
 
       <div style="background:#F9FAFB;border-radius:12px;padding:20px 24px;margin:20px 0;border-left:3px solid #059669;">
-        <p style="color:#E5E7EB;font-weight:600;margin:0 0 6px;font-size:15px;">1. Run a quick scan</p>
+        <p style="color:#374151;font-weight:600;margin:0 0 6px;font-size:15px;">1. Run a quick scan</p>
         <p style="color:#6B7280;margin:0 0 16px;font-size:14px;">Check if any subscriptions have increased their prices since your last visit.</p>
 
-        <p style="color:#E5E7EB;font-weight:600;margin:0 0 6px;font-size:15px;">2. Check your spending</p>
+        <p style="color:#374151;font-weight:600;margin:0 0 6px;font-size:15px;">2. Check your spending</p>
         <p style="color:#6B7280;margin:0 0 16px;font-size:14px;">See where your money went this month with our category breakdown.</p>
 
-        <p style="color:#E5E7EB;font-weight:600;margin:0 0 6px;font-size:15px;">3. Write a complaint letter</p>
+        <p style="color:#374151;font-weight:600;margin:0 0 6px;font-size:15px;">3. Write a complaint letter</p>
         <p style="color:#6B7280;margin:0;font-size:14px;">Been overcharged? Our AI writes a professional complaint citing UK law in 30 seconds.</p>
       </div>
 
@@ -84,15 +84,15 @@ function buildEmail(type: ChurnEmailType, name: string, data: Record<string, any
 
     body = `
       <h1 style="color:#0B1220;font-size:24px;font-weight:700;margin:0 0 16px;line-height:1.3;">Your Paybacker month in review, ${name}</h1>
-      <p style="color:#E5E7EB;font-size:15px;line-height:1.75;margin:0 0 16px;">Your ${tier} plan renews on ${renewalDate}. Here is what Paybacker has done for you:</p>
+      <p style="color:#374151;font-size:15px;line-height:1.75;margin:0 0 16px;">Your ${tier} plan renews on ${renewalDate}. Here is what Paybacker has done for you:</p>
 
       <div style="text-align:center;margin:24px 0;">
         <div style="display:inline-block;background:#F9FAFB;border:1px solid #F9FAFB;border-radius:12px;padding:20px 24px;margin:4px;min-width:120px;">
-          <p style="color:white;font-size:28px;font-weight:800;margin:0;">${lettersGenerated}</p>
+          <p style="color:#0B1220;font-size:28px;font-weight:800;margin:0;">${lettersGenerated}</p>
           <p style="color:#6B7280;font-size:12px;margin:4px 0 0;">Letters generated</p>
         </div>
         <div style="display:inline-block;background:#F9FAFB;border:1px solid #F9FAFB;border-radius:12px;padding:20px 24px;margin:4px;min-width:120px;">
-          <p style="color:white;font-size:28px;font-weight:800;margin:0;">${subsTracked}</p>
+          <p style="color:#0B1220;font-size:28px;font-weight:800;margin:0;">${subsTracked}</p>
           <p style="color:#6B7280;font-size:12px;margin:4px 0 0;">Subscriptions tracked</p>
         </div>
       </div>

--- a/src/lib/email/contract-end-alerts.ts
+++ b/src/lib/email/contract-end-alerts.ts
@@ -96,7 +96,7 @@ export function buildContractEndEmail(
       </div>
     </div>
 
-    <div style="color: #E5E7EB; font-size: 15px; margin-bottom: 20px; line-height: 1.6;">
+    <div style="color: #374151; font-size: 15px; margin-bottom: 20px; line-height: 1.6;">
       Hi ${userName},<br><br>
       ${daysUntilEnd <= 7
         ? 'Your contract is about to end. If you don\'t act now, you\'ll likely be moved to an expensive out-of-contract rate.'

--- a/src/lib/email/deal-alerts.ts
+++ b/src/lib/email/deal-alerts.ts
@@ -198,7 +198,7 @@ export function buildDealAlertEmail(
 
     <!-- Intro -->
     <div style="background: #FFFFFF; padding: 28px 32px;">
-      <div style="color: #E5E7EB; font-size: 15px; line-height: 1.7;">
+      <div style="color: #374151; font-size: 15px; line-height: 1.7;">
         Hi ${userName},<br><br>
         We have analysed your subscriptions and bills and found <strong style="color: #059669;">${topAlerts.length} opportunities</strong> where you could be paying less.
       </div>

--- a/src/lib/email/marketing-automation.ts
+++ b/src/lib/email/marketing-automation.ts
@@ -1,149 +1,142 @@
-import { resend, FROM_EMAIL, REPLY_TO } from '@/lib/resend';
+/**
+ * Lifecycle / marketing automation emails — abandoned cart, activation,
+ * trial-expired, retention, and the AI-generated weekly update.
+ *
+ * Migrated to the canonical PaybackerEmailLayout (2026-05-01) so every send
+ * here renders through `renderPaybackerEmail` — same chrome, contrast and
+ * footer as the rest of the email surface. Earlier hand-rolled inline styles
+ * (white wrap + near-white `#E5E7EB` body text) produced unreadable bodies in
+ * Gmail iOS dark mode; the canonical layout fixes contrast at the source.
+ *
+ * Public API is preserved:
+ *   - `templates.{abandonedCart, activation, trialExpired, retention}(name)` → HTML string
+ *   - `sendEmail(email, subject, html)` → boolean
+ *   - `sendIntelligentUpdate(user, userContext)` → boolean
+ */
+
 import Anthropic from '@anthropic-ai/sdk';
-import { createClient } from '@supabase/supabase-js';
+import { resend, FROM_EMAIL, REPLY_TO } from '@/lib/resend';
+import {
+  renderPaybackerEmail,
+  paragraph,
+  card,
+  callout,
+  unorderedList,
+  type RenderEmailInput,
+} from './PaybackerEmailLayout';
 
-// Gold/Navy design system styles (shared from onboarding)
-const wrap = `font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:600px;margin:0 auto;background:#FFFFFF;border-radius:16px;overflow:hidden;`;
-const header = `background:#F9FAFB;padding:24px 32px;border-bottom:1px solid #F9FAFB;text-align:center;`;
-const body = `padding:32px;`;
-const h1 = `color:#0B1220;font-size:24px;font-weight:700;margin:0 0 16px;line-height:1.3;`;
-const h2 = `color:#0B1220;font-size:18px;font-weight:600;margin:0 0 12px;`;
-const p = `color:#6B7280;font-size:15px;line-height:1.75;margin:0 0 16px;`;
-const pWhite = `color:#E5E7EB;font-size:15px;line-height:1.75;margin:0 0 16px;`;
-const box = `background:#F9FAFB;border-radius:12px;padding:20px 24px;margin:20px 0;border-left:3px solid #059669;`;
-const tipBox = `background:#F9FAFB;border-radius:12px;padding:16px 20px;margin:20px 0;border-left:3px solid #059669;`;
-const cta = `display:inline-block;background:#059669;color:#0B1220;font-weight:700;font-size:15px;padding:14px 28px;border-radius:12px;text-decoration:none;margin:8px 0;`;
-const footer = `padding:20px 32px 28px;border-top:1px solid #F9FAFB;`;
-const footerText = `color:#4B5563;font-size:12px;line-height:1.6;margin:0;text-align:center;`;
+const SITE = process.env.NEXT_PUBLIC_SITE_URL || 'https://paybacker.co.uk';
 
-const Logo = () => `
-  <a href="https://paybacker.co.uk" style="text-decoration:none;">
-    <span style="font-size:22px;font-weight:800;color:#0B1220;">Pay<span style="background:linear-gradient(135deg,#059669,#059669);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;">backer</span></span>
-  </a>
-`;
+// --- Static templates -------------------------------------------------------
 
-const Footer = () => `
-  <div style="${footer}">
-    <p style="${footerText}">
-      <a href="https://paybacker.co.uk" style="color:#059669;text-decoration:none;font-weight:600;">Paybacker LTD</a> · AI-powered money recovery for UK consumers<br/><br/>
-      <a href="https://paybacker.co.uk/privacy-policy" style="color:#4B5563;text-decoration:none;">Privacy Policy</a> &nbsp;·&nbsp;
-      <a href="mailto:support@paybacker.co.uk?subject=Unsubscribe" style="color:#4B5563;text-decoration:none;">Unsubscribe</a>
-    </p>
-  </div>
-`;
+function buildAbandonedCart(name: string): RenderEmailInput {
+  return {
+    preheader: 'Finish setting up Paybacker — most UK households recover £1,000+',
+    heading: `You forgot to finish setting up Paybacker, ${name}`,
+    intro:
+      "You created an account but haven't unlocked your full savings potential yet. The average UK consumer is missing out on over £1,000 in unused subscriptions, overcharges and potential claims.",
+    body: [
+      card(
+        unorderedList([
+          '<strong>Connect your bank:</strong> we automatically identify every subscription and direct debit.',
+          '<strong>Run a scan:</strong> find exactly where you can cut costs immediately.',
+          '<strong>Upgrade to Essential:</strong> unlock unlimited AI complaint letters to reclaim unfair charges.',
+        ]),
+        { eyebrow: 'Complete your setup in 60 seconds' },
+      ),
+      paragraph('Just reply to this email if you have any questions.'),
+    ].join('\n'),
+    cta: { label: 'Finish setup now', href: `${SITE}/dashboard` },
+  };
+}
 
-// --- Templates ---
+function buildActivation(name: string): RenderEmailInput {
+  return {
+    preheader: 'Three things you can do in Paybacker right now',
+    heading: `Ready to get your money back, ${name}?`,
+    intro:
+      "Welcome to Paybacker. We noticed you haven't started using the system yet — let's change that.",
+    body: [
+      callout(
+        'Did you know?',
+        'You can automatically generate legal complaint letters for delayed flights, unfair parking tickets and unexpected bills using our AI dispute generator.',
+      ),
+      paragraph('Here are three things you can do right now:'),
+      card(
+        unorderedList([
+          'Write a dispute letter to your energy provider',
+          'Cancel a subscription you no longer use',
+          'Claim compensation for a delayed flight under UK261',
+        ]),
+        { eyebrow: 'Get value in five minutes' },
+      ),
+    ].join('\n'),
+    cta: { label: 'Go to your dashboard', href: `${SITE}/dashboard` },
+  };
+}
+
+function buildTrialExpired(name: string): RenderEmailInput {
+  return {
+    preheader: 'Your trial ended — your data and letters are still here',
+    heading: `Your Paybacker Pro trial has ended, ${name}`,
+    intro:
+      "Your Pro trial is up. We've moved your account to the Free plan — your data, subscriptions and dispute letters are all still here.",
+    body: [
+      card(
+        unorderedList([
+          '3 AI dispute letters per month (was unlimited)',
+          '2 connected banks and 1 email account',
+          'Top-5 spending categories instead of the full 20+',
+        ]),
+        { eyebrow: 'What changes on Free' },
+      ),
+      paragraph(
+        'Loved the unlimited letters and full Money Hub? Upgrade any time — your data is preserved.',
+      ),
+    ].join('\n'),
+    cta: { label: 'See pricing', href: `${SITE}/pricing` },
+  };
+}
+
+function buildRetention(name: string): RenderEmailInput {
+  return {
+    preheader: "What's new in Paybacker — recover money you didn't know you were owed",
+    heading: `We miss you, ${name}. Have you been overcharged lately?`,
+    intro:
+      "It's been a while since you logged into Paybacker. We've added some powerful new features to help you recover your money.",
+    body: [
+      card(
+        unorderedList([
+          '<strong>Enhanced inbox scanner:</strong> automatically detects receipts and finds flight delay compensation opportunities.',
+          '<strong>Stronger legal AI:</strong> our newest models cite even more specific UK consumer law for higher success rates.',
+          '<strong>Duplicate subs detection:</strong> we now warn you if you are paying for the same service twice.',
+        ]),
+        { eyebrow: "What's new in Paybacker" },
+      ),
+    ].join('\n'),
+    cta: { label: 'See what you can claim', href: `${SITE}/dashboard` },
+  };
+}
 
 export const templates = {
-  abandonedCart: (name: string) => `
-<div style="${wrap}">
-  <div style="${header}">${Logo()}</div>
-  <div style="${body}">
-    <h1 style="${h1}">You forgot to finish setting up Paybacker, ${name}</h1>
-    <p style="${pWhite}">You created an account but haven't unlocked your full savings potential yet. The average UK consumer is missing out on over £1000 in unused subscriptions, overcharges, and potential claims.</p>
-    
-    <div style="${box}">
-      <h2 style="${h2}">Complete your setup in 60 seconds:</h2>
-      <ul style="color:#6B7280;font-size:14px;line-height:1.7;">
-        <li style="margin-bottom:8px;"><strong style="color:#E5E7EB;">Connect your bank:</strong> We'll automatically identify all your subscriptions.</li>
-        <li style="margin-bottom:8px;"><strong style="color:#E5E7EB;">Run a scan:</strong> Find exactly where you can cut costs immediately.</li>
-        <li><strong style="color:#E5E7EB;">Upgrade to Essential:</strong> Unlock unlimited AI complaint letters to get your money back from unfair charges.</li>
-      </ul>
-    </div>
-    
-    <div style="text-align:center;margin:28px 0;">
-      <a href="https://paybacker.co.uk/dashboard" style="${cta}">Finish Setup Now</a>
-    </div>
-    <p style="${p}">Just reply to this email if you have any questions.</p>
-  </div>
-  ${Footer()}
-</div>`,
-
-  activation: (name: string) => `
-<div style="${wrap}">
-  <div style="${header}">${Logo()}</div>
-  <div style="${body}">
-    <h1 style="${h1}">Ready to get your money back, ${name}?</h1>
-    <p style="${pWhite}">Welcome to Paybacker! We noticed you haven't started using the system yet. Let's change that.</p>
-    
-    <div style="${tipBox}">
-      <p style="color:#059669;font-weight:700;margin:0 0 6px;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">Did you know?</p>
-      <p style="color:#6B7280;margin:0;font-size:14px;line-height:1.6;">You can automatically generate legal complaint letters for delayed flights, unfair parking tickets, and unexpected bills using our AI dispute generator.</p>
-    </div>
-    
-    <p style="${p}">Here are three things you can do right now:</p>
-    <ul style="color:#6B7280;font-size:14px;line-height:1.7;">
-      <li>Write a dispute letter to your energy provider</li>
-      <li>Cancel a subscription you no longer use</li>
-      <li>Claim compensation for a delayed flight</li>
-    </ul>
-
-    <div style="text-align:center;margin:28px 0;">
-      <a href="https://paybacker.co.uk/dashboard" style="${cta}">Go to your dashboard</a>
-    </div>
-  </div>
-  ${Footer()}
-</div>`,
-
-  trialExpired: (name: string) => `
-<div style="${wrap}">
-  <div style="${header}">${Logo()}</div>
-  <div style="${body}">
-    <h1 style="${h1}">Your Paybacker Pro trial has ended, ${name}</h1>
-    <p style="${pWhite}">Your 14-day Pro trial is up. We've moved your account to the Free plan — your data, subscriptions, and dispute letters are all still here.</p>
-
-    <div style="${box}">
-      <h2 style="${h2}">What changes on Free:</h2>
-      <ul style="color:#6B7280;font-size:14px;line-height:1.7;">
-        <li style="margin-bottom:8px;">3 AI dispute letters per month (was unlimited)</li>
-        <li style="margin-bottom:8px;">2 connected banks &amp; 1 email account</li>
-        <li>Top-5 spending categories instead of the full 20+</li>
-      </ul>
-    </div>
-
-    <p style="${p}">Loved the unlimited letters and full Money Hub? Upgrade any time — your data is preserved.</p>
-
-    <div style="text-align:center;margin:28px 0;">
-      <a href="https://paybacker.co.uk/pricing" style="${cta}">See pricing</a>
-    </div>
-  </div>
-  ${Footer()}
-</div>`,
-
-  retention: (name: string) => `
-<div style="${wrap}">
-  <div style="${header}">${Logo()}</div>
-  <div style="${body}">
-    <h1 style="${h1}">We miss you, ${name}. Have you been overcharged lately?</h1>
-    <p style="${pWhite}">It's been a while since you logged into Paybacker. We've added some powerful new features to help you recover your money.</p>
-    
-    <div style="${box}">
-      <h2 style="${h2}">What's New in Paybacker:</h2>
-      <ul style="color:#6B7280;font-size:14px;line-height:1.7;">
-        <li><strong style="color:#E5E7EB;">Enhanced Inbox Scanner:</strong> Automatically detects receipts and finds flight delay compensation opportunities.</li>
-        <li><strong style="color:#E5E7EB;">Stronger Legal AI:</strong> Our new models cite even more specific UK consumer law to ensure high success rates.</li>
-        <li><strong style="color:#E5E7EB;">Duplicate Subs Detection:</strong> We now automatically warn you if you're paying for the same service twice.</li>
-      </ul>
-    </div>
-
-    <div style="text-align:center;margin:28px 0;">
-      <a href="https://paybacker.co.uk/dashboard" style="${cta}">See What You Can Claim</a>
-    </div>
-  </div>
-  ${Footer()}
-</div>`
+  abandonedCart: (name: string) => renderPaybackerEmail(buildAbandonedCart(name)),
+  activation: (name: string) => renderPaybackerEmail(buildActivation(name)),
+  trialExpired: (name: string) => renderPaybackerEmail(buildTrialExpired(name)),
+  retention: (name: string) => renderPaybackerEmail(buildRetention(name)),
 };
+
+// --- Sender -----------------------------------------------------------------
 
 export async function sendEmail(email: string, subject: string, html: string) {
   try {
-    const { data, error } = await resend.emails.send({
+    const { error } = await resend.emails.send({
       from: FROM_EMAIL,
       replyTo: REPLY_TO,
       to: email,
       subject,
       html,
     });
-    
+
     if (error) {
       console.error('Error sending email:', error);
       return false;
@@ -155,78 +148,164 @@ export async function sendEmail(email: string, subject: string, html: string) {
   }
 }
 
+// --- AI-generated weekly update --------------------------------------------
+
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY || '',
 });
 
+interface WeeklyUpdateContent {
+  preheader?: string;
+  heading?: string;
+  intro?: string;
+  sections?: { title: string; bullets: string[] }[];
+  closing?: string;
+  cta_label?: string;
+  cta_href?: string;
+  subject?: string;
+}
+
+function safeParseJson(raw: string): WeeklyUpdateContent | null {
+  let text = raw.trim();
+  if (text.startsWith('```')) {
+    text = text.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim();
+  }
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) return null;
+  try {
+    return JSON.parse(text.slice(firstBrace, lastBrace + 1)) as WeeklyUpdateContent;
+  } catch {
+    return null;
+  }
+}
+
+function fallbackContent(name: string, userContext: string): WeeklyUpdateContent {
+  return {
+    preheader: 'Your weekly Paybacker insights',
+    heading: `Your Paybacker weekly update, ${name}`,
+    intro:
+      'A quick summary of what you can do this week to keep more of your money. ' + userContext,
+    sections: [
+      {
+        title: 'Three quick wins',
+        bullets: [
+          'Connect your bank to surface forgotten subscriptions and direct debits.',
+          'Scan your inbox for refund and compensation opportunities (up to £520 for delayed flights).',
+          'Write a complaint letter in 30 seconds — our AI cites the exact UK law.',
+        ],
+      },
+    ],
+    cta_label: 'Open your dashboard',
+    cta_href: `${SITE}/dashboard`,
+  };
+}
+
+function renderWeeklyUpdate(content: WeeklyUpdateContent, name: string): {
+  html: string;
+  subject: string;
+} {
+  const heading = (content.heading || `Your Paybacker weekly update, ${name}`).trim();
+  const preheader = (content.preheader || 'Your weekly Paybacker insights').trim();
+  const intro = content.intro?.trim();
+
+  const sectionBlocks = (content.sections ?? [])
+    .filter((s) => s && s.title && Array.isArray(s.bullets) && s.bullets.length > 0)
+    .map((s) => card(unorderedList(s.bullets), { eyebrow: s.title }));
+
+  const closing = content.closing?.trim();
+
+  const body = [
+    ...sectionBlocks,
+    closing ? paragraph(closing) : '',
+    paragraph('— The Paybacker AI Team'),
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const ctaLabel = (content.cta_label || 'Open your dashboard').trim();
+  const ctaHref = (content.cta_href && content.cta_href.startsWith('http')
+    ? content.cta_href
+    : `${SITE}/dashboard`
+  ).trim();
+
+  const html = renderPaybackerEmail({
+    preheader,
+    heading,
+    intro,
+    body,
+    cta: { label: ctaLabel, href: ctaHref },
+  });
+
+  const subject = content.subject?.trim() || `Your Paybacker weekly update, ${name}`;
+  return { html, subject };
+}
+
 /**
- * Generates and sends a highly personalized, intelligent email using Claude.
- * It uses the user's profile and subscription context to suggest exact actions.
+ * Generates and sends a personalised weekly update email.
+ *
+ * Claude returns STRUCTURED JSON (intro / sections / cta) — never raw HTML —
+ * which we then render through the canonical layout. This guarantees brand
+ * consistency and readable contrast across every recipient, while keeping
+ * the per-user personalisation that made the previous version useful.
  */
 export async function sendIntelligentUpdate(user: any, userContext: string) {
   const name = user.full_name?.split(' ')[0] || 'there';
-  
-  const prompt = `
-You are the AI Assistant for Paybacker, a UK-based platform that helps consumers recover money from unfair charges, manage subscriptions, and dispute bills.
-Write an intelligent, personalized weekly update email for the user. DO NOT USE MARKDOWN, ONLY HTML.
+  const today = new Date().toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
 
-User Name: ${name}
-User Context: ${userContext}
-Current Date: ${new Date().toLocaleDateString('en-GB')}
-Platform Features to highlight: Duplicate subscription detection, AI legal letters (Energy, Broadband, Flight Delays UK261), Bank connection for uncovering hidden costs, Deals engine.
+  const prompt = `You are the AI assistant for Paybacker, a UK platform that helps consumers recover money from unfair charges, manage subscriptions and dispute bills.
 
-Instructions:
-1. Make it sound professional, helpful, and focused on saving money.
-2. Structure the email using inline HTML styles matching a dark mode mint/navy theme.
-3. DO NOT invent or hallucinate dates. Use the Current Date provided above to accurately date your updates.
-4. Include a section about their account/context.
-4. Provide specific suggestions on how they can use the system right now based on their context.
-5. End with a friendly sign off from "The Paybacker AI Team".
+Generate a personalised weekly update for the user as STRICT JSON only — no prose, no Markdown, no HTML. The wrapping email layout (logo, header, footer, button styling) is rendered by Paybacker; you provide only the content slots.
 
-Here are the CSS variables/styles you should use in inline style blocks to match our design system:
-Background wrap: ` + wrap + `
-Header box: ` + header + `
-Body box: ` + body + `
-H1 style: ` + h1 + `
-H2 style: ` + h2 + `
-Primary text: ` + pWhite + `
-Secondary text: ` + p + `
-Highlight Box: ` + box + `
-CTA Button: ` + cta + `
+User first name: ${name}
+User context: ${userContext}
+Today: ${today}
+Features you may reference where relevant: AI dispute letters citing UK consumer law (energy, broadband, flight delays under UK261), bank-connection subscription detection, duplicate-subscription warnings, weekly money digest, deals engine.
 
-Return ONLY the raw HTML of the email inside <div> wrapper. Start directly with the HTML, no generic intro text.`;
+Return ONE JSON object that matches this schema exactly:
+{
+  "subject": "Email subject line, friendly, under 70 chars, may include the first name",
+  "preheader": "One sentence inbox preview under 90 chars",
+  "heading": "Short H1 — 'Your Paybacker weekly update, <name>' or similar",
+  "intro": "1-2 sentences of plain text. No HTML.",
+  "sections": [
+    { "title": "Short section title (Title Case)", "bullets": ["plain-text bullet", "..."] }
+  ],
+  "closing": "One short closing sentence. Optional.",
+  "cta_label": "Button label, e.g. 'Open your dashboard'",
+  "cta_href": "https://paybacker.co.uk/dashboard"
+}
+
+Rules:
+- Output JSON only — no \`\`\` fences, no commentary.
+- Bullets must be plain text (you may use simple <strong>...</strong> for emphasis).
+- 1-3 sections, each with 2-4 bullets.
+- Be specific to the user's context where possible. Never invent dates.
+- Sign-off ("— The Paybacker AI Team") is added automatically. Do not include it.`;
+
+  let content: WeeklyUpdateContent | null = null;
 
   try {
     const response = await anthropic.messages.create({
-      model: "claude-haiku-4-5-20251001",
-      max_tokens: 1500,
-      system: "You are an expert marketing copywriter and email designer for a UK legal tech startup.",
-      messages: [
-        { role: "user", content: prompt }
-      ]
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 1200,
+      system:
+        'You produce strict JSON for a UK consumer fintech weekly email. No prose, no Markdown.',
+      messages: [{ role: 'user', content: prompt }],
     });
 
-    let htmlContent = (response.content[0] as any).text.trim();
-    if (htmlContent.startsWith('```html')) {
-        htmlContent = htmlContent.replace(/^```html\n?/, '').replace(/\n?```$/, '').trim();
-    } else if (htmlContent.startsWith('```')) {
-        htmlContent = htmlContent.replace(/^```\n?/, '').replace(/\n?```$/, '').trim();
-    }
-    
-    // Ensure we include the logo at top and footer at bottom if the AI missed it
-    let finalHtml = htmlContent;
-    if (!finalHtml.includes('https://paybacker.co.uk')) {
-       finalHtml = `<div style="${wrap}"><div style="${header}">${Logo()}</div><div style="${body}">${htmlContent}</div>${Footer()}</div>`;
-    }
-
-    await sendEmail(
-      user.email,
-      `Your Paybacker Weekly Insights & Savings, ${name}`,
-      finalHtml
-    );
-    return true;
+    const raw = (response.content[0] as { type: string; text?: string }).text ?? '';
+    content = safeParseJson(raw);
   } catch (error) {
-    console.error('Failed to generate intelligent email:', error);
-    return false;
+    console.error('Failed to generate intelligent email content:', error);
   }
+
+  const finalContent = content ?? fallbackContent(name, userContext);
+  const { html, subject } = renderWeeklyUpdate(finalContent, name);
+
+  return await sendEmail(user.email, subject, html);
 }

--- a/src/lib/email/overcharge-alerts.ts
+++ b/src/lib/email/overcharge-alerts.ts
@@ -56,7 +56,7 @@ export async function sendOverchargeAlert(
     : `Bill check: ${assessments.length} subscription${assessments.length > 1 ? 's' : ''} reviewed`;
 
   const html = `
-    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; background: #FFFFFF; color: #E5E7EB; padding: 32px 20px;">
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 600px; margin: 0 auto; background: #FFFFFF; color: #374151; padding: 32px 20px;">
       <div style="text-align: center; margin-bottom: 24px;">
         <h1 style="color: #0B1220; font-size: 22px; margin: 0 0 8px;">Overcharge Report</h1>
         <p style="color: #6B7280; font-size: 14px; margin: 0;">Hi ${name}, we found potential savings on your bills.</p>

--- a/src/lib/email/price-increase-alerts.ts
+++ b/src/lib/email/price-increase-alerts.ts
@@ -60,7 +60,7 @@ export function buildPriceIncreaseEmail(
         </div>
       </div>
 
-      <p style="color: #E5E7EB; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">
+      <p style="color: #374151; font-size: 16px; line-height: 1.6; margin: 0 0 24px;">
         Hi ${userName}, we spotted ${alertArray.length === 1 ? 'a price increase' : `${alertArray.length} price increases`} on your payments${alertArray.length > 1 ? `, costing you an extra <strong style="color: #059669;">&pound;${totalAnnualImpact.toFixed(2)}/year</strong>` : ''}.
       </p>
 

--- a/src/lib/email/renewal-reminders.ts
+++ b/src/lib/email/renewal-reminders.ts
@@ -158,7 +158,7 @@ export function buildRenewalEmail(
       <div style="color: #6B7280; font-size: 13px; margin-top: 4px;">${bannerSubtext}</div>
     </div>
 
-    <div style="color: #E5E7EB; font-size: 15px; margin-bottom: 20px; line-height: 1.6;">
+    <div style="color: #374151; font-size: 15px; margin-bottom: 20px; line-height: 1.6;">
       Hi ${userName},<br><br>
       ${bodyText}
     </div>

--- a/src/lib/email/targeted-deals.ts
+++ b/src/lib/email/targeted-deals.ts
@@ -86,7 +86,7 @@ export function buildTargetedEmail(
     <div style="padding: 24px 32px;">
       ${urgencyBanner}
 
-      <div style="color: #E5E7EB; font-size: 15px; line-height: 1.7; margin-bottom: 20px;">
+      <div style="color: #374151; font-size: 15px; line-height: 1.7; margin-bottom: 20px;">
         Hi ${userName},<br><br>
         We have analysed your ${totalMonthlySpend > 0 ? `£${totalMonthlySpend.toFixed(0)}/month in tracked bills` : 'bills'} and identified these specific opportunities:
       </div>

--- a/src/lib/email/waitlist-sequence.ts
+++ b/src/lib/email/waitlist-sequence.ts
@@ -157,10 +157,10 @@ export const WAITLIST_SEQUENCE: SequenceEmail[] = [
 
     <div style="${box}">
       <ul style="color:#6B7280;padding-left:18px;line-height:2.4;margin:0;font-size:14px;">
-        <li><strong style="color:#E5E7EB;">Cites the exact legislation</strong> — Consumer Rights Act 2015, Ofcom, FCA rules. Companies respond differently when the law is named correctly.</li>
-        <li><strong style="color:#E5E7EB;">Sets a 14-day response deadline</strong> — legally significant for Ombudsman escalation.</li>
-        <li><strong style="color:#E5E7EB;">Names the escalation path</strong> — Energy Ombudsman, Financial Ombudsman, Ofcom. They know what comes next.</li>
-        <li><strong style="color:#E5E7EB;">States a specific remedy</strong> — refund amount, service credit, or correction. Vague demands get vague responses.</li>
+        <li><strong style="color:#0B1220;">Cites the exact legislation</strong> — Consumer Rights Act 2015, Ofcom, FCA rules. Companies respond differently when the law is named correctly.</li>
+        <li><strong style="color:#0B1220;">Sets a 14-day response deadline</strong> — legally significant for Ombudsman escalation.</li>
+        <li><strong style="color:#0B1220;">Names the escalation path</strong> — Energy Ombudsman, Financial Ombudsman, Ofcom. They know what comes next.</li>
+        <li><strong style="color:#0B1220;">States a specific remedy</strong> — refund amount, service credit, or correction. Vague demands get vague responses.</li>
       </ul>
     </div>
 
@@ -219,9 +219,9 @@ export const WAITLIST_SEQUENCE: SequenceEmail[] = [
     <div style="${box}">
       <p style="color:#059669;font-weight:700;margin:0 0 12px;font-size:15px;">YOUR EARLY ACCESS BENEFITS</p>
       <ul style="color:#6B7280;padding-left:18px;line-height:2.2;margin:0;font-size:14px;">
-        <li>✅ <strong style="color:#E5E7EB;">3 months free</strong> on any paid plan</li>
-        <li>✅ <strong style="color:#E5E7EB;">Founding member</strong> — locked-in pricing forever</li>
-        <li>✅ <strong style="color:#E5E7EB;">Direct input</strong> on which agents we build next</li>
+        <li>✅ <strong style="color:#0B1220;">3 months free</strong> on any paid plan</li>
+        <li>✅ <strong style="color:#0B1220;">Founding member</strong> — locked-in pricing forever</li>
+        <li>✅ <strong style="color:#0B1220;">Direct input</strong> on which agents we build next</li>
       </ul>
     </div>
 
@@ -248,9 +248,9 @@ export const WAITLIST_SEQUENCE: SequenceEmail[] = [
     <div style="${box}">
       <p style="color:#059669;font-weight:700;margin:0 0 12px;font-size:14px;">WHAT TO DO AT RENEWAL</p>
       <ul style="color:#6B7280;padding-left:18px;margin:0;line-height:2.2;font-size:14px;">
-        <li><strong style="color:#E5E7EB;">30 days before:</strong> Contact them to negotiate — you have the most leverage here.</li>
-        <li><strong style="color:#E5E7EB;">On renewal day:</strong> You can still cancel within 14 days under the Consumer Contracts Regulations 2013.</li>
-        <li><strong style="color:#E5E7EB;">After renewal:</strong> If they raised the price without adequate notice, you have a formal complaint right.</li>
+        <li><strong style="color:#0B1220;">30 days before:</strong> Contact them to negotiate — you have the most leverage here.</li>
+        <li><strong style="color:#0B1220;">On renewal day:</strong> You can still cancel within 14 days under the Consumer Contracts Regulations 2013.</li>
+        <li><strong style="color:#0B1220;">After renewal:</strong> If they raised the price without adequate notice, you have a formal complaint right.</li>
       </ul>
     </div>
 

--- a/src/lib/email/weekly-money-digest.ts
+++ b/src/lib/email/weekly-money-digest.ts
@@ -1,5 +1,22 @@
+/**
+ * Weekly money digest — migrated to canonical PaybackerEmailLayout (2026-05-01).
+ *
+ * Earlier hand-rolled inline styles used near-white text (#E5E7EB) on a white
+ * wrap, which rendered as unreadable low-contrast in Gmail iOS dark mode. The
+ * canonical layout fixes contrast at the source and shares chrome (logo,
+ * footer, button styling) with every other Paybacker email.
+ */
+
 import { resend, FROM_EMAIL, REPLY_TO } from '@/lib/resend';
 import { fmtGBP } from '@/lib/spending';
+import {
+  renderPaybackerEmail,
+  paragraph,
+  card,
+  callout,
+} from './PaybackerEmailLayout';
+
+const SITE = process.env.NEXT_PUBLIC_SITE_URL || 'https://paybacker.co.uk';
 
 const MONEY_TIPS = [
   'Check your bank statements monthly. The average UK household has 2-3 subscriptions they have forgotten about.',
@@ -24,6 +41,124 @@ interface DigestData {
   transactionCount: number;
 }
 
+const COLOR = {
+  ink: '#0B1220',
+  inkSoft: '#374151',
+  inkMuted: '#6B7280',
+  border: '#E5E7EB',
+  surfaceAlt: '#F9FAFB',
+  brand: '#059669',
+  danger: '#EF4444',
+};
+
+function headlineStat(data: DigestData, weekChange: number, changeLabel: string): string {
+  const changeColor = weekChange > 10 ? COLOR.danger : weekChange < -5 ? COLOR.brand : COLOR.inkMuted;
+  const compareLine =
+    data.lastWeekSpend > 0
+      ? `<p style="color:${changeColor};font-size:14px;margin:8px 0 0;">${changeLabel} vs last week (${fmtGBP(data.lastWeekSpend)})</p>`
+      : '';
+  return `
+    <div style="background:${COLOR.surfaceAlt};border:1px solid ${COLOR.border};border-radius:12px;padding:24px;text-align:center;margin:0 0 24px;">
+      <p style="color:${COLOR.inkMuted};font-size:12px;text-transform:uppercase;letter-spacing:1px;margin:0 0 8px;">This week's spending</p>
+      <p style="color:${COLOR.ink};font-size:36px;font-weight:700;margin:0;">${fmtGBP(data.weekSpend)}</p>
+      ${compareLine}
+      <p style="color:${COLOR.inkMuted};font-size:12px;margin:8px 0 0;">${data.transactionCount} transactions</p>
+    </div>
+  `;
+}
+
+function categoriesTable(rows: DigestData['topCategories']): string {
+  if (rows.length === 0) return '';
+  const body = rows
+    .slice(0, 5)
+    .map(
+      (cat) => `
+        <tr>
+          <td style="padding:10px 12px;border-bottom:1px solid ${COLOR.border};color:${COLOR.inkSoft};font-size:14px;">${escapeHtml(cat.category)}</td>
+          <td style="padding:10px 12px;border-bottom:1px solid ${COLOR.border};color:${COLOR.ink};font-weight:600;font-size:14px;text-align:right;">${fmtGBP(cat.total, { fractionDigits: 2 })}</td>
+          <td style="padding:10px 12px;border-bottom:1px solid ${COLOR.border};color:${COLOR.inkMuted};font-size:13px;text-align:right;">${cat.percentage.toFixed(0)}%</td>
+        </tr>
+      `,
+    )
+    .join('');
+  return `
+    <h2 style="color:${COLOR.ink};font-size:16px;margin:0 0 12px;">Where your money went</h2>
+    <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+      <thead>
+        <tr>
+          <th style="padding:8px 12px;text-align:left;color:${COLOR.inkMuted};font-size:12px;border-bottom:2px solid ${COLOR.border};">Category</th>
+          <th style="padding:8px 12px;text-align:right;color:${COLOR.inkMuted};font-size:12px;border-bottom:2px solid ${COLOR.border};">Amount</th>
+          <th style="padding:8px 12px;text-align:right;color:${COLOR.inkMuted};font-size:12px;border-bottom:2px solid ${COLOR.border};">Share</th>
+        </tr>
+      </thead>
+      <tbody>${body}</tbody>
+    </table>
+  `;
+}
+
+function renewalsTable(rows: DigestData['upcomingRenewals']): string {
+  if (rows.length === 0) return '';
+  const body = rows
+    .slice(0, 5)
+    .map((r) => {
+      const dueColor = r.daysUntil <= 7 ? COLOR.danger : COLOR.inkMuted;
+      return `
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid ${COLOR.border};color:${COLOR.inkSoft};font-size:13px;">${escapeHtml(r.provider)}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid ${COLOR.border};color:${COLOR.ink};font-size:13px;text-align:right;">${fmtGBP(r.amount, { fractionDigits: 2 })}</td>
+          <td style="padding:8px 12px;border-bottom:1px solid ${COLOR.border};color:${dueColor};font-size:13px;text-align:right;">${r.daysUntil} day${r.daysUntil !== 1 ? 's' : ''}</td>
+        </tr>
+      `;
+    })
+    .join('');
+  return `
+    <h2 style="color:${COLOR.ink};font-size:16px;margin:0 0 12px;">Renewals coming up</h2>
+    <table style="width:100%;border-collapse:collapse;margin-bottom:24px;">
+      <thead>
+        <tr>
+          <th style="padding:8px 12px;text-align:left;color:${COLOR.inkMuted};font-size:12px;border-bottom:2px solid ${COLOR.border};">Provider</th>
+          <th style="padding:8px 12px;text-align:right;color:${COLOR.inkMuted};font-size:12px;border-bottom:2px solid ${COLOR.border};">Amount</th>
+          <th style="padding:8px 12px;text-align:right;color:${COLOR.inkMuted};font-size:12px;border-bottom:2px solid ${COLOR.border};">Due</th>
+        </tr>
+      </thead>
+      <tbody>${body}</tbody>
+    </table>
+  `;
+}
+
+function budgetSection(rows: DigestData['budgetAlerts']): string {
+  if (rows.length === 0) return '';
+  const items = rows
+    .map((b) => {
+      const barColor = b.percentage >= 100 ? COLOR.danger : COLOR.brand;
+      const barWidth = Math.min(100, b.percentage);
+      return `
+        <div style="margin-bottom:12px;">
+          <div style="display:flex;justify-content:space-between;margin-bottom:4px;">
+            <span style="color:${COLOR.inkSoft};font-size:13px;">${escapeHtml(b.category)}</span>
+            <span style="color:${COLOR.inkMuted};font-size:13px;">${fmtGBP(b.spent)} / ${fmtGBP(b.limit)}</span>
+          </div>
+          <div style="background:${COLOR.border};border-radius:4px;height:6px;overflow:hidden;">
+            <div style="background:${barColor};height:6px;width:${barWidth}%;border-radius:4px;"></div>
+          </div>
+        </div>
+      `;
+    })
+    .join('');
+  return card(
+    `<h2 style="color:${COLOR.ink};font-size:16px;margin:0 0 12px;">Budget tracker</h2>${items}`,
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export function buildWeeklyDigestEmail(
   userName: string,
   data: DigestData,
@@ -33,142 +168,29 @@ export function buildWeeklyDigestEmail(
     ? Math.round(((data.weekSpend - data.lastWeekSpend) / data.lastWeekSpend) * 100)
     : 0;
   const changeLabel = weekChange > 0 ? `+${weekChange}%` : `${weekChange}%`;
-  const changeColor = weekChange > 10 ? '#ef4444' : weekChange < -5 ? '#059669' : '#6B7280';
-
   const tip = MONEY_TIPS[Math.floor(Math.random() * MONEY_TIPS.length)];
 
-  // Category rows
-  const categoryRows = data.topCategories.slice(0, 5).map(cat => `
-    <tr>
-      <td style="padding: 10px 12px; border-bottom: 1px solid #F9FAFB; color: #E5E7EB; font-size: 14px;">${cat.category}</td>
-      <td style="padding: 10px 12px; border-bottom: 1px solid #F9FAFB; color: white; font-weight: 600; font-size: 14px; text-align: right;">${fmtGBP(cat.total, { fractionDigits: 2 })}</td>
-      <td style="padding: 10px 12px; border-bottom: 1px solid #F9FAFB; color: #6B7280; font-size: 13px; text-align: right;">${cat.percentage.toFixed(0)}%</td>
-    </tr>
-  `).join('');
-
-  // Renewal rows
-  const renewalRows = data.upcomingRenewals.slice(0, 5).map(r => `
-    <tr>
-      <td style="padding: 8px 12px; border-bottom: 1px solid #F9FAFB; color: #E5E7EB; font-size: 13px;">${r.provider}</td>
-      <td style="padding: 8px 12px; border-bottom: 1px solid #F9FAFB; color: white; font-size: 13px; text-align: right;">${fmtGBP(r.amount, { fractionDigits: 2 })}</td>
-      <td style="padding: 8px 12px; border-bottom: 1px solid #F9FAFB; color: ${r.daysUntil <= 7 ? '#ef4444' : '#6B7280'}; font-size: 13px; text-align: right;">${r.daysUntil} day${r.daysUntil !== 1 ? 's' : ''}</td>
-    </tr>
-  `).join('');
-
-  // Budget alerts
-  const budgetSection = data.budgetAlerts.length > 0 ? `
-    <div style="background: #F9FAFB; border-radius: 12px; padding: 20px; margin: 20px 0;">
-      <h2 style="color: white; font-size: 16px; margin: 0 0 12px;">Budget Tracker</h2>
-      ${data.budgetAlerts.map(b => {
-        const barColor = b.percentage >= 100 ? '#ef4444' : b.percentage >= 80 ? '#059669' : '#059669';
-        const barWidth = Math.min(100, b.percentage);
-        return `
-          <div style="margin-bottom: 12px;">
-            <div style="display: flex; justify-content: space-between; margin-bottom: 4px;">
-              <span style="color: #E5E7EB; font-size: 13px;">${b.category}</span>
-              <span style="color: #6B7280; font-size: 13px;">${fmtGBP(b.spent)} / ${fmtGBP(b.limit)}</span>
-            </div>
-            <div style="background: #FFFFFF; border-radius: 4px; height: 6px; overflow: hidden;">
-              <div style="background: ${barColor}; height: 6px; width: ${barWidth}%; border-radius: 4px;"></div>
-            </div>
-          </div>
-        `;
-      }).join('')}
-    </div>
-  ` : '';
+  const body = [
+    paragraph(`Hi ${escapeHtml(userName)}, here is your financial snapshot for the past week.`),
+    headlineStat(data, weekChange, changeLabel),
+    categoriesTable(data.topCategories),
+    tier !== 'free' ? budgetSection(data.budgetAlerts) : '',
+    renewalsTable(data.upcomingRenewals),
+    callout('Money tip', tip),
+  ]
+    .filter(Boolean)
+    .join('\n');
 
   const subject = data.weekSpend > 0
-    ? `Your week: ${fmtGBP(data.weekSpend)} spent ${weekChange !== 0 ? `(${changeLabel} vs last week)` : ''}`
+    ? `Your week: ${fmtGBP(data.weekSpend)} spent ${weekChange !== 0 ? `(${changeLabel} vs last week)` : ''}`.trim()
     : 'Your weekly money digest';
 
-  const html = `
-    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; background: #FFFFFF; color: #E5E7EB; padding: 0; border-radius: 16px; overflow: hidden;">
-
-      <!-- Header -->
-      <div style="background: #F9FAFB; padding: 24px 32px; text-align: center; border-bottom: 1px solid #F9FAFB;">
-        <span style="font-size: 22px; font-weight: bold; color: white;">Pay<span style="color: #059669;">backer</span></span>
-        <p style="color: #6B7280; font-size: 12px; margin: 4px 0 0; text-transform: uppercase; letter-spacing: 1px;">Weekly Money Digest</p>
-      </div>
-
-      <div style="padding: 32px;">
-
-        <!-- Greeting -->
-        <p style="color: #6B7280; font-size: 15px; margin: 0 0 24px;">Hi ${userName}, here is your financial snapshot for the past week.</p>
-
-        <!-- Headline stat -->
-        <div style="background: linear-gradient(135deg, #F9FAFB 0%, #F9FAFB 100%); border-radius: 12px; padding: 24px; text-align: center; margin-bottom: 24px; border: 1px solid #F9FAFB;">
-          <p style="color: #6B7280; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 8px;">This week's spending</p>
-          <p style="color: white; font-size: 36px; font-weight: bold; margin: 0;">${fmtGBP(data.weekSpend)}</p>
-          ${data.lastWeekSpend > 0 ? `
-            <p style="color: ${changeColor}; font-size: 14px; margin: 8px 0 0;">
-              ${changeLabel} vs last week (${fmtGBP(data.lastWeekSpend)})
-            </p>
-          ` : ''}
-          <p style="color: #6B7280; font-size: 12px; margin: 8px 0 0;">${data.transactionCount} transactions</p>
-        </div>
-
-        <!-- Top categories -->
-        ${data.topCategories.length > 0 ? `
-          <h2 style="color: white; font-size: 16px; margin: 0 0 12px;">Where your money went</h2>
-          <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
-            <thead>
-              <tr>
-                <th style="padding: 8px 12px; text-align: left; color: #6B7280; font-size: 12px; border-bottom: 2px solid #F9FAFB;">Category</th>
-                <th style="padding: 8px 12px; text-align: right; color: #6B7280; font-size: 12px; border-bottom: 2px solid #F9FAFB;">Amount</th>
-                <th style="padding: 8px 12px; text-align: right; color: #6B7280; font-size: 12px; border-bottom: 2px solid #F9FAFB;">Share</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${categoryRows}
-            </tbody>
-          </table>
-        ` : ''}
-
-        <!-- Budget alerts (Essential+ only) -->
-        ${tier !== 'free' ? budgetSection : ''}
-
-        <!-- Upcoming renewals -->
-        ${data.upcomingRenewals.length > 0 ? `
-          <h2 style="color: white; font-size: 16px; margin: 0 0 12px;">Renewals coming up</h2>
-          <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
-            <thead>
-              <tr>
-                <th style="padding: 8px 12px; text-align: left; color: #6B7280; font-size: 12px; border-bottom: 2px solid #F9FAFB;">Provider</th>
-                <th style="padding: 8px 12px; text-align: right; color: #6B7280; font-size: 12px; border-bottom: 2px solid #F9FAFB;">Amount</th>
-                <th style="padding: 8px 12px; text-align: right; color: #6B7280; font-size: 12px; border-bottom: 2px solid #F9FAFB;">Due</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${renewalRows}
-            </tbody>
-          </table>
-        ` : ''}
-
-        <!-- CTA -->
-        <div style="text-align: center; margin: 28px 0;">
-          <a href="https://paybacker.co.uk/dashboard/money-hub" style="display: inline-block; background: #059669; color: #0B1220; font-weight: bold; padding: 14px 32px; border-radius: 12px; text-decoration: none; font-size: 15px;">
-            View Full Breakdown
-          </a>
-        </div>
-
-        <!-- Money tip -->
-        <div style="background: #F9FAFB; border-left: 3px solid #059669; border-radius: 0 8px 8px 0; padding: 16px 20px; margin-bottom: 24px;">
-          <p style="color: #059669; font-size: 12px; font-weight: bold; margin: 0 0 6px;">MONEY TIP</p>
-          <p style="color: #6B7280; font-size: 13px; line-height: 1.5; margin: 0;">${tip}</p>
-        </div>
-
-        <!-- Footer -->
-        <div style="border-top: 1px solid #F9FAFB; padding-top: 20px; text-align: center;">
-          <p style="color: #6B7280; font-size: 11px; margin: 0;">
-            Paybacker LTD | ICO Registered | paybacker.co.uk
-          </p>
-          <p style="color: #4B5563; font-size: 11px; margin: 8px 0 0;">
-            <a href="https://paybacker.co.uk/dashboard/profile" style="color: #4B5563; text-decoration: underline;">Manage preferences</a>
-          </p>
-        </div>
-      </div>
-    </div>
-  `;
+  const html = renderPaybackerEmail({
+    preheader: `Your weekly money snapshot — ${fmtGBP(data.weekSpend)} spent, ${data.transactionCount} transactions`,
+    heading: 'Your weekly money digest',
+    body,
+    cta: { label: 'View full breakdown', href: `${SITE}/dashboard/money-hub` },
+  });
 
   return { subject, html };
 }


### PR DESCRIPTION
## Summary

The "Your Weekly Paybacker Update" email screenshot showed an unreadable body — light grey text on a dark background — and chrome that didn't match the rest of the email surface. Two senders were hand-rolling inline styles that put near-white text (`#E5E7EB` / pure white) on a white wrap; in Gmail iOS dark mode the wrap flipped dark and the text stayed near-white, killing contrast.

- `src/lib/email/marketing-automation.ts` — abandoned cart, activation, trial-expired, retention templates + AI-generated weekly update (`sendIntelligentUpdate`).
- `src/lib/email/weekly-money-digest.ts` — weekly money digest cron output.

Both now render through the canonical `renderPaybackerEmail` (navy ink `#0B1220` on white wrap, helper-built cards / lists / CTA, shared logo + footer chrome). The AI weekly update was the worst offender because Claude was being asked to emit "dark mode" raw HTML using light-mode tokens — it now returns **structured JSON** (`intro` / `sections` / `cta`) which we render via the canonical helpers, so Claude can no longer produce broken contrast or chrome.

Public API (`templates.*`, `sendEmail`, `sendIntelligentUpdate`, `buildWeeklyDigestEmail`, `sendWeeklyDigestEmail`) is preserved — only the rendered HTML changes, so callers in `/api/cron/marketing-automation`, `/api/cron/trial-expiry` and `/api/cron/weekly-money-digest` need no edits.

## Test plan

- [ ] Trigger `/api/cron/marketing-automation` against a test user; confirm abandoned-cart / activation / retention emails render with navy text on white card and the standard Paybacker footer.
- [ ] Trigger `sendIntelligentUpdate` for a Pro user with 0 subscriptions (matches the screenshot scenario); confirm body text is now legible in Gmail iOS dark mode.
- [ ] Trigger `/api/cron/weekly-money-digest`; confirm category / renewal tables and budget bars render with proper contrast.
- [ ] Verify subject lines unchanged for trial-expiry and abandoned-cart cron paths.

https://claude.ai/code/session_01GUikrrsAsFrnFWAPMapAXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUikrrsAsFrnFWAPMapAXJ)_