### PR TITLE
feat(newsletter): in-dashboard subscribe toggle + newsletter unsubscribe path

### DIFF
--- a/src/app/api/notification-preferences/route.ts
+++ b/src/app/api/notification-preferences/route.ts
@@ -46,7 +46,7 @@ export async function GET() {
       .eq('user_id', user.id),
     supabase
       .from('profiles')
-      .select('quiet_hours_start, quiet_hours_end, notification_timezone')
+      .select('quiet_hours_start, quiet_hours_end, notification_timezone, newsletter_unsubscribed_at')
       .eq('id', user.id)
       .maybeSingle(),
     supabase
@@ -119,6 +119,13 @@ export async function GET() {
     quiet_hours_end: trimTimeOfDay(profileRes.data?.quiet_hours_end),
     timezone: profileRes.data?.notification_timezone ?? 'Europe/London',
     alerts_paused_until: alertPrefsRes.data?.alerts_paused_until ?? null,
+    // Newsletter (Thu 11:00 UTC) opt-in. Source of truth is
+    //   user_metadata.marketing_opt_in === true
+    //   AND profiles.newsletter_unsubscribed_at IS NULL.
+    // Either signal flipping off => unsubscribed.
+    newsletter_opted_in:
+      ((user.user_metadata as { marketing_opt_in?: boolean } | null)?.marketing_opt_in ?? false) === true
+      && !profileRes.data?.newsletter_unsubscribed_at,
   });
 }
 
@@ -174,6 +181,7 @@ interface PutBody {
   }>;
   quiet_hours_start?: string | null;
   quiet_hours_end?: string | null;
