### PR TITLE
feat(dashboard): populate browse deals card with top 3

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1573,14 +1573,17 @@ export default function DashboardPage() {
               ) : (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
                   {collapsedDealsByMerchant.slice(0, 3).map((d, i) => (
-                    <div
+                    <Link
                       key={`${d.sub}-${i}`}
+                      href="/dashboard/deals"
                       style={{
                         display: 'flex',
                         gap: 10,
                         padding: '10px 0',
                         borderTop: '1px solid var(--divider-2)',
                         alignItems: 'flex-start',
+                        textDecoration: 'none',
+                        color: 'inherit',
                       }}
                     >
                       <div style={{ flex: 1, minWidth: 0 }}>
@@ -1592,7 +1595,7 @@ export default function DashboardPage() {
                       <div style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--mint-deep)', whiteSpace: 'nowrap' }}>
                         {formatGBP(d.saving)}/yr
                       </div>
-                    </div>
+                    </Link>
                   ))}
                   <Link
                     href="/dashboard/deals"

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1554,12 +1554,47 @@ export default function DashboardPage() {
                 Every subscription in one place. Sync from your bank or add manually.
               </p>
             </Link>
-            <Link href="/dashboard/deals" className="card" style={{ textDecoration: 'none', color: 'inherit' }}>
+            <div className="card">
               <h3><Tag className="h-4 w-4" style={{ color: 'var(--mint-deep)' }} /> Browse deals</h3>
-              <p style={{ margin: 0, fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.45 }}>
-                Compare energy, broadband, mobile, insurance. Find cheaper alternatives.
-              </p>
-            </Link>
+              {collapsedDealsByMerchant.length === 0 ? (
+                <p style={{ margin: 0, fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.45 }}>
+                  {bankConnected
+                    ? "No cheaper alternatives found yet — we'll keep checking."
+                    : 'Connect a bank to find cheaper deals on your bills.'}
+                </p>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+                  {collapsedDealsByMerchant.slice(0, 3).map((d, i) => (
+                    <div
+                      key={`${d.sub}-${i}`}
+                      style={{
+                        display: 'flex',
+                        gap: 10,
+                        padding: '10px 0',
+                        borderTop: '1px solid var(--divider-2)',
+                        alignItems: 'flex-start',
+                      }}
+                    >
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 13, fontWeight: 600 }}>{d.provider}</div>
+                        <div style={{ fontSize: 11.5, color: 'var(--text-3)', lineHeight: 1.35 }}>
+                          Switch from {d.sub}
+                        </div>
+                      </div>
+                      <div style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--mint-deep)', whiteSpace: 'nowrap' }}>
+                        {formatGBP(d.saving)}/yr
+                      </div>
+                    </div>
+                  ))}
+                  <Link
+                    href="/dashboard/deals"
+                    style={{ fontSize: 12, color: 'var(--mint-deep)', textDecoration: 'none', paddingTop: 10 }}
+                  >
+                    View all {collapsedDealsByMerchant.length} deal{collapsedDealsByMerchant.length === 1 ? '' : 's'} →
+                  </Link>
+                </div>
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1557,11 +1557,19 @@ export default function DashboardPage() {
             <div className="card">
               <h3><Tag className="h-4 w-4" style={{ color: 'var(--mint-deep)' }} /> Browse deals</h3>
               {collapsedDealsByMerchant.length === 0 ? (
-                <p style={{ margin: 0, fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.45 }}>
-                  {bankConnected
-                    ? "No cheaper alternatives found yet — we'll keep checking."
-                    : 'Connect a bank to find cheaper deals on your bills.'}
-                </p>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  <p style={{ margin: 0, fontSize: 12.5, color: 'var(--text-2)', lineHeight: 1.45 }}>
+                    {bankConnected
+                      ? "No cheaper alternatives found yet — we'll keep checking."
+                      : 'Connect a bank to find cheaper deals on your bills.'}
+                  </p>
+                  <Link
+                    href="/dashboard/deals"
+                    style={{ fontSize: 12, color: 'var(--mint-deep)', textDecoration: 'none' }}
+                  >
+                    Browse all deals →
+                  </Link>
+                </div>
               ) : (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
                   {collapsedDealsByMerchant.slice(0, 3).map((d, i) => (


### PR DESCRIPTION
## Summary
- Replaces the static "Browse deals" tile (generic copy + dead link) with a live preview of the top 3 deduped switch opportunities ranked by annual saving, reusing the existing `collapsedDealsByMerchant` array.
- Each row shows the suggested provider, the source subscription, and the £/yr saving (mint accent), matching the visual grammar of the Email Scanner opportunity rows. Footer "View all N deals →" links to `/dashboard/deals`.
- Empty states: prompts to connect a bank when `bankConnected === false`, otherwise shows the no-deals-yet message. Surrounding "Quick actions" grid, h3, and Tag icon are unchanged.

## Test plan
- [ ] User with no bank connected sees the "Connect a bank to find cheaper deals on your bills." empty state in the Browse deals card.
- [ ] User with bank connected but no comparison deals sees "No cheaper alternatives found yet — we'll keep checking."
- [ ] User with comparison deals sees up to 3 rows (provider + £/yr saving), sorted by saving desc.
- [ ] "View all N deals →" routes to `/dashboard/deals`.
- [ ] Action Centre, Email Scanner, Action items, Pocket Agent, Connections, and the surrounding Quick actions tiles are visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)