### PR TITLE
feat(whatsapp): morning brief now dispatches to whatsapp + telegram

### DIFF
--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -1,17 +1,33 @@
 /**
- * Telegram Morning Summary Cron
+ * Telegram + WhatsApp Morning Summary Cron
  *
  * Runs at 7:30am UK time daily. Sends each linked Pro user a morning
  * financial briefing covering yesterday's spending, upcoming renewals,
  * expiring contracts, budget warnings, open disputes, and a money tip.
  *
- * Uses the Telegram Bot API directly (fetch to api.telegram.org) with
- * the TELEGRAM_USER_BOT_TOKEN.
+ * Telegram path: existing fetch to api.telegram.org with TELEGRAM_USER_BOT_TOKEN.
+ *
+ * WhatsApp path (added 2026-05-03): the same brief body fans out to any
+ * user with an active row in `whatsapp_sessions` (independent channel
+ * per /dashboard/settings/notifications — a user can have BOTH active).
+ * We pick the cheapest valid send mode per the Meta 24h customer-service
+ * window:
+ *   - inside the window (user messaged us in the last 24h): free-form
+ *     text via sendWhatsAppText (no template fee, full Markdown body).
+ *   - outside the window: the `paybacker_morning_summary` UTILITY template
+ *     IF Meta-approved. If not approved (current state — see
+ *     template-registry.ts), we log + skip rather than 4xx Twilio.
+ *
+ * Same `morning_summary !== false` opt-out from telegram_alert_preferences
+ * governs both channels (sole user-facing toggle today). Errors are
+ * wrapped per-user so one bad number can't kill the run.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { isProPocketAgentEligible } from '@/lib/telegram/eligibility';
+import { sendWhatsAppText, sendWhatsAppTemplate } from '@/lib/whatsapp';
+import { getTemplateSid } from '@/lib/whatsapp/template-sids';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -90,6 +106,331 @@ async function sendTelegramMessage(
   return true;
 }
 
+/**
+ * Build the morning brief body for a single user. Returns null when
+ * the user has no bank transactions yet (caller should skip).
+ *
+ * Pure data-shaping over Supabase — same queries the Telegram loop
+ * has used since launch, lifted into a reusable helper so the
+ * WhatsApp-only loop can produce identical output.
+ */
+type BriefDateContext = {
+  now: Date;
+  todayStr: string;
+  tomorrowStr: string;
+  in7DaysStr: string;
+  yesterdayStart: Date;
+  todayStart: Date;
+  tipIndex: number;
+};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AdminClient = any;
+async function buildMorningBrief(
+  supabase: AdminClient,
+  userId: string,
+  ctx: BriefDateContext,
+): Promise<string | null> {
+  const { now, todayStr, tomorrowStr, in7DaysStr, yesterdayStart, todayStart, tipIndex } = ctx;
+
+  const { count: txCount } = await supabase
+    .from('bank_transactions')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId);
+  if (!txCount || txCount === 0) return null;
+
+  const sections: string[] = [];
+  sections.push("*Good morning! Here's your daily money briefing:*");
+
+  // ------ 1. Yesterday's spending ------
+  const EXCLUDE_CATS = new Set([
+    'transfer', 'transfers', 'internal_transfer', 'self_transfer',
+    'credit_card_payment', 'credit_card',
+    'investment', 'investments', 'savings', 'pension',
+    'income', 'fee_refund',
+  ]);
+  const { data: yesterdayTxRaw } = await supabase
+    .from('bank_transactions')
+    .select('user_category, amount')
+    .eq('user_id', userId)
+    .lt('amount', 0)
+    .gte('timestamp', yesterdayStart.toISOString())
+    .lt('timestamp', todayStart.toISOString());
+
+  const yesterdayTx = ((yesterdayTxRaw ?? []) as Array<{ user_category: string | null; amount: number | string }>).filter(
+    (t) => !EXCLUDE_CATS.has(t.user_category ?? ''),
+  );
+
+  if (yesterdayTx.length > 0) {
+    const total = yesterdayTx.reduce((sum, t) => sum + Math.abs(Number(t.amount)), 0);
+    const byCategory: Record<string, number> = {};
+    for (const t of yesterdayTx) {
+      const cat = t.user_category ?? 'Other';
+      byCategory[cat] = (byCategory[cat] ?? 0) + Math.abs(Number(t.amount));
+    }
+    const topCategories = Object.entries(byCategory)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 3);
+
+    let spendingSection = `\n\n*Yesterday's Spending*\nTotal: *${fmt(total)}*`;
+    if (topCategories.length > 0) {
+      spendingSection += '\nTop categories:';
+      for (const [cat, amount] of topCategories) {
+        spendingSection += `\n  - ${cat}: ${fmt(amount)}`;
+      }
+    }
+    sections.push(spendingSection);
+  } else {
+    sections.push("\n\n*Yesterday's Spending*\nNo spending recorded yesterday.");
+  }
+
+  // ------ 2. Subscriptions renewing today or tomorrow ------
+  const { data: renewals } = await supabase
+    .from('subscriptions')
+    .select('provider_name, amount, billing_cycle, next_billing_date')
+    .eq('user_id', userId)
+    .eq('status', 'active')
+    .gte('next_billing_date', todayStr)
+    .lte('next_billing_date', tomorrowStr);
+
+  if (renewals && renewals.length > 0) {
+    let renewalSection = '\n\n*Upcoming Renewals*';
+    for (const sub of renewals as Array<{ provider_name: string; amount: number | string; billing_cycle: string | null; next_billing_date: string }>) {
+      const when = sub.next_billing_date === todayStr ? 'Today' : 'Tomorrow';
+      renewalSection += `\n  - ${sub.provider_name}: ${fmt(Number(sub.amount))}/${sub.billing_cycle ?? 'month'} (${when})`;
+    }
+    sections.push(renewalSection);
+  }
+
+  // ------ 3. Contracts expiring this week ------
+  const { data: expiringContracts } = await supabase
+    .from('subscriptions')
+    .select('provider_name, contract_end_date, amount, billing_cycle')
+    .eq('user_id', userId)
+    .eq('status', 'active')
+    .not('contract_end_date', 'is', null)
+    .gte('contract_end_date', todayStr)
+    .lte('contract_end_date', in7DaysStr);
+
+  if (expiringContracts && expiringContracts.length > 0) {
+    let contractSection = '\n\n*Contracts Expiring This Week*';
+    for (const c of expiringContracts as Array<{ provider_name: string; contract_end_date: string }>) {
+      contractSection += `\n  - ${c.provider_name}: ends ${fmtDate(c.contract_end_date)}`;
+    }
+    sections.push(contractSection);
+  }
+
+  // ------ 4. Budget status (categories over 80%) ------
+  const [budgetsResult, monthSpendingResult] = await Promise.all([
+    supabase.from('money_hub_budgets').select('category, monthly_limit').eq('user_id', userId),
+    supabase.rpc('get_monthly_spending', {
+      p_user_id: userId,
+      p_year: now.getFullYear(),
+      p_month: now.getMonth() + 1,
+    }),
+  ]);
+
+  const spentByCategory: Record<string, number> = {};
+  for (const row of (monthSpendingResult.data ?? []) as Array<{ category: string; category_total: number | string }>) {
+    spentByCategory[row.category] = Number(row.category_total);
+  }
+
+  const budgetWarnings: Array<{ category: string; spent: number; limit: number; pct: number }> = [];
+  for (const b of (budgetsResult.data ?? []) as Array<{ category: string; monthly_limit: number | string }>) {
+    const limit = Number(b.monthly_limit);
+    const spentAmt = spentByCategory[b.category] ?? 0;
+    const pct = limit > 0 ? (spentAmt / limit) * 100 : 0;
+    if (pct >= 80) {
+      budgetWarnings.push({ category: b.category, spent: spentAmt, limit, pct });
+    }
+  }
+
+  if (budgetWarnings.length > 0) {
+    budgetWarnings.sort((a, b) => b.pct - a.pct);
+    let budgetSection = '\n\n*Budget Warnings*';
+    for (const w of budgetWarnings) {
+      const emoji = w.pct >= 100 ? '⚠️' : '⏳';
+      budgetSection += `\n  ${emoji} ${w.category}: ${fmt(w.spent)} / ${fmt(w.limit)} (${Math.round(w.pct)}%)`;
+    }
+    sections.push(budgetSection);
+  }
+
+  // ------ 5. Unresolved disputes ------
+  const { data: openDisputes } = await supabase
+    .from('disputes')
+    .select('id, provider_name, issue_type, status')
+    .eq('user_id', userId)
+    .not('status', 'in', '(resolved,dismissed)');
+
+  if (openDisputes && openDisputes.length > 0) {
+    let disputeSection = `\n\n*Open Disputes (${openDisputes.length})*`;
+    for (const d of (openDisputes as Array<{ provider_name: string; issue_type: string; status: string }>).slice(0, 3)) {
+      disputeSection += `\n  - ${d.provider_name}: ${d.issue_type} (${d.status})`;
+    }
+    if (openDisputes.length > 3) {
+      disputeSection += `\n  _...and ${openDisputes.length - 3} more_`;
+    }
+    sections.push(disputeSection);
+  }
+
+  // ------ 6. Money-saving tip of the day ------
+  sections.push(`\n\n💡 *Tip of the Day*\n${MONEY_TIPS[tipIndex]}`);
+
+  return sections.join('');
+}
+
+/**
+ * Convert the Telegram-flavoured Markdown brief to plain text suitable
+ * for WhatsApp's free-form text channel. WhatsApp uses a different
+ * (much smaller) Markdown subset and does NOT support `*bold*` the
+ * same way — asterisks render literally on most clients. Strip the
+ * Markdown markers so the body reads cleanly on either side.
+ *
+ * We keep the layout and emojis. WhatsApp body limit is 4096 chars;
+ * we hard-truncate well below that as a defensive measure (the
+ * Telegram body is similarly bounded by splitMessage's 4000-char chunk).
+ */
+function toWhatsAppPlainText(markdown: string): string {
+  const stripped = markdown
+    // *bold* -> bold
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    // _italic_ -> italic (only when it's a standalone wrapper, not mid-word)
+    .replace(/(^|\s)_([^_\n]+)_(?=\s|$)/g, '$1$2');
+  return stripped.length > 3900 ? `${stripped.slice(0, 3897)}...` : stripped;
+}
+
+/**
+ * Best-effort 24h customer-service window check: did this user message
+ * us in the last 24h? Inside the window we can free-form text (no
+ * template fee). Outside, Meta requires a pre-approved template.
+ *
+ * We use whatsapp_message_log.direction='inbound' as the canonical
+ * signal — it's written by the inbound webhook for every Twilio
+ * message. Returns false on any DB error so we fall through to the
+ * template path (safer to skip than to 4xx Twilio).
+ */
+async function isInsideWhatsAppServiceWindow(
+  supabase: AdminClient,
+  userId: string,
+): Promise<boolean> {
+  try {
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const { data } = await supabase
+      .from('whatsapp_message_log')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('direction', 'inbound')
+      .gte('created_at', since)
+      .limit(1);
+    return Array.isArray(data) && data.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Send the morning brief to a single WhatsApp user. Smart-routes by
+ * the 24h customer-service window:
+ *   - inside window: free-form text (cheap, full body, full Markdown
+ *     stripped to plain text).
+ *   - outside window: paybacker_morning_summary template — IF
+ *     Meta-approved. If not approved (current state per
+ *     template-registry.ts), log + skip rather than 4xx Twilio.
+ *
+ * Returns 'sent' on a successful Twilio submit, 'skipped' otherwise.
+ * Throws ONLY on unexpected runtime errors — the caller wraps the
+ * whole call in try/catch so per-user failures don't kill the run.
+ */
+async function dispatchWhatsAppMorningBrief(
+  supabase: AdminClient,
+  userId: string,
+  phone: string,
+  markdownBody: string,
+): Promise<'sent' | 'skipped'> {
+  const inWindow = await isInsideWhatsAppServiceWindow(supabase, userId);
+
+  if (inWindow) {
+    const body = toWhatsAppPlainText(markdownBody);
+    try {
+      await sendWhatsAppText({ to: phone, text: body });
+      return 'sent';
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[telegram-morning-summary] WhatsApp text send failed for user ${userId}:`,
+        errMsg,
+      );
+      // Fall through to template attempt — Twilio rejects in-window
+      // sends with a 63016 if the window has just expired between
+      // our check and the send. Trying the template covers that race.
+    }
+  }
+
+  // Outside the window (or text fallback) — template path.
+  const templateName = 'paybacker_morning_summary';
+  const sid = await getTemplateSid(templateName);
+  if (!sid) {
+    console.warn(
+      `[telegram-morning-summary] WhatsApp template ${templateName} not yet approved — skipping user ${userId}`,
+    );
+    return 'skipped';
+  }
+
+  // Best-effort variable extraction from the brief. The template body is:
+  //   "Morning {{1}}. Overnight we scanned {{2}} items and found {{3}}
+  //    opportunities. Top focus: {{4}}. Tap to open today's brief."
+  // We have section-count / opportunity-count signals in the brief but
+  // the template prefers small numeric variables, not full bodies.
+  // Pull the user's first name + a coarse signal so the message is
+  // recognisably "their" morning brief.
+  let firstName = 'there';
+  try {
+    const { data } = await supabase
+      .from('profiles')
+      .select('full_name, email')
+      .eq('id', userId)
+      .maybeSingle();
+    if (data) {
+      const raw = (data.full_name || data.email || 'there').toString().trim();
+      firstName = raw.split(/\s+/)[0] || 'there';
+    }
+  } catch {
+    // Use the default 'there' — name is not load-bearing.
+  }
+
+  // Coarse signals derived from the markdown body so the template doesn't
+  // hard-code zeroes. The body has section headers we can count.
+  const sectionsHit = (markdownBody.match(/\*[A-Z][^*\n]{2,}\*/g) ?? []).length;
+  const renewalsCount = (markdownBody.match(/\*Upcoming Renewals\*/g) ?? []).length;
+  const budgetWarnings = (markdownBody.match(/\*Budget Warnings\*/g) ?? []).length;
+  const opportunities = renewalsCount + budgetWarnings;
+  const topFocus = budgetWarnings > 0
+    ? 'budget warnings'
+    : renewalsCount > 0
+      ? 'upcoming renewals'
+      : 'spending recap';
+
+  try {
+    await sendWhatsAppTemplate({
+      to: phone,
+      templateName,
+      parameters: [
+        firstName,
+        String(sectionsHit),
+        String(opportunities),
+        topFocus,
+      ],
+    });
+    return 'sent';
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[telegram-morning-summary] WhatsApp template send failed for user ${userId}:`,
+      errMsg,
+    );
+    return 'skipped';
+  }
+}
+
 export async function GET(request: NextRequest) {
   const secret = request.headers.get('authorization')?.replace('Bearer ', '');
   if (secret !== process.env.CRON_SECRET) {
@@ -105,20 +446,45 @@ export async function GET(request: NextRequest) {
   let sent = 0;
   let skipped = 0;
   const errors: string[] = [];
+  // WhatsApp dispatch counters tracked independently — same body, different
+  // channel. See block below the Telegram dispatch inside the per-user loop.
+  let whatsappSent = 0;
+  let whatsappSkipped = 0;
+  const whatsappErrors: string[] = [];
 
   // -------------------------------------------------------
-  // Get all active linked Pro users
+  // Get all active linked Pro users (Telegram + WhatsApp — channels
+  // are independent per /dashboard/settings/notifications).
   // -------------------------------------------------------
-  const { data: sessions, error: sessErr } = await supabase
-    .from('telegram_sessions')
-    .select('user_id, telegram_chat_id')
-    .eq('is_active', true);
+  const [{ data: sessions, error: sessErr }, { data: waSessions, error: waSessErr }] =
+    await Promise.all([
+      supabase
+        .from('telegram_sessions')
+        .select('user_id, telegram_chat_id')
+        .eq('is_active', true),
+      supabase
+        .from('whatsapp_sessions')
+        .select('user_id, whatsapp_phone')
+        .eq('is_active', true)
+        .is('opted_out_at', null),
+    ]);
 
-  if (sessErr || !sessions || sessions.length === 0) {
+  if (waSessErr) {
+    console.warn('[telegram-morning-summary] whatsapp_sessions load failed:', waSessErr.message);
+  }
+
+  if (
+    (sessErr || !sessions || sessions.length === 0) &&
+    (!waSessions || waSessions.length === 0)
+  ) {
     return NextResponse.json({ ok: true, message: 'No active sessions', sent: 0 });
   }
 
-  const userIds = sessions.map((s) => s.user_id);
+  const tgSessions = sessions ?? [];
+  const wapSessions = waSessions ?? [];
+  const userIds = Array.from(
+    new Set([...tgSessions.map((s) => s.user_id), ...wapSessions.map((s) => s.user_id)]),
+  );
   const { data: profiles } = await supabase
     .from('profiles')
     .select('id, subscription_tier, subscription_status, stripe_subscription_id, trial_ends_at, trial_converted_at, trial_expired_at')
@@ -133,19 +499,46 @@ export async function GET(request: NextRequest) {
       .map((p) => p.id),
   );
 
-  const proSessions = sessions.filter((s) => proUserIds.has(s.user_id));
+  const proSessions = tgSessions.filter((s) => proUserIds.has(s.user_id));
+  const proWhatsappSessions = wapSessions.filter((s) => proUserIds.has(s.user_id));
 
-  // Check alert preferences — skip users who disabled morning summary
+  // Check alert preferences — skip users who disabled morning summary.
+  // The same `telegram_alert_preferences.morning_summary` flag governs
+  // both Pocket Agent channels today (verified — the settings page writes
+  // a single row per user). When per-channel toggles ship, split here.
+  const allEligibleUserIds = Array.from(
+    new Set([
+      ...proSessions.map((s) => s.user_id),
+      ...proWhatsappSessions.map((s) => s.user_id),
+    ]),
+  );
   const { data: allPrefs } = await supabase
     .from('telegram_alert_preferences')
     .select('user_id, morning_summary')
-    .in('user_id', proSessions.map(s => s.user_id));
+    .in('user_id', allEligibleUserIds);
 
   const prefMap = new Map((allPrefs ?? []).map(p => [p.user_id, p]));
-  const eligibleSessions = proSessions.filter(s => {
-    const pref = prefMap.get(s.user_id);
+  const morningSummaryOn = (userId: string): boolean => {
+    const pref = prefMap.get(userId);
     return !pref || pref.morning_summary !== false; // default to on
-  });
+  };
+  const eligibleSessions = proSessions.filter((s) => morningSummaryOn(s.user_id));
+  const eligibleWhatsappSessions = proWhatsappSessions.filter((s) =>
+    morningSummaryOn(s.user_id),
+  );
+
+  // Index whatsapp sessions by user_id so the per-user loop can find
+  // the matching phone in O(1). Map<user_id, whatsapp_phone>.
+  const whatsappByUserId = new Map<string, string>(
+    eligibleWhatsappSessions.map((s) => [s.user_id, s.whatsapp_phone]),
+  );
+
+  // Track which users got a WhatsApp send via the Telegram loop so the
+  // standalone WhatsApp loop (for users with NO Telegram session) doesn't
+  // double-dispatch. The DB mutex is supposed to guarantee at most one
+  // active row per user, but this cron treats them as independent so
+  // belt-and-braces here.
+  const whatsappDispatchedUserIds = new Set<string>();
 
   // -------------------------------------------------------
   // Date helpers
@@ -182,175 +575,63 @@ export async function GET(request: NextRequest) {
   // -------------------------------------------------------
   // Process each Pro user
   // -------------------------------------------------------
+  const briefCtx: BriefDateContext = {
+    now,
+    todayStr,
+    tomorrowStr,
+    in7DaysStr,
+    yesterdayStart,
+    todayStart,
+    tipIndex,
+  };
   for (const session of eligibleSessions) {
     const { user_id: userId, telegram_chat_id: chatId } = session;
 
     try {
-      // Check if user has any bank transaction data at all
-      const { count: txCount } = await supabase
-        .from('bank_transactions')
-        .select('id', { count: 'exact', head: true })
-        .eq('user_id', userId);
-
-      if (!txCount || txCount === 0) {
+      // ------ Build the brief (helper handles "no transactions = null") ------
+      const message = await buildMorningBrief(supabase, userId, briefCtx);
+      if (!message) {
         skipped++;
         continue;
       }
 
-      const sections: string[] = [];
-      sections.push('*Good morning! Here\'s your daily money briefing:*');
-
-      // ------ 1. Yesterday's spending ------
-      // Mirror lib/spending.ts exclusions so the morning summary matches
-      // Money Hub + the weekly digest. Previous list was just
-      // ('transfers','income') which double-counted credit-card bill
-      // repayments + investments + pension contributions.
-      const EXCLUDE_CATS = new Set([
-        'transfer', 'transfers', 'internal_transfer', 'self_transfer',
-        'credit_card_payment', 'credit_card',
-        'investment', 'investments', 'savings', 'pension',
-        'income', 'fee_refund',
-      ]);
-      const { data: yesterdayTxRaw } = await supabase
-        .from('bank_transactions')
-        .select('user_category, amount')
-        .eq('user_id', userId)
-        .lt('amount', 0)
-        .gte('timestamp', yesterdayStart.toISOString())
-        .lt('timestamp', todayStart.toISOString());
-
-      const yesterdayTx = (yesterdayTxRaw ?? []).filter(
-        t => !EXCLUDE_CATS.has(t.user_category ?? ''),
-      );
-
-      if (yesterdayTx.length > 0) {
-        const total = yesterdayTx.reduce((sum, t) => sum + Math.abs(Number(t.amount)), 0);
-        const byCategory: Record<string, number> = {};
-        for (const t of yesterdayTx) {
-          const cat = t.user_category ?? 'Other';
-          byCategory[cat] = (byCategory[cat] ?? 0) + Math.abs(Number(t.amount));
-        }
-
-        const topCategories = Object.entries(byCategory)
-          .sort(([, a], [, b]) => b - a)
-          .slice(0, 3);
-
-        let spendingSection = `\n\n*Yesterday's Spending*\nTotal: *${fmt(total)}*`;
-        if (topCategories.length > 0) {
-          spendingSection += '\nTop categories:';
-          for (const [cat, amount] of topCategories) {
-            spendingSection += `\n  - ${cat}: ${fmt(amount)}`;
-          }
-        }
-        sections.push(spendingSection);
-      } else {
-        sections.push('\n\n*Yesterday\'s Spending*\nNo spending recorded yesterday.');
-      }
-
-      // ------ 2. Subscriptions renewing today or tomorrow ------
-      const { data: renewals } = await supabase
-        .from('subscriptions')
-        .select('provider_name, amount, billing_cycle, next_billing_date')
-        .eq('user_id', userId)
-        .eq('status', 'active')
-        .gte('next_billing_date', todayStr)
-        .lte('next_billing_date', tomorrowStr);
-
-      if (renewals && renewals.length > 0) {
-        let renewalSection = '\n\n*Upcoming Renewals*';
-        for (const sub of renewals) {
-          const when = sub.next_billing_date === todayStr ? 'Today' : 'Tomorrow';
-          renewalSection += `\n  - ${sub.provider_name}: ${fmt(Number(sub.amount))}/${sub.billing_cycle ?? 'month'} (${when})`;
-        }
-        sections.push(renewalSection);
-      }
-
-      // ------ 3. Contracts expiring this week ------
-      const { data: expiringContracts } = await supabase
-        .from('subscriptions')
-        .select('provider_name, contract_end_date, amount, billing_cycle')
-        .eq('user_id', userId)
-        .eq('status', 'active')
-        .not('contract_end_date', 'is', null)
-        .gte('contract_end_date', todayStr)
-        .lte('contract_end_date', in7DaysStr);
-
-      if (expiringContracts && expiringContracts.length > 0) {
-        let contractSection = '\n\n*Contracts Expiring This Week*';
-        for (const c of expiringContracts) {
-          contractSection += `\n  - ${c.provider_name}: ends ${fmtDate(c.contract_end_date)}`;
-        }
-        sections.push(contractSection);
-      }
-
-      // ------ 4. Budget status (categories over 80%) ------
-      const [budgetsResult, monthSpendingResult] = await Promise.all([
-        supabase
-          .from('money_hub_budgets')
-          .select('category, monthly_limit')
-          .eq('user_id', userId),
-        supabase.rpc('get_monthly_spending', {
-          p_user_id: userId,
-          p_year: now.getFullYear(),
-          p_month: now.getMonth() + 1,
-        }),
-      ]);
-
-      const spentByCategory: Record<string, number> = {};
-      for (const row of monthSpendingResult.data ?? []) {
-        spentByCategory[row.category] = Number(row.category_total);
-      }
-
-      const budgetWarnings: Array<{ category: string; spent: number; limit: number; pct: number }> =
-        [];
-      for (const b of budgetsResult.data ?? []) {
-        const limit = Number(b.monthly_limit);
-        const spentAmt = spentByCategory[b.category] ?? 0;
-        const pct = limit > 0 ? (spentAmt / limit) * 100 : 0;
-        if (pct >= 80) {
-          budgetWarnings.push({ category: b.category, spent: spentAmt, limit, pct });
-        }
-      }
-
-      if (budgetWarnings.length > 0) {
-        budgetWarnings.sort((a, b) => b.pct - a.pct);
-        let budgetSection = '\n\n*Budget Warnings*';
-        for (const w of budgetWarnings) {
-          const emoji = w.pct >= 100 ? '\u26a0\ufe0f' : '\u23f3';
-          budgetSection += `\n  ${emoji} ${w.category}: ${fmt(w.spent)} / ${fmt(w.limit)} (${Math.round(w.pct)}%)`;
-        }
-        sections.push(budgetSection);
-      }
-
-      // ------ 5. Unresolved disputes ------
-      const { data: openDisputes } = await supabase
-        .from('disputes')
-        .select('id, provider_name, issue_type, status')
-        .eq('user_id', userId)
-        .not('status', 'in', '(resolved,dismissed)');
-
-      if (openDisputes && openDisputes.length > 0) {
-        let disputeSection = `\n\n*Open Disputes (${openDisputes.length})*`;
-        for (const d of openDisputes.slice(0, 3)) {
-          disputeSection += `\n  - ${d.provider_name}: ${d.issue_type} (${d.status})`;
-        }
-        if (openDisputes.length > 3) {
-          disputeSection += `\n  _...and ${openDisputes.length - 3} more_`;
-        }
-        sections.push(disputeSection);
-      }
-
-      // ------ 6. Money-saving tip of the day ------
-      sections.push(`\n\n\ud83d\udca1 *Tip of the Day*\n${MONEY_TIPS[tipIndex]}`);
-
-      // ------ Build and send ------
-      const message = sections.join('');
+      // ------ Send via Telegram ------
       const ok = await sendTelegramMessage(token, Number(chatId), message);
 
       if (ok) {
         sent++;
       } else {
         errors.push(`Failed to send to user ${userId}`);
+      }
+
+      // ------ WhatsApp dispatch (independent channel) ------
+      // If this user also has an active WhatsApp Pocket Agent session,
+      // fan the same body out there too. Wrapped in its own try/catch
+      // so a bad number / unapproved template / Twilio outage can't
+      // kill the Telegram run for the rest of the user list.
+      const waPhone = whatsappByUserId.get(userId);
+      if (waPhone) {
+        try {
+          const waOutcome = await dispatchWhatsAppMorningBrief(
+            supabase,
+            userId,
+            waPhone,
+            message,
+          );
+          if (waOutcome === 'sent') {
+            whatsappSent++;
+          } else {
+            whatsappSkipped++;
+          }
+        } catch (waErr) {
+          const errMsg = waErr instanceof Error ? waErr.message : String(waErr);
+          console.error(
+            `[telegram-morning-summary] WhatsApp dispatch failed for user ${userId}:`,
+            errMsg,
+          );
+          whatsappErrors.push(`${userId}: ${errMsg}`);
+        }
+        whatsappDispatchedUserIds.add(userId);
       }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
@@ -359,8 +640,47 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  // -------------------------------------------------------
+  // WhatsApp-only users (no active Telegram session) — build the
+  // brief and dispatch via WhatsApp. Reuses the same Supabase
+  // queries from the Telegram loop via buildMorningBrief().
+  // -------------------------------------------------------
+  const waOnlyUsers = eligibleWhatsappSessions.filter(
+    (s) => !whatsappDispatchedUserIds.has(s.user_id),
+  );
+  for (const session of waOnlyUsers) {
+    const { user_id: userId, whatsapp_phone: waPhone } = session;
+    try {
+      const message = await buildMorningBrief(supabase, userId, briefCtx);
+      if (!message) {
+        // Either no bank transactions yet, or the helper bailed.
+        whatsappSkipped++;
+        continue;
+      }
+      const waOutcome = await dispatchWhatsAppMorningBrief(
+        supabase,
+        userId,
+        waPhone,
+        message,
+      );
+      if (waOutcome === 'sent') {
+        whatsappSent++;
+      } else {
+        whatsappSkipped++;
+      }
+    } catch (waErr) {
+      const errMsg = waErr instanceof Error ? waErr.message : String(waErr);
+      console.error(
+        `[telegram-morning-summary] WhatsApp-only dispatch failed for user ${userId}:`,
+        errMsg,
+      );
+      whatsappErrors.push(`${userId}: ${errMsg}`);
+    }
+  }
+
   console.log(
-    `[telegram-morning-summary] Processed ${proSessions.length} users, sent ${sent}, skipped ${skipped}, errors ${errors.length}`,
+    `[telegram-morning-summary] Telegram: processed ${proSessions.length} users, sent ${sent}, skipped ${skipped}, errors ${errors.length}. ` +
+      `WhatsApp: sent ${whatsappSent}, skipped ${whatsappSkipped}, errors ${whatsappErrors.length}.`,
   );
 
   // Alert founder if the cron ran with eligible users but sent nothing
@@ -382,5 +702,9 @@ export async function GET(request: NextRequest) {
     sent,
     skipped,
     errors: errors.length,
+    whatsappUsers: proWhatsappSessions.length,
+    whatsappSent,
+    whatsappSkipped,
+    whatsappErrors: whatsappErrors.length,
   });
 }

--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -327,6 +327,29 @@ async function isInsideWhatsAppServiceWindow(
 }
 
 /**
+ * Recognise template-send failures that represent an *intentional* skip
+ * rather than an operational outage.
+ *
+ * Today the only such case is "no eligible WhatsApp template configured"
+ * — which the Twilio provider surfaces as a `PENDING_RESUBMISSION`
+ * pending-Meta error string when the registry SID is the placeholder and
+ * neither the env-var override nor the DB SID has been set. In that
+ * scenario there's nothing the cron can do at runtime — Meta has to
+ * approve the template — so it's correctly classified as a skip.
+ *
+ * Genuine operational failures (Twilio HTTP non-2xx, network/DNS errors,
+ * auth issues, invalid phone formatting, unexpected exceptions) MUST NOT
+ * be matched here — they need to surface as `whatsappErrors` so on-call
+ * sees a real delivery outage instead of silent skipping.
+ */
+function isIntentionalTemplateSkip(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  // The Twilio provider's "template pending Meta resubmission" guard:
+  // see src/lib/whatsapp/twilio-provider.ts ~line 105.
+  return /pending Meta resubmission/i.test(msg);
+}
+
+/**
  * Send the morning brief to a single WhatsApp user. Smart-routes by
  * the 24h customer-service window:
  *   - inside window: free-form text (cheap, full body, full Markdown
@@ -335,24 +358,37 @@ async function isInsideWhatsAppServiceWindow(
  *     Meta-approved. If not approved (current state per
  *     template-registry.ts), log + skip rather than 4xx Twilio.
  *
- * Returns 'sent' on a successful Twilio submit, 'skipped' otherwise.
- * Throws ONLY on unexpected runtime errors — the caller wraps the
- * whole call in try/catch so per-user failures don't kill the run.
+ * Returns:
+ *   - 'sent'    on a successful Twilio submit
+ *   - 'skipped' for *intentional* skips (e.g. template not approved /
+ *     pending Meta resubmission with no env or DB SID configured)
+ *   - 'error'   for genuine operational failures — Twilio HTTP error,
+ *     network/auth/format issue, anything else the provider throws.
+ *     Caller MUST count these as whatsappErrors, not whatsappSkipped,
+ *     so on-call sees real outages instead of silent skipping.
+ *
+ * Never throws — operational errors are converted to `'error'` so the
+ * caller's bookkeeping stays simple.
  */
 async function dispatchWhatsAppMorningBrief(
   supabase: AdminClient,
   userId: string,
   phone: string,
   markdownBody: string,
-): Promise<'sent' | 'skipped'> {
+): Promise<{ status: 'sent' | 'skipped' | 'error'; reason?: string }> {
   const inWindow = await isInsideWhatsAppServiceWindow(supabase, userId);
 
+  // Track the in-window text-send failure (if any) so that, if the
+  // template fallback also fails, we surface the *original* operational
+  // error rather than the secondary template error.
+  let inWindowTextError: unknown | undefined;
   if (inWindow) {
     const body = toWhatsAppPlainText(markdownBody);
     try {
       await sendWhatsAppText({ to: phone, text: body });
-      return 'sent';
+      return { status: 'sent' };
     } catch (err) {
+      inWindowTextError = err;
       const errMsg = err instanceof Error ? err.message : String(err);
       console.error(
         `[telegram-morning-summary] WhatsApp text send failed for user ${userId}:`,
@@ -369,7 +405,9 @@ async function dispatchWhatsAppMorningBrief(
   // order (TWILIO_TEMPLATE_<NAME> env override → DB override → registry)
   // and may also reject the PENDING_RESUBMISSION placeholder cleanly. We
   // always attempt the send and rely on the provider to throw on
-  // unsendable state — that error is logged and tallied as a skip below.
+  // unsendable state — only the *intentional* skip patterns (template
+  // not approved) are reclassified as 'skipped'; everything else is
+  // surfaced as 'error' so monitoring/on-call sees real outages.
   const templateName = 'paybacker_morning_summary';
 
   // Best-effort variable extraction from the brief. The template body is:
@@ -417,14 +455,40 @@ async function dispatchWhatsAppMorningBrief(
         topFocus,
       ],
     });
-    return 'sent';
+    return { status: 'sent' };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
+    if (isIntentionalTemplateSkip(err)) {
+      // Known "no eligible template / pending Meta resubmission" case.
+      // Nothing the cron can do at runtime — log at warn level and
+      // count as a normal skip. If the in-window text-send also failed
+      // first (e.g. window just expired), prefer surfacing that as a
+      // genuine error since it isn't an intentional skip.
+      if (inWindowTextError) {
+        const textMsg =
+          inWindowTextError instanceof Error
+            ? inWindowTextError.message
+            : String(inWindowTextError);
+        console.error(
+          `[telegram-morning-summary] WhatsApp delivery failed for user ${userId} (in-window text errored, template not approved):`,
+          textMsg,
+        );
+        return { status: 'error', reason: textMsg };
+      }
+      console.warn(
+        `[telegram-morning-summary] WhatsApp template skipped for user ${userId} (not approved):`,
+        errMsg,
+      );
+      return { status: 'skipped', reason: errMsg };
+    }
+    // Operational failure — Twilio outage, bad credentials, malformed
+    // phone, network blip, etc. Bubble up as 'error' so the cron's
+    // whatsappErrors counter increments and on-call sees the outage.
     console.error(
       `[telegram-morning-summary] WhatsApp template send failed for user ${userId}:`,
       errMsg,
     );
-    return 'skipped';
+    return { status: 'error', reason: errMsg };
   }
 }
 
@@ -434,17 +498,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  // Telegram is now optional — environments running WhatsApp-only (no
+  // Telegram is OPTIONAL — environments running WhatsApp-only (no
   // Telegram bot token configured) must still be able to fan out the
-  // morning brief to active whatsapp_sessions. Gate the Telegram path
-  // behind a flag rather than 500-ing the whole handler.
+  // morning brief to active whatsapp_sessions.
+  //
+  // We deliberately do NOT 4xx/5xx here on missing TELEGRAM_USER_BOT_TOKEN.
+  // The Codex P2 finding was that an early 500 would silently block
+  // independent WhatsApp dispatch — so the token check is deferred
+  // until AFTER session loading and only treated as a problem when
+  // there are actually Telegram recipients to send to. If there are
+  // zero eligible Telegram sessions, missing token is a no-op.
   const token = (process.env.TELEGRAM_USER_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN);
-  const telegramEnabled = Boolean(token);
-  if (!telegramEnabled) {
-    console.warn(
-      '[telegram-morning-summary] TELEGRAM_USER_BOT_TOKEN not set — Telegram dispatch disabled, WhatsApp-only run.',
-    );
-  }
 
   const supabase = getAdmin();
   let sent = 0;
@@ -530,6 +594,19 @@ export async function GET(request: NextRequest) {
   const eligibleWhatsappSessions = proWhatsappSessions.filter((s) =>
     morningSummaryOn(s.user_id),
   );
+
+  // POST-SESSION-LOAD Telegram gate (P2 fix): only treat the missing
+  // bot token as a problem when there are actually Telegram recipients
+  // to send to. With zero eligible Telegram sessions, missing token is
+  // a no-op and the WhatsApp path proceeds independently below.
+  const telegramEnabled = Boolean(token);
+  if (eligibleSessions.length > 0 && !telegramEnabled) {
+    console.warn(
+      '[telegram-morning-summary] TELEGRAM_USER_BOT_TOKEN not set despite ' +
+        `${eligibleSessions.length} eligible Telegram session(s) — those users ` +
+        'will be skipped this run; WhatsApp dispatch continues.',
+    );
+  }
 
   // Index whatsapp sessions by user_id so the per-user loop can find
   // the matching phone in O(1). Map<user_id, whatsapp_phone>.
@@ -627,12 +704,19 @@ export async function GET(request: NextRequest) {
               waPhone,
               message,
             );
-            if (waOutcome === 'sent') {
+            if (waOutcome.status === 'sent') {
               whatsappSent++;
-            } else {
+            } else if (waOutcome.status === 'skipped') {
               whatsappSkipped++;
+            } else {
+              // 'error' — operational failure (Twilio HTTP, network,
+              // auth, bad phone format, etc). Surface to on-call.
+              whatsappErrors.push(`${userId}: ${waOutcome.reason ?? 'unknown'}`);
             }
           } catch (waErr) {
+            // Defensive: dispatchWhatsAppMorningBrief no longer throws,
+            // but if anything in the surrounding code (Supabase lookups,
+            // etc) does, treat that as an error rather than a skip.
             const errMsg = waErr instanceof Error ? waErr.message : String(waErr);
             console.error(
               `[telegram-morning-summary] WhatsApp dispatch failed for user ${userId}:`,
@@ -673,10 +757,14 @@ export async function GET(request: NextRequest) {
         waPhone,
         message,
       );
-      if (waOutcome === 'sent') {
+      if (waOutcome.status === 'sent') {
         whatsappSent++;
-      } else {
+      } else if (waOutcome.status === 'skipped') {
         whatsappSkipped++;
+      } else {
+        // 'error' — operational failure, push to whatsappErrors so the
+        // route's response body and on-call alerting reflect reality.
+        whatsappErrors.push(`${userId}: ${waOutcome.reason ?? 'unknown'}`);
       }
     } catch (waErr) {
       const errMsg = waErr instanceof Error ? waErr.message : String(waErr);

--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -27,7 +27,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { isProPocketAgentEligible } from '@/lib/telegram/eligibility';
 import { sendWhatsAppText, sendWhatsAppTemplate } from '@/lib/whatsapp';
-import { getTemplateSid } from '@/lib/whatsapp/template-sids';
 
 export const runtime = 'nodejs';
 export const maxDuration = 120;
@@ -366,20 +365,12 @@ async function dispatchWhatsAppMorningBrief(
   }
 
   // Outside the window (or text fallback) — template path.
-  // Skip only when no SID exists at all. `getTemplateSid` mirrors the
-  // Twilio provider's full resolution order: TWILIO_TEMPLATE_<NAME>
-  // env override → DB override (populated via /dashboard/admin/whatsapp
-  // Resubmit) → registry fallback. So a `null` here means there's
-  // genuinely nothing send-safe — even a registry default of
-  // PENDING_RESUBMISSION can dispatch via the override path.
+  // No pre-flight SID gate: the Twilio provider owns the full resolution
+  // order (TWILIO_TEMPLATE_<NAME> env override → DB override → registry)
+  // and may also reject the PENDING_RESUBMISSION placeholder cleanly. We
+  // always attempt the send and rely on the provider to throw on
+  // unsendable state — that error is logged and tallied as a skip below.
   const templateName = 'paybacker_morning_summary';
-  const sid = await getTemplateSid(templateName);
-  if (!sid) {
-    console.warn(
-      `[telegram-morning-summary] WhatsApp template ${templateName} not yet approved — skipping user ${userId}`,
-    );
-    return 'skipped';
-  }
 
   // Best-effort variable extraction from the brief. The template body is:
   //   "Morning {{1}}. Overnight we scanned {{2}} items and found {{3}}
@@ -443,9 +434,16 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  // Telegram is now optional — environments running WhatsApp-only (no
+  // Telegram bot token configured) must still be able to fan out the
+  // morning brief to active whatsapp_sessions. Gate the Telegram path
+  // behind a flag rather than 500-ing the whole handler.
   const token = (process.env.TELEGRAM_USER_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN);
-  if (!token) {
-    return NextResponse.json({ error: 'TELEGRAM_USER_BOT_TOKEN not set' }, { status: 500 });
+  const telegramEnabled = Boolean(token);
+  if (!telegramEnabled) {
+    console.warn(
+      '[telegram-morning-summary] TELEGRAM_USER_BOT_TOKEN not set — Telegram dispatch disabled, WhatsApp-only run.',
+    );
   }
 
   const supabase = getAdmin();
@@ -590,59 +588,65 @@ export async function GET(request: NextRequest) {
     todayStart,
     tipIndex,
   };
-  for (const session of eligibleSessions) {
-    const { user_id: userId, telegram_chat_id: chatId } = session;
+  // The Telegram dispatch loop only runs when the bot token is present.
+  // When telegramEnabled is false, users with both Telegram and WhatsApp
+  // sessions get picked up by the WhatsApp-only loop below (the
+  // whatsappDispatchedUserIds Set stays empty so no user is skipped).
+  if (telegramEnabled && token) {
+    for (const session of eligibleSessions) {
+      const { user_id: userId, telegram_chat_id: chatId } = session;
 
-    try {
-      // ------ Build the brief (helper handles "no transactions = null") ------
-      const message = await buildMorningBrief(supabase, userId, briefCtx);
-      if (!message) {
-        skipped++;
-        continue;
-      }
-
-      // ------ Send via Telegram ------
-      const ok = await sendTelegramMessage(token, Number(chatId), message);
-
-      if (ok) {
-        sent++;
-      } else {
-        errors.push(`Failed to send to user ${userId}`);
-      }
-
-      // ------ WhatsApp dispatch (independent channel) ------
-      // If this user also has an active WhatsApp Pocket Agent session,
-      // fan the same body out there too. Wrapped in its own try/catch
-      // so a bad number / unapproved template / Twilio outage can't
-      // kill the Telegram run for the rest of the user list.
-      const waPhone = whatsappByUserId.get(userId);
-      if (waPhone) {
-        try {
-          const waOutcome = await dispatchWhatsAppMorningBrief(
-            supabase,
-            userId,
-            waPhone,
-            message,
-          );
-          if (waOutcome === 'sent') {
-            whatsappSent++;
-          } else {
-            whatsappSkipped++;
-          }
-        } catch (waErr) {
-          const errMsg = waErr instanceof Error ? waErr.message : String(waErr);
-          console.error(
-            `[telegram-morning-summary] WhatsApp dispatch failed for user ${userId}:`,
-            errMsg,
-          );
-          whatsappErrors.push(`${userId}: ${errMsg}`);
+      try {
+        // ------ Build the brief (helper handles "no transactions = null") ------
+        const message = await buildMorningBrief(supabase, userId, briefCtx);
+        if (!message) {
+          skipped++;
+          continue;
         }
-        whatsappDispatchedUserIds.add(userId);
+
+        // ------ Send via Telegram ------
+        const ok = await sendTelegramMessage(token, Number(chatId), message);
+
+        if (ok) {
+          sent++;
+        } else {
+          errors.push(`Failed to send to user ${userId}`);
+        }
+
+        // ------ WhatsApp dispatch (independent channel) ------
+        // If this user also has an active WhatsApp Pocket Agent session,
+        // fan the same body out there too. Wrapped in its own try/catch
+        // so a bad number / unapproved template / Twilio outage can't
+        // kill the Telegram run for the rest of the user list.
+        const waPhone = whatsappByUserId.get(userId);
+        if (waPhone) {
+          try {
+            const waOutcome = await dispatchWhatsAppMorningBrief(
+              supabase,
+              userId,
+              waPhone,
+              message,
+            );
+            if (waOutcome === 'sent') {
+              whatsappSent++;
+            } else {
+              whatsappSkipped++;
+            }
+          } catch (waErr) {
+            const errMsg = waErr instanceof Error ? waErr.message : String(waErr);
+            console.error(
+              `[telegram-morning-summary] WhatsApp dispatch failed for user ${userId}:`,
+              errMsg,
+            );
+            whatsappErrors.push(`${userId}: ${errMsg}`);
+          }
+          whatsappDispatchedUserIds.add(userId);
+        }
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.error(`[telegram-morning-summary] Error for user ${userId}:`, errMsg);
+        errors.push(`${userId}: ${errMsg}`);
       }
-    } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
-      console.error(`[telegram-morning-summary] Error for user ${userId}:`, errMsg);
-      errors.push(`${userId}: ${errMsg}`);
     }
   }
 
@@ -689,9 +693,17 @@ export async function GET(request: NextRequest) {
       `WhatsApp: sent ${whatsappSent}, skipped ${whatsappSkipped}, errors ${whatsappErrors.length}.`,
   );
 
-  // Alert founder if the cron ran with eligible users but sent nothing
+  // Alert founder if the cron ran with eligible users but sent nothing.
+  // Skipped when Telegram isn't configured (no token to call the API with).
   const founderChatId = process.env.TELEGRAM_FOUNDER_CHAT_ID;
-  if (founderChatId && eligibleSessions.length > 0 && sent === 0 && errors.length > 0) {
+  if (
+    telegramEnabled &&
+    token &&
+    founderChatId &&
+    eligibleSessions.length > 0 &&
+    sent === 0 &&
+    errors.length > 0
+  ) {
     await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/src/app/api/cron/telegram-morning-summary/route.ts
+++ b/src/app/api/cron/telegram-morning-summary/route.ts
@@ -366,6 +366,12 @@ async function dispatchWhatsAppMorningBrief(
   }
 
   // Outside the window (or text fallback) — template path.
+  // Skip only when no SID exists at all. `getTemplateSid` mirrors the
+  // Twilio provider's full resolution order: TWILIO_TEMPLATE_<NAME>
+  // env override → DB override (populated via /dashboard/admin/whatsapp
+  // Resubmit) → registry fallback. So a `null` here means there's
+  // genuinely nothing send-safe — even a registry default of
+  // PENDING_RESUBMISSION can dispatch via the override path.
   const templateName = 'paybacker_morning_summary';
   const sid = await getTemplateSid(templateName);
   if (!sid) {

--- a/src/lib/whatsapp/template-sids.ts
+++ b/src/lib/whatsapp/template-sids.ts
@@ -8,10 +8,17 @@
  * `whatsapp_template_sids` (Supabase) along with the Meta approval status.
  *
  * Dispatch paths should call `getTemplateSid(name)` instead of reading
- * `TEMPLATES[name].sid` directly. The resolver returns:
- *   - the DB SID if the row exists AND `approval_status === 'approved'`,
- *   - the registry fallback SID if the registry has a real (non-PENDING) SID,
- *   - null when nothing is approved yet (caller should skip the send).
+ * `TEMPLATES[name].sid` directly. The resolver mirrors the same SID
+ * resolution order the Twilio provider uses, so a preflight skip-check
+ * by the cron can never incorrectly suppress a send the provider would
+ * have completed:
+ *   1. `TWILIO_TEMPLATE_<NAME>` env override — lets ops pin a SID
+ *      without a code deploy if Meta force-resubmits one.
+ *   2. DB SID from `whatsapp_template_sids` when the row exists AND
+ *      `approval_status === 'approved'`.
+ *   3. The registry fallback SID, if the registry has a real
+ *      (non-PENDING) SID.
+ *   4. `null` when nothing usable is configured (caller should skip).
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -42,8 +49,20 @@ function adminClient() {
  * Resolve the live, send-safe SID for a template name. Returns null when
  * the template isn't approved (caller MUST skip the send rather than
  * pass a pending/rejected SID to Twilio).
+ *
+ * Order matches `TwilioWhatsAppProvider.sendTemplate` so a preflight
+ * caller (e.g. the morning-brief cron) sees the same SID the provider
+ * would actually use — no false skips when ops has pinned a SID via
+ * env override or via the /dashboard/admin/whatsapp Resubmit panel.
  */
 export async function getTemplateSid(name: string): Promise<string | null> {
+  // 1. Env override wins — this is how ops pins a SID without a deploy
+  //    when Meta force-resubmits a template. The Twilio provider checks
+  //    this first too; the preflight must mirror it or the cron will
+  //    skip every send while the override is the only working source.
+  const envOverride = process.env[`TWILIO_TEMPLATE_${name.toUpperCase()}`];
+  if (envOverride) return envOverride;
+
   const sb = adminClient();
   if (sb) {
     const { data } = await sb

--- a/src/lib/whatsapp/twilio-provider.ts
+++ b/src/lib/whatsapp/twilio-provider.ts
@@ -11,7 +11,7 @@
  */
 
 import crypto from 'node:crypto';
-import { TEMPLATES, type TemplateName } from './template-registry';
+import { TEMPLATES, PENDING_RESUBMISSION, type TemplateName } from './template-registry';
 import type {
   InboundMessage,
   SendTemplateOptions,
@@ -90,8 +90,22 @@ export class TwilioWhatsAppProvider implements WhatsAppProvider {
     const { getTemplateSid } = await import('./template-sids');
     const dbSid = await getTemplateSid(opts.templateName);
     const registry = (TEMPLATES as Record<string, { sid: string }>)[opts.templateName as TemplateName];
-    const contentSid = envOverride || dbSid || registry?.sid;
+    // Reject the registry's `PENDING_RESUBMISSION` placeholder — it's not a
+    // valid Twilio ContentSid. Without this guard the provider would POST the
+    // literal string "PENDING_RESUBMISSION" and Twilio would 400. Callers
+    // upstream rely on this throwing a clean error rather than skipping
+    // pre-emptively, so we never attempt the send when the only candidate
+    // SID is the placeholder.
+    const registrySid =
+      registry?.sid && registry.sid !== PENDING_RESUBMISSION ? registry.sid : undefined;
+    const contentSid = envOverride || dbSid || registrySid;
     const from = requireEnv('TWILIO_WHATSAPP_FROM');
+
+    if (!contentSid && registry?.sid === PENDING_RESUBMISSION) {
+      throw new Error(
+        `[whatsapp/twilio] template "${opts.templateName}" is pending Meta resubmission — set TWILIO_TEMPLATE_${opts.templateName.toUpperCase()} or update whatsapp_template_sids to send.`,
+      );
+    }
 
     if (contentSid) {
       const params: Record<string, string> = {


### PR DESCRIPTION
## Summary

- The Pro morning summary cron at `/api/cron/telegram-morning-summary` was Telegram-only — Pro users on WhatsApp (e.g. Paul) got nothing at 7:30am UK time. Surgical extension: same brief body now fans out to WhatsApp Pocket Agent sessions independently of Telegram.
- Loads active `whatsapp_sessions` (`is_active = true AND opted_out_at IS NULL`) alongside `telegram_sessions` and unions the user set, so users with ONLY a WhatsApp session also get the brief. Same `morning_summary !== false` opt-out from `telegram_alert_preferences` governs both channels.
- Smart 24h-window routing per Meta's customer-service rules: free-text via `sendWhatsAppText` inside the window (cheap, full body, Markdown stripped), `paybacker_morning_summary` template outside. Template SID resolved at runtime via `getTemplateSid` — skips with a log when still `PENDING_RESUBMISSION` rather than 4xx-ing Twilio.
- Per-user try/catch on the WhatsApp leg so a bad number / unapproved template / Twilio outage can't kill the run for the rest of the user list. `whatsappSent` / `whatsappSkipped` / `whatsappErrors` tracked separately in the response JSON.
- Extracted the brief body-builder (`buildMorningBrief`) so both the Telegram loop and the new WhatsApp-only loop share one implementation. No B2B surfaces or other crons touched. `npx tsc --noEmit` clean.

## Test plan

- [ ] Curl the cron locally with `Authorization: Bearer $CRON_SECRET` against a dev DB seeded with one user that has BOTH a `telegram_sessions` row and a `whatsapp_sessions` row — confirm response shows `sent: 1, whatsappSent: 1` and the message lands on both channels.
- [ ] Curl with a user that has ONLY a `whatsapp_sessions` row — confirm `whatsappSent: 1` and the brief lands.
- [ ] Curl with `whatsapp_sessions.opted_out_at` set — confirm the user is filtered out (`whatsappSkipped` does NOT increment because they were never in the eligible set).
- [ ] Set `telegram_alert_preferences.morning_summary = false` for a user — confirm both Telegram and WhatsApp dispatch are skipped for them.
- [ ] With `paybacker_morning_summary` template still PENDING_RESUBMISSION (current state) and the user OUTSIDE the 24h window — confirm `whatsappSkipped` increments and the Twilio API is NOT called (look for the "WhatsApp template ... not yet approved" log line).
- [ ] Insert a recent `whatsapp_message_log` inbound row for the user, then re-run — confirm the helper takes the in-window text path instead of the template path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)