+  newsletter_opted_in?: boolean;
 }
 
 export async function PUT(request: Request) {
@@ -213,6 +221,27 @@ export async function PUT(request: Request) {
       if (error) {
         return NextResponse.json({ error: error.message }, { status: 500 });
       }
+    }
+  }
+
+  if (body.newsletter_opted_in !== undefined) {
+    // Two-write update: keep auth user_metadata.marketing_opt_in
+    // (source-of-truth for the signup-time consent record) and the
+    // profiles.newsletter_unsubscribed_at column (source-of-truth for
+    // post-signup opt-outs, also queried by /api/unsubscribe) in sync.
+    const optedIn = !!body.newsletter_opted_in;
+    const { error: metaErr } = await supabase.auth.updateUser({
+      data: { marketing_opt_in: optedIn },
+    });
+    if (metaErr) {
+      return NextResponse.json({ error: metaErr.message }, { status: 500 });
+    }
+    const { error: profileErr } = await supabase
+      .from('profiles')
+      .update({ newsletter_unsubscribed_at: optedIn ? null : new Date().toISOString() })
+      .eq('id', user.id);
+    if (profileErr) {
+      return NextResponse.json({ error: profileErr.message }, { status: 500 });
     }
   }
 

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -1,13 +1,18 @@
 /**
- * GET /api/unsubscribe?token=... — public, token-gated unsubscribe.
- * POST same — RFC 8058 one-click unsubscribe target (Gmail/Outlook
- * native button POSTs `List-Unsubscribe=One-Click`).
+ * GET /api/unsubscribe?token=...&kind=consumer_lead|newsletter — public,
+ * token-gated unsubscribe. POST same — RFC 8058 one-click unsubscribe
+ * target (Gmail/Outlook native button POSTs `List-Unsubscribe=One-Click`).
  *
  * Honours the request immediately:
- *   - sets unsubscribed_at = now()
- *   - flips funnel_stage to 'unsubscribed'
+ *   - consumer_lead kind: sets unsubscribed_at = now() on the lead row
+ *     and flips funnel_stage = 'unsubscribed'.
+ *   - newsletter kind: sets profiles.newsletter_unsubscribed_at = now()
+ *     for the user whose newsletter_unsub_token matches.
  *   - GET → redirect to /unsubscribe (success page)
  *   - POST → 200 JSON
+ *
+ * `kind` defaults to `consumer_lead` for backward compatibility with
+ * the consumer-nurture footer links that pre-date the newsletter.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -16,6 +21,8 @@ import { captureServer } from '@/lib/posthog-server';
 
 export const runtime = 'nodejs';
 
+type UnsubKind = 'consumer_lead' | 'newsletter';
+
 function getAdmin() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -23,16 +30,56 @@ function getAdmin() {
   );
 }
 
-async function processUnsubscribe(token: string): Promise<{ ok: boolean; alreadyUnsubscribed: boolean; leadId?: string }> {
+function pickKind(raw: string | null): UnsubKind {
+  return raw === 'newsletter' ? 'newsletter' : 'consumer_lead';
+}
+
+interface UnsubResult {
+  ok: boolean;
+  alreadyUnsubscribed: boolean;
+  leadId?: string;
+  userId?: string;
+}
+
+async function processUnsubscribe(token: string, kind: UnsubKind): Promise<UnsubResult> {
   if (!token) return { ok: false, alreadyUnsubscribed: false };
   const supabase = getAdmin();
 
+  if (kind === 'newsletter') {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('id, newsletter_unsubscribed_at')
+      .eq('newsletter_unsub_token', token)
+      .maybeSingle();
+    if (!profile) return { ok: false, alreadyUnsubscribed: false };
+    if (profile.newsletter_unsubscribed_at) {
+      return { ok: true, alreadyUnsubscribed: true, userId: profile.id };
+    }
+    const now = new Date().toISOString();
+    await supabase
+      .from('profiles')
+      .update({ newsletter_unsubscribed_at: now })
+      .eq('id', profile.id);
+    // Mirror to user_metadata so the dashboard toggle reads false on
+    // next load. Service-role admin auth API call.
+    try {
+      await supabase.auth.admin.updateUserById(profile.id, {
+        user_metadata: { marketing_opt_in: false },
+      });
+    } catch {
+      // Non-fatal: profiles flag alone suppresses the cron, the
+      // mirror is just so the settings page stays in sync.
+    }
+    captureServer('newsletter_unsubscribed', `user:${profile.id}`, {});
+    return { ok: true, alreadyUnsubscribed: false, userId: profile.id };
+  }
+
+  // consumer_lead (legacy path — kept for existing nurture footers)
   const { data: lead } = await supabase
     .from('consumer_leads')
     .select('id, unsubscribed_at, email_count')
     .eq('unsubscribe_token', token)
     .maybeSingle();
-
   if (!lead) return { ok: false, alreadyUnsubscribed: false };
   if (lead.unsubscribed_at) {
     return { ok: true, alreadyUnsubscribed: true, leadId: lead.id };
@@ -56,7 +103,8 @@ async function processUnsubscribe(token: string): Promise<{ ok: boolean; already
 
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token') || '';
-  const result = await processUnsubscribe(token);
+  const kind = pickKind(req.nextUrl.searchParams.get('kind'));
+  const result = await processUnsubscribe(token, kind);
   // Always redirect to the success page so unauthenticated browsers don't
   // see a confusing JSON blob — the page itself shows the right message.
   const url = req.nextUrl.clone();
@@ -68,6 +116,7 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   // RFC 8058: token may be in query string OR the body
   let token = req.nextUrl.searchParams.get('token') || '';
+  let kind = pickKind(req.nextUrl.searchParams.get('kind'));
   if (!token) {
     try {
       const ct = req.headers.get('content-type') || '';
@@ -75,14 +124,16 @@ export async function POST(req: NextRequest) {
         const text = await req.text();
         const params = new URLSearchParams(text);
         token = params.get('token') || '';
+        if (params.get('kind')) kind = pickKind(params.get('kind'));
       } else if (ct.includes('application/json')) {
-        const body = (await req.json()) as { token?: string };
+        const body = (await req.json()) as { token?: string; kind?: string };
         token = body.token || '';
+        if (body.kind) kind = pickKind(body.kind);
       }
     } catch {
       /* ignore */
     }
   }
-  const result = await processUnsubscribe(token);
+  const result = await processUnsubscribe(token, kind);
   return NextResponse.json({ ok: result.ok, already_unsubscribed: result.alreadyUnsubscribed });
 }

--- a/src/app/dashboard/settings/notifications/page.tsx
+++ b/src/app/dashboard/settings/notifications/page.tsx
@@ -48,6 +48,7 @@ interface Payload {
   quiet_hours_start: string | null;
   quiet_hours_end: string | null;
   timezone: string;
+  newsletter_opted_in: boolean;
 }
 
 const GROUP_LABELS: Record<EventRow['group'], { label: string; icon: any; blurb: string }> = {
@@ -165,6 +166,26 @@ export default function NotificationsSettingsPage() {
     }
   };
 
