### PR TITLE
feat(whatsapp): morning brief now dispatches to whatsapp + telegram

### DIFF
--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -1,16 +1,37 @@
 /**
- * Telegram Morning Summary Cron
+ * Pocket Agent Morning Summary Cron
  *
  * Runs at 7:30am UK time daily. Sends each linked Pro user a morning
  * financial briefing covering yesterday's spending, upcoming renewals,
  * expiring contracts, budget warnings, open disputes, and a money tip.
  *
- * Uses the Telegram Bot API directly (fetch to api.telegram.org) with
- * the TELEGRAM_USER_BOT_TOKEN.
+ * Channel-agnostic since 2026-05-03: dispatches to BOTH Telegram and
+ * WhatsApp when the user has an active session on each channel. The
+ * mutex on `whatsapp_sessions` ↔ `telegram_sessions` is a soft guarantee
+ * (it can race during a switch), so we treat the channels as
+ * independent and de-dup on the server side via per-user iteration.
+ *
+ * Telegram path: existing direct fetch to api.telegram.org with
+ * TELEGRAM_USER_BOT_TOKEN.
+ *
+ * WhatsApp path: smart 24h-window routing — inside the customer-service
+ * window we send the full Markdown brief as free-form text (£0, no
+ * marketing fee). Outside the window we fall back to the
+ * `paybacker_morning_summary` Meta-approved template (4 vars: name,
+ * scanned_count, opportunities_count, top_focus). The template is
+ * MARKETING-category, so we honour the marketing opt-in + 24h frequency
+ * cap stored on the session row. See `src/lib/whatsapp/template-registry.ts`.
+ *
+ * Opt-out: same `telegram_alert_preferences.morning_summary` flag governs
+ * BOTH channels — there is no separate `whatsapp_alert_preferences`
+ * table. If a Pro user has `morning_summary = false`, we skip both
+ * dispatches.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { sendWhatsAppText, sendWhatsAppTemplate } from '@/lib/whatsapp';
+import { TEMPLATES } from '@/lib/whatsapp/template-registry';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -103,26 +124,62 @@ export async function GET(request: NextRequest) {
   const supabase = getAdmin();
   let sent = 0;
   let skipped = 0;
+  let whatsappSent = 0;
+  let whatsappSkipped = 0;
   const errors: string[] = [];
+  const whatsappErrors: string[] = [];
 
   // -------------------------------------------------------
-  // Get all active linked Pro users
+  // Get all active linked Pro users (Telegram + WhatsApp)
   // -------------------------------------------------------
-  const { data: sessions, error: sessErr } = await supabase
-    .from('telegram_sessions')
-    .select('user_id, telegram_chat_id')
-    .eq('is_active', true);
+  const [telegramRes, whatsappRes] = await Promise.all([
+    supabase
+      .from('telegram_sessions')
+      .select('user_id, telegram_chat_id')
+      .eq('is_active', true),
+    supabase
+      .from('whatsapp_sessions')
+      .select(
+        'user_id, whatsapp_phone, last_message_at, marketing_opt_in_at, last_marketing_template_at',
+      )
+      .eq('is_active', true)
+      .is('opted_out_at', null),
+  ]);
 
-  if (sessErr || !sessions || sessions.length === 0) {
-    return NextResponse.json({ ok: true, message: 'No active sessions', sent: 0 });
+  const sessions = telegramRes.data ?? [];
+  const whatsappSessions = (whatsappRes.data ?? []) as Array<{
+    user_id: string;
+    whatsapp_phone: string;
+    last_message_at: string | null;
+    marketing_opt_in_at: string | null;
+    last_marketing_template_at: string | null;
+  }>;
+  const sessErr = telegramRes.error;
+
+  if ((sessErr || sessions.length === 0) && whatsappSessions.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      message: 'No active sessions',
+      sent: 0,
+      whatsappSent: 0,
+    });
   }
 
-  const userIds = sessions.map((s) => s.user_id);
+  // Union of user_ids across both channels — a user may be on Telegram
+  // only, WhatsApp only, or (briefly during a switch) on both.
+  const allUserIds = Array.from(
+    new Set([
+      ...sessions.map((s) => s.user_id),
+      ...whatsappSessions.map((s) => s.user_id),
+    ]),
+  );
+
   const { data: profiles } = await supabase
     .from('profiles')
-    .select('id, subscription_tier, subscription_status, stripe_subscription_id')
-    .in('id', userIds);
+    .select('id, first_name, subscription_tier, subscription_status, stripe_subscription_id')
+    .in('id', allUserIds);
 
+  const profileMap = new Map((profiles ?? []).map((p) => [p.id, p]));
   const proUserIds = new Set(
     (profiles ?? [])
       .filter((p) => {
@@ -138,18 +195,32 @@ export async function GET(request: NextRequest) {
   );
 
   const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const proWhatsappSessions = whatsappSessions.filter((s) => proUserIds.has(s.user_id));
 
-  // Check alert preferences — skip users who disabled morning summary
+  // Check alert preferences — skip users who disabled morning summary.
+  // The same flag governs both channels (no separate whatsapp pref table).
+  const eligibleUserIds = Array.from(
+    new Set([
+      ...proSessions.map((s) => s.user_id),
+      ...proWhatsappSessions.map((s) => s.user_id),
+    ]),
+  );
   const { data: allPrefs } = await supabase
     .from('telegram_alert_preferences')
     .select('user_id, morning_summary')
-    .in('user_id', proSessions.map(s => s.user_id));
+    .in('user_id', eligibleUserIds);
 
   const prefMap = new Map((allPrefs ?? []).map(p => [p.user_id, p]));
-  const eligibleSessions = proSessions.filter(s => {
-    const pref = prefMap.get(s.user_id);
+  const isMorningSummaryEnabled = (userId: string): boolean => {
+    const pref = prefMap.get(userId);
     return !pref || pref.morning_summary !== false; // default to on
-  });
+  };
+  const eligibleSessions = proSessions.filter((s) => isMorningSummaryEnabled(s.user_id));
+  const whatsappSessionByUserId = new Map(
+    proWhatsappSessions
+      .filter((s) => isMorningSummaryEnabled(s.user_id))
+      .map((s) => [s.user_id, s]),
+  );
 
   // -------------------------------------------------------
   // Date helpers
@@ -184,10 +255,19 @@ export async function GET(request: NextRequest) {
   const tipIndex = dayOfYear % MONEY_TIPS.length;
 
   // -------------------------------------------------------
-  // Process each Pro user
+  // Process each Pro user — iterate per-user so the same body is
+  // dispatched to both channels when present, with a single set of
+  // expensive DB reads.
   // -------------------------------------------------------
-  for (const session of eligibleSessions) {
-    const { user_id: userId, telegram_chat_id: chatId } = session;
+  const eligibleTgByUser = new Map(eligibleSessions.map((s) => [s.user_id, s]));
+  const allEligibleUserIds = Array.from(
+    new Set([...eligibleTgByUser.keys(), ...whatsappSessionByUserId.keys()]),
+  );
+
+  for (const userId of allEligibleUserIds) {
+    const tgSession = eligibleTgByUser.get(userId) ?? null;
+    const waSession = whatsappSessionByUserId.get(userId) ?? null;
+    const chatId = tgSession?.telegram_chat_id ?? null;
 
     try {
       // Check if user has any bank transaction data at all
@@ -197,9 +277,18 @@ export async function GET(request: NextRequest) {
         .eq('user_id', userId);
 
       if (!txCount || txCount === 0) {
-        skipped++;
+        if (tgSession) skipped++;
+        if (waSession) whatsappSkipped++;
         continue;
       }
+
+      // Track summary metadata for the WhatsApp template fallback
+      // (paybacker_morning_summary requires name / scanned_count /
+      // opportunities_count / top_focus). We populate as the body
+      // is built so a single pass produces both the long Markdown
+      // brief AND the short template variables.
+      let opportunitiesCount = 0;
+      const focusCandidates: Array<{ priority: number; label: string }> = [];
 
       const sections: string[] = [];
       sections.push('*Good morning! Here\'s your daily money briefing:*');
@@ -258,6 +347,11 @@ export async function GET(request: NextRequest) {
           renewalSection += `\n  - ${sub.provider_name}: ${fmt(Number(sub.amount))}/${sub.billing_cycle ?? 'month'} (${when})`;
         }
         sections.push(renewalSection);
+        opportunitiesCount += renewals.length;
+        focusCandidates.push({
+          priority: 2,
+          label: `${renewals.length} renewal${renewals.length === 1 ? '' : 's'} this week`,
+        });
       }
 
       // ------ 3. Contracts expiring this week ------
@@ -276,6 +370,11 @@ export async function GET(request: NextRequest) {
           contractSection += `\n  - ${c.provider_name}: ends ${fmtDate(c.contract_end_date)}`;
         }
         sections.push(contractSection);
+        opportunitiesCount += expiringContracts.length;
+        focusCandidates.push({
+          priority: 3,
+          label: `${expiringContracts.length} contract${expiringContracts.length === 1 ? '' : 's'} ending soon`,
+        });
       }
 
       // ------ 4. Budget status (categories over 80%) ------
@@ -315,6 +414,12 @@ export async function GET(request: NextRequest) {
           budgetSection += `\n  ${emoji} ${w.category}: ${fmt(w.spent)} / ${fmt(w.limit)} (${Math.round(w.pct)}%)`;
         }
         sections.push(budgetSection);
+        opportunitiesCount += budgetWarnings.length;
+        const top = budgetWarnings[0];
+        focusCandidates.push({
+          priority: top.pct >= 100 ? 1 : 2,
+          label: `${top.category} ${Math.round(top.pct)}% of budget`,
+        });
       }
 
       // ------ 5. Unresolved disputes ------
@@ -333,49 +438,167 @@ export async function GET(request: NextRequest) {
           disputeSection += `\n  _...and ${openDisputes.length - 3} more_`;
         }
         sections.push(disputeSection);
+        opportunitiesCount += openDisputes.length;
+        focusCandidates.push({
+          priority: 1,
+          label: `${openDisputes.length} open dispute${openDisputes.length === 1 ? '' : 's'}`,
+        });
       }
 
       // ------ 6. Money-saving tip of the day ------
       sections.push(`\n\n\ud83d\udca1 *Tip of the Day*\n${MONEY_TIPS[tipIndex]}`);
 
-      // ------ Build and send ------
+      // ------ Build and dispatch ------
       const message = sections.join('');
-      const ok = await sendTelegramMessage(token, Number(chatId), message);
 
-      if (ok) {
-        sent++;
-      } else {
-        errors.push(`Failed to send to user ${userId}`);
+      // Telegram dispatch (when the user has an active TG session).
+      if (tgSession && chatId) {
+        const ok = await sendTelegramMessage(token, Number(chatId), message);
+        if (ok) {
+          sent++;
+        } else {
+          errors.push(`Failed to send to user ${userId}`);
+        }
+      }
+
+      // WhatsApp dispatch (when the user has an active WA session).
+      // Wrapped independently so a Telegram failure doesn't block the
+      // WhatsApp send and vice versa.
+      if (waSession) {
+        try {
+          const profile = profileMap.get(userId);
+          const firstName =
+            (profile as { first_name?: string | null } | undefined)?.first_name || 'there';
+          // Top focus = highest-priority section we built for the brief.
+          // Priority 1 = budget breach / disputes, 2 = renewals/budget warning,
+          // 3 = contracts ending. Falls back to a friendly "all calm" line.
+          focusCandidates.sort((a, b) => a.priority - b.priority);
+          const topFocus = focusCandidates[0]?.label ?? 'No urgent items today';
+
+          const inWindow =
+            !!waSession.last_message_at &&
+            Date.now() - new Date(waSession.last_message_at).getTime() < 24 * 60 * 60 * 1000;
+
+          if (inWindow) {
+            // Free-form: deliver the same Markdown brief the Telegram
+            // user got. WhatsApp renders *bold* identically, so the
+            // body needs no transformation. Chunk to stay under the
+            // 4096-char WhatsApp limit (same pattern as Telegram).
+            const chunks = splitMessage(message);
+            let lastSid: string | undefined;
+            for (const chunk of chunks) {
+              const result = await sendWhatsAppText({
+                to: waSession.whatsapp_phone,
+                text: chunk,
+              });
+              lastSid = result.providerMessageId;
+            }
+            whatsappSent++;
+            console.log(
+              `[morning-summary/whatsapp] mode=text user=${userId} chunks=${chunks.length} sid=${lastSid}`,
+            );
+          } else {
+            // Outside the 24h customer-service window: fall back to the
+            // Meta-approved paybacker_morning_summary template
+            // (MARKETING category \u2014 opt-in + 24h freq cap apply).
+            const tpl = TEMPLATES.paybacker_morning_summary;
+            if (!waSession.marketing_opt_in_at) {
+              whatsappSkipped++;
+              console.log(
+                `[morning-summary/whatsapp] skip user=${userId} reason=no_marketing_opt_in`,
+              );
+            } else if (
+              waSession.last_marketing_template_at &&
+              Date.now() - new Date(waSession.last_marketing_template_at).getTime() <
+                24 * 60 * 60 * 1000
+            ) {
+              whatsappSkipped++;
+              console.log(
+                `[morning-summary/whatsapp] skip user=${userId} reason=marketing_24h_cap`,
+              );
+            } else if (!tpl.sid || tpl.sid.startsWith('PENDING')) {
+              // Defensive \u2014 the registry will hold a real SID once
+              // approved, so this is a safety net rather than a live
+              // path today (paybacker_morning_summary is approved).
+              whatsappSkipped++;
+              console.log(
+                `[morning-summary/whatsapp] skip user=${userId} reason=template_not_approved`,
+              );
+            } else {
+              const result = await sendWhatsAppTemplate({
+                to: waSession.whatsapp_phone,
+                templateName: 'paybacker_morning_summary',
+                parameters: [
+                  firstName,
+                  String(txCount),
+                  String(opportunitiesCount),
+                  topFocus,
+                ],
+              });
+              whatsappSent++;
+              console.log(
+                `[morning-summary/whatsapp] mode=template user=${userId} sid=${result.providerMessageId}`,
+              );
+              // Stamp the marketing 24h frequency cap so concurrent
+              // crons can't double-charge by both deciding the cap had
+              // elapsed.
+              await supabase
+                .from('whatsapp_sessions')
+                .update({ last_marketing_template_at: new Date().toISOString() })
+                .eq('user_id', userId)
+                .eq('is_active', true);
+            }
+          }
+        } catch (waErr) {
+          const errMsg = waErr instanceof Error ? waErr.message : String(waErr);
+          console.error(
+            `[morning-summary/whatsapp] Error for user ${userId}:`,
+            errMsg,
+          );
+          whatsappErrors.push(`${userId}: ${errMsg}`);
+        }
       }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      console.error(`[telegram-morning-summary] Error for user ${userId}:`, errMsg);
+      console.error(`[morning-summary] Error for user ${userId}:`, errMsg);
       errors.push(`${userId}: ${errMsg}`);
     }
   }
 
   console.log(
-    `[telegram-morning-summary] Processed ${proSessions.length} users, sent ${sent}, skipped ${skipped}, errors ${errors.length}`,
+    `[morning-summary] users=${allEligibleUserIds.length} ` +
+      `tg_sent=${sent} tg_skipped=${skipped} tg_errors=${errors.length} ` +
+      `wa_sent=${whatsappSent} wa_skipped=${whatsappSkipped} wa_errors=${whatsappErrors.length}`,
   );
 
   // Alert founder if the cron ran with eligible users but sent nothing
   const founderChatId = process.env.TELEGRAM_FOUNDER_CHAT_ID;
-  if (founderChatId && eligibleSessions.length > 0 && sent === 0 && errors.length > 0) {
+  if (
+    founderChatId &&
+    allEligibleUserIds.length > 0 &&
+    sent === 0 &&
+    whatsappSent === 0 &&
+    (errors.length > 0 || whatsappErrors.length > 0)
+  ) {
+    const allErrs = [...errors, ...whatsappErrors];
     await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         chat_id: Number(founderChatId),
-        text: `Morning summary failed: ${errors.slice(0, 3).join('; ')}`,
+        text: `Morning summary failed: ${allErrs.slice(0, 3).join('; ')}`,
       }),
     }).catch(() => {});
   }
 
   return NextResponse.json({
     ok: true,
-    users: proSessions.length,
+    users: allEligibleUserIds.length,
     sent,
     skipped,
     errors: errors.length,
+    whatsappSent,
+    whatsappSkipped,
+    whatsappErrors: whatsappErrors.length,
   });
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `src/app/api/cron/telegram-morning-summary/route.ts` was Telegram-only — it iterated `telegram_sessions` and called `sendTelegramMessage` directly. There was no WhatsApp dispatch path, so founder Paul (Pro, WhatsApp connected) and every other Pro WhatsApp user received nothing at 7:30am UK despite the 24h-window WhatsApp helpers landing the week prior.
- **Dispatch logic added**: parallel-fetch `whatsapp_sessions` (active, not opted-out) alongside the existing `telegram_sessions` query, build the per-user union of eligible Pro user_ids, then iterate per-user-id (not per-session) so the expensive body-building DB reads run once and dispatch fans out to BOTH channels independently.
- **24h-window routing**: inside the customer-service window we send the full Markdown brief as free-form text via `sendWhatsAppText` (£0, no marketing fee, chunked at 4000 chars to stay under the 4096 WhatsApp limit). Outside the window we fall back to the Meta-approved `paybacker_morning_summary` template (4 vars: name, scanned_count, opportunities_count, top_focus) and stamp `last_marketing_template_at` so concurrent crons can't double-charge. Pre-checks `marketing_opt_in_at`, the 24h frequency cap, and template SID approval — logs + skips rather than errors when any gate trips.
- **Opt-out honoured**: same `telegram_alert_preferences.morning_summary` flag governs both channels (no separate `whatsapp_alert_preferences` table exists; confirmed via grep). A user with `morning_summary = false` is filtered out before either dispatch.
- **Error isolation**: WhatsApp dispatch is wrapped in its own try/catch inside the per-user try/catch, so one bad number / Twilio error / template gate failure doesn't kill the cron run or block the matching Telegram send. Counts surfaced separately in the JSON response as `whatsappSent` / `whatsappSkipped` / `whatsappErrors`.

## Test plan

- [ ] Verify cron runs at 7:30am UK (`vercel.json` schedule unchanged)
- [ ] Hit `GET /api/cron/telegram-morning-summary` with `Bearer $CRON_SECRET` and confirm response includes `whatsappSent` / `whatsappSkipped` / `whatsappErrors` keys
- [ ] Confirm founder receives morning brief on WhatsApp (Pro, marketing opt-in granted, recently messaged the bot — should hit the free-form text path)
- [ ] Confirm Pro user without marketing opt-in outside window gets logged skip with `reason=no_marketing_opt_in` and is NOT charged
- [ ] Confirm Pro user with `morning_summary = false` in `telegram_alert_preferences` receives nothing on either channel
- [ ] Confirm Telegram dispatch still works for Pro Telegram-only users (regression check)
- [ ] Verify `npx tsc --noEmit` is clean for the modified file (pre-existing yapily-consent-poll errors ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)