### PR TITLE
feat(bot): dispute write parity (5 tools)

### DIFF
--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -2528,6 +2528,7 @@ async function resolveActiveDisputeForBot(
   supabase: ReturnType<typeof getAdmin>,
   userId: string,
   provider: string,
+  options: { allowResolved?: boolean } = {},
 ): Promise<
   | { ok: true; dispute: { id: string; provider_name: string; issue_type: string; issue_summary: string | null; created_at: string } }
   | { ok: false; text: string }
@@ -2543,19 +2544,23 @@ async function resolveActiveDisputeForBot(
   if (!matches || matches.length === 0) {
     return { ok: false, text: `No dispute found matching "${provider}". Open one first via the dashboard or by asking me to "draft a complaint to ${provider}".` };
   }
-  const active = matches.filter((m) => !RESOLVED.has(m.status));
-  if (active.length === 0) {
+  // Codex P2: some bot actions (e.g. clearing the unread badge) MUST
+  // work on closed/resolved disputes — that's exactly when the user
+  // wants the badge gone. Callers opt in with allowResolved=true; the
+  // default still blocks terminal-state writes for safety.
+  const candidates = options.allowResolved ? matches : matches.filter((m) => !RESOLVED.has(m.status));
+  if (candidates.length === 0) {
     return {
       ok: false,
       text: `Your "${provider}" dispute is closed (${matches[0].status.replace(/_/g, ' ')}). Email-linking only applies to active disputes — re-open the case or open a new one if you want to attach replies.`,
     };
   }
-  if (active.length > 1) {
-    let t = `You have ${active.length} active disputes matching "${provider}". Which one do you want to link an email to?\n`;
-    for (const m of active) t += `\n• ${m.provider_name} — opened ${fmtDate(m.created_at)}: _${(m.issue_summary || '').slice(0, 80)}${(m.issue_summary || '').length > 80 ? '…' : ''}_`;
+  if (candidates.length > 1) {
+    let t = `You have ${candidates.length} ${options.allowResolved ? '' : 'active '}disputes matching "${provider}". Which one do you want?\n`;
+    for (const m of candidates) t += `\n• ${m.provider_name} — opened ${fmtDate(m.created_at)}: _${(m.issue_summary || '').slice(0, 80)}${(m.issue_summary || '').length > 80 ? '…' : ''}_`;
     return { ok: false, text: t };
   }
-  const d = active[0];
+  const d = candidates[0];
   return {
     ok: true,
     dispute: {
@@ -6829,6 +6834,36 @@ async function recordDisputeOutcome(
     return { text: `Error: failed to record outcome — ${updErr.message}` };
   }
 
+  // Codex P1: mirror the cascade in src/app/api/disputes/[id]/route.ts
+  // (lines 218-235 / 247-282). When a dispute opened to cancel a
+  // subscription resolves as "won", flip the matching
+  // pending_cancellation subscription to cancelled + stamp
+  // cancelled_at. Without this the bot path leaves subscription
+  // counts and Money Hub drifting out of sync with the dispute
+  // outcome. Same guards as the website: outcome='won' AND
+  // provider_name present AND issue_type='cancellation'. Non-fatal
+  // (matches the website route's behaviour — log and continue).
+  let cascadedSubs = 0;
+  if (outcome === 'won' && full.provider_name && full.issue_type === 'cancellation') {
+    const { data: matched, error: cancelErr } = await supabase
+      .from('subscriptions')
+      .update({
+        status: 'cancelled',
+        cancelled_at: nowIso,
+        notes: `Auto-cancelled on dispute resolution (${dispute.id.slice(0, 8)})`,
+      })
+      .eq('user_id', userId)
+      .eq('status', 'pending_cancellation')
+      .ilike('provider_name', full.provider_name as string)
+      .select('id');
+    if (cancelErr) {
+      console.error('[recordDisputeOutcome] subscription auto-cancel failed:', cancelErr.message);
+    } else if (matched && matched.length > 0) {
+      cascadedSubs = matched.length;
+      console.log(`[recordDisputeOutcome] auto-cancelled ${matched.length} subscription(s) for ${full.provider_name}`);
+    }
+  }
+
   // Append to the outcome event log (intelligence flywheel). Non-fatal
   // if it fails — we don't want the user-facing flow to error just
   // because the audit row didn't insert.
@@ -6847,6 +6882,9 @@ async function recordDisputeOutcome(
 
   let text = `✓ Recorded *${dispute.provider_name}* outcome: *${outcome.replace(/_/g, ' ')}*`;
   if (recovered !== null) text += ` · recovered ${fmt(recovered)}`;
+  if (cascadedSubs > 0) {
+    text += `\n\n✓ Also marked ${cascadedSubs} pending subscription${cascadedSubs === 1 ? '' : 's'} as cancelled.`;
+  }
   if (outcome === 'won') text += `\n\n🎉 Logged to your dispute intelligence dataset.`;
   return { text };
 }
@@ -6860,7 +6898,12 @@ async function markDisputeRead(
     return { text: 'Error: provider is required.' };
   }
 
-  const resolved = await resolveActiveDisputeForBot(supabase, userId, params.provider);
+  // Codex P2: clearing the unread badge must work on closed/resolved
+  // disputes too — that's the most common case (replies trickle in
+  // after the dispute is marked won/lost and the user wants the
+  // badge cleared). The website mark-read route does not filter on
+  // status, so neither should we. opt into allowResolved.
+  const resolved = await resolveActiveDisputeForBot(supabase, userId, params.provider, { allowResolved: true });
   if (!resolved.ok) return { text: resolved.text };
   const dispute = resolved.dispute;
 

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -497,7 +497,13 @@ export async function executeToolCall(
       return attachEvidenceToDispute(supabase, userId, {
         provider: toolInput.provider as string,
         evidence_text: toolInput.evidence_text as string,
-        source: (toolInput.source as 'telegram_chat' | 'whatsapp_chat' | undefined) ?? 'telegram_chat',
+        // Codex P2 round 2: default source from the actual channel the
+        // tool call is coming from. Previously hard-coded to
+        // 'telegram_chat' which mistagged WhatsApp evidence. Caller can
+        // still override via toolInput.source.
+        source:
+          (toolInput.source as 'telegram_chat' | 'whatsapp_chat' | undefined) ??
+          (channel === 'whatsapp' ? 'whatsapp_chat' : 'telegram_chat'),
       });
     case 'edit_correspondence_entry':
       return editCorrespondenceEntry(supabase, userId, {
@@ -2305,9 +2311,15 @@ async function getDisputeDetail(
     return { text: `No dispute found matching "${provider}".` };
   }
 
+  // Codex P2 round 2: select `id` so we can surface each
+  // correspondence entry's UUID in the output text. Without it the
+  // bot has no way to discover the correspondence_id required by
+  // edit_correspondence_entry / delete_correspondence_entry /
+  // move_correspondence_to_dispute. Mirrors the net-worth ID-exposure
+  // fix in #469.
   const { data: letters } = await supabase
     .from('correspondence')
-    .select('entry_type, title, content, entry_date')
+    .select('id, entry_type, title, content, entry_date')
     .eq('dispute_id', dispute.id)
     .eq('user_id', userId)
     .order('entry_date', { ascending: true });
@@ -2337,6 +2349,10 @@ async function getDisputeDetail(
     // still bounded; very long emails get truncated with an ellipsis.
     for (const l of letters) {
       text += `\n📄 *${l.title ?? l.entry_type}* — ${fmtDate(l.entry_date)}\n`;
+      // Surface the correspondence id so edit_correspondence_entry /
+      // delete_correspondence_entry / move_correspondence_to_dispute
+      // have an ID to pass. (Codex P2 round 2.)
+      text += `id: ${l.id}\n`;
       if (l.content) {
         const preview = l.content.length > 1500 ? l.content.slice(0, 1500) + '...' : l.content;
         text += `${preview}\n`;
@@ -2421,14 +2437,19 @@ async function quoteEmailFromThread(
     return { text: `No dispute found matching "${provider}".` };
   }
 
+  // Codex P2 round 2: select `id` so the bot can surface the
+  // correspondence UUID alongside each quoted entry. Required for
+  // edit_correspondence_entry / delete_correspondence_entry /
+  // move_correspondence_to_dispute to be callable from chat.
   const { data: rows } = await supabase
     .from('correspondence')
-    .select('entry_type, title, content, entry_date, sender_address, sender_name')
+    .select('id, entry_type, title, content, entry_date, sender_address, sender_name')
     .eq('dispute_id', dispute.id)
     .eq('user_id', userId)
     .order('entry_date', { ascending: true });
 
   type CorrRow = {
+    id: string;
     entry_type: string;
     title: string | null;
     content: string | null;
@@ -2499,6 +2520,9 @@ async function quoteEmailFromThread(
     lines.push(
       `[entry ${e.message_index_in_thread}/${all.length}] ${fmtDate(r.entry_date)} — direction=${e.direction} — type=${r.entry_type}`,
     );
+    // Surface correspondence id so edit / delete / move tools can be
+    // called with this entry. (Codex P2 round 2.)
+    lines.push(`id: ${r.id}`);
     lines.push(`subject: ${r.title ?? '(no subject)'}`);
     lines.push(`sender: ${senderLabel}`);
     lines.push(`recipient: ${recipientLabel}`);

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -473,6 +473,38 @@ export async function executeToolCall(
     case 'get_failed_payments': return getFailedPayments(supabase, userId);
     case 'get_legal_coverage_status': return getLegalCoverageStatus(supabase, userId);
     case 'get_managed_agent_run_status': return getManagedAgentRunStatus(supabase, userId);
+    // ===== Phase 5 — dispute write parity =====
+    case 'update_dispute':
+      return updateDispute(supabase, userId, {
+        provider: toolInput.provider as string,
+        claim_amount: toolInput.claim_amount as number | undefined,
+        category: toolInput.category as string | undefined,
+        evidence_summary: toolInput.evidence_summary as string | undefined,
+        provider_name: toolInput.provider_name as string | undefined,
+      });
+    case 'record_dispute_outcome':
+      return recordDisputeOutcome(supabase, userId, {
+        provider: toolInput.provider as string,
+        outcome: toolInput.outcome as string,
+        recovered_amount_gbp: toolInput.recovered_amount_gbp as number | undefined,
+        evidence_excerpt: toolInput.evidence_excerpt as string | undefined,
+      });
+    case 'mark_dispute_read':
+      return markDisputeRead(supabase, userId, {
+        provider: toolInput.provider as string,
+      });
+    case 'attach_evidence_to_dispute':
+      return attachEvidenceToDispute(supabase, userId, {
+        provider: toolInput.provider as string,
+        evidence_text: toolInput.evidence_text as string,
+        source: (toolInput.source as 'telegram_chat' | 'whatsapp_chat' | undefined) ?? 'telegram_chat',
+      });
+    case 'edit_correspondence_entry':
+      return editCorrespondenceEntry(supabase, userId, {
+        correspondence_id: toolInput.correspondence_id as string,
+        title: toolInput.title as string | undefined,
+        content: toolInput.content as string | undefined,
+      });
     default:
       return { text: `Unknown tool: ${toolName}` };
   }
@@ -6592,4 +6624,404 @@ async function getManagedAgentRunStatus(supabase: ReturnType<typeof getAdmin>, u
   let text = `*Managed agents (last 24h):*\n`;
   for (const r of data) text += `\n• ${fmtDate(r.created_at)} — *${r.created_by}*: ${r.title}`;
   return { text };
+}
+
+// ============================================================
+// PHASE 5 HANDLERS — dispute write parity
+// ============================================================
+// Each mirrors a website route under /api/disputes/[id]/* but writes
+// in-process via the admin client. We do NOT HTTP-fetch our own routes
+// (PR #463 fix — those routes are cookie-auth and 401 from a bot).
+//
+// All writes resolve the dispute via resolveActiveDisputeForBot first
+// so the user can pass a fuzzy provider name and we surface a useful
+// error if they have multiple active disputes for the same provider.
+
+const VALID_DISPUTE_ISSUE_TYPES = new Set([
+  'complaint',
+  'energy_dispute',
+  'broadband_complaint',
+  'flight_compensation',
+  'parking_appeal',
+  'debt_dispute',
+  'refund_request',
+  'hmrc_tax_rebate',
+  'council_tax_band',
+  'dvla_vehicle',
+  'nhs_complaint',
+]);
+
+async function updateDispute(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  params: {
+    provider: string;
+    claim_amount?: number;
+    category?: string;
+    evidence_summary?: string;
+    provider_name?: string;
+  },
+): Promise<ToolResult> {
+  if (!params.provider || typeof params.provider !== 'string') {
+    return { text: 'Error: provider is required.' };
+  }
+
+  const resolved = await resolveActiveDisputeForBot(supabase, userId, params.provider);
+  if (!resolved.ok) return { text: resolved.text };
+  const dispute = resolved.dispute;
+
+  // Mirror PATCH /api/disputes/[id] writable-field allowlist (the
+  // non-resolve branch). Only fields the website allows go through.
+  const updates: Record<string, unknown> = {};
+
+  if (params.claim_amount !== undefined && params.claim_amount !== null) {
+    const amt = Number(params.claim_amount);
+    if (!Number.isFinite(amt) || amt < 0) {
+      return { text: 'Error: claim_amount must be a non-negative number.' };
+    }
+    updates.disputed_amount = amt;
+  }
+
+  if (params.category !== undefined) {
+    if (!VALID_DISPUTE_ISSUE_TYPES.has(params.category)) {
+      return { text: `Error: invalid category "${params.category}". Allowed: ${Array.from(VALID_DISPUTE_ISSUE_TYPES).join(', ')}.` };
+    }
+    updates.issue_type = params.category;
+  }
+
+  if (params.evidence_summary !== undefined) {
+    const summary = String(params.evidence_summary).trim();
+    if (!summary) {
+      return { text: 'Error: evidence_summary cannot be empty.' };
+    }
+    updates.issue_summary = summary;
+  }
+
+  if (params.provider_name !== undefined) {
+    const newName = String(params.provider_name).trim();
+    if (!newName) {
+      return { text: 'Error: provider_name cannot be empty.' };
+    }
+    updates.provider_name = newName;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { text: 'Error: nothing to update — pass at least one of claim_amount, category, evidence_summary, provider_name.' };
+  }
+
+  updates.updated_at = new Date().toISOString();
+
+  const { error } = await supabase
+    .from('disputes')
+    .update(updates)
+    .eq('id', dispute.id)
+    .eq('user_id', userId);
+
+  if (error) {
+    console.error('[updateDispute] update failed', error);
+    return { text: `Error: failed to update dispute — ${error.message}` };
+  }
+
+  const changed = Object.keys(updates).filter((k) => k !== 'updated_at');
+  return {
+    text: `✓ Updated *${dispute.provider_name}* dispute (${changed.join(', ')}).`,
+  };
+}
+
+async function recordDisputeOutcome(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  params: {
+    provider: string;
+    outcome: string;
+    recovered_amount_gbp?: number;
+    evidence_excerpt?: string;
+  },
+): Promise<ToolResult> {
+  const VALID_OUTCOMES = ['won', 'partial', 'lost', 'withdrawn', 'timeout', 'still_open'];
+  if (!params.provider || typeof params.provider !== 'string') {
+    return { text: 'Error: provider is required.' };
+  }
+  if (!params.outcome || !VALID_OUTCOMES.includes(params.outcome)) {
+    return { text: `Error: outcome must be one of: ${VALID_OUTCOMES.join(', ')}.` };
+  }
+
+  const resolved = await resolveActiveDisputeForBot(supabase, userId, params.provider);
+  if (!resolved.ok) return { text: resolved.text };
+  const dispute = resolved.dispute;
+
+  // Load full row so we can normalise merchant + industry + dispute type
+  // exactly the same way POST /api/disputes/[id]/outcome does.
+  const { data: full, error: loadErr } = await supabase
+    .from('disputes')
+    .select('id, user_id, provider_name, provider_type, issue_type, issue_summary, created_at')
+    .eq('id', dispute.id)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (loadErr || !full) {
+    return { text: `Error: dispute not found.` };
+  }
+
+  const recovered =
+    params.recovered_amount_gbp == null
+      ? null
+      : Number.isFinite(Number(params.recovered_amount_gbp))
+        ? Number(params.recovered_amount_gbp)
+        : null;
+
+  const resolutionDays = Math.max(
+    0,
+    Math.round(
+      (Date.now() - new Date(full.created_at as string).getTime()) /
+        (1000 * 60 * 60 * 24),
+    ),
+  );
+
+  // Same helpers the website's outcome route uses to populate the
+  // intelligence dataset columns (so the bot-driven outcomes show up
+  // in /dashboard/admin/dispute-intelligence rollups).
+  const { inferDisputeType, inferIndustry, normaliseMerchant } = await import(
+    '@/lib/dispute-outcome/normalise'
+  );
+  const merchantNorm = normaliseMerchant(full.provider_name as string | null);
+  const industry =
+    inferIndustry(full.provider_name as string | null) ||
+    (full.provider_type as string | null) ||
+    null;
+  const disputeType = inferDisputeType(
+    full.issue_type as string | null,
+    full.issue_summary as string | null,
+  );
+
+  const outcome = params.outcome;
+  const isTerminal = outcome !== 'still_open';
+  const nowIso = new Date().toISOString();
+
+  const updatePatch: Record<string, unknown> = {
+    outcome,
+    outcome_set_at: nowIso,
+    outcome_set_by: 'user',
+    recovered_amount_gbp: recovered,
+    resolution_time_days: resolutionDays,
+    merchant_normalised: merchantNorm,
+    merchant_industry: industry,
+    dispute_type: disputeType,
+    closed_by: isTerminal ? 'user' : null,
+    updated_at: nowIso,
+  };
+  if (isTerminal) {
+    updatePatch.resolved_at = nowIso;
+    updatePatch.money_recovered = recovered ?? 0;
+    if (outcome === 'won') updatePatch.status = 'resolved_won';
+    else if (outcome === 'partial') updatePatch.status = 'resolved_partial';
+    else if (outcome === 'lost') updatePatch.status = 'resolved_lost';
+    else updatePatch.status = 'closed';
+  }
+
+  const { error: updErr } = await supabase
+    .from('disputes')
+    .update(updatePatch)
+    .eq('id', dispute.id)
+    .eq('user_id', userId);
+  if (updErr) {
+    console.error('[recordDisputeOutcome] update failed', updErr);
+    return { text: `Error: failed to record outcome — ${updErr.message}` };
+  }
+
+  // Append to the outcome event log (intelligence flywheel). Non-fatal
+  // if it fails — we don't want the user-facing flow to error just
+  // because the audit row didn't insert.
+  const { error: evErr } = await supabase.from('dispute_outcome_events').insert({
+    dispute_id: dispute.id,
+    source: 'user',
+    outcome,
+    recovered_amount_gbp: recovered,
+    notes: null,
+    ai_evidence_excerpt: params.evidence_excerpt ?? null,
+    user_id: userId,
+  });
+  if (evErr) {
+    console.warn('[recordDisputeOutcome] event-log insert failed (non-fatal):', evErr.message);
+  }
+
+  let text = `✓ Recorded *${dispute.provider_name}* outcome: *${outcome.replace(/_/g, ' ')}*`;
+  if (recovered !== null) text += ` · recovered ${fmt(recovered)}`;
+  if (outcome === 'won') text += `\n\n🎉 Logged to your dispute intelligence dataset.`;
+  return { text };
+}
+
+async function markDisputeRead(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  params: { provider: string },
+): Promise<ToolResult> {
+  if (!params.provider || typeof params.provider !== 'string') {
+    return { text: 'Error: provider is required.' };
+  }
+
+  const resolved = await resolveActiveDisputeForBot(supabase, userId, params.provider);
+  if (!resolved.ok) return { text: resolved.text };
+  const dispute = resolved.dispute;
+
+  const { data: row, error: fetchErr } = await supabase
+    .from('disputes')
+    .select('id, unread_reply_count')
+    .eq('id', dispute.id)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (fetchErr || !row) {
+    return { text: `Error: dispute not found.` };
+  }
+
+  if ((row.unread_reply_count ?? 0) === 0) {
+    return { text: `✓ *${dispute.provider_name}* — no unread replies to clear.` };
+  }
+
+  const { error: updErr } = await supabase
+    .from('disputes')
+    .update({ unread_reply_count: 0 })
+    .eq('id', dispute.id)
+    .eq('user_id', userId);
+
+  if (updErr) {
+    console.error('[markDisputeRead] update failed', updErr);
+    return { text: `Error: failed to clear badge — ${updErr.message}` };
+  }
+
+  // Mirror the website's mark-read route — also clear the matching
+  // bell-badge notifications so unread counts stay in sync.
+  await supabase
+    .from('user_notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('user_id', userId)
+    .eq('dispute_id', dispute.id)
+    .is('read_at', null)
+    .in('type', ['dispute_reply', 'dispute_reply_action']);
+
+  return { text: `✓ Cleared unread badge on *${dispute.provider_name}* dispute.` };
+}
+
+async function attachEvidenceToDispute(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  params: {
+    provider: string;
+    evidence_text: string;
+    source: 'telegram_chat' | 'whatsapp_chat';
+  },
+): Promise<ToolResult> {
+  if (!params.provider || typeof params.provider !== 'string') {
+    return { text: 'Error: provider is required.' };
+  }
+  const text = (params.evidence_text || '').trim();
+  if (!text) {
+    return { text: 'Error: evidence_text cannot be empty.' };
+  }
+
+  const resolved = await resolveActiveDisputeForBot(supabase, userId, params.provider);
+  if (!resolved.ok) return { text: resolved.text };
+  const dispute = resolved.dispute;
+
+  const today = new Date();
+  const sourceLabel = params.source === 'whatsapp_chat' ? 'WhatsApp chat' : 'Telegram chat';
+  // entry_type='evidence_note' isn't in the correspondence_entry_type
+  // CHECK constraint — the website uses user_note for free-text user
+  // evidence (see POST /api/disputes/[id]/correspondence). We tag the
+  // title so the timeline UI still highlights it as evidence.
+  const title = `Evidence — ${sourceLabel} (${today.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })})`;
+
+  const { error: insertErr } = await supabase.from('correspondence').insert({
+    dispute_id: dispute.id,
+    user_id: userId,
+    entry_type: 'user_note',
+    title,
+    content: text,
+    summary: text.slice(0, 200),
+    entry_date: today.toISOString(),
+    detected_from_email: false,
+  });
+
+  if (insertErr) {
+    console.error('[attachEvidenceToDispute] insert failed', insertErr);
+    return { text: `Error: failed to save evidence — ${insertErr.message}` };
+  }
+
+  // Bump the dispute's updated_at so list ordering reflects the new entry.
+  await supabase
+    .from('disputes')
+    .update({ updated_at: today.toISOString() })
+    .eq('id', dispute.id)
+    .eq('user_id', userId);
+
+  return {
+    text: `✓ Saved evidence to *${dispute.provider_name}* dispute timeline (${text.length} chars). Photo / PDF uploads still go through the website at paybacker.co.uk/dashboard/disputes.`,
+  };
+}
+
+async function editCorrespondenceEntry(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  params: {
+    correspondence_id: string;
+    title?: string;
+    content?: string;
+  },
+): Promise<ToolResult> {
+  if (!params.correspondence_id || typeof params.correspondence_id !== 'string') {
+    return { text: 'Error: correspondence_id is required.' };
+  }
+
+  // Verify ownership + check entry_type — mirrors the website's PATCH
+  // route. AI-generated letters are read-only.
+  const { data: existing, error: fetchErr } = await supabase
+    .from('correspondence')
+    .select('id, user_id, entry_type, dispute_id')
+    .eq('id', params.correspondence_id)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (fetchErr) {
+    console.error('[editCorrespondenceEntry] fetch failed', fetchErr);
+    return { text: `Error: database error — ${fetchErr.message}` };
+  }
+  if (!existing) {
+    return { text: `Error: correspondence entry not found (or not yours).` };
+  }
+  if (existing.entry_type === 'ai_letter') {
+    return { text: `Error: AI-generated letters cannot be edited.` };
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (params.title !== undefined) {
+    const trimmed = String(params.title).trim();
+    updates.title = trimmed.length > 0 ? trimmed : null;
+  }
+  if (params.content !== undefined) {
+    const trimmed = String(params.content).trim();
+    if (!trimmed) {
+      return { text: 'Error: content must be a non-empty string.' };
+    }
+    updates.content = trimmed;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { text: 'Error: nothing to update — pass at least one of title or content.' };
+  }
+
+  const { error: updErr } = await supabase
+    .from('correspondence')
+    .update(updates)
+    .eq('id', params.correspondence_id)
+    .eq('user_id', userId);
+
+  if (updErr) {
+    console.error('[editCorrespondenceEntry] update failed', updErr);
+    return { text: `Error: failed to save changes — ${updErr.message}` };
+  }
+
+  return {
+    text: `✓ Updated correspondence entry (${Object.keys(updates).join(', ')}).`,
+  };
 }

--- a/src/lib/telegram/tools.ts
+++ b/src/lib/telegram/tools.ts
@@ -270,7 +270,7 @@ export const telegramTools: Tool[] = [
   {
     name: 'get_dispute_detail',
     description:
-      "Get the full detail of a specific dispute including all correspondence (letters sent, responses received). Use when the user asks about a specific complaint or dispute with a provider.",
+      "Get the full detail of a specific dispute including all correspondence (letters sent, responses received). Use when the user asks about a specific complaint or dispute with a provider. Each correspondence entry includes its `id:` (UUID) — pass that to edit_correspondence_entry / delete_correspondence_entry / move_correspondence_to_dispute.",
     input_schema: {
       type: 'object' as const,
       properties: {
@@ -286,7 +286,7 @@ export const telegramTools: Tool[] = [
   {
     name: 'quote_email_from_thread',
     description:
-      "Read the actual body text of the user's correspondence on a dispute — the linked email thread plus AI-drafted letters they've sent. ALWAYS call this tool when the user asks about content, amounts, dates, deadlines, demands, requests, or specific words from any email or letter on a dispute (e.g. 'what did I write', 'what amount did I demand', 'what was in my last letter', 'what did they offer', 'what date did they say', 'confirm the figure I quoted'). NEVER infer email content from summaries, dispute metadata, offer figures, or earlier conversation context — always call this tool first and quote verbatim from the returned `body` field. Returns the most recent N entries with FULL body text (not snippets), ordered most-recent first, with structured fields {date, sender, recipient, subject, body, direction, message_index_in_thread}.",
+      "Read the actual body text of the user's correspondence on a dispute — the linked email thread plus AI-drafted letters they've sent. ALWAYS call this tool when the user asks about content, amounts, dates, deadlines, demands, requests, or specific words from any email or letter on a dispute (e.g. 'what did I write', 'what amount did I demand', 'what was in my last letter', 'what did they offer', 'what date did they say', 'confirm the figure I quoted'). NEVER infer email content from summaries, dispute metadata, offer figures, or earlier conversation context — always call this tool first and quote verbatim from the returned `body` field. Returns the most recent N entries with FULL body text (not snippets), ordered most-recent first, with structured fields {id, date, sender, recipient, subject, body, direction, message_index_in_thread}. The `id` is the correspondence UUID — pass it to edit_correspondence_entry / delete_correspondence_entry / move_correspondence_to_dispute.",
     input_schema: {
       type: 'object' as const,
       properties: {
@@ -2087,7 +2087,7 @@ export const telegramTools: Tool[] = [
         source: {
           type: 'string',
           enum: ['telegram_chat', 'whatsapp_chat'],
-          description: "Which channel the evidence came from. Used to label the timeline entry. Defaults to telegram_chat.",
+          description: "Which channel the evidence came from. Used to label the timeline entry. Defaults to whichever channel the bot is currently running on (telegram_chat for Telegram, whatsapp_chat for WhatsApp) — you usually don't need to set this explicitly.",
         },
       },
       required: ['provider', 'evidence_text'],

--- a/src/lib/telegram/tools.ts
+++ b/src/lib/telegram/tools.ts
@@ -1976,4 +1976,144 @@ export const telegramTools: Tool[] = [
     description: "[FOUNDER ONLY] Recent managed-agent session activity (alert-tester, support-triager, bug-triager, etc.) — last run time, status.",
     input_schema: { type: 'object' as const, properties: {}, required: [] },
   },
+
+  // ============================================================
+  // PHASE 5 — dispute write parity (mirrors website /dashboard/disputes
+  // edit / outcome / mark-read / evidence / correspondence-edit flows
+  // so users can drive the full dispute workflow from chat).
+  // ============================================================
+  {
+    name: 'update_dispute',
+    description:
+      "Patch editable fields on an existing dispute (claim amount, category/issue type, evidence summary, provider name). Mirrors the website's PATCH /api/disputes/[id] non-resolve path. Use when the user says 'update the amount to £X', 'change the category to broadband_complaint', 'rename the dispute to <provider>', or wants to edit the issue summary mid-flight. For terminal outcomes (won / lost / partial / withdrawn) call record_dispute_outcome instead.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        provider: {
+          type: 'string',
+          description: 'Provider name of the dispute to update (case-insensitive partial match — same shape as get_dispute_detail).',
+        },
+        claim_amount: {
+          type: 'number',
+          description: "New disputed_amount in GBP (positive number). Optional.",
+        },
+        category: {
+          type: 'string',
+          enum: [
+            'complaint',
+            'energy_dispute',
+            'broadband_complaint',
+            'flight_compensation',
+            'parking_appeal',
+            'debt_dispute',
+            'refund_request',
+            'hmrc_tax_rebate',
+            'council_tax_band',
+            'dvla_vehicle',
+            'nhs_complaint',
+          ],
+          description: 'New issue_type for the dispute. Optional.',
+        },
+        evidence_summary: {
+          type: 'string',
+          description: "New issue_summary text — the plain-English description shown on the dispute card. Optional.",
+        },
+        provider_name: {
+          type: 'string',
+          description: "New provider_name (rename the dispute, e.g. 'British Gas' → 'British Gas Trading Ltd'). Optional.",
+        },
+      },
+      required: ['provider'],
+    },
+  },
+  {
+    name: 'record_dispute_outcome',
+    description:
+      "Tag a terminal outcome on a dispute and write a row to dispute_outcome_events for the intelligence flywheel. Mirrors POST /api/disputes/[id]/outcome. Use when the user confirms a result — won / partial / lost / withdrawn / timeout / still_open. Always pass recovered_amount_gbp when outcome is won or partial. The matching subscription auto-cancel only fires for 'won' on cancellation-type disputes — same guards as the website.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        provider: {
+          type: 'string',
+          description: 'Provider name of the dispute (case-insensitive partial match).',
+        },
+        outcome: {
+          type: 'string',
+          enum: ['won', 'partial', 'lost', 'withdrawn', 'timeout', 'still_open'],
+          description: "Terminal outcome to record. 'still_open' keeps the dispute active but tags the dataset row.",
+        },
+        recovered_amount_gbp: {
+          type: 'number',
+          description: 'Money recovered in GBP. Required for won/partial; ignored otherwise.',
+        },
+        evidence_excerpt: {
+          type: 'string',
+          description: "Optional short quote from the supplier's reply that proves the outcome — stored on dispute_outcome_events.ai_evidence_excerpt for the intelligence dataset.",
+        },
+      },
+      required: ['provider', 'outcome'],
+    },
+  },
+  {
+    name: 'mark_dispute_read',
+    description:
+      "Clear the unread-replies badge on a dispute (zero out unread_reply_count). Mirrors POST /api/disputes/[id]/mark-read. Use when the user has read or quoted from the latest supplier reply in chat and you want the dashboard 'NEW REPLY · N' badge to clear.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        provider: {
+          type: 'string',
+          description: 'Provider name of the dispute (case-insensitive partial match).',
+        },
+      },
+      required: ['provider'],
+    },
+  },
+  {
+    name: 'attach_evidence_to_dispute',
+    description:
+      "Save a free-text evidence note to the dispute timeline. Use when the user pastes an excerpt, observation, or proof point from chat (e.g. 'add this to my Sky dispute: meter read on 14 Apr was 12345'). The bot only handles text — for photo / PDF uploads tell the user to use the website upload flow at /dashboard/disputes. Inserts a user_note row tagged 'Evidence — <source>' so it stands out in the timeline alongside ai_letter and company_email entries.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        provider: {
+          type: 'string',
+          description: 'Provider name of the dispute (case-insensitive partial match).',
+        },
+        evidence_text: {
+          type: 'string',
+          description: 'The full evidence text to save. Must be a non-empty string — the bot does not handle file uploads.',
+        },
+        source: {
+          type: 'string',
+          enum: ['telegram_chat', 'whatsapp_chat'],
+          description: "Which channel the evidence came from. Used to label the timeline entry. Defaults to telegram_chat.",
+        },
+      },
+      required: ['provider', 'evidence_text'],
+    },
+  },
+  {
+    name: 'edit_correspondence_entry',
+    description:
+      "Edit the title or content of an existing correspondence entry (the user's own notes / pasted supplier responses). Mirrors PATCH /api/disputes/[id]/correspondence/[entryId]. Use when the user wants to fix a typo or update text on a previously-saved entry. AI-generated letters cannot be edited (engine refuses). Pass the correspondence_id from get_dispute_detail or quote_email_from_thread output.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        correspondence_id: {
+          type: 'string',
+          description: 'UUID of the correspondence row to edit. Must belong to the calling user (security predicate is enforced server-side).',
+        },
+        title: {
+          type: 'string',
+          description: 'New title for the entry. Optional — pass empty string to clear.',
+        },
+        content: {
+          type: 'string',
+          description: 'New content body for the entry. Optional. Must be non-empty if provided.',
+        },
+      },
+      required: ['correspondence_id'],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Brings the consumer Pocket Agent (Telegram / WhatsApp) to write parity with the website's dispute workflow. Five new tools, all calling the underlying logic **in-process** via the admin Supabase client — never HTTP-fetching our own API (PR #463 fix: those routes are cookie-auth and 401 from a bot).

- `update_dispute` — patch claim_amount / category / evidence_summary / provider_name. Mirrors the non-resolve branch of `PATCH /api/disputes/[id]`. Resolves dispute via `resolveActiveDisputeForBot`, validates `issue_type` against the same allowlist as the website, then `supabase.from('disputes').update(...).eq('id', resolved.dispute.id).eq('user_id', userId)`.
- `record_dispute_outcome` — set terminal outcome (won / partial / lost / withdrawn / timeout / still_open) with `recovered_amount_gbp` and optional `evidence_excerpt`. Mirrors `POST /api/disputes/[id]/outcome`. Reuses `inferDisputeType`, `inferIndustry`, `normaliseMerchant` from `src/lib/dispute-outcome/normalise` so bot-driven outcomes populate the intelligence-dataset columns and show up in `/dashboard/admin/dispute-intelligence`. Inserts into `dispute_outcome_events` for the audit log (non-fatal if it fails).
- `mark_dispute_read` — zero out `disputes.unread_reply_count` to clear the dashboard "NEW REPLY · N" badge. Also flips matching `user_notifications.read_at` for `dispute_reply` / `dispute_reply_action` types so the bell badge stays in sync (same as the website's mark-read route).
- `attach_evidence_to_dispute` — save free-text evidence from a chat message into the dispute timeline. Inserts into `correspondence` with `entry_type='user_note'` (the `evidence_note` value isn't in the CHECK constraint — title flags it as "Evidence — Telegram/WhatsApp chat (date)" so it stands out). Photo / PDF uploads still go through the website upload route.
- `edit_correspondence_entry` — edit `title` / `content` of an existing entry. Mirrors `PATCH /api/disputes/[id]/correspondence/[entryId]`. Enforces `user_id = userId` predicate and the same `ai_letter` read-only guard the website uses.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally, exit 0)
- [ ] Telegram bot: ask "update my Sky dispute amount to £85" → confirm `disputed_amount` flips
- [ ] Telegram bot: ask "mark my Vodafone dispute as won, recovered £50" → confirm `disputes.outcome='won'`, `dispute_outcome_events` row inserted, `/dashboard/admin/dispute-intelligence` rollup picks up the new row
- [ ] Telegram bot: ask "clear unread on my OneStream dispute" → confirm `unread_reply_count=0` and `user_notifications.read_at` set
- [ ] Telegram bot: ask "attach this to my British Gas dispute: meter read on 14 Apr was 12345" → confirm `correspondence` row inserted with `entry_type='user_note'` and the evidence-tagged title
- [ ] Telegram bot: ask to edit a previously-saved user_note → confirm content updates; ask to edit an `ai_letter` row → confirm it's rejected with the read-only error

🤖 Generated with [Claude Code](https://claude.com/claude-code)