### PR TITLE
fix(auth): homepage honours live session + Apple sign-in button

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -12,6 +12,15 @@ import { MarkNav } from '@/app/blog/_shared';
 import '../../(marketing)/styles.css';
 import '../auth.css';
 
+// Inline Capacitor shell detection. Checks for window.Capacitor.isNativePlatform()
+// which is injected by the Capacitor runtime on iOS/Android only. Returns false
+// in any browser context (including SSR — window is undefined).
+function detectNativeShell(): boolean {
+  if (typeof window === 'undefined') return false;
+  const cap = (window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } }).Capacitor;
+  return Boolean(cap?.isNativePlatform?.());
+}
+
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -22,6 +31,12 @@ export default function LoginPage() {
   const [stayLoggedIn, setStayLoggedIn] = useState(true);
   const [loginAttempts, setLoginAttempts] = useState(0);
   const [lockoutUntil, setLockoutUntil] = useState<number | null>(null);
+  // Hide Google sign-in button when running inside the iOS Capacitor
+  // shell — Google blocks OAuth in embedded WebViews and the flow
+  // bounces to Safari, losing the session. Apple sign-in + email work
+  // fine in WebView.
+  const [hideGoogleAuth, setHideGoogleAuth] = useState(false);
+  useEffect(() => { setHideGoogleAuth(detectNativeShell()); }, []);
   const router = useRouter();
   const searchParams = useSearchParams();
   const rawRedirect = searchParams.get('redirect');
@@ -103,6 +118,20 @@ export default function LoginPage() {
     }
   };
 
+  const handleAppleLogin = async () => {
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'apple',
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectTo)}`,
+        },
+      });
+      if (error) throw error;
+    } catch (err: any) {
+      setError(err.message || 'Failed to sign in with Apple');
+    }
+  };
+
   const handleMagicLink = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -156,18 +185,31 @@ export default function LoginPage() {
               </div>
             ) : (
               <>
+                {!hideGoogleAuth && (
+                  <button
+                    type="button"
+                    onClick={handleGoogleLogin}
+                    className="oauth-btn"
+                  >
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                    </svg>
+                    Continue with Google
+                  </button>
+                )}
+
                 <button
                   type="button"
-                  onClick={handleGoogleLogin}
+                  onClick={handleAppleLogin}
                   className="oauth-btn"
                 >
-                  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+                    <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
                   </svg>
-                  Continue with Google
+                  Continue with Apple
                 </button>
 
                 <div className="oauth-divider">

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -23,6 +23,13 @@ const PW_RULES = [
   { id: 'number', label: 'Contains a number', test: (v: string) => /\d/.test(v) },
 ] as const;
 
+// Inline Capacitor shell detection — see auth/login/page.tsx for the same.
+function detectNativeShell(): boolean {
+  if (typeof window === 'undefined') return false;
+  const cap = (window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } }).Capacitor;
+  return Boolean(cap?.isNativePlatform?.());
+}
+
 export default function SignupPage() {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
@@ -33,6 +40,8 @@ export default function SignupPage() {
   const [marketingOptIn, setMarketingOptIn] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [hideGoogleAuth, setHideGoogleAuth] = useState(false);
+  useEffect(() => { setHideGoogleAuth(detectNativeShell()); }, []);
   const [verifyMode, setVerifyMode] = useState(false);
 
   const passedRules = PW_RULES.filter((r) => r.test(password));
@@ -108,6 +117,35 @@ export default function SignupPage() {
       if (error) throw error;
     } catch (err: any) {
       setError(err.message || 'Failed to sign in with Google');
+    }
+  };
+
+  const handleAppleSignup = async () => {
+    // Mirrors handleGoogleSignup — same consent gate + sessionStorage
+    // stash so the dashboard layout can drain consent into user_metadata
+    // once the OAuth callback establishes a session.
+    if (!termsAccepted) {
+      setError('Please agree to the Terms of Service and Privacy Policy to continue.');
+      return;
+    }
+    try {
+      sessionStorage.setItem(
+        'pb_pending_consent',
+        JSON.stringify({
+          terms_accepted_at: new Date().toISOString(),
+          marketing_opt_in: marketingOptIn,
+          created_at: Date.now(),
+        })
+      );
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'apple',
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectTo || '/dashboard')}`,
+        },
+      });
+      if (error) throw error;
+    } catch (err: any) {
+      setError(err.message || 'Failed to sign in with Apple');
     }
   };
 
