### PR TITLE
fix(admin): swipeable tab strip + Compliance Centre sources card

### DIFF
--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -901,10 +901,10 @@ export default function LegalRefsAdminPage() {
           <div>
             <h1 className="text-4xl font-bold text-slate-900 mb-2 flex items-center gap-3 font-[family-name:var(--font-heading)]">
               <Shield className="h-9 w-9 text-emerald-600" />
-              Legal References
+              Compliance Centre
             </h1>
             <p className="text-slate-600">
-              {counts.dbTotal} references across {categories.length} categories
+              {counts.dbTotal} legal references · {categories.length} categories · cross-referenced against canonical UK government sources
               {counts.dbTotal !== counts.total && (
                 <span className="text-amber-600"> · {counts.total} loaded</span>
               )}
@@ -922,6 +922,65 @@ export default function LegalRefsAdminPage() {
             </button>
           </div>
         </div>
+      </div>
+
+      {/* Canonical sources card — explains the four fetchers the
+          Compliance Centre rotates through, in the order they're tried.
+          The chips next to each ref in the Review queue match these
+          labels (legislation.gov.uk / gov-uk-content / find-case-law /
+          perplexity) so the founder can see at a glance which fetcher
+          owns each citation. */}
+      <div className="mb-6 bg-white border border-emerald-200 rounded-2xl p-5 shadow-sm">
+        <div className="flex items-start gap-3 mb-4">
+          <Shield className="h-5 w-5 text-emerald-600 mt-0.5 flex-shrink-0" />
+          <div>
+            <h2 className="text-base font-bold text-slate-900">Canonical sources</h2>
+            <p className="text-xs text-slate-600 mt-0.5">
+              Every citation in this library is verified against at least one of the four sources below. Daily 03:00 UTC `compliance-sync` cron probes for dead URLs, audits authority, runs Perplexity discovery, enriches new candidates, auto-rejects non-authority sources, auto-applies low-risk mechanical fixes, and emails a punch-list of anything that needs a founder click.
+            </p>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3">
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="inline-block w-2 h-2 rounded-full bg-emerald-500" />
+              <span className="text-[10px] uppercase tracking-wider font-semibold text-emerald-800">legislation.gov.uk</span>
+            </div>
+            <p className="text-xs text-slate-700 leading-snug">
+              Open Data API → canonical UK statute text + amendments + retained EU law. Hash-checked nightly so a Westminster amendment flips the citation to <span className="font-mono text-[11px]">stale</span> within 24 hours.
+            </p>
+          </div>
+          <div className="rounded-xl border border-sky-200 bg-sky-50 p-3">
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="inline-block w-2 h-2 rounded-full bg-sky-500" />
+              <span className="text-[10px] uppercase tracking-wider font-semibold text-sky-800">gov-uk-content</span>
+            </div>
+            <p className="text-xs text-slate-700 leading-snug">
+              GOV.UK Content API → CMA, ASA, ICO, and HMRC guidance. Scoped to publishing-application allowlist so blog drafts and DDoS pages can&apos;t be cited as authority.
+            </p>
+          </div>
+          <div className="rounded-xl border border-violet-200 bg-violet-50 p-3">
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="inline-block w-2 h-2 rounded-full bg-violet-500" />
+              <span className="text-[10px] uppercase tracking-wider font-semibold text-violet-800">find-case-law</span>
+            </div>
+            <p className="text-xs text-slate-700 leading-snug">
+              The National Archives → judgments + case citations. Pending licence (CAS-329011-J5F7H9) — flips on once approved without code changes.
+            </p>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="inline-block w-2 h-2 rounded-full bg-slate-500" />
+              <span className="text-[10px] uppercase tracking-wider font-semibold text-slate-700">perplexity sonar pro</span>
+            </div>
+            <p className="text-xs text-slate-700 leading-snug">
+              Discovery + cross-check. Proposes corrections to the staging table; never overwrites canonical fields directly. Non-authority hits are auto-rejected before they reach the founder queue.
+            </p>
+          </div>
+        </div>
+        <p className="text-[11px] text-slate-500 mt-3 leading-relaxed">
+          Hard rule: AI proposes, founder approves. No code path mutates a citation&apos;s law name, source URL, source type or verification status to a non-pending value without passing through <span className="font-mono">legal_ref_corrections</span> and a founder approval click — except the same-host redirect fast-path (e.g. <span className="font-mono">legislation.gov.uk/x/y → /x/y/contents</span>) where no semantic change is possible by definition.
+        </p>
       </div>
 
       {/* Section A — "What needs your attention". Daily-driver summary

--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -496,20 +496,29 @@
   padding: 18px;
 }
 
-/* 5. AdminTabStrip horizontal-scroll affordance.
-   PR #417 added flex-wrap to the strip but on very narrow phones (≤
-   360px) wrapping still produced 4 lines. Allow the strip to scroll-x
-   instead of growing tall. Only kick in below 480px so most phones
-   keep the wrapped layout. */
-@media (max-width: 480px) {
-  .shell-v2 .main-inner .flex.flex-wrap.items-center.gap-2.mb-6 {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    padding-bottom: 6px;
-    margin-left: -4px;
-    padding-left: 4px;
-  }
+/* 5. AdminTabStrip horizontal-scroll behaviour.
+   The strip is now a single flat row of every admin destination
+   (no More dropdown — the dropdown was clipped inside the iOS
+   Capacitor webview). Always scrolls-x, on every viewport. The
+   right-edge fade hints there's more to swipe to. */
+.shell-v2 .admin-tab-strip {
+  flex-wrap: nowrap;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x proximity;
+  padding-bottom: 6px;
+  scrollbar-width: none;
+}
+.shell-v2 .admin-tab-strip::-webkit-scrollbar { display: none; }
+.shell-v2 .admin-tab-strip > * { scroll-snap-align: start; }
+.shell-v2 .admin-tab-strip-wrap::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 28px;
+  height: calc(100% - 6px);
+  pointer-events: none;
+  background: linear-gradient(to left, var(--paper, #FAFAF7), transparent);
 }
 
 /* 6. Mobile-safe break-words on admin headings + breadcrumb.

--- a/src/components/admin/AdminTabStrip.tsx
+++ b/src/components/admin/AdminTabStrip.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import {
   Ticket, Users, Brain, UserPlus, Activity, Gavel, MessageSquare,
   PoundSterling, Shield, Clock, BarChart3, Tag, Briefcase, RefreshCw,
-  ChevronDown,
 } from 'lucide-react';
 
 type AdminTab = 'overview' | 'members' | 'tickets' | 'leads' | 'ai_team';
@@ -24,16 +23,25 @@ interface AdvancedItem {
   title?: string;
 }
 
+// Long-tail admin pages. Used to live behind a "More" dropdown but the
+// dropdown was clipped inside the iOS Capacitor webview, so users could
+// see the trigger but not the menu. Flatten them all into the same
+// horizontally-scrollable strip so every admin destination is reachable
+// with a swipe — no dropdowns, no hidden state.
 const ADVANCED: AdvancedItem[] = [
+  { href: '/dashboard/admin/billing', label: 'Billing', icon: PoundSterling,
+    title: 'API cost ledger — Anthropic / Perplexity / Resend / Stripe / TrueLayer spend' },
+  { href: '/dashboard/admin/analytics', label: 'Analytics', icon: BarChart3 },
   { href: '/dashboard/admin/consumer-leads', label: 'Consumer Leads', icon: UserPlus,
-    title: 'Consumer abandonment nurture funnel — cart-abandonment / pricing-page leads (separate table from social-DM Leads tab above)' },
+    title: 'Consumer abandonment nurture funnel — cart-abandonment / pricing-page leads' },
   { href: '/dashboard/admin/dispute-intelligence', label: 'Dispute Intel', icon: Activity,
     title: 'Dispute outcome dataset — funnel, win rates, merchant × legal-ref heatmap' },
   { href: '/dashboard/admin/dispute-agent', label: 'Dispute Agent', icon: Gavel,
     title: 'Autonomous dispute-agent decisions, approve/override rate, recommendation effectiveness' },
   { href: '/dashboard/admin/whatsapp', label: 'WhatsApp', icon: MessageSquare,
     title: 'WhatsApp template SIDs + Meta approval status' },
-  { href: '/dashboard/admin/legal-refs', label: 'Legal Refs', icon: Shield },
+  { href: '/dashboard/admin/legal-refs', label: 'Compliance Centre', icon: Shield,
+    title: 'Legal references + canonical-source pipeline (legislation.gov.uk, GOV.UK CMA, Find Case Law)' },
   { href: '/dashboard/admin/crons', label: 'Crons', icon: Clock },
   { href: '/dashboard/admin/cancel-info', label: 'Cancel Info', icon: Tag },
   { href: '/dashboard/admin/b2b', label: 'B2B', icon: Briefcase, title: 'B2B waitlist + API keys' },
@@ -42,104 +50,65 @@ const ADVANCED: AdvancedItem[] = [
 ];
 
 export default function AdminTabStrip({ tab, setTab, loadMembers, setSelectedMember }: Props) {
-  const [moreOpen, setMoreOpen] = useState(false);
-  const moreRef = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
 
-  // Close on outside click / Esc.
-  useEffect(() => {
-    if (!moreOpen) return;
-    const onClick = (e: MouseEvent) => {
-      if (moreRef.current && !moreRef.current.contains(e.target as Node)) setMoreOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setMoreOpen(false); };
-    document.addEventListener('mousedown', onClick);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onClick);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [moreOpen]);
-
-  const baseBtn = 'px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5';
+  const baseBtn = 'shrink-0 px-3.5 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-1.5 whitespace-nowrap';
   const inactive = 'bg-slate-100 text-slate-600 hover:text-slate-900';
   const active = 'bg-emerald-500 text-slate-900';
 
   return (
-    <div className="flex flex-wrap items-center gap-2 mb-6">
-      <button
-        onClick={() => { setTab('overview'); setSelectedMember(null); }}
-        className={`${baseBtn} ${tab === 'overview' ? active : inactive}`}
+    <div className="admin-tab-strip-wrap relative mb-6">
+      <div
+        className="admin-tab-strip flex items-center gap-2 overflow-x-auto"
+        role="tablist"
+        aria-label="Admin sections"
       >
-        Overview
-      </button>
-      <button
-        onClick={() => { setTab('members'); loadMembers(); setSelectedMember(null); }}
-        className={`${baseBtn} ${tab === 'members' ? active : inactive}`}
-      >
-        Members
-      </button>
-      <button
-        onClick={() => { setTab('tickets'); setSelectedMember(null); }}
-        className={`${baseBtn} ${tab === 'tickets' ? active : inactive}`}
-      >
-        <Ticket className="h-4 w-4" /> Tickets
-      </button>
-      <button
-        onClick={() => { setTab('leads'); setSelectedMember(null); }}
-        className={`${baseBtn} ${tab === 'leads' ? active : inactive}`}
-      >
-        <Users className="h-4 w-4" /> Leads
-      </button>
-      <button
-        onClick={() => { setTab('ai_team'); setSelectedMember(null); }}
-        className={`${baseBtn} ${tab === 'ai_team' ? active : inactive}`}
-      >
-        <Brain className="h-4 w-4" /> AI Team
-      </button>
-      <Link href="/dashboard/admin/billing" className={`${baseBtn} ${inactive}`}
-        title="API cost ledger — Anthropic / Perplexity / Resend / Stripe / TrueLayer spend">
-        <PoundSterling className="h-4 w-4" /> Billing
-      </Link>
-      <Link href="/dashboard/admin/analytics" className={`${baseBtn} ${inactive}`}>
-        <BarChart3 className="h-4 w-4" /> Analytics
-      </Link>
-
-      {/* More popover — long-tail admin tools live here so the primary
-          row never overflows horizontally on narrow viewports. */}
-      <div className="relative" ref={moreRef}>
         <button
-          type="button"
-          onClick={() => setMoreOpen((v) => !v)}
-          aria-expanded={moreOpen}
-          aria-haspopup="menu"
-          className={`${baseBtn} ${inactive}`}
+          onClick={() => { setTab('overview'); setSelectedMember(null); }}
+          className={`${baseBtn} ${tab === 'overview' ? active : inactive}`}
         >
-          More
-          <ChevronDown className={`h-4 w-4 transition-transform ${moreOpen ? 'rotate-180' : ''}`} />
+          Overview
         </button>
-        {moreOpen && (
-          <div
-            role="menu"
-            className="absolute left-0 top-full mt-2 z-30 w-60 bg-white border border-slate-200 rounded-lg shadow-lg py-1.5"
-          >
-            {ADVANCED.map((item) => {
-              const Icon = item.icon;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  title={item.title}
-                  onClick={() => setMoreOpen(false)}
-                  className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 hover:text-slate-900"
-                  role="menuitem"
-                >
-                  <Icon className="h-4 w-4 text-slate-500" />
-                  {item.label}
-                </Link>
-              );
-            })}
-          </div>
-        )}
+        <button
+          onClick={() => { setTab('members'); loadMembers(); setSelectedMember(null); }}
+          className={`${baseBtn} ${tab === 'members' ? active : inactive}`}
+        >
+          Members
+        </button>
+        <button
+          onClick={() => { setTab('tickets'); setSelectedMember(null); }}
+          className={`${baseBtn} ${tab === 'tickets' ? active : inactive}`}
+        >
+          <Ticket className="h-4 w-4" /> Tickets
+        </button>
+        <button
+          onClick={() => { setTab('leads'); setSelectedMember(null); }}
+          className={`${baseBtn} ${tab === 'leads' ? active : inactive}`}
+        >
+          <Users className="h-4 w-4" /> Leads
+        </button>
+        <button
+          onClick={() => { setTab('ai_team'); setSelectedMember(null); }}
+          className={`${baseBtn} ${tab === 'ai_team' ? active : inactive}`}
+        >
+          <Brain className="h-4 w-4" /> AI Team
+        </button>
+
+        {ADVANCED.map((item) => {
+          const Icon = item.icon;
+          const isActive = pathname?.startsWith(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              title={item.title}
+              className={`${baseBtn} ${isActive ? active : inactive}`}
+            >
+              <Icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Two issues from the legal-refs admin screenshot:

### 1. iOS tab "More" dropdown was hidden
On the Capacitor iOS app the absolute-positioned **More** dropdown on the AdminTabStrip was clipped by the webview, so Legal Refs / Dispute Intel / WhatsApp / Crons / Cancel Info / B2B / Restore data were all unreachable from the in-app shell.

Killed the dropdown and flattened every admin destination into a single horizontally-scrollable tab strip:
- Always scrolls-x (not just <480px)
- Scroll-snap for an app-like swipe feel
- Right-edge fade gradient hinting there's more to see
- Active state for Link tabs derives from the URL pathname so navigating to a sub-page highlights the right tab

### 2. Legal-refs page didn't explain what the "Compliance Centre" actually is
Readers saw raw \`perplexity\` / \`legislation.gov.uk\` source chips with no context for what they meant or which sources Paybacker actually verifies citations against.

- Renamed the page H1 to **Compliance Centre** with a one-line strapline
- Added a Canonical sources card explaining the four fetchers in pipeline order:
  - **legislation.gov.uk** — Open Data API for canonical UK statute text + amendments + retained EU law (hash-checked nightly)
  - **gov-uk-content** — GOV.UK Content API for CMA, ASA, ICO and HMRC guidance
  - **find-case-law** — TNA judgments (pending licence CAS-329011-J5F7H9)
  - **perplexity** — Sonar Pro discovery + cross-check (proposes corrections, never overwrites)
- Spelt out the daily 03:00 UTC \`compliance-sync\` chain (probe url_dead → audit → discover → enrich → auto-reject non-authority → auto-apply low-risk → email punch-list)
- Restated the human-in-the-loop rule + the same-host fast-path exception in plain English

## Test plan
- [ ] Open \`/dashboard/admin\` in the iOS Capacitor app — tab strip swipes left/right, every destination reachable, no dropdown
- [ ] Tap a Link tab (e.g. Compliance Centre) — strip stays in place, active highlight follows
- [ ] Open \`/dashboard/admin/legal-refs\` — H1 reads Compliance Centre, sources card visible above the action panel
- [ ] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)