### PR TITLE
Homepage: move Pocket Agent to slot 2 (right after AI Disputes)

### DIFF
--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -1133,6 +1133,48 @@ export default function HomepageV3PreviewPage() {
         </div>
       </section>
 
+      {/* ----- Pocket Agent · reframed as "personal caseworker" ----- */}
+      <section className="feature-section feature-section--ink" id="pocket-agent">
+        <div className="wrap">
+          <div className="feature-grid">
+            <Reveal className="feature-copy">
+              <h2 className="feature-title">Your personal caseworker — over WhatsApp &amp; Telegram</h2>
+              <p className="feature-tagline">
+                A solicitor takes a week to reply to email. Your Paybacker
+                caseworker is on chat 24/7.
+              </p>
+              <p>
+                It tells you when a dispute is ready to send, when the company
+                replies, and when the 8-week Ombudsman clock hits. Tap to
+                approve. Done — no chasing, no hold music.
+              </p>
+              <ul className="feature-bullets">
+                <li>Drafts ready in 30 seconds — approve with one tap</li>
+                <li>Watches your inbox for the provider&rsquo;s response</li>
+                <li>Auto-escalates to Ombudsman at the 8-week mark</li>
+                <li>
+                  <strong>Telegram Pocket Agent</strong>{' '}
+                  <span className="tier-chip tier-chip--free">Free</span> — across all plans.
+                </li>
+                <li>
+                  <strong>WhatsApp Pocket Agent</strong>{' '}
+                  <span className="tier-chip tier-chip--pro">Pro</span> — £9.99/month.
+                  Same caseworker, different chat.
+                </li>
+              </ul>
+              <div className="feature-cta-row">
+                <Link className="btn btn-mint" href="/pocket-agent">
+                  Set up your Pocket Agent →
+                </Link>
+              </div>
+            </Reveal>
+            <Reveal className="feature-stage" delay={120}>
+              <PocketAgentDemo />
+            </Reveal>
+          </div>
+        </div>
+      </section>
+
       {/* ----- 02 · Compliance pipeline (trust strip between Disputes
               and Money Hub) ----- */}
       <section
@@ -1284,48 +1326,6 @@ export default function HomepageV3PreviewPage() {
             </Reveal>
             <Reveal className="feature-stage" delay={120}>
               <ExportDemo />
-            </Reveal>
-          </div>
-        </div>
-      </section>
-
-      {/* ----- Pocket Agent · reframed as "personal caseworker" ----- */}
-      <section className="feature-section feature-section--ink" id="pocket-agent">
-        <div className="wrap">
-          <div className="feature-grid">
-            <Reveal className="feature-copy">
-              <h2 className="feature-title">Your personal caseworker — over WhatsApp &amp; Telegram</h2>
-              <p className="feature-tagline">
-                A solicitor takes a week to reply to email. Your Paybacker
-                caseworker is on chat 24/7.
-              </p>
-              <p>
-                It tells you when a dispute is ready to send, when the company
-                replies, and when the 8-week Ombudsman clock hits. Tap to
-                approve. Done — no chasing, no hold music.
-              </p>
-              <ul className="feature-bullets">
-                <li>Drafts ready in 30 seconds — approve with one tap</li>
-                <li>Watches your inbox for the provider&rsquo;s response</li>
-                <li>Auto-escalates to Ombudsman at the 8-week mark</li>
-                <li>
-                  <strong>Telegram Pocket Agent</strong>{' '}
-                  <span className="tier-chip tier-chip--free">Free</span> — across all plans.
-                </li>
-                <li>
-                  <strong>WhatsApp Pocket Agent</strong>{' '}
-                  <span className="tier-chip tier-chip--pro">Pro</span> — £9.99/month.
-                  Same caseworker, different chat.
-                </li>
-              </ul>
-              <div className="feature-cta-row">
-                <Link className="btn btn-mint" href="/pocket-agent">
-                  Set up your Pocket Agent →
-                </Link>
-              </div>
-            </Reveal>
-            <Reveal className="feature-stage" delay={120}>
-              <PocketAgentDemo />
             </Reveal>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Pure positional move inside the homepage feature block. Pocket Agent was the **last** feature deep-dive (slot 6); it's now the **second** (slot 2), immediately after AI Disputes. The two product USPs lead the feature surface together.

## New feature block order

| # | Section | Demo |
|---|---------|------|
| 1 | AI Disputes Centre | `DisputesDemo` |
| 2 | **Pocket Agent** *(was slot 6)* | `PocketAgentDemo` |
| 3 | Compliance pipeline | — |
| 4 | Money Hub | `MoneyHubDemo` |
| 5 | Subscriptions Tracker | `SubscriptionsDemo` |
| 6 | Export Hub | `ExportDemo` |

The Compliance pipeline still backs the AI letter engine (referenced from the freshness chip's `See how →` anchor in AI Disputes) and now also serves Pocket Agent letters since both surfaces call the same engine.

## What's preserved

- All 8 demo components in their original sections (`DisputesDemo`, `PocketAgentDemo`, `MoneyHubDemo`, `SubscriptionsDemo`, `ExportDemo`, `HeroDemo`, `DealsDemo`, `McpDemo`).
- All 19 sections (no additions, no removals).
- All copy identical.
- Line count unchanged (1999 → 1999).
- Tag balance preserved (19 section opens / 19 closes).

## Test plan

- [ ] Wait for Vercel preview deploy on this branch.
- [ ] Confirm scroll order on the preview: trust band → AI Disputes → Pocket Agent → Compliance → Money Hub → Subscriptions → Export → real-win → vs-lawyers → how-it-works → compare → deals → pricing → testimonials → MCP → final CTA.
- [ ] Verify all demos play in their sections.
- [ ] Confirm the freshness chip's `See how →` anchor still resolves to `#compliance`.

https://claude.ai/code/session_018R1VR79H8N7TjiEGTBjtnz

---
_Generated by [Claude Code](https://claude.ai/code/session_018R1VR79H8N7TjiEGTBjtnz)_