### PR TITLE
fix(dispute-detail): repair 'Where this dispute stands' + redesign Dispute Agent banner

### DIFF
--- a/src/app/api/disputes/[id]/ai-overview/route.ts
+++ b/src/app/api/disputes/[id]/ai-overview/route.ts
@@ -62,11 +62,14 @@ export async function GET(
     .maybeSingle();
   if (!dispute) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-  const { data: correspondence } = await admin
+  const { data: correspondence, error: corrErr } = await admin
     .from('correspondence')
-    .select('id, entry_type, direction, content, sender_name, occurred_at, entry_date, title')
+    .select('id, entry_type, content, sender_name, entry_date, title, ai_category, ai_respond_needed, ai_urgency')
     .eq('dispute_id', id)
-    .order('occurred_at', { ascending: true, nullsFirst: false });
+    .order('entry_date', { ascending: true, nullsFirst: false });
+  if (corrErr) {
+    return NextResponse.json({ error: `Failed to load thread: ${corrErr.message}` }, { status: 500 });
+  }
   const corrs = correspondence ?? [];
 
   // Cache hit — same number of messages and we already have a summary.
@@ -90,7 +93,7 @@ export async function GET(
   // Build a compact thread digest for the prompt — cap each entry so
   // we stay within Haiku\'s context budget on long disputes.
   const lines = corrs.map((c) => {
-    const date = (c.occurred_at || c.entry_date || '').slice(0, 10);
+    const date = (c.entry_date || '').slice(0, 10);
     const who = c.entry_type === 'ai_letter' ? 'You sent (AI letter)'
       : c.entry_type === 'user_note' || c.entry_type === 'user_reply' ? `You wrote`
       : c.entry_type === 'company_email' ? `${c.sender_name ?? 'Company'} replied`
@@ -98,8 +101,15 @@ export async function GET(
       : c.entry_type === 'phone_call' ? 'Phone call'
       : c.entry_type;
     const body = (c.content || '').slice(0, 600);
-    return `[${date}] ${who}${c.title ? ` — ${c.title}` : ''}\n${body}`;
+    const tag = c.ai_category ? ` [${c.ai_category}${c.ai_urgency ? `/${c.ai_urgency}` : ''}]` : '';
+    return `[${date}] ${who}${c.title ? ` — ${c.title}` : ''}${tag}\n${body}`;
   }).join('\n\n---\n\n');
+
+  // Count what actually came back from the supplier so we can detect
+  // stale "No reply yet" output even if the AI ignores the thread.
+  const supplierReplyCount = corrs.filter((c) => c.entry_type === 'company_email' || c.entry_type === 'company_letter' || c.entry_type === 'company_response').length;
+  const lastSupplierEntry = [...corrs].reverse().find((c) => c.entry_type === 'company_email' || c.entry_type === 'company_letter' || c.entry_type === 'company_response');
+  const lastSupplierDate = lastSupplierEntry?.entry_date?.slice(0, 10) ?? null;
 
   const prompt = `You\'re writing a status update for a UK consumer dispute, addressed to the customer (the person reading this is the customer, not the company).
 
@@ -109,12 +119,16 @@ What the dispute is about: ${dispute.issue_summary || 'not stated'}
 Desired outcome: ${dispute.desired_outcome || 'not stated'}
 Status: ${dispute.status}
 
+Thread stats: ${corrs.length} total entries, ${supplierReplyCount} from ${dispute.provider_name}${lastSupplierDate ? ` (latest on ${lastSupplierDate})` : ''}.
+
 Correspondence so far (oldest → newest):
 ${lines || '(no correspondence yet — only the user\'s opening note)'}
 
+The "summary" must describe WHERE THE DISPUTE STANDS RIGHT NOW — what's the current position, what has the supplier said most recently, what is outstanding. DO NOT just paraphrase the original issue summary above; assume the customer already knows why they raised the dispute. If the supplier has replied, lead with what they said and where that leaves things. If the customer has just sent a letter and is waiting, say that. If the dispute has stalled (multiple replies but no resolution, or no reply for 14+ days), say so explicitly.
+
 Return JSON only with these keys:
-- "summary": 2-3 sentence neutral overview of what this dispute is about and the current state. Plain English.
-- "latest_update": one sentence describing the MOST RECENT activity (e.g. "The company replied on 21 April offering a £50 partial refund", "Your AI letter was sent on 18 April but no reply yet"). If no correspondence beyond the opening note: "No reply yet from ${dispute.provider_name}."
+- "summary": 2-3 sentence description of the CURRENT STATE of the dispute — what has happened most recently, what position both sides are in, what's outstanding. Plain English. Do NOT just restate the original complaint.
+- "latest_update": one sentence describing the MOST RECENT meaningful activity. Examples: "${dispute.provider_name} replied on 28 Apr asking for tenants' contact details before booking the engineer.", "Your AI letter was sent on 18 Apr but no reply yet." Use ONLY "No reply yet from ${dispute.provider_name}." when supplierReplyCount above is 0.
 - "next_action": one short sentence telling the user what to do RIGHT NOW. Start with a verb. Examples: "Reply to their partial-refund offer.", "Wait 14 days then escalate to the ombudsman.", "Send the first complaint letter."
 - "suggested_steps": array of 2-3 concrete bullet-point next steps in plain English. Each ≤ 18 words.
 

--- a/src/components/disputes/DisputeAgentBanner.tsx
+++ b/src/components/disputes/DisputeAgentBanner.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
+import { Sparkles, Info, ChevronDown, Check, Hand, Clock, ShieldCheck } from 'lucide-react';
 
 interface HistoricalSignal {
   merchant_win_rate: number;
@@ -55,8 +56,18 @@ const ACTION_LABELS: Record<string, string> = {
   manual_review: 'Manual review needed',
   send_letter_before_action: 'Send a Letter Before Action',
   small_claims: 'Open a small-claims case',
-  wait: 'Wait for the next update',
+  wait: 'Wait — nothing to do right now',
 };
+
+const USER_ACTION_LABELS: Record<string, string> = {
+  approved: 'You approved',
+  overridden: 'You overrode',
+  snoozed: 'You snoozed',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
 
 export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
   const [data, setData] = useState<ApiResponse | null>(null);
@@ -64,6 +75,7 @@ export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [showLog, setShowLog] = useState(false);
+  const [showWhat, setShowWhat] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -110,14 +122,14 @@ export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
 
   if (loading) {
     return (
-      <div className="rounded-lg border border-slate-700 bg-slate-900/40 p-4 text-sm text-slate-400">
-        Loading agent recommendation…
+      <div className="rounded-2xl border border-emerald-200 bg-emerald-50/60 p-4 text-sm text-emerald-700 mb-4">
+        Loading Dispute Agent…
       </div>
     );
   }
   if (err) {
     return (
-      <div className="rounded-lg border border-amber-700 bg-amber-900/20 p-4 text-sm text-amber-300">
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 mb-4">
         {err}
       </div>
     );
@@ -127,90 +139,184 @@ export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
   const { latest, history, dispute } = data;
   const merchant = dispute.provider_name ?? dispute.merchant_normalised ?? 'this merchant';
 
-  if (!latest) {
-    return (
-      <div className="rounded-lg border border-slate-700 bg-slate-900/40 p-4 text-sm text-slate-300">
-        <div className="font-semibold text-slate-100">Dispute Agent</div>
-        <div className="mt-1 text-slate-400">
-          No pending recommendation. The agent will check again on its next tick (every 6 hours).
-        </div>
-        {history.length > 0 && (
+  // Wait recommendations that the user has already approved (or that have no
+  // pending action) shouldn't shout for attention — they're "all caught up".
+  const isWaitingQuiet = latest && latest.recommended_action === 'wait' && !!latest.user_action;
+  const showActionable = latest && !isWaitingQuiet;
+
+  return (
+    <div className="rounded-2xl border border-emerald-200 bg-white p-5 mb-4 shadow-sm">
+      <Header showWhat={showWhat} setShowWhat={setShowWhat} />
+
+      {showWhat && <WhatExplainer />}
+
+      {showActionable && latest && (
+        <ActionableCard
+          latest={latest}
+          merchant={merchant}
+          busy={busy}
+          onAct={act}
+        />
+      )}
+
+      {!showActionable && (
+        <CaughtUpCard latest={latest} />
+      )}
+
+      {history.length > 0 && (
+        <div className="mt-4 border-t border-slate-200 pt-3">
           <button
             type="button"
-            className="mt-2 text-xs text-amber-300 underline"
+            className="text-xs font-medium text-emerald-700 hover:text-emerald-900 inline-flex items-center gap-1"
             onClick={() => setShowLog((s) => !s)}
           >
+            <ChevronDown className={`h-3 w-3 transition-transform ${showLog ? 'rotate-180' : ''}`} />
             {showLog ? 'Hide' : 'Show'} past decisions ({history.length})
           </button>
-        )}
-        {showLog && <DecisionLog history={history} />}
-      </div>
-    );
-  }
+          {showLog && <DecisionLog history={history} />}
+        </div>
+      )}
+    </div>
+  );
+}
 
+function Header({ showWhat, setShowWhat }: { showWhat: boolean; setShowWhat: (v: boolean) => void }) {
+  return (
+    <div className="flex items-start justify-between gap-3 mb-3">
+      <div className="flex items-center gap-2">
+        <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+          <Sparkles className="h-4 w-4" />
+        </span>
+        <div>
+          <h3 className="text-sm font-semibold text-slate-900">Dispute Agent</h3>
+          <p className="text-xs text-slate-500">Your AI caseworker for this dispute</p>
+        </div>
+      </div>
+      <button
+        type="button"
+        className="text-xs text-slate-500 hover:text-emerald-700 inline-flex items-center gap-1"
+        onClick={() => setShowWhat(!showWhat)}
+      >
+        <Info className="h-3 w-3" />
+        {showWhat ? 'Hide' : 'What is this?'}
+      </button>
+    </div>
+  );
+}
+
+function WhatExplainer() {
+  return (
+    <div className="rounded-xl bg-slate-50 border border-slate-200 p-3 mb-3 text-xs text-slate-700 leading-relaxed">
+      <p className="font-semibold text-slate-900 mb-1">What does the Dispute Agent do?</p>
+      <p className="mb-2">
+        Every 6 hours it reviews this dispute — your letters, any replies, deadlines,
+        and how similar disputes have been won by other Paybacker users — and decides
+        what to do next.
+      </p>
+      <ul className="space-y-1 list-disc pl-4">
+        <li>If it&apos;s time to act, it surfaces a recommendation here for you to approve, override or snooze.</li>
+        <li>If the supplier is still inside their reply window, it waits and checks again later.</li>
+        <li>It never auto-sends letters or contacts the supplier. You stay in control.</li>
+      </ul>
+    </div>
+  );
+}
+
+function ActionableCard({
+  latest,
+  merchant,
+  busy,
+  onAct,
+}: {
+  latest: Decision;
+  merchant: string;
+  busy: boolean;
+  onAct: (a: 'approve' | 'override' | 'snooze') => void;
+}) {
   const label = ACTION_LABELS[latest.recommended_action] ?? latest.recommended_action;
   const sig = latest.historical_signal;
 
   return (
-    <div className="rounded-lg border border-amber-600/60 bg-amber-900/10 p-4 text-sm">
+    <div className="rounded-xl border border-amber-300 bg-amber-50 p-4">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <div className="text-xs uppercase tracking-wide text-amber-400">Agent recommendation</div>
-          <div className="mt-1 text-base font-semibold text-amber-100">{label}</div>
+          <div className="text-[10px] uppercase tracking-wider text-amber-700 font-semibold">
+            Recommended next step
+          </div>
+          <div className="mt-0.5 text-base font-semibold text-slate-900">{label}</div>
         </div>
         {latest.data_grounded && (
-          <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-xs font-medium text-amber-300">
-            Data-grounded
+          <span
+            className="inline-flex items-center gap-1 rounded-full bg-emerald-100 text-emerald-800 px-2 py-0.5 text-[10px] font-semibold"
+            title="Backed by Paybacker's dispute outcome dataset"
+          >
+            <ShieldCheck className="h-3 w-3" /> Data-grounded
           </span>
         )}
       </div>
-      <p className="mt-2 text-slate-200">{latest.rationale}</p>
+
+      <p className="mt-2 text-sm text-slate-800 leading-relaxed">{latest.rationale}</p>
+
       {sig && (
-        <div className="mt-3 rounded-md border border-amber-600/40 bg-slate-900/40 p-3 text-slate-200">
-          <div className="text-xs uppercase tracking-wide text-amber-400">Historical signal</div>
-          <div className="mt-1">
-            <strong>{(sig.merchant_win_rate * 100).toFixed(0)}%</strong> of similar disputes against{' '}
-            <strong>{merchant}</strong> were won using <em>{sig.top_legal_basis}</em>{' '}
-            <span className="text-slate-400">({sig.sample_size} cases, Paybacker dataset)</span>
+        <div className="mt-3 rounded-lg border border-emerald-200 bg-white p-3 text-xs text-slate-700">
+          <div className="text-[10px] uppercase tracking-wider text-emerald-700 font-semibold mb-1">
+            What works against {merchant}
+          </div>
+          <div>
+            <strong>{(sig.merchant_win_rate * 100).toFixed(0)}%</strong> of Paybacker users won their{' '}
+            {merchant} dispute by citing <em>{sig.top_legal_basis}</em>{' '}
+            <span className="text-slate-500">({sig.sample_size} similar cases)</span>.
           </div>
         </div>
       )}
+
       <div className="mt-4 flex flex-wrap gap-2">
         <button
           type="button"
           disabled={busy}
-          onClick={() => act('approve')}
-          className="rounded-md bg-amber-500 px-3 py-1.5 text-sm font-semibold text-slate-900 hover:bg-amber-400 disabled:opacity-50"
+          onClick={() => onAct('approve')}
+          className="inline-flex items-center gap-1 rounded-lg bg-emerald-600 hover:bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white disabled:opacity-50"
         >
+          <Check className="h-3.5 w-3.5" />
           Approve
         </button>
         <button
           type="button"
           disabled={busy}
-          onClick={() => act('override')}
-          className="rounded-md border border-slate-600 bg-slate-800 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-700 disabled:opacity-50"
+          onClick={() => onAct('override')}
+          className="inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white hover:bg-slate-50 px-3 py-1.5 text-sm text-slate-800 disabled:opacity-50"
         >
-          Override
+          <Hand className="h-3.5 w-3.5" />
+          I&apos;ll do something else
         </button>
         <button
           type="button"
           disabled={busy}
-          onClick={() => act('snooze')}
-          className="rounded-md border border-slate-600 bg-slate-800 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-700 disabled:opacity-50"
+          onClick={() => onAct('snooze')}
+          className="inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white hover:bg-slate-50 px-3 py-1.5 text-sm text-slate-800 disabled:opacity-50"
         >
-          Snooze 7d
+          <Clock className="h-3.5 w-3.5" />
+          Snooze 7 days
         </button>
       </div>
-      {history.length > 1 && (
-        <button
-          type="button"
-          className="mt-3 text-xs text-amber-300 underline"
-          onClick={() => setShowLog((s) => !s)}
-        >
-          {showLog ? 'Hide' : 'Show'} past decisions ({history.length - 1})
-        </button>
-      )}
-      {showLog && <DecisionLog history={history.filter((h) => h.id !== latest.id)} />}
+    </div>
+  );
+}
+
+function CaughtUpCard({ latest }: { latest: Decision | null }) {
+  return (
+    <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm">
+      <div className="flex items-start gap-2">
+        <Check className="h-4 w-4 text-emerald-700 mt-0.5 flex-shrink-0" />
+        <div>
+          <div className="font-semibold text-emerald-900">All caught up — no action needed</div>
+          <p className="mt-1 text-slate-700 text-xs leading-relaxed">
+            {latest
+              ? `The agent reviewed this dispute on ${formatDate(latest.decided_at)} and decided to wait. ${latest.rationale}`
+              : 'The agent will review this dispute again at the next 6-hour check. We’ll surface a recommendation if anything changes.'}
+          </p>
+        </div>
+      </div>
     </div>
   );
 }
@@ -218,15 +324,27 @@ export function DisputeAgentBanner({ disputeId }: { disputeId: string }) {
 function DecisionLog({ history }: { history: Decision[] }) {
   if (history.length === 0) return null;
   return (
-    <ul className="mt-3 space-y-2 border-t border-slate-700 pt-3 text-xs text-slate-400">
-      {history.map((h) => (
-        <li key={h.id}>
-          <span className="text-slate-500">{new Date(h.decided_at).toLocaleString('en-GB')}</span>{' '}
-          <span className="text-slate-300">{h.recommended_action}</span>
-          {h.user_action && <span className="ml-1 text-amber-400">({h.user_action})</span>}
-          <div className="text-slate-500">{h.rationale}</div>
-        </li>
-      ))}
+    <ul className="mt-3 space-y-3">
+      {history.map((h) => {
+        const label = ACTION_LABELS[h.recommended_action] ?? h.recommended_action;
+        const userActionLabel = h.user_action ? USER_ACTION_LABELS[h.user_action] ?? h.user_action : null;
+        return (
+          <li key={h.id} className="rounded-lg bg-slate-50 border border-slate-200 p-3 text-xs">
+            <div className="flex items-start justify-between gap-2 mb-1">
+              <div>
+                <div className="text-slate-500">{formatDate(h.decided_at)}</div>
+                <div className="font-semibold text-slate-900 mt-0.5">{label}</div>
+              </div>
+              {userActionLabel && (
+                <span className="inline-block rounded-full bg-emerald-100 text-emerald-800 px-2 py-0.5 text-[10px] font-semibold whitespace-nowrap">
+                  {userActionLabel}
+                </span>
+              )}
+            </div>
+            <p className="text-slate-600 leading-relaxed">{h.rationale}</p>
+          </li>
+        );
+      })}
     </ul>
   );
 }


### PR DESCRIPTION
## Summary

Two bugs reported on the OneStream dispute screenshot:

### 1. "Where this dispute stands" panel
- **Bug:** the panel paraphrased the original complaint and said *"No reply yet from OneStream"* — while 9 supplier replies were visible right below it.
- **Root cause:** `/api/disputes/[id]/ai-overview` was selecting `occurred_at` and `direction` from the `correspondence` table; neither column exists, so Supabase silently returned no rows and Haiku was prompted with an empty thread.
- **Fix:** select `entry_date` (which exists), surface query errors instead of swallowing them, feed Haiku per-entry AI category/urgency tags + a thread-stats line (total entries, supplier replies, latest reply date), and tighten the prompt to demand a CURRENT-STATE summary led by the most recent supplier activity rather than restating the issue. Stale cached summaries naturally re-run on the next page load because the count check now actually counts the replies.

### 2. Dispute Agent banner
- **Bug:** rendered as an unreadable grey/teal blob on the light dispute page (slate-900 backgrounds + amber-100 text on white) and used raw enum strings like *"wait (approved)"* with no explanation of what the agent does.
- **Fix:** rebuilt for light theme.
  - Header explains *"Your AI caseworker for this dispute"* with an inline **"What is this?"** expander covering the 6-hour cadence, the human-in-the-loop rule, and that letters are never auto-sent.
  - `wait` recommendations the user has already approved now render as a calm **All caught up** card instead of an amber action prompt.
  - Past decisions show friendly action labels, a *You approved / overrode / snoozed* pill, and the rationale.
  - Approve / Override / Snooze buttons get icons + plain-English copy (*"I'll do something else"* in place of *"Override"*).

## Test plan
- [ ] Open a dispute with multiple supplier replies — *"Where this dispute stands"* leads with the latest reply, not the original issue
- [ ] Open a dispute with no supplier replies — latest_update reads *"No reply yet from {provider}"*
- [ ] Refresh button re-runs Haiku
- [ ] Dispute Agent banner is readable on the light theme
- [ ] *"What is this?"* toggles the explainer
- [ ] An already-approved `wait` decision shows the calm green All caught up state
- [ ] An actionable recommendation still shows Approve / Override / Snooze and works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)