### PR TITLE
feat(newsletter): flip to opt-OUT — every confirmed user gets it by default

### DIFF
--- a/src/app/api/notification-preferences/route.ts
+++ b/src/app/api/notification-preferences/route.ts
@@ -119,13 +119,14 @@ export async function GET() {
     quiet_hours_end: trimTimeOfDay(profileRes.data?.quiet_hours_end),
     timezone: profileRes.data?.notification_timezone ?? 'Europe/London',
     alerts_paused_until: alertPrefsRes.data?.alerts_paused_until ?? null,
-    // Newsletter (Thu 11:00 UTC) opt-in. Source of truth is
-    //   user_metadata.marketing_opt_in === true
-    //   AND profiles.newsletter_unsubscribed_at IS NULL.
-    // Either signal flipping off => unsubscribed.
-    newsletter_opted_in:
-      ((user.user_metadata as { marketing_opt_in?: boolean } | null)?.marketing_opt_in ?? false) === true
-      && !profileRes.data?.newsletter_unsubscribed_at,
+    // Newsletter (Thu 11:00 UTC) is opt-OUT by default — the
+    // newsletter_audience view sends to every confirmed user unless
+    // they've set newsletter_unsubscribed_at. So the toggle reads
+    // "subscribed" unless explicitly opted out. The signup-time
+    // marketing_opt_in flag is no longer load-bearing for the
+    // newsletter audience (kept on user_metadata for the consent
+    // audit trail and for any future opt-IN-only marketing).
+    newsletter_opted_in: !profileRes.data?.newsletter_unsubscribed_at,
   });
 }
 

