### PR TITLE
fix(admin): dashboard nav reachability + cron UX + blog revalidation

### DIFF
--- a/src/app/api/admin/crons/list/route.ts
+++ b/src/app/api/admin/crons/list/route.ts
@@ -57,9 +57,11 @@ export async function GET() {
 
   // Pull the last 500 cron_run rows and collapse in memory. Faster than
   // 43 × DISTINCT ON queries and keeps the SQL boring.
+  // Note: business_log has no severity column — we infer "failed" from
+  // the content text (the proxy writes "FAILED" for non-OK responses).
   const { data: recentRuns } = await admin
     .from('business_log')
-    .select('title, content, severity, created_at')
+    .select('title, content, created_at')
     .eq('category', 'cron_run')
     .order('created_at', { ascending: false })
     .limit(500);
@@ -71,10 +73,12 @@ export async function GET() {
     const match = title.match(/^cron_run\s+(.+)$/);
     const cronPath = match ? match[1] : title;
     if (!lastByPath.has(cronPath)) {
+      const content = row.content ?? '';
+      const inferredSeverity = /FAILED|HTTP 5\d\d|HTTP 4\d\d/.test(content) ? 'error' : 'info';
       lastByPath.set(cronPath, {
         at: row.created_at,
-        severity: row.severity ?? 'info',
-        summary: (row.content ?? '').slice(0, 240),
+        severity: inferredSeverity,
+        summary: content.slice(0, 240),
       });
     }
   }

--- a/src/app/api/admin/crons/run/route.ts
+++ b/src/app/api/admin/crons/run/route.ts
@@ -76,17 +76,32 @@ export async function POST(request: NextRequest) {
   const url = `${origin}${requestedPath}`;
   const startedAt = Date.now();
 
+  // Long-running crons (publish-blog, compliance-sync) can take 1-3
+  // minutes. We don't want the admin UI to spin indefinitely waiting
+  // for them — instead, we wait up to 25s for a fast response, and
+  // if the inner cron is still running we return "started_in_background"
+  // so the founder can check the Last-run column for the outcome.
+  // Aborting the outer fetch closes the proxy's TCP connection but the
+  // inner Vercel function keeps running through to its own maxDuration
+  // (publish-blog doesn't read request.signal).
+  const FAST_TIMEOUT_MS = 25_000;
+  const ac = new AbortController();
+  const fastTimer = setTimeout(() => ac.abort(), FAST_TIMEOUT_MS);
+
   let ok = false;
   let status = 0;
   let responseBody: unknown = null;
   let errorMessage: string | null = null;
+  let backgrounded = false;
 
   try {
     const res = await fetch(url, {
       method: 'GET',
       headers: { Authorization: `Bearer ${cronSecret}` },
       cache: 'no-store',
+      signal: ac.signal,
     });
+    clearTimeout(fastTimer);
     status = res.status;
     try {
       responseBody = await res.json();
@@ -100,7 +115,19 @@ export async function POST(request: NextRequest) {
         : String(responseBody).slice(0, 500);
     }
   } catch (err) {
-    errorMessage = err instanceof Error ? err.message : String(err);
+    clearTimeout(fastTimer);
+    if (err instanceof Error && err.name === 'AbortError') {
+      // Inner cron is still running. We're returning to the user with
+      // "started" — the cron itself will log its outcome to
+      // business_log when it finishes (e.g. publish-blog logs a
+      // `blog_publish` row), and the Last-run column on the admin
+      // page shows it on next refresh.
+      backgrounded = true;
+      ok = true;
+      status = 202;
+    } else {
+      errorMessage = err instanceof Error ? err.message : String(err);
+    }
   }
 
   const durationMs = Date.now() - startedAt;
@@ -114,10 +141,11 @@ export async function POST(request: NextRequest) {
   await admin.from('business_log').insert({
     category: 'cron_run',
     title: `cron_run ${requestedPath}`,
-    content: ok
-      ? `Manual run by ${user.email} succeeded in ${durationMs}ms. Response: ${JSON.stringify(responseBody).slice(0, 400)}`
-      : `Manual run by ${user.email} FAILED (HTTP ${status} in ${durationMs}ms): ${errorMessage}`,
-    severity: ok ? 'info' : 'error',
+    content: backgrounded
+      ? `Manual run by ${user.email} kicked off (still running in background after ${durationMs}ms). Outcome will be logged separately by the cron handler when it finishes.`
+      : ok
+        ? `Manual run by ${user.email} succeeded in ${durationMs}ms. Response: ${JSON.stringify(responseBody).slice(0, 400)}`
+        : `Manual run by ${user.email} FAILED (HTTP ${status} in ${durationMs}ms): ${errorMessage}`,
   }).then(({ error: e }) => {
     if (e) console.error('[admin/crons/run] business_log insert failed:', e.message);
   });
@@ -127,6 +155,15 @@ export async function POST(request: NextRequest) {
       { ok: false, status, error: errorMessage, durationMs },
       { status: 502 },
     );
+  }
+  if (backgrounded) {
+    return NextResponse.json({
+      ok: true,
+      status: 202,
+      durationMs,
+      backgrounded: true,
+      response: { message: 'Cron started in background — refresh the page in ~1-3 minutes to see the outcome in the Last run column.' },
+    });
   }
   return NextResponse.json({ ok: true, status, durationMs, response: responseBody });
 }

--- a/src/app/api/cron/publish-blog/route.ts
+++ b/src/app/api/cron/publish-blog/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
 import { createClient } from '@supabase/supabase-js';
 import Anthropic from '@anthropic-ai/sdk';
 import { resend, FROM_EMAIL } from '@/lib/resend';
@@ -333,6 +334,28 @@ Make it genuinely useful for someone searching "${topic.keyword}" on Google. Inc
   if (insertErr) {
     console.error('[blog] Supabase upsert failed:', insertErr.message);
     return NextResponse.json({ error: insertErr.message }, { status: 500 });
+  }
+
+  // /blog index has revalidate=3600. Without an explicit revalidate
+  // call here, a manual "Run now" looks broken — the post is in the
+  // DB but the marketing index won't show it for up to an hour.
+  try {
+    revalidatePath('/blog');
+    revalidatePath(`/blog/${topic.slug}`);
+  } catch (revalErr) {
+    console.warn('[blog] revalidatePath failed (non-fatal):', revalErr);
+  }
+
+  // Audit log so the founder can see in /dashboard/admin/crons that
+  // the cron actually fired without trawling Vercel logs.
+  try {
+    await supabase.from('business_log').insert({
+      category: 'blog_publish',
+      title: `Blog published: ${topic.slug}`,
+      content: `"${parsed.title}" — keyword="${topic.keyword}". Topics remaining: ${unwritten.length > 0 ? unwritten.length - 1 : TOPIC_POOL.length - 1}.`,
+    });
+  } catch (logErr) {
+    console.warn('[blog] business_log insert failed (non-fatal):', logErr);
   }
 
   console.log(`[blog] Published: ${topic.slug} - "${parsed.title}"`);

--- a/src/app/dashboard/admin/billing/page.tsx
+++ b/src/app/dashboard/admin/billing/page.tsx
@@ -73,7 +73,7 @@ export default async function AdminBillingPage() {
   return (
     <AdminPage
       title="API Billing"
-      description={`Internal cost ledger — actual paid third-party API spend across Anthropic, Perplexity, Resend, Stripe, TrueLayer. Generated ${new Date(summary.generatedAt).toLocaleString('en-GB')}.`}
+      description={`Internal cost ledger — actual paid third-party API spend across Anthropic, Perplexity, Resend, Stripe, Yapily. Generated ${new Date(summary.generatedAt).toLocaleString('en-GB')}.`}
     >
       <section className="grid md:grid-cols-3 gap-4">
         <Card label="This month so far" value={gbp(summary.monthSoFar.total_gbp)} />

--- a/src/app/dashboard/admin/crons/page.tsx
+++ b/src/app/dashboard/admin/crons/page.tsx
@@ -117,6 +117,15 @@ export default function AdminCronsPage() {
       const data = await res.json();
       if (!res.ok) {
         setRunResult({ path: cronPath, ok: false, message: data.error ?? `HTTP ${res.status}` });
+      } else if (data.backgrounded) {
+        setRunResult({
+          path: cronPath,
+          ok: true,
+          message: data.response?.message ?? 'Started in background — refresh in 1-3 min for the result.',
+        });
+        // Auto-refresh after 30s so the Last-run column picks up the
+        // cron's own log row when it finishes.
+        setTimeout(loadCrons, 30_000);
       } else {
         const responseSummary = typeof data.response === 'object'
           ? JSON.stringify(data.response).slice(0, 200)

--- a/src/app/dashboard/shell-v2.css
+++ b/src/app/dashboard/shell-v2.css
@@ -496,11 +496,12 @@
   padding: 18px;
 }
 
-/* 5. AdminTabStrip horizontal-scroll behaviour.
-   The strip is now a single flat row of every admin destination
-   (no More dropdown — the dropdown was clipped inside the iOS
-   Capacitor webview). Always scrolls-x, on every viewport. The
-   right-edge fade hints there's more to swipe to. */
+/* 5. AdminTabStrip behaviour.
+   On mobile/iOS Capacitor: swipeable horizontal strip with hidden
+   scrollbar + right-edge fade hint. On desktop (>=980px) the strip
+   wraps to multiple lines so every admin destination is reachable
+   without horizontal trackpad scroll — founder reported "tabs aren't
+   viewable so I can't reach it" on desktop. */
 .shell-v2 .admin-tab-strip {
   flex-wrap: nowrap;
   -webkit-overflow-scrolling: touch;
@@ -519,6 +520,14 @@
   height: calc(100% - 6px);
   pointer-events: none;
   background: linear-gradient(to left, var(--paper, #FAFAF7), transparent);
+}
+@media (min-width: 980px) {
+  .shell-v2 .admin-tab-strip {
+    flex-wrap: wrap;
+    overflow-x: visible;
+    scroll-snap-type: none;
+  }
+  .shell-v2 .admin-tab-strip-wrap::after { display: none; }
 }
 
 /* 6. Mobile-safe break-words on admin headings + breadcrumb.


### PR DESCRIPTION
## Summary
Three founder-blocking issues that share the same root cause: visibility of admin actions.

1. **AdminTabStrip now wraps on desktop.** The strip was `flex-wrap: nowrap` with the scrollbar hidden — on a desktop trackpad the founder couldn't reach tabs that overflowed the right edge. Above 980px the strip now wraps to multiple lines so every admin destination is visible. Mobile keeps the swipeable behaviour for iOS Capacitor.
2. **\`/api/admin/crons/run\` no longer blocks the dashboard UI** for the cron's full duration. Waits up to 25s for a fast response; if the inner cron is still running, returns \`backgrounded: true\` so the UI shows "started, refresh in 1-3 min" instead of spinning. The cron continues to completion in the background. Auto-refreshes the Last-run column 30s later.
3. **\`publish-blog\` cron now calls \`revalidatePath('/blog')\`** after upserting so manual "Run now" surfaces the new post immediately instead of after the 1h ISR cache expires. Also writes a \`blog_publish\` row to \`business_log\`.

### Bonus fixes spotted while in the area
- \`/api/admin/crons/list\` selected a non-existent \`severity\` column — that's why the Last-run column was empty. Inferred from content text instead.
- \`/api/admin/crons/run\` also tried to insert non-existent \`severity\`, which silently broke the entire \`cron_run\` log path.
- \`/dashboard/admin/billing\` description listed "TrueLayer" — switched to "Yapily".

## Test plan
- [ ] Visit \`/dashboard/admin\` on desktop ≥980px — every tab is visible without horizontal scroll
- [ ] Visit \`/dashboard/admin\` on mobile — strip still swipes horizontally
- [ ] Click "Run now" on \`publish-blog\` from \`/dashboard/admin/crons\` — UI returns within 25s with "started in background, refresh in 1-3 min"
- [ ] After 1-3 min, refresh — Last-run column shows the cron_run row
- [ ] Visit \`/blog\` — newly-published post appears at the top without waiting an hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)