### PR TITLE
feat(admin-bot): tool-use so Charlie can carry out work, not just talk

### DIFF
--- a/src/app/api/telegram/admin-command/route.ts
+++ b/src/app/api/telegram/admin-command/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
+import {
+  TOOL_DEFINITIONS,
+  executeAdminTool,
+  loadFounderWhatsAppPhone,
+} from '@/lib/telegram/admin-tools';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -668,13 +673,19 @@ ${liveData}`,
     await saveMessage(supabase, chatId, 'user', text);
 
     const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-    const response = await anthropic.messages.create({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 1024,
-      system: `You are Charlie, Executive Assistant at Paybacker LTD. You're chatting with Paul (the founder) via Telegram. You have persistent memory of the conversation and full access to business data.
+    const SYSTEM_PROMPT = `You are Charlie, Executive Assistant at Paybacker LTD. You're chatting with Paul (the founder) via Telegram. You have persistent memory of the conversation and full access to business data.
 
 CRITICAL RULES:
 - You have LIVE data from the database loaded below. This is real-time, not cached.
+- You ALSO have tools that can carry out work — read fresh DB rows (run_sql_query),
+  fire crons (trigger_cron / morning_brief_now), resubmit WhatsApp templates
+  (resubmit_whatsapp_templates), send a real WhatsApp template to Paul for
+  verification (send_test_whatsapp_template). Use them when Paul asks you to DO
+  something rather than just discuss it. After a tool runs, summarise the result
+  in plain English — never just paste raw JSON.
+- For ad-hoc business questions (MRR right now, today's signups, last week's
+  disputes, recent alert sends), prefer run_sql_query over the pre-loaded
+  context — it's always fresher.
 - NEVER say "I'll check with them", "let me ask them", "waiting for responses", or "pulling updates now". You already HAVE the data. Just answer.
 - NEVER write /ask commands in your responses. You cannot execute commands. Just use the data below.
 - NEVER pretend to be contacting other agents. You ARE the central hub with all the data already loaded.
@@ -689,17 +700,107 @@ The AI team: Alex (CFO), Morgan (CTO), Jamie (CAO), Taylor (CMO), Jordan (Head o
 
 The BUSINESS LOG section below has the most current information. Always prioritise it over stale agent reports.
 
-${context}${agentContext}`,
-      messages: [
-        ...history,
-        { role: 'user', content: text },
-      ],
+${context}${agentContext}`;
+
+    // Tool execution context — resolved once and passed through every
+    // tool-loop iteration. baseUrl prefers VERCEL_URL so we hit the
+    // current deploy in preview branches; falls back to the canonical
+    // production host so a missing env var doesn't 500 every reply.
+    const baseUrl = process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : 'https://paybacker.co.uk';
+    // Resolve founder user_id via the profiles mirror (id == auth.users.id)
+    // so we don't need to schema('auth') from supabase-js. The founder is
+    // the only chat_id past the gate above, so this is safe to look up
+    // by env email.
+    const founderEmail = process.env.FOUNDER_EMAIL || 'aireypaul@googlemail.com';
+    const { data: founderRow } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('email', founderEmail)
+      .maybeSingle();
+    const founderUserId = founderRow?.id ?? '';
+    const founderWhatsAppPhone = founderUserId
+      ? await loadFounderWhatsAppPhone(founderUserId)
+      : null;
+    const toolCtx = {
+      cronSecret: process.env.CRON_SECRET ?? '',
+      baseUrl,
+      founderWhatsAppPhone,
+    };
+
+    const messageHistory: Anthropic.MessageParam[] = [
+      ...(history as Anthropic.MessageParam[]),
+      { role: 'user', content: text },
+    ];
+
+    let response = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      tools: TOOL_DEFINITIONS,
+      messages: messageHistory,
     });
 
-    const reply = response.content.find(b => b.type === 'text');
-    if (reply?.type === 'text') {
-      await saveMessage(supabase, chatId, 'assistant', reply.text);
-      await sendTelegram(chatId, reply.text);
+    // Tool-use loop. Cap at 5 iterations + a soft timeout to stay well
+    // under Vercel's maxDuration=120s — each tool call typically takes
+    // 2-15s (run_sql_query and trigger_cron dominate). On timeout we
+    // break and surface whatever text the model already produced so
+    // Paul gets a useful reply even if the work didn't fully complete.
+    const MAX_ITERATIONS = 5;
+    const HARD_TIMEOUT_MS = 90_000;
+    const loopStart = Date.now();
+    let iterations = 0;
+
+    while (response.stop_reason === 'tool_use' && iterations < MAX_ITERATIONS) {
+      if (Date.now() - loopStart > HARD_TIMEOUT_MS) {
+        console.warn('[admin-bot] tool loop hit soft timeout, breaking');
+        break;
+      }
+      iterations++;
+
+      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+      for (const block of response.content) {
+        if (block.type !== 'tool_use') continue;
+        let result;
+        try {
+          result = await executeAdminTool(
+            block.name,
+            (block.input as Record<string, unknown>) ?? {},
+            toolCtx,
+          );
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          result = { text: `Tool ${block.name} threw: ${msg}` };
+        }
+        toolResults.push({
+          type: 'tool_result',
+          tool_use_id: block.id,
+          content: result.text,
+        });
+      }
+
+      messageHistory.push({ role: 'assistant', content: response.content });
+      messageHistory.push({ role: 'user', content: toolResults });
+
+      response = await anthropic.messages.create({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 1024,
+        system: SYSTEM_PROMPT,
+        tools: TOOL_DEFINITIONS,
+        messages: messageHistory,
+      });
+    }
+
+    const finalText = response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('')
+      .trim();
+
+    if (finalText) {
+      await saveMessage(supabase, chatId, 'assistant', finalText);
+      await sendTelegram(chatId, finalText);
 
       const devPhrases = [
         'build a ', 'build the ', 'create a component', 'create a page', 'add a component',
@@ -719,6 +820,10 @@ ${context}${agentContext}`,
           body: JSON.stringify({ chatId, task: text }),
         }).catch(() => {});
       }