+  const setNewsletterOptIn = async (next: boolean) => {
+    setData((prev) => prev ? { ...prev, newsletter_opted_in: next } : prev);
+    try {
+      const res = await fetch('/api/notification-preferences', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ newsletter_opted_in: next }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Update failed (${res.status})`);
+      }
+    } catch (e: any) {
+      // Roll back on failure so the UI reflects truth.
+      setData((prev) => prev ? { ...prev, newsletter_opted_in: !next } : prev);
+      setError(e?.message || 'Could not update newsletter preference');
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
@@ -192,6 +213,50 @@ export default function NotificationsSettingsPage() {
       <p className="text-sm text-slate-500 mb-6">
         Pick where each kind of alert lands. Turn off the channels you don&apos;t want — leave Paybacker to reach you how you prefer.
       </p>
+
+      {/* Weekly newsletter opt-in — saved to user_metadata + profiles
+          on click (no Save button needed). The cron at Thu 11:00 UTC
+          reads from `newsletter_audience` view which gates on both. */}
+      <section className="bg-white border border-slate-200 rounded-2xl p-5 mb-6">
+        <div className="flex items-start gap-3">
+          <div className="p-2 rounded-lg bg-emerald-100 flex-shrink-0">
+            <Mail className="h-5 w-5 text-emerald-700" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <div>
+                <h2 className="text-base font-semibold text-slate-900">Weekly newsletter</h2>
+                <p className="text-xs text-slate-500 mt-0.5">
+                  Every Thursday at 11:00 UTC. UK consumer-rights wins, recent law changes, the Paybacker Index, and one quick action you can take that week.
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={data.newsletter_opted_in}
+                onClick={() => setNewsletterOptIn(!data.newsletter_opted_in)}
+                className={[
+                  'relative inline-flex h-7 w-12 items-center rounded-full transition-colors flex-shrink-0',
+                  data.newsletter_opted_in ? 'bg-emerald-600' : 'bg-slate-300',
+                ].join(' ')}
+              >
+                <span
+                  className={[
+                    'inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform',
+                    data.newsletter_opted_in ? 'translate-x-6' : 'translate-x-1',
+                  ].join(' ')}
+                />
+                <span className="sr-only">Toggle weekly newsletter</span>
+              </button>
+            </div>
+            <p className="text-[11px] text-slate-400 mt-2">
+              {data.newsletter_opted_in
+                ? "Subscribed. We'll never share your email and you can unsubscribe in one click from any newsletter."
+                : 'Not subscribed. Flip the switch to start receiving the Thursday newsletter.'}
+            </p>
+          </div>
+        </div>
+      </section>
 
       {/* Pocket Agent channel picker — telegram XOR whatsapp */}
       <section className="bg-white border border-slate-200 rounded-2xl p-5 mb-6">


### PR DESCRIPTION
## Summary

Closes the loop on the Thu-11:00 weekly newsletter shipped in #444:

1. **Dashboard toggle** — \`/dashboard/settings/notifications\` now has a "Weekly newsletter" card at the top with an instant-save switch. No Save button needed; saves on click and rolls back on API failure so the UI never lies.

2. **API surface** — \`/api/notification-preferences\` GET returns \`newsletter_opted_in\`. PUT accepts a \`newsletter_opted_in\` boolean and writes to BOTH \`auth.users.user_metadata.marketing_opt_in\` (signup-time consent record) and \`profiles.newsletter_unsubscribed_at\` (post-signup opt-out). Either signal flipping off counts as unsubscribed.

3. **One-click unsubscribe** — \`/api/unsubscribe\` now accepts \`?kind=newsletter|consumer_lead\` (defaults to \`consumer_lead\` for backward-compat with existing nurture-funnel footers). Newsletter kind looks up by \`profiles.newsletter_unsub_token\`, stamps \`newsletter_unsubscribed_at\`, and mirrors \`marketing_opt_in=false\` back to auth metadata via the admin SDK so the toggle reflects the unsubscribe on next page load. RFC 8058 POST flow preserved (token + kind via querystring / urlencoded / JSON body).

PostHog now emits \`newsletter_unsubscribed\` keyed on user id alongside the existing \`lead_unsubscribed\` so unsubscribe rate is trivially queryable.

## Test plan
- [ ] Open \`/dashboard/settings/notifications\` — newsletter card shows current opt-in state from signup
- [ ] Toggle off → reload → still off; \`profiles.newsletter_unsubscribed_at\` populated
- [ ] Toggle on → \`profiles.newsletter_unsubscribed_at\` cleared, \`user_metadata.marketing_opt_in\` true
- [ ] Click footer unsubscribe link in a real newsletter send → redirected to \`/unsubscribe?ok=1\` and the dashboard toggle is off on next load
- [ ] Run \`SELECT * FROM newsletter_audience\` after each toggle — row appears/disappears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)