### PR TITLE
feat(compliance): write founder action instructions when AI gives up on stuck items

### DIFF
--- a/src/app/api/admin/legal-refs/recover-url-dead/route.ts
+++ b/src/app/api/admin/legal-refs/recover-url-dead/route.ts
@@ -46,6 +46,27 @@ function publisherDomain(url: string): string | null {
   }
 }
 
+/**
+ * Phase 3 of compliance UX overhaul: when Perplexity can't recover a
+ * url_dead citation, write a SHORT one-line founder instruction so the
+ * Compliance Centre surfaces "do exactly this" instead of just burying
+ * "manual research needed" in business_log.
+ *
+ * Output is one sentence the founder can act on — search-and-paste, not
+ * a research project. Specialise on the publishers we hit most (legislation,
+ * Ofcom) and fall back to a generic search-the-domain prompt.
+ */
+function buildActionInstruction(publisherDomain: string, lawName: string): string {
+  const name = lawName.trim() || 'this citation';
+  if (publisherDomain === 'legislation.gov.uk') {
+    return `Search legislation.gov.uk for '${name}' and paste the current URL into a fresh correction (or mark this ref retired).`;
+  }
+  if (publisherDomain === 'ofcom.org.uk') {
+    return `Search ofcom.org.uk for '${name}' (try the General Conditions index page) and paste the current URL.`;
+  }
+  return `Original URL on ${publisherDomain} 4xx'd. Search ${publisherDomain} for '${name}' and either paste the new URL or mark this citation retired.`;
+}
+
 async function askPerplexityForRecovery(args: {
   oldUrl: string;
   lawName: string;
@@ -426,20 +447,57 @@ export async function POST(request: NextRequest) {
             }
           }
         } else {
-          // Null / low confidence / off-domain — leave url_dead, log for
-          // founder so manual research is visible in business_log.
+          // Null / low confidence / off-domain — Perplexity gave up.
+          //
+          // Phase 3: instead of just logging "manual research needed" to
+          // business_log (where it gets buried), also write a low-confidence
+          // pending correction with an action_instructions one-liner so the
+          // founder sees "do exactly this" inline in the Compliance Centre
+          // review queue. Keep the business_log row too — it's the audit
+          // trail the cron summary email scrapes.
+          const giveUpReasoning =
+            `Ref ${row.id} (${row.law_name}) source ${row.source_url} ` +
+            `still 4xx after browser-UA probe. Perplexity recovery returned ` +
+            `${proposedUrl ? `URL ${proposedUrl}` : 'no URL'} ` +
+            `with confidence=${recovery?.confidence ?? 'n/a'}` +
+            (recovery?.reasoning ? `. Reasoning: ${recovery.reasoning}` : '.');
+
           // eslint-disable-next-line no-await-in-loop
           await admin.from('business_log').insert({
             category: 'compliance',
             title: `url_dead — manual research needed: ${row.law_name}`,
-            content:
-              `Ref ${row.id} (${row.law_name}) source ${row.source_url} ` +
-              `still 4xx after browser-UA probe. Perplexity recovery returned ` +
-              `${proposedUrl ? `URL ${proposedUrl}` : 'no URL'} ` +
-              `with confidence=${recovery?.confidence ?? 'n/a'}` +
-              (recovery?.reasoning ? `. Reasoning: ${recovery.reasoning}` : '.'),
+            content: giveUpReasoning,
             created_by: 'system',
           });
+
+          const actionInstruction = buildActionInstruction(pubDomain, row.law_name);
+          // eslint-disable-next-line no-await-in-loop
+          const { data: insertedRow, error: insErr } = await admin
+            .from('legal_ref_corrections')
+            .insert({
+              ref_id: row.id,
+              proposer: 'url-recovery-action-needed-2026-05-03',
+              before_law_name: row.law_name,
+              before_source_url: row.source_url,
+              before_status: 'url_dead',
+              proposed_law_name: null,
+              proposed_source_url: null,
+              proposed_status: null,
+              reasoning: giveUpReasoning,
+              confidence: 'low',
+              status: 'pending',
+              action_instructions: actionInstruction,
+            })
+            .select('id')
+            .maybeSingle();
+          if (insErr) {
+            summary.errors.push(`${row.id} (action-needed): ${insErr.message}`);
+          } else if (insertedRow?.id) {
+            summary.queued++;
+            // Fire enrichment fire-and-forget (same pattern as the other
+            // inserts in this file — added in PR #470).
+            enrichSingleCorrection(admin, insertedRow.id).catch(() => {});
+          }
         }
       }
     }

