### PR TITLE
feat(bot): miscellaneous parity (4 tools)

### DIFF
--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -5962,6 +5962,37 @@ async function getContractAlertsForBot(
   const days = withinDays ?? 60;
   const cutoff = new Date(Date.now() + days * 86400_000).toISOString().slice(0, 10);
   const today = new Date().toISOString().slice(0, 10);
+
+  // Pull in-app contract renewal alerts (the canonical row dismiss_contract_alert
+  // operates on) so the bot can surface the UUID needed for dismissal. Falls
+  // back to the subscriptions-based listing if no alerts have been generated
+  // yet by the contract-expiry cron.
+  const { data: alerts } = await supabase
+    .from('contract_renewal_alerts')
+    .select('id, provider_name, category, contract_end_date, current_amount, alert_type, potential_saving_monthly, potential_saving_annual')
+    .eq('user_id', userId)
+    .eq('alert_channel', 'in_app')
+    .in('status', ['pending', 'sent'])
+    .gte('contract_end_date', today)
+    .lte('contract_end_date', cutoff)
+    .order('contract_end_date', { ascending: true });
+
+  if (alerts && alerts.length > 0) {
+    let text = `*Contract alerts (within ${days} days):*\n`;
+    for (const a of alerts) {
+      const amount = a.current_amount != null ? fmt(Number(a.current_amount)) : '—';
+      text += `\n• *${a.provider_name}* — ends ${fmtDate(a.contract_end_date)} · ${amount}/mo`;
+      if (a.potential_saving_monthly) {
+        text += ` · save ~${fmt(Number(a.potential_saving_monthly))}/mo with a switch`;
+      }
+      text += `\n  · id: \`${a.id}\` (use this for dismiss_contract_alert)`;
+    }
+    return { text };
+  }
+
+  // No generated alerts yet — fall back to the subscriptions table so the user
+  // still sees what's coming up. Dismissal needs a contract_renewal_alerts row,
+  // which the cron creates closer to the renewal date.
   const { data } = await supabase
     .from('subscriptions')
     .select('provider_name, contract_end_date, amount, billing_cycle, early_exit_fee, auto_renews')
@@ -6601,7 +6632,10 @@ async function renewBankConsent(
     return { text: `No bank connection matches "${bankName ?? ''}". Try get_bank_connections.` };
   }
 
-  if (data.length > 1 && !bankName) {
+  // If only one connection actually needs renewal, auto-select it and skip
+  // the disambiguation prompt — the documented behaviour is "if only one
+  // connection needs renewal, that one is used".
+  if (data.length > 1 && !bankName && renewable.length !== 1) {
     const list = data.map((c) => `• ${c.bank_name ?? 'Unknown'} (${c.status})`).join('\n');
     return { text: `You have ${data.length} bank connections:\n${list}\n\nSay "renew consent for [bank name]" so I know which one.` };
   }

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -464,6 +464,11 @@ export async function executeToolCall(
     case 'start_subscription_cancel': return startSubscriptionCancel();
     case 'start_account_deletion': return startAccountDeletion(supabase, userId, toolInput.reason as string | undefined);
     case 'start_data_export_download': return startDataExportDownload(supabase, userId);
+    // ===== Phase 3d — misc parity =====
+    case 'scan_receipt': return scanReceipt(toolInput.receipt_text as string, toolInput.suggested_action as string | undefined);
+    case 'renew_bank_consent': return renewBankConsent(supabase, userId, toolInput.bank_name as string | undefined);
+    case 'dismiss_contract_alert': return dismissContractAlert(supabase, userId, toolInput.alert_id as string);
+    case 'dismiss_bank_prompt': return dismissBankPrompt(supabase, userId);
     // ===== Phase 4 — founder-only =====
     case 'get_business_log': return getBusinessLog(supabase, userId, toolInput.category as string | undefined, toolInput.limit as number | undefined);
     case 'get_open_support_tickets': return getOpenSupportTicketsAdmin(supabase, userId, toolInput.limit as number | undefined);
@@ -6495,6 +6500,158 @@ async function startDataExportDownload(supabase: ReturnType<typeof getAdmin>, us
   const { data } = await supabase.from('business_log').select('content, created_at').eq('category', 'gdpr_request').ilike('content', `%${userId}%`).order('created_at', { ascending: false }).limit(1).maybeSingle();
   if (!data) return { text: `No data export requested yet. Run request_data_export first, then I'll have a download link within 24h.` };
   return { text: `Latest export requested ${fmtDate(data.created_at)}. Download link will be emailed to your account address once ready (within 24h of the request). Links expire after 7 days.` };
+}
+
+// ============================================================
+// PHASE 3d HANDLERS — miscellaneous parity
+// ============================================================
+
+async function scanReceipt(receiptText: string, suggestedAction?: string): Promise<ToolResult> {
+  const text = (receiptText || '').trim();
+  if (!text) {
+    return { text: 'No receipt text provided. Paste the contents of the receipt/bill and I\'ll pull out the merchant, amount and category.' };
+  }
+  if (text.length > 8000) {
+    return { text: 'That\'s a lot of text. Trim it to just the receipt/bill body (~8k chars max) and resend.' };
+  }
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return { text: 'Receipt scanning is offline right now (AI key not configured). Try again later.' };
+  }
+
+  const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  const prompt = `Extract from this UK receipt / bill / invoice text:
+- merchant: the company / supplier name
+- amount: total amount in £ as a number (no currency symbol, no commas)
+- date: in YYYY-MM-DD if present, else null
+- category: ONE of mortgage, loans, credit, council_tax, energy, water, broadband, mobile, streaming, fitness, groceries, eating_out, fuel, shopping, insurance, transport, software, tax, professional, bills, other
+- reference: any account / customer / order reference number, else null
+
+Receipt text:
+"""
+${text.slice(0, 8000)}
+"""
+
+Return ONLY valid JSON, no other text. Example: {"merchant":"EE","amount":42.50,"date":"2026-04-30","category":"mobile","reference":"123456"}`;
+
+  let extracted: { merchant?: string; amount?: number | string; date?: string | null; category?: string; reference?: string | null } = {};
+  try {
+    const message = await anthropic.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 512,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const responseText = message.content[0]?.type === 'text' ? message.content[0].text : '';
+    const cleaned = responseText.replace(/```json?\n?/g, '').replace(/```\n?/g, '').trim();
+    extracted = JSON.parse(cleaned);
+  } catch (err) {
+    console.error('scan_receipt parse error:', err);
+    return { text: 'Couldn\'t parse that receipt. Make sure the text includes a merchant, amount and (ideally) a date, then try again.' };
+  }
+
+  const merchant = extracted.merchant || 'Unknown';
+  const amountNum = typeof extracted.amount === 'string' ? parseFloat(extracted.amount) : (extracted.amount ?? 0);
+  const category = (extracted.category || 'other').toLowerCase();
+  const categoryLabel = CATEGORY_LABELS[category] || extracted.category || 'Other';
+
+  let body = `📄 *Receipt parsed*\n\n• Merchant: *${merchant}*\n• Amount: *${fmt(amountNum)}*\n• Category: ${categoryLabel}`;
+  if (extracted.date) body += `\n• Date: ${fmtDate(extracted.date)}`;
+  if (extracted.reference) body += `\n• Ref: ${extracted.reference}`;
+
+  const action = suggestedAction || 'just_categorise';
+  if (action === 'add_subscription') {
+    body += `\n\nNext: I can add this as a recurring subscription — say "add ${merchant} to subscriptions" to confirm.`;
+  } else if (action === 'create_dispute') {
+    body += `\n\nNext: I can draft a dispute letter for ${merchant} — say "dispute this charge" to start.`;
+  } else {
+    body += `\n\nLet me know if you want to add this as a subscription, dispute it, or just file it.`;
+  }
+
+  return { text: body };
+}
+
+async function renewBankConsent(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  bankName?: string,
+): Promise<ToolResult> {
+  let query = supabase
+    .from('bank_connections')
+    .select('id, bank_name, status, consent_expires_at')
+    .eq('user_id', userId)
+    .is('deleted_at', null)
+    .not('status', 'in', '("revoked","expired_legacy")')
+    .order('connected_at', { ascending: false });
+
+  if (bankName) {
+    query = query.ilike('bank_name', `%${bankName}%`);
+  }
+
+  const { data, error } = await query;
+  if (error || !data || data.length === 0) {
+    return { text: bankName
+      ? `No bank connection matches "${bankName}". Try get_bank_connections to see what's connected.`
+      : `No bank accounts connected. Connect one at ${SITE()}/dashboard/profile?connect=bank` };
+  }
+
+  // Prefer connections that actually need renewal
+  const renewable = data.filter((c) => ['expiring_soon', 'expired', 'token_expired'].includes(c.status));
+  const target = renewable[0] || data[0];
+
+  if (!target) {
+    return { text: `No bank connection matches "${bankName ?? ''}". Try get_bank_connections.` };
+  }
+
+  if (data.length > 1 && !bankName) {
+    const list = data.map((c) => `• ${c.bank_name ?? 'Unknown'} (${c.status})`).join('\n');
+    return { text: `You have ${data.length} bank connections:\n${list}\n\nSay "renew consent for [bank name]" so I know which one.` };
+  }
+
+  const url = `${SITE()}/dashboard/profile?renew_bank=${encodeURIComponent(target.id)}`;
+  const expiry = target.consent_expires_at ? ` (consent expires ${fmtDate(target.consent_expires_at)})` : '';
+  return { text: `Renew consent for ${target.bank_name ?? 'your bank'} here: ${url}${expiry}\n\nUK Open Banking requires a 90-day re-auth — takes ~30 seconds via your bank app.` };
+}
+
+async function dismissContractAlert(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  alertId: string,
+): Promise<ToolResult> {
+  if (!alertId) {
+    return { text: 'No alert id provided. Use get_contract_alerts (or list_contract_alerts) first to find the id.' };
+  }
+
+  const { data, error } = await supabase
+    .from('contract_renewal_alerts')
+    .update({ status: 'dismissed', dismissed_at: new Date().toISOString() })
+    .eq('id', alertId)
+    .eq('user_id', userId)
+    .select('id')
+    .maybeSingle();
+
+  if (error) {
+    console.error('dismiss_contract_alert error:', error);
+    return { text: `Couldn't dismiss that alert: ${error.message}` };
+  }
+  if (!data) {
+    return { text: `No alert found with id ${alertId} on your account.` };
+  }
+  return { text: '✓ Contract alert dismissed.' };
+}
+
+async function dismissBankPrompt(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+): Promise<ToolResult> {
+  const { error } = await supabase
+    .from('profiles')
+    .update({ bank_prompt_dismissed_at: new Date().toISOString() })
+    .eq('id', userId);
+
+  if (error) {
+    console.error('dismiss_bank_prompt error:', error);
+    return { text: `Couldn't dismiss the bank prompt: ${error.message}` };
+  }
+  return { text: '✓ "Connect a bank" banner dismissed. You won\'t see it on the dashboard again.' };
 }
 
 // ============================================================

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -6590,7 +6590,7 @@ async function renewBankConsent(
   if (error || !data || data.length === 0) {
     return { text: bankName
       ? `No bank connection matches "${bankName}". Try get_bank_connections to see what's connected.`
-      : `No bank accounts connected. Connect one at ${SITE()}/dashboard/profile?connect=bank` };
+      : `No bank accounts connected. Connect one at ${SITE()}/dashboard/subscriptions?connectBank=true` };
   }
 
   // Prefer connections that actually need renewal
@@ -6606,9 +6606,14 @@ async function renewBankConsent(
     return { text: `You have ${data.length} bank connections:\n${list}\n\nSay "renew consent for [bank name]" so I know which one.` };
   }
 
-  const url = `${SITE()}/dashboard/profile?renew_bank=${encodeURIComponent(target.id)}`;
+  // Send users to the subscriptions page — this is the canonical bank-management
+  // surface that lists expired connections with a Reconnect button per row, and
+  // ?connectBank=true auto-opens the bank-picker modal so the OAuth re-auth flow
+  // starts immediately. (The dashboard/profile page does NOT handle renew_bank.)
+  const url = `${SITE()}/dashboard/subscriptions?connectBank=true`;
   const expiry = target.consent_expires_at ? ` (consent expires ${fmtDate(target.consent_expires_at)})` : '';
-  return { text: `Renew consent for ${target.bank_name ?? 'your bank'} here: ${url}${expiry}\n\nUK Open Banking requires a 90-day re-auth — takes ~30 seconds via your bank app.` };
+  const bankLabel = target.bank_name ?? 'your bank';
+  return { text: `Renew consent for ${bankLabel} here: ${url}${expiry}\n\nThis opens the bank picker — pick ${bankLabel} again to re-authorise. UK Open Banking requires a 90-day re-auth and takes ~30 seconds via your bank app.` };
 }
 
 async function dismissContractAlert(

--- a/src/lib/telegram/tools.ts
+++ b/src/lib/telegram/tools.ts
@@ -1959,13 +1959,13 @@ export const telegramTools: Tool[] = [
   {
     name: 'dismiss_contract_alert',
     description:
-      "Clear a contract end-date / renewal alert from the dashboard. Use when the user says 'dismiss that alert', 'I've dealt with the EE renewal one', etc. Sets `dismissed_at = now()` and status='dismissed' on the contract_renewal_alerts row.",
+      "Clear a contract end-date / renewal alert from the dashboard. Use when the user says 'dismiss that alert', 'I've dealt with the EE renewal one', etc. Sets `dismissed_at = now()` and status='dismissed' on the contract_renewal_alerts row. Get the id from get_contract_alerts (each row's output now includes its id).",
     input_schema: {
       type: 'object' as const,
       properties: {
         alert_id: {
           type: 'string',
-          description: 'The contract_renewal_alerts row id to dismiss.',
+          description: 'The contract_renewal_alerts row id to dismiss. Obtain it via get_contract_alerts — each alert row is surfaced with its id.',
         },
       },
       required: ['alert_id'],

--- a/src/lib/telegram/tools.ts
+++ b/src/lib/telegram/tools.ts
@@ -1919,6 +1919,70 @@ export const telegramTools: Tool[] = [
   },
 
   // ============================================================
+  // PHASE 3d — miscellaneous parity tools
+  // ============================================================
+  {
+    name: 'scan_receipt',
+    description:
+      "Parse pasted/forwarded receipt or bill text to extract merchant, amount, date and category. Use when the user types or forwards the contents of a receipt, invoice or bill in chat (e.g. 'just got this from EE: ...'). The bot does NOT accept image uploads here — only the text the user has typed/pasted. Optionally suggests a follow-up action.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        receipt_text: {
+          type: 'string',
+          description: 'The full text of the receipt / bill / invoice the user has pasted or forwarded.',
+        },
+        suggested_action: {
+          type: 'string',
+          enum: ['add_subscription', 'create_dispute', 'just_categorise'],
+          description: "Optional follow-up suggestion after extraction. 'just_categorise' is the safe default.",
+        },
+      },
+      required: ['receipt_text'],
+    },
+  },
+  {
+    name: 'renew_bank_consent',
+    description:
+      "Return the URL where the user can renew Open Banking consent for a connected bank (UK 90-day cycle). Bank consent renewal needs a browser hand-off — we surface the dashboard URL rather than try to do the OAuth re-auth in chat. If multiple banks are connected, pass `bank_name` to disambiguate.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        bank_name: {
+          type: 'string',
+          description: 'Optional: filter by bank name (partial match, case-insensitive, e.g. "Barclays", "Monzo"). If omitted and only one connection needs renewal, that one is used.',
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: 'dismiss_contract_alert',
+    description:
+      "Clear a contract end-date / renewal alert from the dashboard. Use when the user says 'dismiss that alert', 'I've dealt with the EE renewal one', etc. Sets `dismissed_at = now()` and status='dismissed' on the contract_renewal_alerts row.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        alert_id: {
+          type: 'string',
+          description: 'The contract_renewal_alerts row id to dismiss.',
+        },
+      },
+      required: ['alert_id'],
+    },
+  },
+  {
+    name: 'dismiss_bank_prompt',
+    description:
+      "Dismiss the dashboard 'connect a bank' banner for the current user. Use when the user says they don't want to be nagged about connecting a bank account. Sets profile.bank_prompt_dismissed_at = now().",
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+  },
+
+  // ============================================================
   // PHASE 4 — founder-only admin tools
   // ============================================================
   {


### PR DESCRIPTION
## Summary
- Adds `scan_receipt`, `renew_bank_consent`, `dismiss_contract_alert`, `dismiss_bank_prompt` to the consumer Pocket Agent (`src/lib/telegram/tools.ts` + `tool-handlers.ts`).
- All four execute in-process via the admin Supabase client (or a direct Anthropic Haiku call for receipt parsing) — no self-HTTP fetch of our own API, per the PR #463 lesson.
- `scan_receipt` accepts pasted/forwarded text only (no image upload in this PR) and returns merchant / amount / category / date / reference plus an optional follow-up suggestion.
- `renew_bank_consent` looks up `bank_connections` for the user, prefers ones in `expiring_soon` / `expired` / `token_expired`, and returns the `/dashboard/profile?renew_bank=<id>` URL so the user can re-auth in the browser; `dismiss_contract_alert` updates `contract_renewal_alerts.dismissed_at` + `status='dismissed'` scoped to `user_id`; `dismiss_bank_prompt` sets `profiles.bank_prompt_dismissed_at = now()`.

## Test plan
- [ ] Trigger `scan_receipt` from the bot with a pasted EE bill — confirm merchant / amount / category extracted and reply formats correctly.
- [ ] Trigger `renew_bank_consent` for a user with one expiring connection — confirm renewal URL returned.
- [ ] Trigger `renew_bank_consent` for a user with multiple banks (no `bank_name`) — confirm disambiguation prompt.
- [ ] Trigger `dismiss_contract_alert` with a valid alert id — confirm the row's `dismissed_at` is set and the alert disappears from the dashboard.
- [ ] Trigger `dismiss_bank_prompt` — confirm `profiles.bank_prompt_dismissed_at` is set and the dashboard banner is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)