--- a/src/app/dashboard/settings/notifications/page.tsx
+++ b/src/app/dashboard/settings/notifications/page.tsx
@@ -214,9 +214,11 @@ export default function NotificationsSettingsPage() {
         Pick where each kind of alert lands. Turn off the channels you don&apos;t want — leave Paybacker to reach you how you prefer.
       </p>
 
-      {/* Weekly newsletter opt-in — saved to user_metadata + profiles
-          on click (no Save button needed). The cron at Thu 11:00 UTC
-          reads from `newsletter_audience` view which gates on both. */}
+      {/* Weekly newsletter — opt-OUT by default. Every confirmed
+          Paybacker user is in the audience unless they flip this off
+          (or use the one-click footer link in any send). The toggle
+          writes profiles.newsletter_unsubscribed_at and the
+          newsletter_audience view filters on it. */}
       <section className="bg-white border border-slate-200 rounded-2xl p-5 mb-6">
         <div className="flex items-start gap-3">
           <div className="p-2 rounded-lg bg-emerald-100 flex-shrink-0">
@@ -227,7 +229,7 @@ export default function NotificationsSettingsPage() {
               <div>
                 <h2 className="text-base font-semibold text-slate-900">Weekly newsletter</h2>
                 <p className="text-xs text-slate-500 mt-0.5">
-                  Every Thursday at 11:00 UTC. UK consumer-rights wins, recent law changes, the Paybacker Index, and one quick action you can take that week.
+                  Every Thursday morning. UK consumer-rights wins, recent law changes, the Paybacker Index, and one quick action you can take that week. Free for every Paybacker member.
                 </p>
               </div>
               <button
@@ -251,8 +253,8 @@ export default function NotificationsSettingsPage() {
             </div>
             <p className="text-[11px] text-slate-400 mt-2">
               {data.newsletter_opted_in
-                ? "Subscribed. We'll never share your email and you can unsubscribe in one click from any newsletter."
-                : 'Not subscribed. Flip the switch to start receiving the Thursday newsletter.'}
+                ? "You're subscribed. Toggle off to opt out — every send also has a one-click unsubscribe link in the footer."
+                : 'Opted out. Toggle on to start receiving the Thursday newsletter.'}
             </p>
           </div>
         </div>

--- a/supabase/migrations/20260502130000_newsletter_default_on.sql
+++ b/supabase/migrations/20260502130000_newsletter_default_on.sql
@@ -1,0 +1,49 @@
+-- Newsletter audience: flip from opt-IN to opt-OUT.
+--
+-- Founder decision (2026-05-02): the weekly newsletter goes to every
+-- confirmed Paybacker user by default. Users who don't want it use
+-- the in-dashboard toggle or the one-click footer link to opt out.
+--
+-- Lawful basis (PECR reg. 22(3) soft opt-in):
+--   1. Recipient gave email during sale negotiation (signup) — ✓
+--   2. Marketing relates to similar products / services (UK consumer
+--      rights education + Paybacker product updates — directly
+--      relevant to the service they signed up for) — ✓
+--   3. One-click unsubscribe in every send — ✓ (List-Unsubscribe
+--      header + tokenised footer link, plus dashboard toggle)
+--
+-- Strictly additive: replaces the view, doesn't drop any column.
+-- Existing opt-outs (anyone with newsletter_unsubscribed_at set) are
+-- naturally preserved by the new gate.
+
+-- 1. Make sure every confirmed user has an unsubscribe token. The
+--    20260502120000 migration backfilled tokens for all profiles, but
+--    we re-run defensively so any rows created in the gap (or any
+--    rows that NULLed the token for some reason) get a fresh one.
+UPDATE profiles
+SET newsletter_unsub_token = encode(gen_random_bytes(18), 'base64')
+WHERE newsletter_unsub_token IS NULL;
+
+-- 2. Replace the audience view. Drops the
+--    `marketing_opt_in = TRUE` gate. Keeps the safety filters
+--    (email confirmed, account not deleted, not unsubscribed).
+CREATE OR REPLACE VIEW newsletter_audience AS
+SELECT
+  p.id                            AS user_id,
+  u.email                         AS email,
+  p.first_name                    AS first_name,
+  p.newsletter_last_sent_at       AS newsletter_last_sent_at,
+  p.newsletter_unsub_token        AS newsletter_unsub_token
+FROM profiles p
+JOIN auth.users u ON u.id = p.id
+WHERE
+  p.newsletter_unsubscribed_at IS NULL
+  AND u.email_confirmed_at IS NOT NULL
+  AND u.deleted_at IS NULL;
+
+COMMENT ON VIEW newsletter_audience IS
+  'Opt-OUT audience for the weekly Thu-11:00 newsletter cron. Every '
+  'confirmed Paybacker user is in unless they explicitly unsubscribed '
+  '(via in-dashboard toggle or RFC 8058 one-click footer link). '
+  'PECR soft opt-in basis: signup gave email during sale negotiation; '
+  'newsletter is similar-product marketing; opt-out in every send.';


### PR DESCRIPTION
## Summary

Founder approved the test newsletter and asked to send it to **all users** with an **opt-out** path. This PR flips the audience model.

## What changes

**Audience definition** (\`newsletter_audience\` view):

| Before | After |
|---|---|
| \`marketing_opt_in = TRUE\` AND \`newsletter_unsubscribed_at IS NULL\` AND email confirmed | \`newsletter_unsubscribed_at IS NULL\` AND email confirmed |

The signup-time \`marketing_opt_in\` checkbox is no longer load-bearing for the newsletter — it stays on \`user_metadata\` for the consent audit trail and any future opt-IN-only marketing.

**Toggle behaviour** at \`/dashboard/settings/notifications\`:
- Defaults to ON for every user
- Toggling off writes \`newsletter_unsubscribed_at = now()\` and removes them from the audience immediately
- Copy updated to be honest: "You're subscribed. Toggle off to opt out — every send also has a one-click unsubscribe link in the footer."

**One-click unsubscribe** (\`/api/unsubscribe?kind=newsletter\`) — already shipped in #445; unchanged.

## Lawful basis (PECR reg. 22(3) soft opt-in)

1. Recipient gave email during sale negotiation (Paybacker signup) ✓
2. Marketing relates to similar products / services (UK consumer-rights education + Paybacker product updates — directly relevant to what they signed up for) ✓
3. One-click unsubscribe in every send (RFC 8058 \`List-Unsubscribe\` header + tokenised footer link + dashboard toggle) ✓

## Existing opt-outs

Anyone who already has \`newsletter_unsubscribed_at\` set stays out — the new gate naturally preserves their preference.

## Test plan
- [ ] Apply migration \`20260502130000_newsletter_default_on.sql\` to production Supabase
- [ ] \`SELECT count(*) FROM newsletter_audience\` should now include all confirmed Paybacker users (minus existing opt-outs)
- [ ] Open \`/dashboard/settings/notifications\` as a user who never ticked the signup checkbox — toggle shows ON
- [ ] Toggle off → row disappears from \`newsletter_audience\`
- [ ] Toggle on → row reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)