+    } else {
+      // No final text — most likely we hit MAX_ITERATIONS or the soft
+      // timeout. Surface a short status so Paul isn't left in silence.
+      await sendTelegram(chatId, '_Worked on that but ran out of time before finishing the reply. Try a more specific question or break it into steps._');
     }
 
     return NextResponse.json({ ok: true });

--- a/src/lib/telegram/admin-tools.ts
+++ b/src/lib/telegram/admin-tools.ts
@@ -194,8 +194,12 @@ export async function executeAdminTool(
 async function runSqlQuery(rawQuery: string): Promise<ToolResult> {
   const query = rawQuery.trim();
   if (!query) return { text: 'Error: empty query.' };
-  if (!/^select\b/i.test(query)) {
-    return { text: 'Error: only SELECT queries are allowed. Got: ' + query.slice(0, 60) };
+  // Mirror the RPC's accepted shapes: leading SELECT or WITH (CTE).
+  // Codex P2 (PR #454): LLMs commonly write CTE-prefixed analytics
+  // queries; rejecting them here would cause avoidable tool failures
+  // even though the underlying RPC accepts them.
+  if (!/^(select|with)\b/i.test(query)) {
+    return { text: 'Error: only SELECT or WITH queries are allowed. Got: ' + query.slice(0, 60) };
   }
   // Reject multi-statement queries — semicolons inside string literals
   // would be a false positive, but ad-hoc admin queries don't need

--- a/src/lib/telegram/admin-tools.ts
+++ b/src/lib/telegram/admin-tools.ts
@@ -1,0 +1,374 @@
+/**
+ * Anthropic tool-use definitions + dispatcher for the founder-only
+ * Paybacker Assistant admin bot (TELEGRAM_ADMIN_BOT_TOKEN).
+ *
+ * Wired into the natural-language fallback at
+ *   src/app/api/telegram/admin-command/route.ts
+ * so when the founder replies in plain English the bot can actually
+ * carry out work — read DB rows, fire crons, resubmit templates —
+ * not just talk about it.
+ *
+ * AUTH MODEL
+ * ──────────
+ * The route already gates on FOUNDER_CHAT_ID before this module is
+ * even imported, so we don't re-check identity here. Every tool runs
+ * with full service-role privileges; never expose this dispatcher to
+ * an endpoint that's reachable by anyone other than the founder.
+ *
+ * TOOLS
+ * ─────
+ *   - run_sql_query           SELECT-only ad-hoc queries
+ *   - trigger_cron            Fire any cron in the whitelist
+ *   - resubmit_whatsapp_templates  Resubmit pending WhatsApp templates to Meta
+ *   - send_test_whatsapp_template  Send a real template to founder for verification
+ *   - morning_brief_now       Convenience: trigger telegram-morning-summary
+ *
+ * Adding a tool: append to TOOL_DEFINITIONS + a `case` in `executeAdminTool`.
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * Cron routes the admin bot is allowed to fire on demand. Keep this
+ * tight — anything not on the list is rejected. Mirrors the entries
+ * in vercel.json that are safe to manually trigger (read-mostly or
+ * idempotent).
+ */
+const CRON_WHITELIST = new Set<string>([
+  'telegram-morning-summary',
+  'telegram-evening-summary',
+  'telegram-alerts',
+  'whatsapp-alerts',
+  'whatsapp-template-status',
+  'income-received',
+  'bank-sync',
+  'dispute-agent',
+  'dispute-reply-sync',
+  'compliance-sync',
+  'weekly-money-digest',
+  'weekly-newsletter',
+  'consumer-nurture',
+  'b2b-nurture',
+  'price-increases',
+  'renewal-reminders',
+  'compute-dispute-intelligence',
+]);
+
+export const TOOL_DEFINITIONS: Anthropic.Tool[] = [
+  {
+    name: 'run_sql_query',
+    description:
+      'Run a read-only SELECT query against the Paybacker Postgres database (Supabase) and return the rows as JSON. ' +
+      'Use this for ad-hoc business questions: MRR, signups today, dispute counts, recent errors, ' +
+      'whatsapp_message_log inspection, etc. ' +
+      'STRICT RULES: SELECT only. No DDL/DML — anything other than SELECT is rejected. ' +
+      'Auto-LIMIT 100 rows is added if you omit LIMIT. The function rejects multi-statement queries. ' +
+      'Schema-qualify auth tables (auth.users) but plain table names are fine for the public schema.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'A single SELECT statement. Must start with SELECT (case-insensitive, leading whitespace allowed).',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'trigger_cron',
+    description:
+      'Manually fire one of our Vercel cron routes by name. The route runs end-to-end (same path the scheduler uses) and returns its JSON response. ' +
+      'Use this when the founder wants to force a refresh — e.g. "send me the morning brief now", "rerun the dispute-agent", ' +
+      '"resync the bank". Only whitelisted crons can be triggered. ' +
+      'Long-running crons may exceed the bot\'s timeout — they will still complete on Vercel even if this tool returns a timeout.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        cron_name: {
+          type: 'string',
+          description:
+            'Path segment under /api/cron — e.g. "telegram-morning-summary", "income-received", "compliance-sync".',
+        },
+      },
+      required: ['cron_name'],
+    },
+  },
+  {
+    name: 'resubmit_whatsapp_templates',
+    description:
+      'Resubmit one or more PENDING_RESUBMISSION WhatsApp templates to Meta via Twilio. ' +
+      'Use when the founder asks to fix a rejected template (e.g. "resubmit the price increase template") ' +
+      'or after a code change to a template body. ' +
+      'Pass an array of template names from the registry, or omit to resubmit ALL pending templates. ' +
+      'Returns per-template outcome (success / error). Approval still takes Meta hours-to-days afterward.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        template_names: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Specific templates to resubmit, e.g. ["paybacker_alert_price_increase", "paybacker_alert_unusual_charge"]. ' +
+            'Omit to resubmit every PENDING_RESUBMISSION template at once.',
+        },
+      },
+    },
+  },
+  {
+    name: 'send_test_whatsapp_template',
+    description:
+      'Send a real approved WhatsApp template to the founder\'s own WhatsApp number for verification. ' +
+      'Use after a resubmit to confirm Meta has approved it, or to spot-check formatting. ' +
+      'Costs one Meta template fee per call — use sparingly. Fails cleanly if the template is not yet approved.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        template_name: {
+          type: 'string',
+          description: 'Template name from the registry, e.g. "paybacker_morning_summary".',
+        },
+        parameters: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Positional parameters filling {{1}}, {{2}}, ... in the template. ' +
+            'Provide sensible test values matching the template\'s vars order.',
+        },
+      },
+      required: ['template_name'],
+    },
+  },
+  {
+    name: 'morning_brief_now',
+    description:
+      'Convenience wrapper: trigger the telegram-morning-summary cron immediately. ' +
+      'Equivalent to trigger_cron with cron_name="telegram-morning-summary" but presented as ' +
+      'a friendlier verb so the founder can just say "send me the morning brief".',
+    input_schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+];
+
+interface ExecutionContext {
+  cronSecret: string;
+  baseUrl: string;
+  founderWhatsAppPhone: string | null;
+}
+
+interface ToolResult {
+  text: string;
+}
+
+export async function executeAdminTool(
+  name: string,
+  input: Record<string, unknown>,
+  ctx: ExecutionContext,
+): Promise<ToolResult> {
+  switch (name) {
+    case 'run_sql_query':
+      return runSqlQuery(String(input.query ?? ''));
+    case 'trigger_cron':
+      return triggerCron(String(input.cron_name ?? ''), ctx);
+    case 'resubmit_whatsapp_templates':
+      return resubmitTemplates(input.template_names as string[] | undefined, ctx);
+    case 'send_test_whatsapp_template':
+      return sendTestTemplate(
+        String(input.template_name ?? ''),
+        (input.parameters as string[] | undefined) ?? [],
+        ctx,
+      );
+    case 'morning_brief_now':
+      return triggerCron('telegram-morning-summary', ctx);
+    default:
+      return { text: `Unknown tool: ${name}` };
+  }
+}
+
+/* ---------- Tool implementations ---------- */
+
+async function runSqlQuery(rawQuery: string): Promise<ToolResult> {
+  const query = rawQuery.trim();
+  if (!query) return { text: 'Error: empty query.' };
+  if (!/^select\b/i.test(query)) {
+    return { text: 'Error: only SELECT queries are allowed. Got: ' + query.slice(0, 60) };
+  }
+  // Reject multi-statement queries — semicolons inside string literals
+  // would be a false positive, but ad-hoc admin queries don't need
+  // them and the safe stance wins.
+  if (/;\s*\S/.test(query)) {
+    return { text: 'Error: multi-statement queries are not allowed.' };
+  }
+  // Add an implicit LIMIT 100 if the query doesn't already have one,
+  // so a careless `SELECT * FROM bank_transactions` doesn't spam back
+  // 50k rows into a Telegram message.
+  const hasLimit = /\blimit\b\s+\d+/i.test(query);
+  const finalQuery = hasLimit ? query : `${query.replace(/;\s*$/, '')} LIMIT 100`;
+
+  const sb = adminSupabase();
+  if (!sb) return { text: 'Error: Supabase admin client not available (env not set).' };
+
+  // Use rpc('exec_sql') if the project has it; otherwise fall back to
+  // pg-meta. We keep it simple and rely on a `pg_query` RPC convention
+  // — most Supabase projects don't have this, so we use a safer
+  // workaround: ask Postgres to format the rows as JSON via a wrapping
+  // SELECT. That requires querying via the supabase-js generic SQL
+  // path, which doesn't exist for arbitrary SQL — so we use the
+  // PostgREST endpoint with `rpc('run_sql', { query })` if available,
+  // else surface a clear error.
+  //
+  // Reality: the project relies on the MCP `execute_sql` tool for
+  // ad-hoc SQL, not a permanent endpoint. To keep this admin tool
+  // self-contained without adding a new RPC, we use the postgres
+  // metadata via service-role REST, which only supports table reads.
+  // For arbitrary SELECT we POST to a `/rest/v1/rpc/run_sql` if the
+  // founder has set one up; if not, return a clear instruction so
+  // the founder can wire it in 30 seconds.
+  const rpcRes = await sb.rpc('run_sql', { query: finalQuery });
+  if (rpcRes.error) {
+    return {
+      text:
+        `Error running query: ${rpcRes.error.message}. ` +
+        `If the error mentions "function run_sql" or "could not find function", ` +
+        `the project doesn't have the helper RPC yet. Create it once with: ` +
+        `CREATE OR REPLACE FUNCTION run_sql(query text) RETURNS jsonb LANGUAGE plpgsql ` +
+        `SECURITY DEFINER AS $$ DECLARE result jsonb; BEGIN EXECUTE 'SELECT to_jsonb(array_agg(row_to_json(t))) FROM (' || query || ') t' INTO result; RETURN COALESCE(result, '[]'::jsonb); END; $$; ` +
+        `Then revoke EXECUTE from anon: REVOKE EXECUTE ON FUNCTION run_sql FROM anon, authenticated;`,
+    };
+  }
+  const rows = rpcRes.data as unknown[];
+  const json = JSON.stringify(rows, null, 2);
+  // Telegram caps at 4096 chars per message; the route splits, but
+  // we cap the JSON we hand back to Claude at 8KB so the next loop
+  // iteration's context doesn't balloon.
+  const trimmed = json.length > 8000 ? json.slice(0, 8000) + '\n... (truncated)' : json;
+  return { text: trimmed };
+}
+
+async function triggerCron(name: string, ctx: ExecutionContext): Promise<ToolResult> {
+  if (!CRON_WHITELIST.has(name)) {
+    return {
+      text:
+        `Cron "${name}" is not in the admin-bot whitelist. ` +
+        `Allowed: ${[...CRON_WHITELIST].sort().join(', ')}.`,
+    };
+  }
+  if (!ctx.cronSecret) return { text: 'Error: CRON_SECRET not configured.' };
+
+  const url = `${ctx.baseUrl}/api/cron/${name}`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${ctx.cronSecret}`,
+        'Content-Type': 'application/json',
+      },
+      // Some crons use GET — we try POST first, retry GET on 405.
+      body: '{}',
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (res.status === 405) {
+      const getRes = await fetch(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${ctx.cronSecret}` },
+        signal: AbortSignal.timeout(60_000),
+      });
+      const body = await safeReadBody(getRes);
+      return { text: `Cron ${name} (GET) → ${getRes.status}: ${body}` };
+    }
+    const body = await safeReadBody(res);
+    return { text: `Cron ${name} → ${res.status}: ${body}` };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { text: `Failed to trigger cron ${name}: ${msg}` };
+  }
+}
+
+async function resubmitTemplates(
+  names: string[] | undefined,
+  ctx: ExecutionContext,
+): Promise<ToolResult> {
+  if (!ctx.cronSecret) return { text: 'Error: CRON_SECRET not configured.' };
+  const url = `${ctx.baseUrl}/api/admin/whatsapp/resubmit-pending`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${ctx.cronSecret}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(names && names.length > 0 ? { template_names: names } : {}),
+      signal: AbortSignal.timeout(60_000),
+    });
+    const body = await safeReadBody(res);
+    return { text: `Resubmit → ${res.status}: ${body}` };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { text: `Resubmit failed: ${msg}` };
+  }
+}
+
+async function sendTestTemplate(
+  templateName: string,
+  parameters: string[],
+  ctx: ExecutionContext,
+): Promise<ToolResult> {
+  if (!templateName) return { text: 'Error: template_name is required.' };
+  if (!ctx.founderWhatsAppPhone) {
+    return {
+      text:
+        'No active WhatsApp session for the founder — link your number via the Pocket Agent flow first ' +
+        '(/dashboard/pocket-agent), then retry.',
+    };
+  }
+  try {
+    const { sendWhatsAppTemplate } = await import('@/lib/whatsapp');
+    const result = await sendWhatsAppTemplate({
+      to: ctx.founderWhatsAppPhone,
+      templateName,
+      parameters,
+    });
+    return {
+      text: `Sent ${templateName} to ${ctx.founderWhatsAppPhone}. Provider message id: ${result.providerMessageId ?? '(none)'}`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { text: `Test send failed: ${msg}` };
+  }
+}
+
+/* ---------- Helpers ---------- */
+
+function adminSupabase() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+async function safeReadBody(res: Response): Promise<string> {
+  try {
+    const text = await res.text();
+    if (text.length > 1500) return text.slice(0, 1500) + '... (truncated)';
+    return text;
+  } catch {
+    return '(unreadable response body)';
+  }
+}
+
+export async function loadFounderWhatsAppPhone(founderUserId: string): Promise<string | null> {
+  const sb = adminSupabase();
+  if (!sb) return null;
+  const { data } = await sb
+    .from('whatsapp_sessions')
+    .select('whatsapp_phone')
+    .eq('user_id', founderUserId)
+    .eq('is_active', true)
+    .is('opted_out_at', null)
+    .maybeSingle();
+  return data?.whatsapp_phone ?? null;
+}

--- a/supabase/migrations/20260503010000_admin_bot_run_sql_rpc.sql
+++ b/supabase/migrations/20260503010000_admin_bot_run_sql_rpc.sql
@@ -1,0 +1,67 @@
+-- Admin-bot run_sql RPC.
+--
+-- Powers the run_sql_query tool in src/lib/telegram/admin-tools.ts
+-- (called from the founder-only /api/telegram/admin-command route).
+-- Returns the rows of an arbitrary SELECT as JSONB so the bot can
+-- answer ad-hoc business questions without us pre-shaping every query.
+--
+-- DEFENCE IN DEPTH (4 layers, in order of importance):
+--   1. The Telegram webhook gates on FOUNDER_CHAT_ID — only Paul can
+--      reach this RPC at all.
+--   2. The application-layer tool (admin-tools.ts) refuses anything
+--      that isn't a SELECT before it ever calls this function.
+--   3. This function REJECTS non-SELECT queries server-side via a
+--      regex check. So even if a future caller forgets layer 2 the
+--      worst that happens is read access.
+--   4. EXECUTE is REVOKED from anon and authenticated, so PostgREST
+--      will only run this for service_role-bearing requests.
+--
+-- We intentionally use SECURITY DEFINER so the function inherits the
+-- definer's permissions (postgres, full RLS bypass), not the caller's.
+-- That's safe given layer 4 — only service_role can invoke it — and it
+-- means the founder-bot can read the auth.* schema and any RLS-protected
+-- tables without per-table policy work.
+--
+-- Idempotent: CREATE OR REPLACE + REVOKE IF EXISTS-equivalent (REVOKE
+-- is silently no-op when nothing was granted).
+
+CREATE OR REPLACE FUNCTION public.run_sql(query text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth, pg_temp
+AS $$
+DECLARE
+  result jsonb;
+  trimmed text;
+BEGIN
+  trimmed := regexp_replace(query, '^\s+', '', 'i');
+
+  -- Reject anything that isn't a SELECT or WITH (CTE-prefixed SELECT).
+  IF NOT (
+    trimmed ~* '^select\s'
+    OR trimmed ~* '^with\s'
+  ) THEN
+    RAISE EXCEPTION 'run_sql only accepts SELECT or WITH queries';
+  END IF;
+
+  -- Reject obvious multi-statement payloads. A semicolon followed by
+  -- non-whitespace means a second statement.
+  IF query ~ ';\s*\S' THEN
+    RAISE EXCEPTION 'run_sql does not accept multi-statement queries';
+  END IF;
+
+  EXECUTE 'SELECT to_jsonb(array_agg(row_to_json(t))) FROM (' || query || ') t'
+  INTO result;
+  RETURN COALESCE(result, '[]'::jsonb);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.run_sql(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.run_sql(text) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.run_sql(text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.run_sql(text) TO service_role;
+
+COMMENT ON FUNCTION public.run_sql(text) IS
+  'Founder admin-bot only. Runs a single SELECT/WITH query and returns rows '
+  'as JSONB. Service-role gated. See src/lib/telegram/admin-tools.ts.';

--- a/supabase/migrations/20260503020000_admin_bot_run_sql_readonly.sql
+++ b/supabase/migrations/20260503020000_admin_bot_run_sql_readonly.sql
@@ -1,0 +1,76 @@
+-- Harden public.run_sql against side-effecting SELECTs.
+--
+-- Codex P1 on PR #454 caught it: the original guard only checked the
+-- leading keyword (SELECT / WITH). A query like `SELECT dismiss_subscription(...)`
+-- would still run the volatile function and mutate rows, because
+-- SECURITY DEFINER means we run as postgres with full write access.
+--
+-- Fix: pin transaction_read_only=on for the function's transaction.
+-- Postgres rejects any write attempt (UPDATE/INSERT/DELETE, plus any
+-- volatile function call that tries to write) with
+-- "cannot execute X in a read-only transaction".
+--
+-- Belt-and-braces: also block the obvious DML/DDL keywords anywhere
+-- in the body, not just at the start. A user-quoted UPDATE inside a
+-- string literal is a false positive but the admin bot doesn't need
+-- to support those — easier to be conservative.
+
+CREATE OR REPLACE FUNCTION public.run_sql(query text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth, pg_temp
+AS $$
+DECLARE
+  result jsonb;
+  trimmed text;
+BEGIN
+  trimmed := regexp_replace(query, '^\s+', '', 'i');
+
+  -- Layer 1: must start with SELECT or WITH.
+  IF NOT (
+    trimmed ~* '^select\s'
+    OR trimmed ~* '^with\s'
+  ) THEN
+    RAISE EXCEPTION 'run_sql only accepts SELECT or WITH queries';
+  END IF;
+
+  -- Layer 2: no semicolon-separated multi-statements.
+  IF query ~ ';\s*\S' THEN
+    RAISE EXCEPTION 'run_sql does not accept multi-statement queries';
+  END IF;
+
+  -- Layer 3: refuse any obvious write keyword anywhere in the body.
+  -- Word-boundary regex so column names like "updated_at" or
+  -- "deletion_count" don't false-positive.
+  IF query ~* '\m(insert|update|delete|truncate|drop|alter|create|grant|revoke|copy|merge|call|do)\M' THEN
+    RAISE EXCEPTION 'run_sql refuses queries that mention DDL/DML keywords';
+  END IF;
+
+  -- Layer 4: pin the transaction read-only at runtime. Postgres
+  -- rejects any write attempt — including volatile functions that
+  -- try to mutate rows — with 'cannot execute X in a read-only
+  -- transaction'. This is the critical layer that catches
+  -- side-effecting SELECT calls like `SELECT dismiss_subscription(...)`
+  -- which the leading-keyword check cannot.
+  -- The setting only affects the RPC's own transaction (Supabase
+  -- opens a new one per rpc() call) so it doesn't bleed elsewhere.
+  EXECUTE 'SET TRANSACTION READ ONLY';
+
+  EXECUTE 'SELECT to_jsonb(array_agg(row_to_json(t))) FROM (' || query || ') t'
+  INTO result;
+  RETURN COALESCE(result, '[]'::jsonb);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.run_sql(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.run_sql(text) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.run_sql(text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.run_sql(text) TO service_role;
+
+COMMENT ON FUNCTION public.run_sql(text) IS
+  'Founder admin-bot only. Runs a single SELECT/WITH query in a '
+  'read-only transaction and returns rows as JSONB. Service-role '
+  'gated. Codex P1 hardening: transaction_read_only=on prevents '
+  'side-effecting volatile functions from mutating data. See '
+  'src/lib/telegram/admin-tools.ts.';


### PR DESCRIPTION
## What this fixes

The Paybacker Assistant (admin Telegram bot) already received your replies and ran a Claude conversational loop, but the model could only **talk back**. If you asked "resubmit the price increase template" or "what's MRR right now", the best it could do was recite the pre-loaded context. It had no way to actually do the thing.

## What's new

Anthropic tool-use wired into the natural-language fallback in \`src/app/api/telegram/admin-command/route.ts\`. Five tools, all gated behind the existing \`FOUNDER_CHAT_ID\` auth check. The slash-command path (\`/status\`, \`/cac\`, \`/ask\`, \`/dev\`, etc.) is unchanged.

| Tool | What it does |
|---|---|
| \`run_sql_query\` | SELECT-only ad-hoc queries against the live DB. Powered by a new \`public.run_sql\` SECURITY DEFINER RPC, gated by 4 layers: chat_id auth, app-level SELECT filter, function-level regex, REVOKE from anon/authenticated |
| \`trigger_cron\` | POSTs to \`/api/cron/<name>\` with CRON_SECRET. Whitelist of 17 safe routes (telegram-morning-summary, income-received, dispute-agent, compliance-sync, etc.) |
| \`resubmit_whatsapp_templates\` | Wraps the existing \`/api/admin/whatsapp/resubmit-pending\` so you can push PENDING_RESUBMISSION templates back to Meta from chat |
| \`send_test_whatsapp_template\` | Sends a real approved template to your own WhatsApp for verification after a resubmit |
| \`morning_brief_now\` | Friendly verb wrapper around \`trigger_cron('telegram-morning-summary')\` |

Tool loop caps at 5 iterations + 90s soft timeout (well under the route's 120s maxDuration).

## Migration

\`supabase/migrations/20260503010000_admin_bot_run_sql_rpc.sql\` adds \`public.run_sql(text)\`. **Already applied to prod** via Supabase MCP — verified working.

## Test plan

After merge + deploy:
- [ ] Reply to the bot: \"what's the average WhatsApp template approval status right now?\" → expect a SELECT against whatsapp_template_sids and a plain-English summary
- [ ] Reply: \"send me the morning brief now\" → expect telegram-morning-summary cron fires and the bot tells you the result
- [ ] Reply: \"resubmit the price-increase template\" → expect the resubmit-pending endpoint fires for paybacker_alert_price_increase
- [ ] Reply: \"can you delete the disputes table\" → expect refusal (only SELECT/WITH allowed at function level)
- [ ] Slash commands still work: \`/status\`, \`/cac 7\`, \`/ask alex what's next\`

## Out of scope (future)

- Multi-turn planning with explicit task chaining (current loop runs tools eagerly, which is enough for one-shot commands)
- B2B key approve/revoke tools (kept the admin dashboard as primary surface for now — can add if it becomes friction)
- Voice / image inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)