### PR TITLE
fix(bot): watchdog sync calls runner directly instead of self-fetching

### DIFF
--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/notifications/events';
 import { getEffectiveTier } from '@/lib/plan-limits';
 import { generateDisputeReply } from '@/lib/agents/dispute-reply-engine';
+import { syncLinkedThread } from '@/lib/dispute-sync/sync-runner';
 
 const CATEGORY_LABELS: Record<string, string> = {
   mortgage: 'Mortgage', loans: 'Loans & Finance', credit: 'Credit Cards',
@@ -5734,29 +5735,36 @@ async function syncRepliesNow(
 ): Promise<ToolResult> {
   const resolved = await resolveActiveDisputeForBot(supabase, userId, provider);
   if (!resolved.ok) return { text: resolved.text };
-  // Trigger the existing sync endpoint via fetch so we reuse its logic.
-  const origin = process.env.NEXT_PUBLIC_SITE_URL || 'https://paybacker.co.uk';
-  try {
-    const res = await fetch(`${origin}/api/disputes/${resolved.dispute.id}/sync-replies-now`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.CRON_SECRET}`,
-        'X-User-Id': userId,
-      },
-    });
-    if (!res.ok) {
-      const txt = await res.text();
-      return { text: `Sync failed (${res.status}): ${txt.slice(0, 200)}` };
-    }
-    const data = await res.json();
-    const imported = (data as { imported?: number }).imported ?? 0;
-    return imported > 0
-      ? { text: `✓ Synced *${resolved.dispute.provider_name}* — imported ${imported} new repl${imported === 1 ? 'y' : 'ies'}. Check the dispute timeline.` }
-      : { text: `✓ Synced *${resolved.dispute.provider_name}* — no new replies since last check.` };
-  } catch (err) {
-    return { text: `Sync request failed: ${err instanceof Error ? err.message : 'unknown error'}. The watchdog cron will catch up on its next 30-min run.` };
+
+  // Call the watchdog runner directly. The bot is already on the server
+  // with the admin Supabase client, so going through the HTTP route just
+  // to be 401'd by cookie-only auth (the route runs `supabase.auth.getUser()`
+  // and ignores `Authorization: Bearer ${CRON_SECRET}` + `X-User-Id`) is both
+  // pointless and misleading — the LLM was surfacing those 401s as
+  // "authorisation error" and telling users their email/bank connection had
+  // expired. Mirror the route's logic in-process instead.
+  const { data: link } = await supabase
+    .from('dispute_watchdog_links')
+    .select('id')
+    .eq('dispute_id', resolved.dispute.id)
+    .eq('user_id', userId)
+    .eq('sync_enabled', true)
+    .maybeSingle();
+
+  if (!link) {
+    return { text: `No linked email thread for *${resolved.dispute.provider_name}* yet. Link one via /dashboard/disputes first.` };
   }
+
+  const result = await syncLinkedThread(link.id, { sendNotifications: true });
+
+  if (result.error) {
+    return { text: `Sync failed: ${result.error}. The watchdog cron will retry on its next 30-min run.` };
+  }
+
+  const imported = result.imported;
+  return imported > 0
+    ? { text: `✓ Synced *${resolved.dispute.provider_name}* — imported ${imported} new repl${imported === 1 ? 'y' : 'ies'}. Check the dispute timeline.` }
+    : { text: `✓ Synced *${resolved.dispute.provider_name}* — no new replies since last check.` };
 }
 
 async function getNotifications(

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -5743,7 +5743,7 @@ async function syncRepliesNow(
   // pointless and misleading — the LLM was surfacing those 401s as
   // "authorisation error" and telling users their email/bank connection had
   // expired. Mirror the route's logic in-process instead.
-  const { data: link } = await supabase
+  const { data: link, error } = await supabase
     .from('dispute_watchdog_links')
     .select('id')
     .eq('dispute_id', resolved.dispute.id)
@@ -5751,6 +5751,9 @@ async function syncRepliesNow(
     .eq('sync_enabled', true)
     .maybeSingle();
 
+  if (error) {
+    return { text: `Couldn't check the linked email thread — DB error. The watchdog cron will retry on its next 30-min run.` };
+  }
   if (!link) {
     return { text: `No linked email thread for *${resolved.dispute.provider_name}* yet. Link one via /dashboard/disputes first.` };
   }


### PR DESCRIPTION
## Summary

- **The 401 root cause:** the bot's `syncRepliesNow` (in `src/lib/telegram/tool-handlers.ts`) was POSTing to `/api/disputes/[id]/sync-replies-now` with `Authorization: Bearer ${CRON_SECRET}` + `X-User-Id` headers. But that route only authenticates via `supabase.auth.getUser()` (cookie session) — it never reads either header — so every bot-initiated sync came back `401 {"error":"Unauthorized"}`.
- **The LLM mis-diagnosis it caused:** the bot surfaced that 401 to the user as "authorisation error", which the conversational LLM consistently translated into "your email/bank connection seems to have expired — please reconnect". Users were being told to redo OAuth flows that were perfectly healthy; the only thing actually broken was the bot's call to its own backend.
- **The in-process fix:** the bot already runs on the server with the admin Supabase client, so the HTTP roundtrip is pointless. We now query `dispute_watchdog_links` directly and call `syncLinkedThread(link.id, { sendNotifications: true })` — the same two operations the route performs in-process. No more cron-secret header smuggling, no more 401s, no more misleading "your connection expired" messages.
- **The website's HTTP route is unaffected:** `/api/disputes/[id]/sync-replies-now` is untouched, so the dashboard's "Sync now" button (which legitimately uses cookie auth) keeps working exactly as before.

## Test plan

- [ ] In Telegram, ask the bot to "sync replies now" on a dispute with an active watchdog link → expect the success message ("imported N new replies" / "no new replies since last check"), no 401.
- [ ] On a dispute with no `dispute_watchdog_links` row → expect "No linked email thread for *<provider>* yet" instead of a 404 wrapped in "authorisation error".
- [ ] On a dispute whose link references a stale `email_connection_id` → expect the runner's "Email connection missing — reconnect..." string surfaced as `Sync failed: ...` (this is the legitimate "reconnect" case the LLM was previously giving for everyone).
- [ ] Click "Sync now" on `/dashboard/disputes` for the same dispute (cookie auth path) → expect it still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)