### PR TITLE
fix: trial-ended dedupe + homepage WhatsApp reskin + email-scan refresh

### DIFF
--- a/src/app/api/cron/founding-member-expiry/route.ts
+++ b/src/app/api/cron/founding-member-expiry/route.ts
@@ -84,7 +84,7 @@ function buildExpiredEmail(name: string): string {
     <p style="color:#e2e8f0;font-size:16px;line-height:1.6;">Hi ${name || 'there'},</p>
 
     <p style="color:#94a3b8;font-size:14px;line-height:1.8;">
-      Your free free trial trial has ended and your account has moved to the <strong style="color:#fff;">Free plan</strong>.
+      Your free Pro trial has ended and your account has moved to the <strong style="color:#fff;">Free plan</strong>.
     </p>
 
     <div style="background:#22c55e15;border:1px solid #22c55e30;border-radius:12px;padding:20px;margin:24px 0;">
@@ -204,13 +204,15 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // 2. Downgrade expired free trials
+  // 2. Downgrade expired free trials. Skip rows we've already stamped so
+  // a same-day re-run can't double-email the user.
   const now = new Date().toISOString();
   const { data: expired } = await supabase
     .from('profiles')
     .select('id, email, full_name, subscription_tier, stripe_subscription_id')
     .eq('founding_member', true)
-    .lt('founding_member_expires', now);
+    .lt('founding_member_expires', now)
+    .is('trial_expired_at', null);
 
   for (const user of expired || []) {
     // Skip if they've already paid for a subscription via Stripe

--- a/src/app/api/cron/trial-expiry/route.ts
+++ b/src/app/api/cron/trial-expiry/route.ts
@@ -6,10 +6,11 @@ export const runtime = 'edge';
 export const maxDuration = 300;
 
 export async function GET(request: Request) {
-  // Optional cron secret check
+  // Cron auth — fail closed. A misconfigured (unset) CRON_SECRET must NOT
+  // make the route public; mass downgrades + outbound emails are gated.
   const authHeader = request.headers.get('authorization');
   if (
-    process.env.CRON_SECRET &&
+    !process.env.CRON_SECRET ||
     authHeader !== `Bearer ${process.env.CRON_SECRET}`
   ) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -58,8 +59,11 @@ export async function GET(request: Request) {
 
     // 2. Downgrade their tier and status. Stamp trial_expired_at so this
     // row is idempotent — any subsequent run (or the founding-member cron)
-    // will skip it.
-    const { error: updateError } = await supabase
+    // will skip it. The .eq('subscription_status', 'trialing') guard means
+    // a row that flipped to e.g. 'active' (user upgraded mid-cron) won't
+    // be touched. Use .select() to recover ONLY the rows that were
+    // actually updated, so we email exactly the users we downgraded.
+    const { data: downgradedUsers, error: updateError } = await supabase
       .from('profiles')
       .update({
         subscription_tier: 'free',
@@ -67,21 +71,22 @@ export async function GET(request: Request) {
         trial_expired_at: new Date().toISOString(),
       })
       .in('id', userIds)
-      .eq('subscription_status', 'trialing');
+      .eq('subscription_status', 'trialing')
+      .select('id, email, first_name, full_name');
 
     if (updateError) {
       console.error('[trial-expiry] Error updating users:', updateError);
       return NextResponse.json({ error: updateError.message }, { status: 500 });
     }
 
-    // 3. Send them the trial expired email
+    // 3. Send the trial-expired email only to users we actually downgraded.
     let emailsSent = 0;
-    for (const user of expiredUsers) {
+    for (const user of downgradedUsers ?? []) {
       if (!user.email) continue;
-      
+
       const name = user.first_name || user.full_name?.split(' ')[0] || 'there';
       const html = templates.trialExpired(name);
-      
+
       const success = await sendEmail(
         user.email,
         'Your Paybacker Pro trial has ended',
@@ -91,14 +96,14 @@ export async function GET(request: Request) {
       if (success) {
         emailsSent++;
       }
-      
+
       // small delay to prevent rate limits from Resend
       await new Promise(r => setTimeout(r, 100));
     }
 
     return NextResponse.json({
       success: true,
-      downgraded: expiredUsers.length,
+      downgraded: downgradedUsers?.length ?? 0,
       emailsSent,
     });
   } catch (err: any) {

--- a/src/app/api/cron/trial-expiry/route.ts
+++ b/src/app/api/cron/trial-expiry/route.ts
@@ -28,13 +28,20 @@ export async function GET(request: Request) {
   const supabase = createClient(supabaseUrl, supabaseKey);
 
   try {
-    // 1. Find all users who are trialing and their trial has expired
+    // 1. Find all users who are trialing and their trial has expired.
+    // Exclude founding members — /api/cron/founding-member-expiry is the
+    // single source of truth for that cohort and runs an hour earlier.
+    // Exclude users who already have trial_expired_at set so we don't
+    // re-email anyone whose downgrade has already been processed (the
+    // founding-member cron sets this column when it downgrades).
     const { data: expiredUsers, error: fetchError } = await supabase
       .from('profiles')
       .select('id, email, first_name, full_name')
       .eq('subscription_status', 'trialing')
       .lt('trial_ends_at', new Date().toISOString())
-      .is('stripe_subscription_id', null);
+      .is('stripe_subscription_id', null)
+      .is('trial_expired_at', null)
+      .or('founding_member.is.null,founding_member.eq.false');
 
     if (fetchError) {
       console.error('[trial-expiry] Error fetching expired users:', fetchError);
@@ -49,12 +56,15 @@ export async function GET(request: Request) {
 
     const userIds = expiredUsers.map((u) => u.id);
 
-    // 2. Downgrade their tier and status
+    // 2. Downgrade their tier and status. Stamp trial_expired_at so this
+    // row is idempotent — any subsequent run (or the founding-member cron)
+    // will skip it.
     const { error: updateError } = await supabase
       .from('profiles')
       .update({
         subscription_tier: 'free',
         subscription_status: 'active', // they are active free users now
+        trial_expired_at: new Date().toISOString(),
       })
       .in('id', userIds)
       .eq('subscription_status', 'trialing');

--- a/src/app/api/email/scan/route.ts
+++ b/src/app/api/email/scan/route.ts
@@ -345,6 +345,43 @@ IMPORTANT:
             }))
           ).then(({ error: e }) => { if (e) console.error('[email/scan] money_hub_alerts insert error:', e.message); });
         }
+
+        // The dashboard's "Email scanner" card reads from
+        // `email_scan_findings` (status in [new, reviewing]). Gmail
+        // writes there; IMAP previously did not, so non-Gmail scans
+        // produced findings the user never saw. Mirror Gmail's insert
+        // here — filtered to the CHECK-constraint type allowlist.
+        const FINDING_TYPES = new Set([
+          'subscription', 'bill', 'contract', 'dispute_response',
+          'cancellation_confirmation', 'price_increase', 'refund_opportunity',
+          'flight_delay', 'debt_dispute', 'tax_rebate', 'renewal',
+          'forgotten_subscription', 'upcoming_payment', 'deal_expiry',
+          'bank_gap',
+        ]);
+        const findings = newOpportunities.filter((o: any) => FINDING_TYPES.has(o.type));
+        if (findings.length > 0) {
+          await admin.from('email_scan_findings').insert(
+            findings.map((o: any) => ({
+              user_id: user.id,
+              finding_type: o.type,
+              provider: o.provider || 'Unknown',
+              email_id: o.emailId || null,
+              title: o.title,
+              description: o.description || null,
+              amount: o.amount || o.paymentAmount || null,
+              due_date: o.nextPaymentDate || null,
+              contract_end_date: o.contractEndDate || null,
+              previous_amount: o.previousAmount || null,
+              price_change_date: o.priceChangeDate || null,
+              payment_frequency: o.paymentFrequency || null,
+              confidence: o.confidence || 70,
+              urgency: o.urgency || 'routine',
+              status: 'new',
+              source: 'imap',
+              metadata: o,
+            }))
+          ).then(({ error: e }) => { if (e) console.error('[email/scan] email_scan_findings insert:', e.message); });
+        }
       }
 
       // Also save to scanned_receipts for the Scanner UI

--- a/src/app/api/outlook/scan/route.ts
+++ b/src/app/api/outlook/scan/route.ts
@@ -170,6 +170,43 @@ export async function POST(request: NextRequest) {
             }))
           ).then(({ error: e }) => { if (e) console.error('[outlook-scan] money_hub_alerts insert error:', e.message); });
         }
+
+        // The dashboard's "Email scanner" card reads from
+        // `email_scan_findings` (status in [new, reviewing]). Gmail
+        // writes there; Outlook previously did not, so Outlook scans
+        // produced findings the user never saw. Mirror Gmail's insert
+        // here — filtered to the CHECK-constraint type allowlist.
+        const FINDING_TYPES = new Set([
+          'subscription', 'bill', 'contract', 'dispute_response',
+          'cancellation_confirmation', 'price_increase', 'refund_opportunity',
+          'flight_delay', 'debt_dispute', 'tax_rebate', 'renewal',
+          'forgotten_subscription', 'upcoming_payment', 'deal_expiry',
+          'bank_gap',
+        ]);
+        const findings = newOpportunities.filter((o: any) => FINDING_TYPES.has(o.type));
+        if (findings.length > 0) {
+          await admin.from('email_scan_findings').insert(
+            findings.map((o: any) => ({
+              user_id: user.id,
+              finding_type: o.type,
+              provider: o.provider || 'Unknown',
+              email_id: o.emailId || null,
+              title: o.title,
+              description: o.description || null,
+              amount: o.amount || o.paymentAmount || null,
+              due_date: o.nextPaymentDate || null,
+              contract_end_date: o.contractEndDate || null,
+              previous_amount: o.previousAmount || null,
+              price_change_date: o.priceChangeDate || null,
+              payment_frequency: o.paymentFrequency || null,
+              confidence: o.confidence || 70,
+              urgency: o.urgency || 'routine',
+              status: 'new',
+              source: 'outlook',
+              metadata: o,
+            }))
+          ).then(({ error: e }) => { if (e) console.error('[outlook-scan] email_scan_findings insert:', e.message); });
+        }
       }
 
       // Also save to scanned_receipts for the Scanner UI

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -649,7 +649,16 @@ export default function DashboardPage() {
       // (limited to 30) list length. Without this, a user going from 30
       // → 31 actual findings would see "no new findings (30 total)"
       // because mapped.length saturates at the cap — Codex P2 round 2.
-      const [{ data: scanFindings }, { count: trueTotal }, { data: refreshedConns }] = await Promise.all([
+      // Refetch tasks alongside the findings so the "Action items"
+      // count reflects new pending_review rows that the scan just
+      // inserted. Without this the count stays frozen at the initial
+      // load value even though the user can see "386 new findings".
+      const [
+        { data: scanFindings },
+        { count: trueTotal },
+        { data: refreshedConns },
+        { data: refreshedTasks },
+      ] = await Promise.all([
         supabase
           .from('email_scan_findings')
           .select('*')
@@ -667,6 +676,13 @@ export default function DashboardPage() {
           .select('id, email_address, provider_type, last_scanned_at')
           .eq('user_id', authUser.id)
           .eq('status', 'active'),
+        supabase
+          .from('tasks')
+          .select('id, title, description, type, provider_name, disputed_amount, status, created_at, priority, snooze_until')
+          .eq('user_id', authUser.id)
+          .eq('status', 'pending_review')
+          .order('created_at', { ascending: false })
+          .limit(50),
       ]);
 
       const mapped = (scanFindings ?? []).map((f: any) => {
@@ -689,6 +705,39 @@ export default function DashboardPage() {
       });
       setEmailOpportunities(mapped);
       setEmailScanResults(mapped.length);
+
+      // Mirror the initial-load task grouping (lines 478-503) so the
+      // "Action items" count picks up newly inserted pending_review
+      // rows from the scan. Same paybacker-self-filter, same snooze
+      // filter, same provider+type grouping.
+      if (refreshedTasks) {
+        const nowMs = Date.now();
+        const allRaw = refreshedTasks.filter((t: any) =>
+          !((t.provider_name || '').toLowerCase().includes('paybacker'))
+        );
+        const snoozedCount = allRaw.filter((t: any) =>
+          t.snooze_until && new Date(t.snooze_until).getTime() > nowMs
+        ).length;
+        setSnoozedTaskCount(snoozedCount);
+        const cleanTasks = allRaw.filter((t: any) =>
+          !t.snooze_until || new Date(t.snooze_until).getTime() <= nowMs
+        );
+        const taskGroups = new Map<string, any>();
+        for (const t of cleanTasks) {
+          const key = `${(t.provider_name || '').toLowerCase()}::${(t.type || '').toLowerCase()}`;
+          const cur = taskGroups.get(key);
+          if (!cur) {
+            taskGroups.set(key, { ...t, _groupIds: [t.id], _groupCount: 1, _groupTotal: parseFloat(t.disputed_amount) || 0 });
+          } else {
+            cur._groupIds.push(t.id);
+            cur._groupCount += 1;
+            cur._groupTotal += parseFloat(t.disputed_amount) || 0;
+          }
+        }
+        setPendingTasks(Array.from(taskGroups.values()).sort((a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        ));
+      }
 
       // Visible completion signal — addresses "spins and items don't
       // update — is it working?". A same-count scan (30 → 30) used to

--- a/src/app/preview/homepage/demos.tsx
+++ b/src/app/preview/homepage/demos.tsx
@@ -526,7 +526,7 @@ export function DisputesDemo() {
                     }}
                   />
                   <span>
-                    Alert sent: <b>Paybacker inbox</b> + <b>Telegram</b>
+                    Alert sent: <b>Paybacker inbox</b> + <b>WhatsApp</b>
                   </span>
                   <div style={{ marginLeft: 'auto', display: 'flex', gap: 4 }}>
                     <div
@@ -551,7 +551,7 @@ export function DisputesDemo() {
                         fontWeight: 700,
                       }}
                     >
-                      ✈ Telegram
+                      💬 WhatsApp
                     </div>
                   </div>
                 </div>
@@ -679,7 +679,7 @@ export function DisputesDemo() {
 }
 
 // ---------------------------------------------------------------------------
-// 2 · Pocket Agent · Telegram
+// 2 · Pocket Agent · WhatsApp (Pro driver — see CLAUDE.md "main drivers")
 // ---------------------------------------------------------------------------
 type PAMsg =
   | { from: number; kind: 'bot-alert' }
@@ -771,7 +771,7 @@ export function PocketAgentDemo() {
             }}
           >
             <span style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--mint)', animation: 'demoPulse 1.6s infinite' }} />
-            Pocket Agent · Telegram + WhatsApp
+            Pocket Agent · WhatsApp
           </div>
           <div
             style={{
@@ -816,14 +816,14 @@ export function PocketAgentDemo() {
           </div>
         </div>
 
-        {/* RIGHT Telegram phone */}
+        {/* RIGHT WhatsApp phone */}
         <div style={{ padding: '18px 22px 18px 0', display: 'flex', alignItems: 'center' }}>
           <div
             style={{
               width: '100%',
               height: '100%',
               maxHeight: 520,
-              background: '#17212B',
+              background: '#0B141A',
               borderRadius: 28,
               overflow: 'hidden',
               border: '7px solid #0D0D10',
@@ -834,7 +834,7 @@ export function PocketAgentDemo() {
           >
             <div
               style={{
-                background: '#202B36',
+                background: '#1F2C34',
                 padding: '8px 12px',
                 display: 'flex',
                 alignItems: 'center',
@@ -860,7 +860,7 @@ export function PocketAgentDemo() {
               </div>
               <div style={{ flex: 1 }}>
                 <div style={{ fontSize: 11.5, fontWeight: 700, color: '#fff' }}>Paybacker</div>
-                <div style={{ fontSize: 9.5, color: 'rgba(255,255,255,.5)' }}>assistant · online</div>
+                <div style={{ fontSize: 9.5, color: 'rgba(255,255,255,.5)' }}>online</div>
               </div>
             </div>
 
@@ -908,7 +908,7 @@ export function PocketAgentDemo() {
                       key={i}
                       style={{
                         alignSelf: 'flex-end',
-                        background: '#2B5278',
+                        background: '#005C4B',
                         color: '#fff',
                         padding: '5px 9px',
                         borderRadius: '10px 10px 2px 10px',
@@ -927,7 +927,7 @@ export function PocketAgentDemo() {
                       key={i}
                       style={{
                         alignSelf: 'flex-end',
-                        background: '#2B5278',
+                        background: '#005C4B',
                         color: '#fff',
                         padding: '5px 9px',
                         borderRadius: '10px 10px 2px 10px',
@@ -946,7 +946,7 @@ export function PocketAgentDemo() {
                       key={i}
                       style={{
                         alignSelf: 'flex-start',
-                        background: '#182533',
+                        background: '#1F2C34',
                         color: '#fff',
                         padding: '8px 10px',
                         borderRadius: '10px 10px 10px 2px',
@@ -1005,7 +1005,7 @@ export function PocketAgentDemo() {
                       key={i}
                       style={{
                         alignSelf: 'flex-start',
-                        background: '#182533',
+                        background: '#1F2C34',
                         color: '#fff',
                         padding: '8px 10px',
                         borderRadius: '10px 10px 10px 2px',
@@ -1045,7 +1045,7 @@ export function PocketAgentDemo() {
                       key={i}
                       style={{
                         alignSelf: 'flex-start',
-                        background: '#182533',
+                        background: '#1F2C34',
                         color: '#fff',
                         padding: '8px 10px',
                         borderRadius: '10px 10px 10px 2px',
@@ -1095,7 +1095,7 @@ export function PocketAgentDemo() {
                       key={i}
                       style={{
                         alignSelf: 'flex-start',
-                        background: '#182533',
+                        background: '#1F2C34',
                         color: '#fff',
                         padding: '7px 9px',
                         borderRadius: '10px 10px 10px 2px',
@@ -1161,7 +1161,7 @@ export function PocketAgentDemo() {
                   style={{
                     alignSelf: 'flex-start',
                     padding: '7px 11px',
-                    background: '#182533',
+                    background: '#1F2C34',
                     borderRadius: '10px 10px 10px 2px',
                     display: 'flex',
                     gap: 3,
@@ -1185,7 +1185,7 @@ export function PocketAgentDemo() {
 
             <div
               style={{
-                background: '#17212B',
+                background: '#0B141A',
                 padding: '7px 9px',
                 borderTop: '1px solid rgba(255,255,255,.04)',
                 display: 'flex',
@@ -1197,7 +1197,7 @@ export function PocketAgentDemo() {
               <div
                 style={{
                   flex: 1,
-                  background: '#242F3D',
+                  background: '#2A3942',
                   borderRadius: 12,
                   padding: '5px 9px',
                   fontSize: 9.5,

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -7,7 +7,7 @@
  *   design_handoff_paybacker_homepage/index.html
  * with extra scroll-driven dynamism (intersection-observer reveals,
  * animated counters, scroll progress bar, 3D dashboard tilt, sticky
- * conversion CTA, marquee testimonials).
+ * conversion CTA).
  *
  * Everything is wrapped in `.m-v2-root` so the scoped stylesheet at
  * `./styles.css` cannot leak onto `/`, the dashboard, or any other
@@ -17,7 +17,8 @@
  * Content rules (see redesign/CONTENT_SOURCES_OF_TRUTH.md):
  *   - No fabricated specific savings claims.
  *   - Member counts are forbidden.
- *   - Six named testimonials may appear ONLY on this surface.
+ *   - No testimonials anywhere — first-launch trust would suffer from
+ *     unverifiable named quotes.
  */
 
 import Link from 'next/link';
@@ -502,7 +503,7 @@ function HeroVisual() {
 
       <div className="agent-bubble float" style={{ animationDelay: '-3s' }}>
         <div className="who">
-          <span className="dot-mint" /> Pocket Agent · Telegram
+          <span className="dot-mint" /> Pocket Agent · WhatsApp
         </div>
         <div className="msg">
           Virgin Media bill increased by <strong>£12</strong> this month — want me to draft a dispute citing Ofcom&rsquo;s mid-contract price rise rules?
@@ -733,101 +734,6 @@ function HeroDemo() {
         </>
       )}
     </form>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Testimonials — marquee, doubled for seamless loop
-// ---------------------------------------------------------------------------
-const TESTIMONIALS = [
-  {
-    name: 'Paul R.',
-    meta: 'Founder · verified user · Bristol',
-    quote:
-      "Found nearly a grand of forgotten subs in five minutes. The Virgin dispute letter cut my bill back to the original contract rate — first try.",
-    saved: 'Saved £1,240 over the year',
-    color: 'var(--accent-mint-deep)',
-  },
-  {
-    name: 'Sarah K.',
-    meta: 'Freelancer · Manchester',
-    quote:
-      "I was about to call a solicitor — Paybacker had the letter drafted before I'd finished my coffee. Got £340 back from EE for a mid-contract price hike.",
-    saved: 'Recovered £340 · kept 100%',
-    color: 'var(--accent-orange-deep)',
-  },
-  {
-    name: 'Dan M.',
-    meta: 'Commuter · London',
-    quote:
-      "The Ofcom letter took 30 seconds. EE cancelled the mid-contract rise without a phone call. Still can't quite believe it.",
-    saved: 'Saved £168',
-    color: 'var(--accent-mint-deep)',
-  },
-  {
-    name: 'Sarah J.',
-    meta: 'Student · Edinburgh',
-    quote:
-      "Pocket Agent in Telegram is the bit I didn't expect to love. I just ask if things are fair and it tells me.",
-    saved: 'Saved £284',
-    color: 'var(--accent-orange-deep)',
-  },
-  {
-    name: 'Rita N.',
-    meta: 'Teacher · Leeds',
-    quote:
-      "A claims firm wanted 30% to chase British Gas for me. Paybacker caught the £41/month hike, drafted the letter, and I kept every pound. Paid for a year of Pro in one go.",
-    saved: 'Recovered £492 · kept 100%',
-    color: 'var(--accent-mint-deep)',
-  },
-  {
-    name: 'Tom B.',
-    meta: 'New parent · Cardiff',
-    quote:
-      "Tiny baby, no time to read bills. Paybacker does it for us. The broadband switch alone saved us £400 a year.",
-    saved: 'Saved £638',
-    color: 'var(--accent-orange-deep)',
-  },
-];
-
-function Testimonials() {
-  const trackRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const node = trackRef.current;
-    if (!node || typeof IntersectionObserver === 'undefined') return;
-    const io = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          node.style.animationPlayState = entry.isIntersecting ? 'running' : 'paused';
-        });
-      },
-      { threshold: 0.05 }
-    );
-    io.observe(node);
-    return () => io.disconnect();
-  }, []);
-
-  const doubled = [...TESTIMONIALS, ...TESTIMONIALS];
-
-  return (
-    <div className="t-track" ref={trackRef}>
-      {doubled.map((t, i) => (
-        <div className="t-card" key={`${t.name}-${i}`}>
-          <div className="who">
-            <div className="avatar" style={{ background: t.color }}>
-              {t.name[0]}
-            </div>
-            <div>
-              <div className="name">{t.name}</div>
-              <div className="meta">{t.meta}</div>
-            </div>
-          </div>
-          <div className="quote">&ldquo;{t.quote}&rdquo;</div>
-          <div className="saved">{t.saved}</div>
-        </div>
-      ))}
-    </div>
   );
 }
 
@@ -1144,10 +1050,10 @@ export default function HomepageV3PreviewPage() {
         <div className="wrap">
           <div className="feature-grid">
             <Reveal className="feature-copy">
-              <h2 className="feature-title">Your personal caseworker — over WhatsApp &amp; Telegram</h2>
+              <h2 className="feature-title">Your personal caseworker — on WhatsApp</h2>
               <p className="feature-tagline">
                 A solicitor takes a week to reply to email. Your Paybacker
-                caseworker is on chat 24/7.
+                caseworker is on WhatsApp 24/7.
               </p>
               <p>
                 It tells you when a dispute is ready to send, when the company
@@ -1159,13 +1065,14 @@ export default function HomepageV3PreviewPage() {
                 <li>Watches your inbox for the provider&rsquo;s response</li>
                 <li>Auto-escalates to Ombudsman at the 8-week mark</li>
                 <li>
-                  <strong>Telegram Pocket Agent</strong>{' '}
-                  <span className="tier-chip tier-chip--free">Free</span> — across all plans.
-                </li>
-                <li>
                   <strong>WhatsApp Pocket Agent</strong>{' '}
                   <span className="tier-chip tier-chip--pro">Pro</span> — £9.99/month.
-                  Same caseworker, different chat.
+                  Your caseworker on the app you already use every day.
+                </li>
+                <li>
+                  Also available on{' '}
+                  <strong>Telegram</strong>{' '}
+                  <span className="tier-chip tier-chip--free">Free</span> — same agent, any plan.
                 </li>
               </ul>
               <div className="feature-cta-row">
@@ -1860,19 +1767,6 @@ export default function HomepageV3PreviewPage() {
             <Link href="/pricing">See the full feature comparison →</Link>
           </p>
         </div>
-      </section>
-
-      {/* ========== Testimonials ========== */}
-      <section className="testimonials-section section-light" id="testimonials">
-        <Reveal className="testimonials-head">
-          <span className="eyebrow">Honest words from real users</span>
-          <h2>
-            They skipped the solicitor.
-            <br />
-            Kept 100% of the refund.
-          </h2>
-        </Reveal>
-        <Testimonials />
       </section>
 
       {/* ========== Developer · MCP ========== */}

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -845,52 +845,6 @@
 
 .m-v2-root .compare-link a:hover { text-decoration: underline; }
 
-/* Testimonials */
-
-.m-v2-root .testimonials-section { padding: 120px 0; overflow: hidden; }
-
-.m-v2-root .testimonials-head { text-align: center; margin-bottom: 56px; }
-
-.m-v2-root .testimonials-head h2 { font-size: var(--fs-h2); letter-spacing: var(--track-tight); font-weight: 700; margin: 12px 0; }
-
-.m-v2-root .t-track {
-  display: flex; gap: 22px; width: max-content;
-  animation: tscroll 60s linear infinite;
-}
-
-.m-v2-root .testimonials-section:hover .t-track { animation-play-state: paused; }
-
-@keyframes tscroll {
-  from { transform: translateX(0); }
-  to { transform: translateX(-50%); }
-}
-
-.m-v2-root .t-card {
-  width: 380px; flex-shrink: 0;
-  background: #fff;
-  border: 1px solid var(--divider);
-  border-radius: var(--r-card);
-  padding: 26px;
-  display: flex; flex-direction: column; gap: 14px;
-}
-
-.m-v2-root .t-card .who { display: flex; align-items: center; gap: 12px; }
-
-.m-v2-root .t-card .avatar {
-  width: 40px; height: 40px; border-radius: 50%;
-  display: grid; place-items: center;
-  font-weight: 700; color: #fff;
-  font-size: 15px;
-}
-
-.m-v2-root .t-card .name { font-weight: 600; font-size: 14px; }
-
-.m-v2-root .t-card .meta { font-size: 12px; color: var(--text-tertiary); }
-
-.m-v2-root .t-card .quote { font-size: 15px; color: var(--text-primary); line-height: 1.45; text-wrap: pretty; }
-
-.m-v2-root .t-card .saved { color: var(--accent-orange-deep); font-weight: 600; font-size: 13px; }
-
 /* Final CTA */
 
 .m-v2-root .final-cta { padding: 140px 0; position: relative; overflow: hidden; }
@@ -979,7 +933,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .m-v2-root .reveal, .m-v2-root .reveal.in { opacity: 1; transform: none; transition: none; }
-  .m-v2-root .float, .m-v2-root .pulse, .m-v2-root .t-track, .m-v2-root .nav-progress { animation: none !important; transition: none !important; }
+  .m-v2-root .float, .m-v2-root .pulse, .m-v2-root .nav-progress { animation: none !important; transition: none !important; }
 }
 
 /* Responsive */
@@ -999,7 +953,7 @@
   .m-v2-root .dash-card { width: 300px; height: 420px; right: 0; top: 10px; }
   .m-v2-root .mini-card { width: 200px; height: 280px; left: 0; top: 120px; }
   .m-v2-root .agent-bubble { width: 240px; right: 0; bottom: 0; }
-  .m-v2-root .stats-section, .m-v2-root .pillars-section, .m-v2-root .deals-section, .m-v2-root .pricing-section, .m-v2-root .testimonials-section { padding: 80px 0; }
+  .m-v2-root .stats-section, .m-v2-root .pillars-section, .m-v2-root .deals-section, .m-v2-root .pricing-section { padding: 80px 0; }
   .m-v2-root .how-section, .m-v2-root .final-cta { padding: 100px 0; }
 }
 


### PR DESCRIPTION
Three independent consumer-side fixes bundled on this branch per the harness branch instruction.

## 1. De-dupe Pro-trial-ended emails (original PR)

`paul@airproperty.co.uk` received two near-identical "Pro trial ended" emails an hour apart on 2026-05-07. Two crons were processing the same downgrade event for users with both `founding_member=true` and `subscription_status='trialing'`:

- `/api/cron/founding-member-expiry` at `0 8 * * *` UTC
- `/api/cron/trial-expiry` at `0 9 * * *` UTC

**Fix:** `trial-expiry` now excludes founding members (handled exclusively by founding-member-expiry) and skips rows where `trial_expired_at IS NOT NULL`. Both crons stamp / check that column for idempotency. Also fixed the doubled-word typo "Your free free trial trial has ended". Codex follow-ups: fail closed on missing CRON_SECRET; email only the users whose downgrade actually succeeded (via `.update(...).select(...)`).

## 2. Homepage refresh

- Removed the testimonials section (six named savings-quote testimonials) — unverifiable named quotes hurt trust at first contact for a launch. Pulled the array, the `Testimonials` component, the section, and the dead CSS.
- Reskinned the Pocket Agent chat-demo from Telegram to WhatsApp dark palette (`#0B141A` / `#1F2C34` / `#005C4B` / `#2A3942`). The two main consumer drivers are AI disputes + WhatsApp Pocket Agent, so the primary chat visual now reads as WhatsApp.
- Hero floating bubble label: "Pocket Agent · Telegram" → "Pocket Agent · WhatsApp".
- Pocket Agent section: title "on WhatsApp", bullets reordered with WhatsApp leading, Telegram demoted to a "also available, free" footnote.
- Alerts demo's channel pill: "✈ Telegram" → "💬 WhatsApp".
- Copy elsewhere (pricing table, footer manage-line, feature-table row) still lists both — Telegram remains a real free-tier feature.

## 3. Email-scan refresh bug

Founder triggered an email scan that reported "Scan complete · 386 new findings (416 total)" but the dashboard's "Email scanner" card and "Action items 26" stayed frozen. Two failures stacked:

- **Layer A** — only `/api/gmail/scan` wrote rows to `email_scan_findings`. The IMAP scanner (`/api/email/scan`) and `/api/outlook/scan` wrote to `tasks`, `subscriptions`, `money_hub_alerts`, `scanned_receipts` — but not the table the dashboard "Email scanner" card reads from. Both endpoints now mirror Gmail's insert, filtered to the CHECK-constraint type allowlist.
- **Layer B** — `handleEmailScan` refreshed `emailOpportunities` from `email_scan_findings` but never re-queried `tasks`. The "Action items" badge stayed at the initial-load value even when the scan inserted new `pending_review` rows. Added a fourth Promise.all leg and re-applied the same snooze + paybacker-self + provider+type grouping the initial load uses.

## Test plan

- [ ] Trial expiry: user with both `founding_member=true` and `subscription_status='trialing'` only receives the founding-member-expiry email at 08:00 UTC; email body reads "Your free Pro trial has ended" (no doubled words). Non-founding trialist still gets the trial-expiry email at 09:00 UTC. Same-day re-runs don't double-email.
- [ ] Trial expiry: an unset `CRON_SECRET` returns 401 (fails closed).
- [ ] Trial expiry: a user who upgrades between SELECT and UPDATE is neither downgraded nor emailed.
- [ ] Homepage: testimonials section is gone; Pocket Agent chat demo reads as WhatsApp green; hero floating bubble shows "Pocket Agent · WhatsApp".
- [ ] Email scan: trigger scan on an IMAP account (Yahoo / iCloud / BT / Sky); confirm "Email scanner" card count increments AND "Action items" badge increments without a page refresh.
- [ ] Email scan: same on an Outlook account.

https://claude.ai/code/session_018hb8AfBpBnSnATphzSxwYK