--- a/src/app/dashboard/admin/legal-refs/PendingCorrectionsSection.tsx
+++ b/src/app/dashboard/admin/legal-refs/PendingCorrectionsSection.tsx
@@ -40,6 +40,11 @@ interface Correction {
   } | null;
   enrichment_data?: { risk_score?: 'low' | 'medium' | 'high' | null } | null;
   enriched_at?: string | null;
+  // Phase 3 of compliance UX overhaul: AI-written one-line founder
+  // instruction for stuck items (e.g. "Search legislation.gov.uk for
+  // 'Consumer Rights Act 2015 s.9' and paste the new URL"). NULL on
+  // normal proposed-change corrections. Phase 1 will render this inline.
+  action_instructions?: string | null;
 }
 
 const CONFIDENCE_CLASS: Record<string, string> = {

--- a/supabase/migrations/20260503150000_legal_ref_corrections_action_instructions.sql
+++ b/supabase/migrations/20260503150000_legal_ref_corrections_action_instructions.sql
@@ -1,0 +1,17 @@
+-- Phase 3 of compliance UX overhaul: when the AI gives up on a stuck
+-- compliance item (url_dead with no recoverable URL, ambiguous corrections,
+-- non-authority candidates we can't resolve), it writes a one-line
+-- founder instruction here instead of just logging "manual research needed"
+-- to business_log where it gets buried.
+--
+-- The admin Compliance Centre surfaces this inline so the founder knows
+-- exactly what to do — e.g. "Search legislation.gov.uk for 'Consumer
+-- Rights Act 2015 s.9' and paste the new URL".
+
+ALTER TABLE legal_ref_corrections
+ADD COLUMN IF NOT EXISTS action_instructions TEXT;
+
+COMMENT ON COLUMN legal_ref_corrections.action_instructions IS
+  'AI-written one-line founder instruction for stuck items. NULL when '
+  'the correction is a normal proposed change. Surfaced in the '
+  'Compliance Centre review queue.';


### PR DESCRIPTION
## Summary

Phase 3 of the Compliance Centre upgrade. When the AI can't recover a `url_dead` citation (Perplexity returned no URL, low confidence, or off-domain), instead of just logging "manual research needed" to `business_log` (where it gets buried), the system now writes a **low-confidence pending `legal_ref_corrections` row** with a one-line `action_instructions` field that tells the founder exactly what to do.

- **Migration** (`20260503150000_legal_ref_corrections_action_instructions.sql`): adds `action_instructions TEXT` to `legal_ref_corrections` — additive only, with a column comment documenting intent.
- **`recover-url-dead` give-up branch** now writes a pending correction with a concrete one-liner generated by a new `buildActionInstruction(publisherDomain, lawName)` helper, e.g.:
  - legislation.gov.uk → `"Search legislation.gov.uk for '<law>' and paste the current URL into a fresh correction (or mark this ref retired)."`
  - ofcom.org.uk → `"Search ofcom.org.uk for '<law>' (try the General Conditions index page) and paste the current URL."`
  - generic → `"Original URL on <domain> 4xx'd. Search <domain> for '<law>' and either paste the new URL or mark this citation retired."`
  The existing `business_log` row stays for audit trail. `enrichSingleCorrection` fires fire-and-forget after insert (same pattern as other inserts in this route, added in PR #470).
- **API surface**: the GET handler at `/api/admin/legal-ref-corrections` already uses `select('*', ...)` so `action_instructions` flows through automatically. The `Correction` TypeScript interface in `PendingCorrectionsSection` now declares it (a follow-up Phase 1 PR will surface it inline in the UI).

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally).
- [ ] Apply migration on a Supabase branch and confirm `action_instructions` column exists.
- [ ] POST `/api/admin/legal-refs/recover-url-dead` with `{queue:true}` against a fixture row whose URL Perplexity can't recover; assert one new `legal_ref_corrections` row with `proposer='url-recovery-action-needed-2026-05-03'`, `confidence='low'`, `status='pending'`, and a non-null `action_instructions` matching the publisher's template.
- [ ] GET `/api/admin/legal-ref-corrections?status=pending` and confirm the new row's `action_instructions` is present in the JSON response.
- [ ] Confirm the legacy `business_log` row is still inserted for the same event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)