### PR TITLE
feat(compliance): inline diffs + approve/reject in review queue + top-3 previews in attention panel

### DIFF
--- a/src/app/api/admin/legal-refs/[id]/confirm-auto-correction/route.ts
+++ b/src/app/api/admin/legal-refs/[id]/confirm-auto-correction/route.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/admin/legal-refs/:id/confirm-auto-correction
+ *
+ * Founder-gated. Marks an auto-corrected legal_references row as
+ * confirmed (i.e. the founder has eyeballed the AI-overwritten citation
+ * and accepts it). Sets `auto_corrected = false` and stamps
+ * `last_human_review_at` so the row drops out of the "AI auto-correction
+ * — please review" badge in the Compliance Centre.
+ *
+ * No content mutations — this only flips the verification flag. The
+ * underlying canonical fields (law_name, source_url, verification_status)
+ * were already set by the auto-apply path; the founder is just
+ * acknowledging them.
+ *
+ * Phase 1 of the actionable Compliance Centre UX: gives the founder a
+ * one-click way to clear the amber flag without scrolling to a separate
+ * panel. Pairs with the inline diff panel rendered under the
+ * auto-corrected row in the Review queue.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@supabase/supabase-js';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+async function requireAdmin(): Promise<
+  { ok: true; email: string } | { ok: false; res: NextResponse }
+> {
+  const supabase = await createServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email) {
+    return { ok: false, res: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const adminEmails = (process.env.NEXT_PUBLIC_ADMIN_EMAILS || 'aireypaul@googlemail.com')
+    .split(',').map((e) => e.trim().toLowerCase()).filter(Boolean);
+  if (!adminEmails.includes(user.email.toLowerCase())) {
+    return { ok: false, res: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+  return { ok: true, email: user.email };
+}
+
+export async function POST(
+  _request: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAdmin();
+  if (!auth.ok) return auth.res;
+
+  const { id } = await ctx.params;
+  if (!id) {
+    return NextResponse.json({ error: 'Missing ref id' }, { status: 400 });
+  }
+
+  const supabase = getAdmin();
+
+  const { data: ref, error: refErr } = await supabase
+    .from('legal_references')
+    .select('id, auto_corrected')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (refErr) {
+    return NextResponse.json({ error: refErr.message }, { status: 500 });
+  }
+  if (!ref) {
+    return NextResponse.json({ error: 'Ref not found' }, { status: 404 });
+  }
+
+  const nowIso = new Date().toISOString();
+  const { error: updErr } = await supabase
+    .from('legal_references')
+    .update({
+      auto_corrected: false,
+      last_human_review_at: nowIso,
+      updated_at: nowIso,
+    })
+    .eq('id', id);
+
+  if (updErr) {
+    return NextResponse.json({ error: updErr.message }, { status: 500 });
+  }
+
+  // Audit row in legal_ref_verifications. Soft-fail if the table isn't
+  // present (older snapshots / pre-γ environments).
+  try {
+    await supabase.from('legal_ref_verifications').insert({
+      ref_id: id,
+      verifier: 'manual-confirm-auto-correction',
+      result_status: 'confirmed',
+      reasoning: `Founder confirmed AI auto-correction is correct (cleared auto_corrected flag).`,
+    });
+  } catch {
+    // table-not-present — non-fatal
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/dashboard/admin/legal-refs/InlineCorrectionPanel.tsx
+++ b/src/app/dashboard/admin/legal-refs/InlineCorrectionPanel.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+/**
+ * Compliance Centre — Phase 1 of "actionable queue" UX.
+ *
+ * Reusable inline panel that shows BEFORE → PROPOSED diff for a pending
+ * correction, surfaces the AI's reasoning, the optional founder
+ * `action_instructions` (Phase 3 stuck-item flow, written by
+ * recover-url-dead when Perplexity gives up), and one-click
+ * Approve / Reject / Mark-duplicate buttons that hit
+ * `/api/admin/legal-ref-corrections/{id}/decision`.
+ *
+ * Used in three places:
+ *   1. PendingCorrectionsSection rows (replaces the previous inline
+ *      JSX so the section keeps its existing layout but shares a
+ *      single source of truth for the diff card).
+ *   2. Inline expansion under each affected row in the page-level
+ *      Review queue (so the founder doesn't have to scroll to the
+ *      Pending section to see the AI proposal for a `url_dead` /
+ *      `auto_corrected` row).
+ *   3. The "What needs your attention" panel previews.
+ */
+
+import { useState } from 'react';
+import {
+  ExternalLink,
+  Check,
+  X,
+  Copy,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+  AlertTriangle,
+} from 'lucide-react';
+
+export interface InlineCorrection {
+  id: string;
+  ref_id: string;
+  proposer: string;
+  proposed_at: string;
+  before_law_name: string | null;
+  before_source_url: string | null;
+  before_status: string | null;
+  proposed_law_name: string | null;
+  proposed_source_url: string | null;
+  proposed_status: string | null;
+  superseded_by: string | null;
+  reasoning: string | null;
+  confidence: 'high' | 'medium' | 'low';
+  cost_gbp: number | null;
+  status: string;
+  action_instructions?: string | null;
+  enrichment_data?: { risk_score?: 'low' | 'medium' | 'high' | null } | null;
+  enriched_at?: string | null;
+}
+
+const CONFIDENCE_CLASS: Record<string, string> = {
+  high: 'bg-green-100 text-green-700 border-green-300',
+  medium: 'bg-amber-100 text-amber-700 border-amber-300',
+  low: 'bg-red-100 text-red-700 border-red-300',
+};
+
+interface Props {
+  correction: InlineCorrection;
+  /** Called after a decision succeeds so caller can refresh state. */
+  onResolve?: (id: string, action: 'approve' | 'reject' | 'mark_duplicate') => void | Promise<void>;
+  /** When true, renders compact (no proposer line, smaller padding). For attention panel previews. */
+  compact?: boolean;
+  /** Show the Mark-duplicate button. Defaults true. */
+  allowDuplicate?: boolean;
+}
+
+export default function InlineCorrectionPanel({
+  correction: c,
+  onResolve,
+  compact = false,
+  allowDuplicate = true,
+}: Props) {
+  const [busy, setBusy] = useState<null | 'approve' | 'reject' | 'mark_duplicate'>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reasoningOpen, setReasoningOpen] = useState(false);
+
+  const reasoningShort = (c.reasoning ?? '').slice(0, 250);
+  const reasoningHasMore = (c.reasoning ?? '').length > 250;
+
+  const lawNameChanged = c.proposed_law_name && c.proposed_law_name !== c.before_law_name;
+  const urlChanged = c.proposed_source_url && c.proposed_source_url !== c.before_source_url;
+
+  const decide = async (action: 'approve' | 'reject' | 'mark_duplicate') => {
+    setBusy(action);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/legal-ref-corrections/${c.id}/decision`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ action }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      if (onResolve) await onResolve(c.id, action);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className={compact ? '' : 'space-y-3'}>
+      {!compact && (
+        <div className="flex items-start justify-between gap-3">
+          <div className="text-xs text-slate-500">
+            proposed by {c.proposer} · {new Date(c.proposed_at).toLocaleString('en-GB')}
+            {c.cost_gbp != null && ` · £${c.cost_gbp.toFixed(4)}`}
+          </div>
+          <span
+            className={`inline-flex text-[11px] font-medium px-2 py-0.5 rounded-full border ${CONFIDENCE_CLASS[c.confidence]}`}
+          >
+            {c.confidence}
+          </span>
+        </div>
+      )}
+
+      {c.action_instructions && (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2.5 flex gap-2 items-start">
+          <AlertTriangle className="h-4 w-4 text-amber-600 flex-shrink-0 mt-0.5" />
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-bold uppercase tracking-wide text-amber-800">
+              Action required
+            </p>
+            <p className="text-sm text-amber-900 mt-0.5">{c.action_instructions}</p>
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+        <div className="bg-slate-50 border border-slate-200 rounded-lg p-3">
+          <p className="text-[11px] font-semibold text-slate-500 uppercase tracking-wide mb-1">
+            Before
+          </p>
+          <p className="text-slate-800 break-words">{c.before_law_name ?? '—'}</p>
+          {c.before_source_url ? (
+            <a
+              href={c.before_source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-slate-500 text-xs mt-1 break-all underline decoration-dotted hover:text-slate-700 inline-block"
+            >
+              {c.before_source_url}
+            </a>
+          ) : (
+            <p className="text-slate-500 text-xs mt-1 break-all">—</p>
+          )}
+          {c.before_status && (
+            <p className="text-slate-500 text-xs mt-1">status: {c.before_status}</p>
+          )}
+        </div>
+        <div
+          className={`border rounded-lg p-3 ${
+            lawNameChanged || urlChanged
+              ? 'bg-emerald-50 border-emerald-200'
+              : 'bg-slate-50 border-slate-200'
+          }`}
+        >
+          <p className="text-[11px] font-semibold text-emerald-700 uppercase tracking-wide mb-1">
+            Proposed
+          </p>
+          <p
+            className={`text-slate-900 break-words ${lawNameChanged ? 'font-semibold text-emerald-800' : ''}`}
+          >
+            {c.proposed_law_name ?? c.before_law_name ?? '—'}
+          </p>
+          {c.proposed_source_url ? (
+            <a
+              href={c.proposed_source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`text-xs mt-1 break-all underline decoration-dotted inline-block ${
+                urlChanged ? 'text-emerald-700 font-medium hover:text-emerald-800' : 'text-slate-500 hover:text-slate-700'
+              }`}
+            >
+              {c.proposed_source_url}
+            </a>
+          ) : (
+            <p className="text-xs mt-1 break-all text-slate-500">—</p>
+          )}
+          {c.proposed_status && (
+            <p className="text-emerald-700 text-xs mt-1">status: {c.proposed_status}</p>
+          )}
+          {c.superseded_by && (
+            <p className="text-amber-700 text-xs mt-1">superseded by: {c.superseded_by}</p>
+          )}
+        </div>
+      </div>
+
+      {c.reasoning && (
+        <div className="text-sm text-slate-700">
+          <p className="whitespace-pre-wrap">
+            {reasoningOpen ? c.reasoning : reasoningShort}
+            {!reasoningOpen && reasoningHasMore && '…'}
+          </p>
+          {reasoningHasMore && (
+            <button
+              type="button"
+              onClick={() => setReasoningOpen((s) => !s)}
+              className="mt-1 inline-flex items-center gap-1 text-xs text-emerald-600 hover:text-emerald-700"
+            >
+              {reasoningOpen ? (
+                <>
+                  <ChevronUp className="h-3 w-3" />
+                  collapse
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-3 w-3" />
+                  expand reasoning
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2 pt-1">
+        {c.proposed_source_url && (
+          <a
+            href={c.proposed_source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs text-slate-700 hover:text-slate-900 px-3 py-1.5 border border-slate-200 rounded-lg"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            Open proposed source
+          </a>
+        )}
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={() => decide('approve')}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1.5 text-xs font-semibold bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg"
+        >
+          {busy === 'approve' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+          Approve
+        </button>
+        <button
+          type="button"
+          onClick={() => decide('reject')}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1.5 text-xs font-semibold bg-red-50 hover:bg-red-100 disabled:opacity-50 text-red-700 px-3 py-1.5 rounded-lg border border-red-200"
+        >
+          {busy === 'reject' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <X className="h-3.5 w-3.5" />}
+          Reject
+        </button>
+        {allowDuplicate && (
+          <button
+            type="button"
+            onClick={() => decide('mark_duplicate')}
+            disabled={busy !== null}
+            className="inline-flex items-center gap-1.5 text-xs font-semibold bg-slate-50 hover:bg-slate-100 disabled:opacity-50 text-slate-700 px-3 py-1.5 rounded-lg border border-slate-200"
+          >
+            {busy === 'mark_duplicate' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Copy className="h-3.5 w-3.5" />}
+            Mark duplicate
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/legal-refs/PendingCorrectionsSection.tsx
+++ b/src/app/dashboard/admin/legal-refs/PendingCorrectionsSection.tsx
@@ -12,24 +12,10 @@
  */
 
 import { useEffect, useState, useCallback } from 'react';
-import { ExternalLink, Check, X, Copy, Loader2, AlertTriangle, ChevronDown, ChevronUp } from 'lucide-react';
+import { Check, Loader2, AlertTriangle } from 'lucide-react';
+import InlineCorrectionPanel, { InlineCorrection } from './InlineCorrectionPanel';
 
-interface Correction {
-  id: string;
-  ref_id: string;
-  proposer: string;
-  proposed_at: string;
-  before_law_name: string | null;
-  before_source_url: string | null;
-  before_status: string | null;
-  proposed_law_name: string | null;
-  proposed_source_url: string | null;
-  proposed_status: string | null;
-  superseded_by: string | null;
-  reasoning: string | null;
-  confidence: 'high' | 'medium' | 'low';
-  cost_gbp: number | null;
-  status: string;
+interface Correction extends InlineCorrection {
   legal_references?: {
     id: string;
     law_name: string;
@@ -38,27 +24,19 @@ interface Correction {
     subcategory: string | null;
     verification_status: string;
   } | null;
-  enrichment_data?: { risk_score?: 'low' | 'medium' | 'high' | null } | null;
-  enriched_at?: string | null;
-  // Phase 3 of compliance UX overhaul: AI-written one-line founder
-  // instruction for stuck items (e.g. "Search legislation.gov.uk for
-  // 'Consumer Rights Act 2015 s.9' and paste the new URL"). NULL on
-  // normal proposed-change corrections. Phase 1 will render this inline.
-  action_instructions?: string | null;
 }
 
-const CONFIDENCE_CLASS: Record<string, string> = {
-  high: 'bg-green-100 text-green-700 border-green-300',
-  medium: 'bg-amber-100 text-amber-700 border-amber-300',
-  low: 'bg-red-100 text-red-700 border-red-300',
-};
+interface PendingCorrectionsSectionProps {
+  /** Optional callback so the parent page can refresh its own state when
+   *  a correction is resolved (used by the page-level review queue to
+   *  drop the row out of the queue once approved). */
+  onResolved?: () => void | Promise<void>;
+}
 
-export default function PendingCorrectionsSection() {
+export default function PendingCorrectionsSection({ onResolved }: PendingCorrectionsSectionProps = {}) {
   const [corrections, setCorrections] = useState<Correction[]>([]);
   const [loading, setLoading] = useState(true);
-  const [busyId, setBusyId] = useState<string | null>(null);
   const [bulkBusy, setBulkBusy] = useState(false);
-  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
   // Default view = only items that genuinely need a human eye (enriched
   // AND medium/high risk). Toggle to show every pending row.
@@ -85,24 +63,10 @@ export default function PendingCorrectionsSection() {
     load();
   }, [load]);
 
-  const decide = async (id: string, action: 'approve' | 'reject' | 'mark_duplicate') => {
-    setBusyId(id);
-    try {
-      const res = await fetch(`/api/admin/legal-ref-corrections/${id}/decision`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ action }),
-      });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
-      await load();
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusyId(null);
-    }
-  };
+  const handleResolved = useCallback(async () => {
+    await load();
+    if (onResolved) await onResolved();
+  }, [load, onResolved]);
 
   const bulkApproveHigh = async () => {
     const highCount = corrections.filter((c) => c.confidence === 'high').length;
@@ -122,7 +86,7 @@ export default function PendingCorrectionsSection() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
-      await load();
+      await handleResolved();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -206,167 +170,34 @@ export default function PendingCorrectionsSection() {
         </div>
       ) : (
         <div className="space-y-3">
-          {visible.map((c) => {
-            const isOpen = expanded[c.id] ?? false;
-            const reasoningShort = (c.reasoning ?? '').slice(0, 200);
-            const reasoningHasMore = (c.reasoning ?? '').length > 200;
-            const lawNameChanged =
-              c.proposed_law_name && c.proposed_law_name !== c.before_law_name;
-            const urlChanged =
-              c.proposed_source_url && c.proposed_source_url !== c.before_source_url;
-            return (
-              <div
-                key={c.id}
-                id={`correction-${c.id}`}
-                className="border border-slate-200 rounded-2xl p-5 bg-white scroll-mt-24"
-              >
-                <div className="flex items-start justify-between gap-4 mb-3">
-                  <div className="flex-1 min-w-0">
-                    <a
-                      href={`#ref-${c.ref_id}`}
-                      className="text-sm font-semibold text-slate-900 hover:text-emerald-600"
-                    >
-                      {c.legal_references?.law_name ?? c.before_law_name ?? '(unknown ref)'}
-                    </a>
-                    <p className="text-xs text-slate-500 mt-0.5">
-                      proposed by {c.proposer} · {new Date(c.proposed_at).toLocaleString('en-GB')}
-                      {c.cost_gbp != null && ` · £${c.cost_gbp.toFixed(4)}`}
-                    </p>
-                    {/* Amendments-sweep proposals are XML-hash drift signals
-                        (high trust, deterministic) — distinguish them from
-                        Perplexity-verdict proposals so the founder knows
-                        what they're approving. Added 2026-05-01. */}
-                    {c.proposer && c.proposer.includes('amendments-sweep') && (
-                      <span className="inline-flex items-center gap-1 mt-1 text-[11px] font-semibold px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 border border-blue-300">
-                        🔁 amendments sweep
-                      </span>
-                    )}
-                  </div>
-                  <span
-                    className={`inline-flex text-xs font-medium px-2.5 py-1 rounded-full border ${CONFIDENCE_CLASS[c.confidence]}`}
+          {visible.map((c) => (
+            <div
+              key={c.id}
+              id={`correction-${c.id}`}
+              className="border border-slate-200 rounded-2xl p-5 bg-white scroll-mt-24"
+            >
+              <div className="flex items-start justify-between gap-4 mb-3">
+                <div className="flex-1 min-w-0">
+                  <a
+                    href={`#ref-${c.ref_id}`}
+                    className="text-sm font-semibold text-slate-900 hover:text-emerald-600"
                   >
-                    {c.confidence}
-                  </span>
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
-                  <div className="bg-slate-50 border border-slate-200 rounded-lg p-3">
-                    <p className="text-[11px] font-semibold text-slate-500 uppercase tracking-wide mb-1">
-                      Before
-                    </p>
-                    <p className="text-slate-800">{c.before_law_name ?? '—'}</p>
-                    <p className="text-slate-500 text-xs mt-1 break-all">
-                      {c.before_source_url ?? '—'}
-                    </p>
-                    {c.before_status && (
-                      <p className="text-slate-500 text-xs mt-1">status: {c.before_status}</p>
-                    )}
-                  </div>
-                  <div
-                    className={`border rounded-lg p-3 ${
-                      lawNameChanged || urlChanged
-                        ? 'bg-emerald-50 border-emerald-200'
-                        : 'bg-slate-50 border-slate-200'
-                    }`}
-                  >
-                    <p className="text-[11px] font-semibold text-emerald-700 uppercase tracking-wide mb-1">
-                      Proposed
-                    </p>
-                    <p
-                      className={`text-slate-900 ${lawNameChanged ? 'font-semibold text-emerald-800' : ''}`}
-                    >
-                      {c.proposed_law_name ?? c.before_law_name ?? '—'}
-                    </p>
-                    <p
-                      className={`text-xs mt-1 break-all ${urlChanged ? 'text-emerald-700 font-medium' : 'text-slate-500'}`}
-                    >
-                      {c.proposed_source_url ?? c.before_source_url ?? '—'}
-                    </p>
-                    {c.proposed_status && (
-                      <p className="text-emerald-700 text-xs mt-1">status: {c.proposed_status}</p>
-                    )}
-                    {c.superseded_by && (
-                      <p className="text-amber-700 text-xs mt-1">
-                        superseded by: {c.superseded_by}
-                      </p>
-                    )}
-                  </div>
-                </div>
-
-                {c.reasoning && (
-                  <div className="mt-3 text-sm text-slate-700">
-                    <p className="whitespace-pre-wrap">
-                      {isOpen ? c.reasoning : reasoningShort}
-                      {!isOpen && reasoningHasMore && '…'}
-                    </p>
-                    {reasoningHasMore && (
-                      <button
-                        onClick={() =>
-                          setExpanded((s) => ({ ...s, [c.id]: !isOpen }))
-                        }
-                        className="mt-1 inline-flex items-center gap-1 text-xs text-emerald-600 hover:text-emerald-700"
-                      >
-                        {isOpen ? (
-                          <>
-                            <ChevronUp className="h-3 w-3" />
-                            collapse
-                          </>
-                        ) : (
-                          <>
-                            <ChevronDown className="h-3 w-3" />
-                            expand
-                          </>
-                        )}
-                      </button>
-                    )}
-                  </div>
-                )}
-
-                <div className="mt-4 flex flex-wrap items-center gap-2">
-                  {c.proposed_source_url && (
-                    <a
-                      href={c.proposed_source_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 text-xs text-slate-700 hover:text-slate-900 px-3 py-1.5 border border-slate-200 rounded-lg"
-                    >
-                      <ExternalLink className="h-3.5 w-3.5" />
-                      Open proposed source
-                    </a>
+                    {c.legal_references?.law_name ?? c.before_law_name ?? '(unknown ref)'}
+                  </a>
+                  {/* Amendments-sweep proposals are XML-hash drift signals
+                      (high trust, deterministic) — distinguish them from
+                      Perplexity-verdict proposals so the founder knows
+                      what they're approving. Added 2026-05-01. */}
+                  {c.proposer && c.proposer.includes('amendments-sweep') && (
+                    <span className="inline-flex items-center gap-1 ml-2 text-[11px] font-semibold px-2 py-0.5 rounded-full bg-blue-100 text-blue-800 border border-blue-300">
+                      🔁 amendments sweep
+                    </span>
                   )}
-                  <div className="flex-1" />
-                  <button
-                    onClick={() => decide(c.id, 'approve')}
-                    disabled={busyId === c.id}
-                    className="inline-flex items-center gap-1.5 text-xs font-semibold bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg"
-                  >
-                    {busyId === c.id ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <Check className="h-3.5 w-3.5" />
-                    )}
-                    Approve
-                  </button>
-                  <button
-                    onClick={() => decide(c.id, 'reject')}
-                    disabled={busyId === c.id}
-                    className="inline-flex items-center gap-1.5 text-xs font-semibold bg-red-50 hover:bg-red-100 disabled:opacity-50 text-red-700 px-3 py-1.5 rounded-lg border border-red-200"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                    Reject
-                  </button>
-                  <button
-                    onClick={() => decide(c.id, 'mark_duplicate')}
-                    disabled={busyId === c.id}
-                    className="inline-flex items-center gap-1.5 text-xs font-semibold bg-slate-50 hover:bg-slate-100 disabled:opacity-50 text-slate-700 px-3 py-1.5 rounded-lg border border-slate-200"
-                  >
-                    <Copy className="h-3.5 w-3.5" />
-                    Mark duplicate
-                  </button>
                 </div>
               </div>
-            );
-          })}
+              <InlineCorrectionPanel correction={c} onResolve={handleResolved} />
+            </div>
+          ))}
         </div>
       )}
     </section>

--- a/src/app/dashboard/admin/legal-refs/page.tsx
+++ b/src/app/dashboard/admin/legal-refs/page.tsx
@@ -2,15 +2,17 @@
 
 export const dynamic = 'force-dynamic';
 
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import {
   Shield, CheckCircle, AlertTriangle, Clock, RefreshCw, ExternalLink,
-  Loader2, ChevronLeft, ArrowLeft, Search, Filter,
+  Loader2, ChevronLeft, ArrowLeft, Search, Filter, ChevronDown, ChevronRight,
+  Check, Play,
 } from 'lucide-react';
 import Link from 'next/link';
 import { AutoAppliedPanel } from './AutoAppliedPanel';
 import PendingCorrectionsSection from './PendingCorrectionsSection';
+import InlineCorrectionPanel, { InlineCorrection } from './InlineCorrectionPanel';
 import { pickCanonicalSource, SOURCE_LABEL } from '@/lib/legal-data/source-router';
 
 /**
@@ -228,6 +230,23 @@ export default function LegalRefsAdminPage() {
   const [lastSyncRun, setLastSyncRun] = useState<{ at: string; ok: boolean; failedPhases: string[] } | null>(null);
   const [allRefsExpanded, setAllRefsExpanded] = useState<boolean>(false);
   const [expandedNotes, setExpandedNotes] = useState<Set<string>>(new Set());
+
+  // Phase 1 actionable-UX (2026-05-03): page-level pending-corrections
+  // index. Fetched alongside refs so each review-queue / attention-panel
+  // row can render its corresponding correction inline (without forcing
+  // the founder to scroll to the dedicated PendingCorrectionsSection).
+  const [pendingCorrectionsByRefId, setPendingCorrectionsByRefId] = useState<
+    Record<string, InlineCorrection[]>
+  >({});
+  const [allPendingCorrections, setAllPendingCorrections] = useState<InlineCorrection[]>([]);
+  // Per-row toggle for the inline panel under review-queue rows. Default
+  // open for url_dead and auto_corrected rows (which is what the founder
+  // actually needs to act on); closed for everything else.
+  const [reviewRowExpanded, setReviewRowExpanded] = useState<Record<string, boolean>>({});
+  // Confirmation state for "Confirm correct" on auto-corrected rows.
+  const [confirmingAutoCorr, setConfirmingAutoCorr] = useState<Set<string>>(new Set());
+  // Inline runner for "Run url-dead recovery now" from the attention panel.
+  const [recoveringUrlDead, setRecoveringUrlDead] = useState<boolean>(false);
   // Freshness pipeline filters (added 2026-05-01).
   const [filterStaleOnly, setFilterStaleOnly] = useState<boolean>(false);
   const [filterUnappliedOnly, setFilterUnappliedOnly] = useState<boolean>(false);
@@ -249,7 +268,7 @@ export default function LegalRefsAdminPage() {
         return;
       }
       setAuthorized(true);
-      await Promise.all([fetchRefs(), fetchCandidates(), fetchActionPanelCounts()]);
+      await Promise.all([fetchRefs(), fetchCandidates(), fetchActionPanelCounts(), fetchPendingCorrections()]);
     };
     load();
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -334,6 +353,34 @@ export default function LegalRefsAdminPage() {
       }
     } catch {
       // non-fatal
+    }
+  };
+
+  // Page-level pending-corrections fetch. We index by ref_id so the
+  // review-queue and attention-panel rows can render their proposal
+  // inline. Same endpoint that PendingCorrectionsSection uses, so the two
+  // views always show the same data — they just present it differently
+  // (per-ref inline vs. flat queue).
+  const fetchPendingCorrections = async () => {
+    try {
+      const res = await fetch('/api/admin/legal-ref-corrections?status=pending', {
+        credentials: 'include',
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      const list: InlineCorrection[] = data.corrections || [];
+      setAllPendingCorrections(list);
+      const idx: Record<string, InlineCorrection[]> = {};
+      for (const c of list) {
+        if (!c.ref_id) continue;
+        if (!idx[c.ref_id]) idx[c.ref_id] = [];
+        idx[c.ref_id].push(c);
+      }
+      setPendingCorrectionsByRefId(idx);
+      setPendingCorrectionsCount(list.length);
+    } catch {
+      // non-fatal — the count widget falls back to the supabase query in
+      // fetchActionPanelCounts
     }
   };
 
@@ -522,7 +569,12 @@ export default function LegalRefsAdminPage() {
     try {
       const result = await fn();
       setOpToast({ kind: result.ok ? 'ok' : 'err', text: result.text });
-      await Promise.all([fetchRefs(), fetchCandidates(), fetchActionPanelCounts()]);
+      await Promise.all([
+        fetchRefs(),
+        fetchCandidates(),
+        fetchActionPanelCounts(),
+        fetchPendingCorrections(),
+      ]);
     } catch (err) {
       setOpToast({
         kind: 'err',
@@ -530,6 +582,78 @@ export default function LegalRefsAdminPage() {
       });
     } finally {
       setOpRunning(null);
+    }
+  };
+
+  // Called whenever a correction is approved / rejected from any inline
+  // panel on the page. Refreshes refs (status may flip to current),
+  // pending corrections (row drops out), and the attention-panel counts.
+  const handleCorrectionResolved = async () => {
+    await Promise.all([fetchRefs(), fetchPendingCorrections(), fetchActionPanelCounts()]);
+  };
+
+  // "Confirm correct" handler for auto-corrected rows. Hits the
+  // confirm-auto-correction endpoint added in this PR.
+  const confirmAutoCorrection = async (refId: string) => {
+    setConfirmingAutoCorr((prev) => new Set(prev).add(refId));
+    try {
+      const res = await fetch(`/api/admin/legal-refs/${refId}/confirm-auto-correction`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setOpToast({ kind: 'err', text: `Confirm failed: ${data.error || res.statusText}` });
+      } else {
+        setOpToast({ kind: 'ok', text: 'Auto-correction confirmed. Amber flag cleared.' });
+        await fetchRefs();
+      }
+    } catch (err) {
+      setOpToast({
+        kind: 'err',
+        text: `Failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    } finally {
+      setConfirmingAutoCorr((prev) => {
+        const next = new Set(prev);
+        next.delete(refId);
+        return next;
+      });
+    }
+  };
+
+  // Inline "Run url-dead recovery now" — same op as the modal-confirmed
+  // version above, but kicks off without the confirmation prompt because
+  // the founder triggered it from the attention panel where context is
+  // unambiguous.
+  const runUrlDeadRecoveryInline = async () => {
+    setRecoveringUrlDead(true);
+    try {
+      const res = await fetch('/api/admin/legal-refs/recover-url-dead', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ queue: true }),
+      });
+      const data = await res.json();
+      if (!data.ok) {
+        setOpToast({ kind: 'err', text: `Error: ${data.error || 'Unknown'}` });
+      } else {
+        setOpToast({
+          kind: 'ok',
+          text:
+            `Probed ${data.probed} · still dead ${data.still_dead} · now resolves ${data.now_resolves} · ` +
+            `queued ${data.queued} pending correction${data.queued === 1 ? '' : 's'}.`,
+        });
+        await Promise.all([fetchRefs(), fetchPendingCorrections(), fetchActionPanelCounts()]);
+      }
+    } catch (err) {
+      setOpToast({
+        kind: 'err',
+        text: `Failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    } finally {
+      setRecoveringUrlDead(false);
     }
   };
 
@@ -984,58 +1108,303 @@ export default function LegalRefsAdminPage() {
       </div>
 
       {/* Section A — "What needs your attention". Daily-driver summary
-          panel that surfaces only the action items: pending corrections,
-          url_dead refs needing recovery, AI auto-corrections needing
-          founder eyeball, candidates pending approval, and last sync
-          outcome. Founder reads this, clicks the right link, deals with
-          what matters — without scrolling through 124-row tables. */}
+          panel that surfaces only the action items, with top-3 inline
+          previews per non-zero bucket so the founder can see the issue
+          at a glance and act in 1 click without scrolling. */}
       {(() => {
-        const autoCorrectedCount = refs.filter((r) => r.auto_corrected === true).length;
-        const items: Array<{ label: string; count: number; href?: string; tone: 'amber' | 'red' | 'slate' }> = [
-          { label: 'pending corrections need review', count: pendingCorrectionsCount, href: '#pending-corrections', tone: 'amber' },
-          { label: 'URL_DEAD refs need recovery', count: urlDeadCount, href: '#review-queue', tone: 'red' },
-          { label: '"AI auto-correction" rows need verification', count: autoCorrectedCount, href: '#review-queue', tone: 'amber' },
-          { label: 'candidates pending approval', count: pendingCandCount, tone: 'slate' },
-        ];
-        const totalAction = items.reduce((s, i) => s + i.count, 0);
-        const tonePill = (t: 'amber' | 'red' | 'slate') =>
-          t === 'red'
-            ? 'bg-red-100 text-red-700 border-red-200'
-            : t === 'amber'
-              ? 'bg-amber-100 text-amber-700 border-amber-200'
-              : 'bg-slate-100 text-slate-700 border-slate-200';
+        const autoCorrectedRefs = refs.filter((r) => r.auto_corrected === true);
+        const autoCorrectedCount = autoCorrectedRefs.length;
+        const urlDeadRefs = refs.filter((r) => r.verification_status === 'url_dead');
+        const top3Pending = allPendingCorrections.slice(0, 3);
+        const top3UrlDead = urlDeadRefs.slice(0, 3);
+        const top3AutoCorr = autoCorrectedRefs.slice(0, 3);
+        const top3Candidates = candidates.slice(0, 3);
+
+        const totalAction =
+          pendingCorrectionsCount + urlDeadCount + autoCorrectedCount + pendingCandCount;
+
         return (
           <div className="mb-6 bg-white border-2 border-amber-300 rounded-2xl p-5 shadow-sm">
-            <div className="flex items-center gap-2 mb-3">
+            <div className="flex items-center gap-2 mb-4">
               <AlertTriangle className="h-5 w-5 text-amber-600" />
               <h2 className="text-lg font-bold text-slate-900">What needs your attention</h2>
             </div>
+
             {totalAction === 0 ? (
               <p className="text-sm text-emerald-700 font-medium flex items-center gap-2">
                 <CheckCircle className="h-4 w-4" />
                 Nothing needs your attention. Last sync clean.
               </p>
             ) : (
-              <ul className="space-y-2">
-                {items
-                  .filter((i) => i.count > 0)
-                  .map((i) => (
-                    <li key={i.label} className="flex items-center gap-3 text-sm">
-                      <span className={`inline-flex items-center justify-center min-w-[2rem] h-7 px-2 rounded-full border text-xs font-bold ${tonePill(i.tone)}`}>
-                        {i.count}
-                      </span>
-                      {i.href ? (
-                        <a href={i.href} className="text-slate-800 hover:text-emerald-700 hover:underline">
-                          {i.label}
+              <div className="space-y-5">
+                {/* Bucket: pending corrections */}
+                {pendingCorrectionsCount > 0 && (
+                  <div>
+                    <div className="flex items-baseline justify-between gap-3 mb-2">
+                      <h3 className="text-sm font-semibold text-slate-900">
+                        <span className="inline-flex items-center justify-center min-w-[1.75rem] h-6 px-2 rounded-full border bg-amber-100 text-amber-700 border-amber-200 text-xs font-bold mr-2">
+                          {pendingCorrectionsCount}
+                        </span>
+                        pending correction{pendingCorrectionsCount === 1 ? '' : 's'} need review
+                      </h3>
+                      {pendingCorrectionsCount > top3Pending.length && (
+                        <a
+                          href="#pending-corrections"
+                          className="text-xs text-emerald-700 hover:text-emerald-800 hover:underline"
+                        >
+                          View all {pendingCorrectionsCount} ↓
                         </a>
-                      ) : (
-                        <span className="text-slate-800">{i.label}</span>
                       )}
-                    </li>
-                  ))}
-              </ul>
+                    </div>
+                    <div className="space-y-2">
+                      {top3Pending.map((c) => (
+                        <details
+                          key={c.id}
+                          className="border border-amber-200 rounded-xl bg-amber-50/40 group"
+                          open
+                        >
+                          <summary className="cursor-pointer list-none px-3 py-2 flex items-center gap-2 text-xs hover:bg-amber-50 rounded-xl">
+                            <ChevronDown className="h-3.5 w-3.5 text-slate-500 group-open:rotate-0 -rotate-90 transition-transform" />
+                            <span className="font-medium text-slate-900 truncate flex-1">
+                              {c.before_law_name ?? '(unknown)'}
+                            </span>
+                            <span className="text-[10px] text-slate-500 font-mono whitespace-nowrap">
+                              {c.confidence}
+                            </span>
+                          </summary>
+                          <div className="px-3 pb-3 pt-1">
+                            <InlineCorrectionPanel
+                              correction={c}
+                              onResolve={handleCorrectionResolved}
+                              compact
+                              allowDuplicate={false}
+                            />
+                          </div>
+                        </details>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Bucket: url_dead refs needing recovery */}
+                {urlDeadCount > 0 && (
+                  <div>
+                    <div className="flex items-baseline justify-between gap-3 mb-2">
+                      <h3 className="text-sm font-semibold text-slate-900">
+                        <span className="inline-flex items-center justify-center min-w-[1.75rem] h-6 px-2 rounded-full border bg-red-100 text-red-700 border-red-200 text-xs font-bold mr-2">
+                          {urlDeadCount}
+                        </span>
+                        URL_DEAD ref{urlDeadCount === 1 ? '' : 's'} need recovery
+                      </h3>
+                      {urlDeadCount > top3UrlDead.length && (
+                        <a
+                          href="#review-queue"
+                          className="text-xs text-emerald-700 hover:text-emerald-800 hover:underline"
+                        >
+                          View all in review queue ↓
+                        </a>
+                      )}
+                    </div>
+                    <div className="space-y-2">
+                      {top3UrlDead.map((r) => {
+                        const corrs = pendingCorrectionsByRefId[r.id] ?? [];
+                        const top = corrs[0];
+                        return (
+                          <div
+                            key={r.id}
+                            className="border border-red-200 rounded-xl bg-red-50/40 px-3 py-2"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0 flex-1">
+                                <p className="text-sm font-medium text-slate-900 truncate">
+                                  {r.law_name}
+                                </p>
+                                <a
+                                  href={r.source_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-[11px] text-slate-500 break-all underline decoration-dotted hover:text-slate-700"
+                                >
+                                  {r.source_url}
+                                </a>
+                              </div>
+                              <a
+                                href={`#ref-${r.id}`}
+                                className="text-[11px] text-emerald-700 hover:text-emerald-800 hover:underline whitespace-nowrap"
+                              >
+                                jump to row
+                              </a>
+                            </div>
+                            {top ? (
+                              <div className="mt-2 pt-2 border-t border-red-200">
+                                <InlineCorrectionPanel
+                                  correction={top}
+                                  onResolve={handleCorrectionResolved}
+                                  compact
+                                  allowDuplicate={false}
+                                />
+                              </div>
+                            ) : (
+                              <div className="mt-2 pt-2 border-t border-red-200 text-[11px] text-slate-600 italic">
+                                AI hasn&apos;t been able to find a replacement yet.
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                    <div className="mt-2">
+                      <button
+                        type="button"
+                        onClick={runUrlDeadRecoveryInline}
+                        disabled={recoveringUrlDead || opRunning !== null}
+                        className="inline-flex items-center gap-1.5 text-xs font-semibold bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg"
+                      >
+                        {recoveringUrlDead ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Play className="h-3.5 w-3.5" />
+                        )}
+                        Run url-dead recovery now
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Bucket: AI auto-corrected refs needing verification */}
+                {autoCorrectedCount > 0 && (
+                  <div>
+                    <div className="flex items-baseline justify-between gap-3 mb-2">
+                      <h3 className="text-sm font-semibold text-slate-900">
+                        <span className="inline-flex items-center justify-center min-w-[1.75rem] h-6 px-2 rounded-full border bg-amber-100 text-amber-700 border-amber-200 text-xs font-bold mr-2">
+                          {autoCorrectedCount}
+                        </span>
+                        &quot;AI auto-correction&quot; row{autoCorrectedCount === 1 ? '' : 's'} need verification
+                      </h3>
+                      {autoCorrectedCount > top3AutoCorr.length && (
+                        <a
+                          href="#review-queue"
+                          className="text-xs text-emerald-700 hover:text-emerald-800 hover:underline"
+                        >
+                          View all in review queue ↓
+                        </a>
+                      )}
+                    </div>
+                    <div className="space-y-2">
+                      {top3AutoCorr.map((r) => {
+                        const isConfirming = confirmingAutoCorr.has(r.id);
+                        return (
+                          <div
+                            key={r.id}
+                            className="border border-amber-200 rounded-xl bg-amber-50/40 px-3 py-2"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0 flex-1">
+                                <p className="text-sm font-medium text-slate-900 truncate">
+                                  {r.law_name}
+                                </p>
+                                <a
+                                  href={r.source_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-[11px] text-slate-600 break-all underline decoration-dotted hover:text-slate-800"
+                                >
+                                  {r.source_url}
+                                </a>
+                                {r.verification_notes && (
+                                  <p className="text-[11px] text-slate-500 mt-1 line-clamp-2">
+                                    {r.verification_notes}
+                                  </p>
+                                )}
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => confirmAutoCorrection(r.id)}
+                                disabled={isConfirming}
+                                className="inline-flex items-center gap-1 text-[11px] font-semibold bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white px-2.5 py-1 rounded-lg whitespace-nowrap"
+                              >
+                                {isConfirming ? (
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                ) : (
+                                  <Check className="h-3 w-3" />
+                                )}
+                                Confirm correct
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Bucket: discovery candidates pending approval */}
+                {pendingCandCount > 0 && (
+                  <div>
+                    <div className="flex items-baseline justify-between gap-3 mb-2">
+                      <h3 className="text-sm font-semibold text-slate-900">
+                        <span className="inline-flex items-center justify-center min-w-[1.75rem] h-6 px-2 rounded-full border bg-slate-100 text-slate-700 border-slate-200 text-xs font-bold mr-2">
+                          {pendingCandCount}
+                        </span>
+                        candidate{pendingCandCount === 1 ? '' : 's'} pending approval
+                      </h3>
+                    </div>
+                    <div className="space-y-2">
+                      {top3Candidates.map((c) => (
+                        <div
+                          key={c.id}
+                          className="border border-slate-200 rounded-xl bg-slate-50/60 px-3 py-2"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0 flex-1">
+                              <p className="text-sm font-medium text-slate-900 truncate">
+                                {c.title}
+                              </p>
+                              {c.category && (
+                                <span className="inline-block mt-1 text-[10px] bg-slate-100 text-slate-700 px-2 py-0.5 rounded-full">
+                                  {CATEGORY_LABELS[c.category] || c.category}
+                                </span>
+                              )}
+                              {c.source_url && (
+                                <a
+                                  href={c.source_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="ml-2 inline-flex items-center gap-1 text-[11px] text-emerald-700 hover:underline"
+                                >
+                                  <ExternalLink className="h-3 w-3" /> source
+                                </a>
+                              )}
+                            </div>
+                            <div className="flex items-center gap-1 whitespace-nowrap">
+                              <button
+                                type="button"
+                                onClick={() => decideCandidate(c.id, 'approve')}
+                                className="text-[11px] px-2 py-1 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white font-semibold"
+                              >
+                                Approve
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  const notes = window.prompt('Notes (optional)') ?? undefined;
+                                  void decideCandidate(c.id, 'reject', notes);
+                                }}
+                                className="text-[11px] px-2 py-1 rounded-md bg-white border border-slate-200 hover:border-red-400 text-slate-700"
+                              >
+                                Reject
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
             )}
-            <div className="mt-4 pt-3 border-t border-slate-200 text-xs text-slate-600">
+
+            <div className="mt-5 pt-3 border-t border-slate-200 text-xs text-slate-600">
               {lastSyncRun ? (
                 <span>
                   Last sync run: {formatDate(lastSyncRun.at)} —{' '}
@@ -1254,7 +1623,7 @@ export default function LegalRefsAdminPage() {
 
       {/* Pending corrections (PR ε — human-in-loop gate) */}
       <div id="pending-corrections">
-        <PendingCorrectionsSection />
+        <PendingCorrectionsSection onResolved={handleCorrectionResolved} />
       </div>
 
       {/* Section C — "All references" collapsed by default. Founder
@@ -1693,74 +2062,196 @@ export default function LegalRefsAdminPage() {
                       const truncated = ref.source_url.length > 50
                         ? ref.source_url.slice(0, 47) + '…'
                         : ref.source_url;
+                      // Phase 1 actionable-UX: pull pending corrections for
+                      // this ref so we can render the diff inline.
+                      const refCorrections = pendingCorrectionsByRefId[ref.id] ?? [];
+                      const hasPendingCorrection = refCorrections.length > 0;
+                      const isUrlDead = ref.verification_status === 'url_dead';
+                      const isAutoCorrected = ref.auto_corrected === true;
+                      // Default expanded for url_dead / auto_corrected so
+                      // the founder sees the AI's proposal without an
+                      // extra click. For other rows the chevron is
+                      // closed-by-default — the diff exists but isn't
+                      // urgent enough to grab attention by default.
+                      const defaultOpen = isUrlDead || isAutoCorrected;
+                      const isExpanded = reviewRowExpanded[ref.id] ?? defaultOpen;
+                      const canExpand = hasPendingCorrection || isAutoCorrected;
+                      const isConfirming = confirmingAutoCorr.has(ref.id);
                       return (
-                        <tr key={ref.id} className="border-b border-slate-200 hover:bg-slate-50 transition-colors">
-                          <td className="px-5 py-4">
-                            <p className="text-slate-900 text-sm font-medium">{ref.law_name}</p>
-                            <p className="text-slate-600 text-xs mt-0.5 flex flex-wrap items-center gap-1.5">
-                              <span>{ref.source_type || '—'}{ref.section ? ` · ${ref.section}` : ''}</span>
-                              <SourceKindChip url={ref.source_url} />
-                            </p>
-                          </td>
-                          <td className="px-5 py-4 text-slate-700 text-sm hidden md:table-cell">{year}</td>
-                          <td className="px-5 py-4 hidden md:table-cell">
-                            <a
-                              href={ref.source_url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-emerald-600 hover:text-emerald-500 text-xs"
-                              title={ref.source_url}
-                            >
-                              {truncated}
-                            </a>
-                          </td>
-                          <td className="px-5 py-4">
-                            <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full ${status.className}`}>
-                              <StatusIcon className="h-3 w-3" />
-                              {status.label}
-                            </span>
-                            {ref.auto_corrected && (
-                              <span className="ml-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
-                                <AlertTriangle className="h-3 w-3" />
-                                AI auto-correction — please review
-                              </span>
-                            )}
-                          </td>
-                          <td className="px-5 py-4 hidden lg:table-cell text-slate-600 text-xs">
-                            {relativeTime(ref.last_verified)}
-                          </td>
-                          <td className="px-5 py-4">
-                            <div className="flex items-center justify-end gap-2 flex-wrap">
+                        <Fragment key={ref.id}>
+                          <tr className="border-b border-slate-200 hover:bg-slate-50 transition-colors">
+                            <td className="px-5 py-4">
+                              <div className="flex items-start gap-2">
+                                {canExpand && (
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      setReviewRowExpanded((prev) => ({
+                                        ...prev,
+                                        [ref.id]: !isExpanded,
+                                      }))
+                                    }
+                                    className="mt-0.5 p-0.5 rounded hover:bg-slate-200 text-slate-500"
+                                    aria-label={isExpanded ? 'Collapse correction' : 'Expand correction'}
+                                  >
+                                    {isExpanded ? (
+                                      <ChevronDown className="h-3.5 w-3.5" />
+                                    ) : (
+                                      <ChevronRight className="h-3.5 w-3.5" />
+                                    )}
+                                  </button>
+                                )}
+                                <div className="min-w-0">
+                                  <p className="text-slate-900 text-sm font-medium">{ref.law_name}</p>
+                                  <p className="text-slate-600 text-xs mt-0.5 flex flex-wrap items-center gap-1.5">
+                                    <span>{ref.source_type || '—'}{ref.section ? ` · ${ref.section}` : ''}</span>
+                                    <SourceKindChip url={ref.source_url} />
+                                    {hasPendingCorrection && (
+                                      <span className="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 border border-emerald-200">
+                                        AI proposal ready
+                                      </span>
+                                    )}
+                                  </p>
+                                </div>
+                              </div>
+                            </td>
+                            <td className="px-5 py-4 text-slate-700 text-sm hidden md:table-cell">{year}</td>
+                            <td className="px-5 py-4 hidden md:table-cell">
                               <a
                                 href={ref.source_url}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="inline-flex items-center gap-1 text-xs text-slate-700 hover:text-slate-900 px-2.5 py-1.5 border border-slate-200 rounded-lg"
+                                className="text-emerald-600 hover:text-emerald-500 text-xs"
+                                title={ref.source_url}
                               >
-                                <ExternalLink className="h-3 w-3" />
-                                Open URL
+                                {truncated}
                               </a>
-                              <button
-                                onClick={() => verifyWithAi([ref.id])}
-                                disabled={verifying}
-                                className="inline-flex items-center gap-1 text-xs font-semibold bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 px-2.5 py-1.5 rounded-lg"
-                              >
-                                {verifying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
-                                Verify with AI
-                              </button>
-                            </div>
-                            {result && (
-                              <p className={`text-[11px] mt-1.5 text-right ${result.ok ? 'text-emerald-600' : 'text-red-500'}`}>
-                                {result.ok ? '✓ ' : '✗ '}{result.ok ? (
-                                  result.status === 'no_change' ? 'No change · still current'
-                                  : result.status === 'queued' ? 'Correction queued for review'
-                                  : result.status === 'auto_applied' ? 'Auto-applied (low-risk)'
-                                  : `Verified · ${result.status}`
-                                ) : (result.notes || 'Failed')}
-                              </p>
-                            )}
-                          </td>
-                        </tr>
+                            </td>
+                            <td className="px-5 py-4">
+                              <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full ${status.className}`}>
+                                <StatusIcon className="h-3 w-3" />
+                                {status.label}
+                              </span>
+                              {ref.auto_corrected && (
+                                <span className="ml-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-200" title="Perplexity auto-overwrote the canonical citation. Please review.">
+                                  <AlertTriangle className="h-3 w-3" />
+                                  AI auto-correction — please review
+                                </span>
+                              )}
+                            </td>
+                            <td className="px-5 py-4 hidden lg:table-cell text-slate-600 text-xs">
+                              {relativeTime(ref.last_verified)}
+                            </td>
+                            <td className="px-5 py-4">
+                              <div className="flex items-center justify-end gap-2 flex-wrap">
+                                <a
+                                  href={ref.source_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="inline-flex items-center gap-1 text-xs text-slate-700 hover:text-slate-900 px-2.5 py-1.5 border border-slate-200 rounded-lg"
+                                >
+                                  <ExternalLink className="h-3 w-3" />
+                                  Open URL
+                                </a>
+                                <button
+                                  onClick={() => verifyWithAi([ref.id])}
+                                  disabled={verifying}
+                                  className="inline-flex items-center gap-1 text-xs font-semibold bg-emerald-500 hover:bg-emerald-600 disabled:opacity-50 text-slate-900 px-2.5 py-1.5 rounded-lg"
+                                >
+                                  {verifying ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                                  Verify with AI
+                                </button>
+                              </div>
+                              {result && (
+                                <p className={`text-[11px] mt-1.5 text-right ${result.ok ? 'text-emerald-600' : 'text-red-500'}`}>
+                                  {result.ok ? '✓ ' : '✗ '}{result.ok ? (
+                                    result.status === 'no_change' ? 'No change · still current'
+                                    : result.status === 'queued' ? 'Correction queued for review'
+                                    : result.status === 'auto_applied' ? 'Auto-applied (low-risk)'
+                                    : `Verified · ${result.status}`
+                                  ) : (result.notes || 'Failed')}
+                                </p>
+                              )}
+                            </td>
+                          </tr>
+                          {canExpand && isExpanded && (
+                            <tr className="border-b border-slate-200">
+                              <td colSpan={6} className="px-5 py-4 bg-slate-50/60">
+                                {hasPendingCorrection && (
+                                  <div className="space-y-3">
+                                    {refCorrections.map((c) => (
+                                      <div
+                                        key={c.id}
+                                        className="bg-white border border-slate-200 rounded-xl p-4"
+                                      >
+                                        <InlineCorrectionPanel
+                                          correction={c}
+                                          onResolve={handleCorrectionResolved}
+                                          allowDuplicate={false}
+                                        />
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
+                                {!hasPendingCorrection && isAutoCorrected && (
+                                  <div className="bg-white border border-amber-200 rounded-xl p-4">
+                                    <p className="text-[11px] font-bold uppercase tracking-wide text-amber-700 mb-2 flex items-center gap-1.5">
+                                      <AlertTriangle className="h-3.5 w-3.5" />
+                                      AI auto-correction — verify
+                                    </p>
+                                    <p className="text-sm text-slate-700 mb-2">
+                                      Perplexity overwrote this citation via the high-confidence
+                                      auto-apply path. Confirm if it&apos;s correct, or revert via
+                                      the Auto-applied panel above.
+                                    </p>
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs mb-3">
+                                      <div className="bg-slate-50 border border-slate-200 rounded-lg p-2.5">
+                                        <p className="text-[11px] font-semibold text-slate-500 uppercase tracking-wide mb-0.5">
+                                          Current
+                                        </p>
+                                        <p className="text-slate-800">{ref.law_name}</p>
+                                        <a
+                                          href={ref.source_url}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                          className="text-slate-600 break-all underline decoration-dotted hover:text-slate-800 inline-block mt-0.5"
+                                        >
+                                          {ref.source_url}
+                                        </a>
+                                      </div>
+                                      <div className="bg-slate-50 border border-slate-200 rounded-lg p-2.5">
+                                        <p className="text-[11px] font-semibold text-slate-500 uppercase tracking-wide mb-0.5">
+                                          Verifier notes
+                                        </p>
+                                        <p className="text-slate-700 whitespace-pre-wrap">
+                                          {ref.verification_notes || '(no notes recorded)'}
+                                        </p>
+                                      </div>
+                                    </div>
+                                    <div className="flex flex-wrap items-center gap-2">
+                                      <button
+                                        type="button"
+                                        onClick={() => confirmAutoCorrection(ref.id)}
+                                        disabled={isConfirming}
+                                        className="inline-flex items-center gap-1.5 text-xs font-semibold bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white px-3 py-1.5 rounded-lg"
+                                      >
+                                        {isConfirming ? (
+                                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                        ) : (
+                                          <Check className="h-3.5 w-3.5" />
+                                        )}
+                                        Confirm correct
+                                      </button>
+                                      <p className="text-[11px] text-slate-500">
+                                        To revert, use the Auto-applied (last 7 days) panel above.
+                                      </p>
+                                    </div>
+                                  </div>
+                                )}
+                              </td>
+                            </tr>
+                          )}
+                        </Fragment>
                       );
                     })}
                   </tbody>


### PR DESCRIPTION
Phase 1 of the Compliance Centre actionable-UX upgrade. Founder feedback: *"approve all is no use if I don't understand the issue"* — this PR makes the diff + AI proposal visible inline next to every queue row so the founder can act in 1 click without scrolling.

## A. Review queue rows: inline pending-correction diff
- Each row in the page-level Review queue now has a chevron toggle that expands an inline panel showing BEFORE → PROPOSED diff, Perplexity reasoning (with expand), `action_instructions` (Phase 3 stuck-item surface), Approve / Reject buttons.
- Default-open for `url_dead` / `auto_corrected` (which is what actually needs founder eyes); closed for everything else.
- "AI proposal ready" pill on the row label so the founder can see at a glance which rows have the AI's homework attached.

## B. Auto-corrected rows: Confirm correct / fallback diff
- Adds new founder-gated endpoint `POST /api/admin/legal-refs/{id}/confirm-auto-correction` that sets `auto_corrected=false` + stamps `last_human_review_at` (writes audit row to `legal_ref_verifications` if available).
- Inline panel under auto-corrected rows shows current state + verifier notes + "Confirm correct" button. When the underlying correction record is still in pending state, the row gets the standard Approve/Reject flow instead. Revert link points to the existing AutoAppliedPanel.

## C. "What needs your attention": top-3 inline previews
- Each non-zero bucket (pending corrections / url_dead / auto-corrected / candidates) renders top-3 items with one-click actions and the diff cards inline.
- "Run url-dead recovery now" button when the bucket is non-empty but the top items have no AI proposal yet.
- "View all in section ↓" anchor links to full tables when bucket > 3.
- Empty buckets are hidden; full-zero state still shows "Nothing needs your attention."

## D. action_instructions throughout
- Renders with amber "⚠ Action required" prefix in the shared `InlineCorrectionPanel`, used across the queue, page-level review, and attention-panel previews.
- `PendingCorrectionsSection` refactored to use the same component so the visual language stays identical — outer fetch/filter logic untouched.

## Files changed
- `src/app/dashboard/admin/legal-refs/InlineCorrectionPanel.tsx` (new — shared)
- `src/app/dashboard/admin/legal-refs/PendingCorrectionsSection.tsx` (extracted to use the shared panel)
- `src/app/dashboard/admin/legal-refs/page.tsx` (review queue + attention panel)
- `src/app/api/admin/legal-refs/[id]/confirm-auto-correction/route.ts` (new — founder-gated)

## Test plan
- [ ] Visit `/dashboard/admin/legal-refs` as `aireypaul@googlemail.com`.
- [ ] Confirm "What needs your attention" shows top-3 inline cards per non-zero bucket.
- [ ] Expand a `url_dead` review-queue row and approve / reject the inline correction; row drops out.
- [ ] Verify Pending corrections section still works (now using the shared component).
- [ ] Click "Confirm correct" on an `auto_corrected` row's inline panel; amber flag clears.
- [ ] Confirm `npx tsc --noEmit` and `npm run build` clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)