@@ -335,20 +373,35 @@ export default function SignupPage() {
                   </label>
                 </div>
 
+                {!hideGoogleAuth && (
+                  <button
+                    type="button"
+                    onClick={handleGoogleSignup}
+                    className="oauth-btn"
+                    disabled={!termsAccepted}
+                    aria-disabled={!termsAccepted}
+                  >
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                    </svg>
+                    Continue with Google
+                  </button>
+                )}
+
                 <button
                   type="button"
-                  onClick={handleGoogleSignup}
+                  onClick={handleAppleSignup}
                   className="oauth-btn"
                   disabled={!termsAccepted}
                   aria-disabled={!termsAccepted}
                 >
-                  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
-                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+                    <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
                   </svg>
-                  Continue with Google
+                  Continue with Apple
                 </button>
 
                 <div className="oauth-divider">

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -40,6 +40,7 @@ import {
   DealsDemo,
   McpDemo,
 } from './demos';
+import { createClient } from '@/lib/supabase/client';
 import './styles.css';
 
 // React.CSSProperties doesn't know about CSS custom properties.
@@ -173,8 +174,43 @@ function Counter({
 // ---------------------------------------------------------------------------
 // Nav — pill nav with scroll-shrink + scroll-progress bar
 // ---------------------------------------------------------------------------
+// Client-side auth probe used by the marketing nav / mobile drawer to
+// swap "Sign in / Start free" → "Open Dashboard" for users who already
+// have a valid Supabase session. Without this, signed-in users land
+// here in a new tab, see the prominent "Sign in" button, and assume
+// their session has expired — even though the cookie is still valid
+// (proxy.ts has been refreshing it on every request). Returns:
+//   null  → not yet resolved (initial server-matched render)
+//   true  → logged in
+//   false → logged out
+function useIsLoggedIn(): boolean | null {
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data }) => {
+      if (cancelled) return;
+      setIsLoggedIn(!!data.user);
+    }).catch(() => {
+      if (cancelled) return;
+      setIsLoggedIn(false);
+    });
+    // Pick up sign-in / sign-out that happened in another tab.
+    const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
+      if (cancelled) return;
+      setIsLoggedIn(!!session?.user);
+    });
+    return () => {
+      cancelled = true;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+  return isLoggedIn;
+}
+
 function Nav() {
   const [scrolled, setScrolled] = useState(false);
+  const isLoggedIn = useIsLoggedIn();
 
   useEffect(() => {
     let rafId = 0;
@@ -251,12 +287,20 @@ function Nav() {
             )}
           </div>
           <div className="nav-cta-row">
-            <Link className="nav-signin" href="/auth/login">
-              Sign in
-            </Link>
-            <Link className="nav-start" href="/auth/signup">
-              Start free
-            </Link>
+            {isLoggedIn ? (
+              <Link className="nav-start" href="/dashboard">
+                Open Dashboard
+              </Link>
+            ) : (
+              <>
+                <Link className="nav-signin" href="/auth/login">
+                  Sign in
+                </Link>
+                <Link className="nav-start" href="/auth/signup">
+                  Start free
+                </Link>
+              </>
+            )}
             <button
               type="button"
               className="nav-burger"
@@ -305,12 +349,20 @@ function Nav() {
               )}
             </div>
             <div className="nav-drawer-ctas">
-              <Link className="btn btn-ghost" href="/auth/login" onClick={() => setMenuOpen(false)}>
-                Sign in
-              </Link>
-              <Link className="btn btn-mint" href="/auth/signup" onClick={() => setMenuOpen(false)}>
-                Sign up free
-              </Link>
+              {isLoggedIn ? (
+                <Link className="btn btn-mint" href="/dashboard" onClick={() => setMenuOpen(false)}>
+                  Open Dashboard
+                </Link>
+              ) : (
+                <>
+                  <Link className="btn btn-ghost" href="/auth/login" onClick={() => setMenuOpen(false)}>
+                    Sign in
+                  </Link>
+                  <Link className="btn btn-mint" href="/auth/signup" onClick={() => setMenuOpen(false)}>
+                    Sign up free
+                  </Link>
+                </>
+              )}
             </div>
           </div>
         </>

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -287,11 +287,20 @@ function Nav() {
             )}
           </div>
           <div className="nav-cta-row">
-            {isLoggedIn ? (
+            {/*
+              While the auth probe is in flight (`isLoggedIn === null`)
+              we render the logged-out CTAs but visually hide them so
+              the slot reserves layout (matches SSR + prevents layout
+              shift) and signed-in users don't see a flash of
+              "Sign in / Start free" before the probe resolves. Codex
+              P2 on PR #450 — the whole point of this hook is to kill
+              that flash.
+            */}
+            {isLoggedIn === true ? (
               <Link className="nav-start" href="/dashboard">
                 Open Dashboard
               </Link>
-            ) : (
+            ) : isLoggedIn === false ? (
               <>
                 <Link className="nav-signin" href="/auth/login">
                   Sign in
@@ -300,6 +309,14 @@ function Nav() {
                   Start free
                 </Link>
               </>
+            ) : (
+              <span
+                aria-hidden="true"
+                style={{ visibility: 'hidden', display: 'inline-flex', gap: 'var(--m-v2-cta-gap, 8px)' }}
+              >
+                <span className="nav-signin">Sign in</span>
+                <span className="nav-start">Start free</span>
+              </span>
             )}
             <button
               type="button"
@@ -349,11 +366,11 @@ function Nav() {
               )}
             </div>
             <div className="nav-drawer-ctas">
-              {isLoggedIn ? (
+              {isLoggedIn === true ? (
                 <Link className="btn btn-mint" href="/dashboard" onClick={() => setMenuOpen(false)}>
                   Open Dashboard
                 </Link>
-              ) : (
+              ) : isLoggedIn === false ? (
                 <>
                   <Link className="btn btn-ghost" href="/auth/login" onClick={() => setMenuOpen(false)}>
                     Sign in
@@ -362,6 +379,13 @@ function Nav() {
                     Sign up free
                   </Link>
                 </>
+              ) : (
+                // Same null-state guard as the desktop nav — reserve
+                // layout but stay invisible until the probe resolves.
+                <span aria-hidden="true" style={{ visibility: 'hidden' }}>
+                  <span className="btn btn-ghost">Sign in</span>
+                  <span className="btn btn-mint">Sign up free</span>
+                </span>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Two perceived-logout bugs

### 1. Homepage was auth-unaware → felt like every new tab logged you out

The marketing homepage at \`/\` always rendered the \"Sign in / Start free\" CTAs regardless of whether the visitor had a valid Supabase session. Combined with how often users open the marketing page in a new tab, this looked exactly like the session had expired.

I checked the database first to rule out actual session loss:

- \`auth.refresh_tokens\` shows two stable active sessions for the founder account
- Both rotating every ~59 minutes for the last 16+ hours with no failures
- No new \`is_rotated_child=false\` rows (which is what re-login would create)

So the cookie was always there. The user just wasn't being shown that.

**Fix:** \`useIsLoggedIn()\` hook in \`src/app/preview/homepage/page.tsx\` — uses \`createBrowserClient\` (cookie-backed via \`@supabase/ssr\`) to detect session in a \`useEffect\`, plus an \`onAuthStateChange\` subscription so cross-tab sign-in/out propagates. Desktop nav and mobile drawer swap \"Sign in / Start free\" → \"Open Dashboard\" once a session is detected. Initial SSR render stays on the logged-out variant to avoid hydration mismatch.

### 2. Apple sign-in button was never wired into the UI

Apple OAuth was configured at the Supabase project level (and is required for the iOS Capacitor shell, where Google's webview policy bounces users to Safari and breaks the session). But \`/auth/login\` and \`/auth/signup\` only ever rendered the Google button.

**Fix:** \`handleAppleLogin\` (login) + \`handleAppleSignup\` (signup) mirror the Google pattern — same \`/auth/callback\` redirect, signup variant inherits the consent gate + \`sessionStorage\` stash for terms acceptance. Apple is rendered unconditionally because, unlike Google, it works inside the iOS native shell.

## Test plan

- [ ] Logged-out: visit paybacker.co.uk → see \"Sign in\" + \"Start free\" in nav (unchanged)
- [ ] Logged-in: visit paybacker.co.uk in new tab → see single \"Open Dashboard\" CTA, no flash of \"Sign in\"
- [ ] Mobile drawer: same swap on the burger-menu CTAs
- [ ] Sign out in tab A → tab B's homepage flips back to logged-out CTAs without reload
- [ ] /auth/login shows Google + Apple buttons; clicking Apple kicks off the OAuth redirect
- [ ] /auth/signup shows Google + Apple, both gated on terms-accepted checkbox
- [ ] iOS Capacitor shell: only Apple visible (Google hidden by \`detectNativeShell()\`), Apple flow completes
- [ ] OAuth callback successfully drains \`pb_pending_consent\` from Apple signups too

🤖 Generated with [Claude Code](https://claude.com/claude-code)