### PR TITLE
fix(pocket-agent): natural-language dispute outcomes + batch resolution

### DIFF
--- a/src/app/api/auth/yapily/route.ts
+++ b/src/app/api/auth/yapily/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { createAccountAuthorisation } from '@/lib/yapily';
+import { createClient as createAdmin } from '@supabase/supabase-js';
+import {
+  createAccountAuthorisation,
+  createHostedConsentRequest,
+  isHostedPagesEnabled,
+} from '@/lib/yapily';
 import { UPCOMING_FEATURE_SCOPES } from '@/lib/yapily/upcoming';
 import { TIER_CONFIG, type BankTier } from '@/lib/bank-tier-config';
 
@@ -89,29 +94,87 @@ export async function GET(request: NextRequest) {
     'https://paybacker.co.uk/api/yapily/callback';
 
   // ── Create authorisation request ──
-  try {
-    // Encode user ID + institution ID + returnTo as state for CSRF protection + post-callback redirect
-    const returnTo = searchParams.get('returnTo') || '/dashboard/money-hub';
-    const state = Buffer.from(
-      JSON.stringify({ userId: user.id, institutionId, returnTo })
-    ).toString('base64');
+  // Encode user ID + institution ID + returnTo as state for CSRF protection
+  // + post-callback redirect.
+  const returnTo = searchParams.get('returnTo') || '/dashboard/money-hub';
+  const state = Buffer.from(
+    JSON.stringify({ userId: user.id, institutionId, returnTo })
+  ).toString('base64');
+  const redirectWithState = `${callbackUrl}?state=${encodeURIComponent(state)}`;
 
-    // Include the upcoming-payments feature scopes so new consents
-    // are granted enough access to read scheduled + periodic
-    // payments + direct debits + pending transactions. Existing
-    // bank_connections continue to work on their original consent;
-    // the expanded scope applies from the next renewal onward.
+  try {
+    if (isHostedPagesEnabled()) {
+      // Hosted Pages flow (Migle's onboarding plan, 29 Apr 2026).
+      // Yapily renders the bank-picker / consent / decoupled-auth
+      // screens on its own domain; we get back a hostedUrl + a
+      // consentRequestId we'll use in the callback to retrieve the
+      // consentId + consentToken via GET /hosted/consent-requests/{id}.
+      //
+      // We DO set institutionId because our UI already picks the bank,
+      // so Yapily skips its own picker (per HostedAccountRequest spec
+      // — institutionIdentifiers + institutionId pre-selects).
+      //
+      // featureScope (resolved 29 Apr from the OpenAPI spec): passed
+      // via the `accountRequest.featureScope` body field. Mirrors the
+      // upcoming-payments scopes we already request on the legacy
+      // /account-auth-requests path.
+      const hosted = await createHostedConsentRequest({
+        applicationUserId: user.id,
+        redirectUrl: redirectWithState,
+        institutionCountryCode: 'GB',
+        institutionId,
+        language: 'EN',
+        location: 'GB',
+        featureScope: UPCOMING_FEATURE_SCOPES,
+      });
+
+      // Track this in-flight request so the abandonment poller can
+      // chase it if the user never returns. Best-effort: a failure to
+      // record the pending row should not block the user from being
+      // redirected to Yapily.
+      try {
+        const admin = createAdmin(
+          process.env.NEXT_PUBLIC_SUPABASE_URL!,
+          process.env.SUPABASE_SERVICE_ROLE_KEY!,
+        );
+        await admin.from('yapily_pending_consent_requests').insert({
+          user_id: user.id,
+          consent_request_id: hosted.consentRequestId,
+          institution_id: institutionId,
+          redirect_url: redirectWithState,
+          status: 'pending',
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'unknown';
+        console.error(`[yapily.auth] pending row insert failed (non-fatal): ${msg}`);
+      }
+
+      console.log(
+        `Yapily auth (hosted): created hosted consent for user=${user.id} institution=${institutionId} consentRequestId=${hosted.consentRequestId}`
+      );
+      return NextResponse.json({
+        // Frontend-facing URL — kept under both names so existing
+        // consumers reading authorisationUrl don't break during the
+        // cutover, and any new code can prefer hostedUrl.
+        authorisationUrl: hosted.hostedUrl,
+        hostedUrl: hosted.hostedUrl,
+        consentRequestId: hosted.consentRequestId,
+        // No consentId at this stage; we'll fetch it in the callback
+        // alongside the consentToken.
+      });
+    }
+
+    // Legacy flow — kept reachable behind the flag so we can roll back
+    // by flipping one env var.
     const authData = await createAccountAuthorisation(
       institutionId,
-      `${callbackUrl}?state=${encodeURIComponent(state)}`,
+      redirectWithState,
       user.id,
       UPCOMING_FEATURE_SCOPES,
     );
-
     console.log(
-      `Yapily auth: created authorisation for user=${user.id} institution=${institutionId}`
+      `Yapily auth (legacy): created authorisation for user=${user.id} institution=${institutionId}`
     );
-
     return NextResponse.json({
       authorisationUrl: authData.authorisationUrl,
       consentId: authData.id,

--- a/src/app/api/bank/disconnect/route.ts
+++ b/src/app/api/bank/disconnect/route.ts
@@ -46,6 +46,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { createClient as createAdmin } from '@supabase/supabase-js';
+import { deleteConsent } from '@/lib/yapily';
 
 type DisconnectMode = 'keep_history' | 'delete_transactions' | 'erase_all';
 
@@ -54,6 +55,26 @@ function getAdmin() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
   );
+}
+
+/**
+ * Best-effort revoke of the upstream Yapily consent. We never block local
+ * cleanup on this — if Yapily is down, we still want the user's bank
+ * disappearing from their dashboard. Logged failures get surfaced via the
+ * standard error path (Sentry / Telegram alerts) so we can chase them.
+ *
+ * 404 from Yapily means the consent is already gone, which is the exact
+ * end-state we're trying to achieve, so deleteConsent() treats it as
+ * success (no throw).
+ */
+async function revokeYapilyConsentIfPossible(consentId: string | null | undefined): Promise<void> {
+  if (!consentId) return; // legacy connection without yapily_consent_id — nothing to revoke
+  try {
+    await deleteConsent(consentId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    console.error(`[bank.disconnect] yapily deleteConsent failed for ${consentId}: ${msg}`);
+  }
 }
 
 export async function POST(request: NextRequest) {
@@ -75,6 +96,18 @@ export async function POST(request: NextRequest) {
   if (!connectionId) {
     // Legacy "revoke everything" path for callers that don't pass an id.
     // Stays at keep_history semantics for backwards compatibility.
+    // Best-effort revoke each consent on Yapily's side too — we can't
+    // tell from here which provider each row uses, so we just attempt
+    // the call and let yapily_consent_id being null short-circuit it.
+    const adminBulk = getAdmin();
+    const { data: bulkRows } = await adminBulk
+      .from('bank_connections')
+      .select('yapily_consent_id')
+      .eq('user_id', user.id)
+      .in('status', ['active', 'expired', 'token_expired', 'expired_legacy', 'expiring_soon']);
+    if (bulkRows?.length) {
+      await Promise.all(bulkRows.map((r) => revokeYapilyConsentIfPossible(r.yapily_consent_id)));
+    }
     const { error } = await supabase
       .from('bank_connections')
       .update({ status: 'revoked', updated_at: new Date().toISOString() })
@@ -86,11 +119,11 @@ export async function POST(request: NextRequest) {
 
   // Look up the connection so we can record bank_name/provider in the
   // audit row (especially important for erase_all where we then delete
-  // the row).
+  // the row) and revoke the upstream Yapily consent.
   const admin = getAdmin();
   const { data: conn, error: connErr } = await admin
     .from('bank_connections')
-    .select('id, user_id, bank_name, provider, status, account_ids, account_display_names')
+    .select('id, user_id, bank_name, provider, status, account_ids, account_display_names, yapily_consent_id')
     .eq('id', connectionId)
     .eq('user_id', user.id)
     .maybeSingle();
@@ -125,6 +158,17 @@ export async function POST(request: NextRequest) {
         .filter((n): n is string => n !== null)
     : [];
   const willRevokeConnection = !isAccountScoped || remainingAccountIds.length === 0;
+
+  // If this disconnect is going to revoke the entire connection (rather
+  // than just trim one account off a multi-account consent), revoke the
+  // upstream Yapily consent too. We do this BEFORE the local mutations
+  // so a Yapily-side success isn't followed by a local failure that
+  // leaves us out of sync. Per Migle's compliance requirement (29 Apr
+  // call): user-initiated disconnect must reach Yapily, not just flip
+  // local rows.
+  if (willRevokeConnection) {
+    await revokeYapilyConsentIfPossible(conn.yapily_consent_id);
+  }
 
   let transactionsAffected = 0;
 

--- a/src/app/api/bank/renew-consent/route.ts
+++ b/src/app/api/bank/renew-consent/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
 
   const { data: connection, error: connError } = await admin
     .from('bank_connections')
-    .select('id, user_id, consent_token, status, bank_name')
+    .select('id, user_id, consent_token, yapily_consent_id, status, bank_name')
     .eq('id', connectionId)
     .single();
 
@@ -80,12 +80,18 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // ── Check consent token exists ──
-  if (!connection.consent_token) {
+  // ── Check consent identifiers exist ──
+  // reconfirmConsent calls PUT /account-auth-requests/{consentId} — that's
+  // the opaque Yapily consent identifier, NOT the consent_token (the
+  // credential we attach to data calls). The pre-2026-04-27 callback stored
+  // only consent_token, so legacy connections may have null yapily_consent_id;
+  // in that case the user must full-reconnect, since we don't have the URL
+  // path component the renew endpoint requires.
+  if (!connection.yapily_consent_id) {
     return NextResponse.json(
       {
         error:
-          'No consent token found. Please disconnect and reconnect your bank account.',
+          'This bank connection predates our 90-day renewal flow. Please disconnect and reconnect to enable in-place renewal.',
       },
       { status: 400 }
     );
@@ -93,7 +99,7 @@ export async function POST(request: NextRequest) {
 
   // ── Call Yapily reconfirmConsent ──
   try {
-    await reconfirmConsent(connection.consent_token);
+    await reconfirmConsent(connection.yapily_consent_id);
 
     // Success — extend consent by 90 days
     const now = new Date();

--- a/src/app/api/cron/sync-upcoming/route.ts
+++ b/src/app/api/cron/sync-upcoming/route.ts
@@ -11,6 +11,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { decrypt } from '@/lib/encrypt';
+import { supportsFeature } from '@/lib/yapily';
 import {
   getScheduledPayments,
   getPeriodicPayments,
@@ -37,8 +38,10 @@ interface BankConnection {
   user_id: string;
   provider: string;
   provider_id: string | null;
+  institution_id: string | null;
   consent_token: string | null;
   consent_expires_at: string | null;
+  upcoming_endpoints_fetched_at: string | null;
   account_ids: string[] | null;
   status: string;
 }
@@ -70,7 +73,7 @@ export async function GET(request: NextRequest) {
   // Pull active Yapily connections with a non-expired consent.
   const { data: connections, error: connErr } = await supabase
     .from('bank_connections')
-    .select('id, user_id, provider, provider_id, consent_token, consent_expires_at, account_ids, status')
+    .select('id, user_id, provider, provider_id, institution_id, consent_token, consent_expires_at, upcoming_endpoints_fetched_at, account_ids, status')
     .eq('provider', 'yapily')
     .eq('status', 'active')
     .is('archived_at', null);
@@ -119,16 +122,48 @@ export async function GET(request: NextRequest) {
       continue;
     }
 
+    // Single-use semantics (Migle, 29 Apr): the deterministic
+    // upcoming-payments endpoints are callable ONCE per consent.
+    // If we've already pulled them on this consent, skip the calls
+    // and rely on the recurrence detector + transaction history (run
+    // unconditionally below) to keep predicted rows fresh.
+    // upcoming_endpoints_fetched_at is reset to NULL on reconnect by
+    // upsertYapilyConnection.
+    const alreadyFetchedDeterministic = !!conn.upcoming_endpoints_fetched_at;
+
+    // Per-institution feature check (Migle's spec: ~70% of UK banks
+    // support these). Looking once per connection — for all accounts
+    // on the same consent the feature flags are identical. Defaults
+    // to true when institution_id is missing (legacy rows pre-migration)
+    // so we don't regress existing behaviour for connections without
+    // metadata.
+    const instId = conn.institution_id ?? '';
+    const [hasScheduled, hasPeriodic, hasDirectDebits] = alreadyFetchedDeterministic
+      ? [false, false, false]
+      : instId
+        ? await Promise.all([
+            supportsFeature(instId, 'ACCOUNT_SCHEDULED_PAYMENTS'),
+            supportsFeature(instId, 'ACCOUNT_PERIODIC_PAYMENTS'),
+            supportsFeature(instId, 'ACCOUNT_DIRECT_DEBITS'),
+          ])
+        : [true, true, true];
+
     for (const accountId of conn.account_ids) {
       const rows: UpsertRow[] = [];
 
-      // Deterministic endpoints — small wrapper so one failing
-      // source doesn't block the others.
-      const endpoints: Array<[string, () => Promise<UpcomingRow[]>]> = [
-        ['scheduled-payments', () => getScheduledPayments(accountId, decrypted)],
-        ['periodic-payments',  () => getPeriodicPayments(accountId, decrypted)],
-        ['direct-debits',      () => getDirectDebits(accountId, decrypted)],
-      ];
+      // Deterministic endpoints — short-circuit when the institution
+      // doesn't expose the feature so we don't burn API quota on a
+      // guaranteed 404. Each call still wrapped in try/catch so a
+      // mid-flight Yapily blip on one source doesn't block the others.
+      const endpoints: Array<[string, () => Promise<UpcomingRow[]>]> = [];
+      if (hasScheduled) endpoints.push(['scheduled-payments', () => getScheduledPayments(accountId, decrypted)]);
+      if (hasPeriodic)  endpoints.push(['periodic-payments',  () => getPeriodicPayments(accountId, decrypted)]);
+      if (hasDirectDebits) endpoints.push(['direct-debits',   () => getDirectDebits(accountId, decrypted)]);
+      if (endpoints.length === 0) {
+        console.log(
+          `[sync-upcoming] institution=${instId || 'unknown'} account=${accountId} — no upcoming-payment features supported, skipping`,
+        );
+      }
 
       for (const [label, fn] of endpoints) {
         try {
@@ -236,6 +271,23 @@ export async function GET(request: NextRequest) {
         } else {
           summary.predictedRowsUpserted += predictedRows.length;
         }
+      }
+    }
+
+    // Stamp upcoming_endpoints_fetched_at so the next cron tick
+    // skips the deterministic endpoints (single-use semantics). We
+    // only stamp when we actually attempted to call them on this
+    // tick — if alreadyFetchedDeterministic was true we don't need
+    // to re-stamp, the original timestamp stands. We also stamp
+    // even if the calls returned no rows / threw — Yapily counts
+    // the call regardless of outcome.
+    if (!alreadyFetchedDeterministic && (hasScheduled || hasPeriodic || hasDirectDebits)) {
+      const { error: stampErr } = await supabase
+        .from('bank_connections')
+        .update({ upcoming_endpoints_fetched_at: new Date().toISOString() })
+        .eq('id', conn.id);
+      if (stampErr) {
+        console.error(`[sync-upcoming] stamp failed for conn=${conn.id}:`, stampErr.message);
       }
     }
 

--- a/src/app/api/cron/yapily-consent-abandonment/route.ts
+++ b/src/app/api/cron/yapily-consent-abandonment/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { getHostedConsentRequest } from '@/lib/yapily';
+
+export const maxDuration = 60;
+
+function getAdmin() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+/**
+ * Hosted Pages abandonment poller.
+ *
+ * Spec source: Vitally checklist GH2 + Hosted Pages tutorial step 4.
+ *   - Start polling /hosted/consent-requests/{id} 5 minutes after the
+ *     hosted URL was issued, if no callback received.
+ *   - Poll every 5–10 seconds until status resolves OR 15 minutes elapse.
+ *   - Past 15 minutes, treat as abandoned.
+ *
+ * Implementation note on cadence: a Vercel cron tick gives us a 5-minute
+ * floor, not seconds-level polling. That's fine for our purposes —
+ * abandonment handling is non-realtime housekeeping. The "every 5–10s"
+ * recommendation matters for client-side polling during an active
+ * journey; for server-side reconciliation a 5-minute cron is enough.
+ *
+ * The cron does three things on each tick:
+ *   1. Find pending requests aged 5–15 minutes → poll Yapily once. If
+ *      AUTHORIZED but no callback ever arrived (rare; user closed the
+ *      tab between bank-side success and our callback), log it. Without
+ *      a state cookie we can't safely auto-create the connection on
+ *      their behalf — surface this for ops review.
+ *   2. Find pending requests aged > 15 minutes → mark abandoned.
+ *   3. Fold any FAILED / REJECTED / REVOKED responses into the row's
+ *      status so the funnel-analysis surface is honest.
+ *
+ * This route is idempotent — re-running it is safe.
+ *
+ * Auth: Bearer ${CRON_SECRET}, same pattern as the other crons.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const admin = getAdmin();
+  const now = new Date();
+  const fiveMinAgo = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
+  const fifteenMinAgo = new Date(now.getTime() - 15 * 60 * 1000).toISOString();
+
+  let polled = 0;
+  let markedAbandoned = 0;
+  let markedFailed = 0;
+  let authoredButNoCallback = 0;
+
+  // ── Step 1: poll the still-young pending rows ──
+  const { data: youngPending, error: youngErr } = await admin
+    .from('yapily_pending_consent_requests')
+    .select('id, consent_request_id, user_id')
+    .eq('status', 'pending')
+    .lte('created_at', fiveMinAgo)
+    .gt('created_at', fifteenMinAgo);
+
+  if (youngErr) {
+    console.error('[yapily.abandonment] young-pending lookup failed:', youngErr.message);
+    return NextResponse.json({ error: 'lookup failed' }, { status: 500 });
+  }
+
+  for (const row of youngPending ?? []) {
+    polled++;
+    try {
+      const hosted = await getHostedConsentRequest(row.consent_request_id);
+      const status = (hosted.status || '').toUpperCase();
+      const updates: Record<string, unknown> = {
+        last_polled_at: now.toISOString(),
+        yapily_status: hosted.status ?? null,
+      };
+
+      if (status === 'FAILED' || status === 'REVOKED' || status === 'REJECTED') {
+        updates.status = 'failed';
+        updates.resolved_at = now.toISOString();
+        markedFailed++;
+      } else if (status === 'AUTHORIZED' || status === 'AUTHORISED') {
+        // Yapily reports success but our callback never persisted a
+        // connection. The user likely closed the tab between bank-side
+        // success and our callback. We CAN'T auto-create the connection
+        // without their session cookie — log so ops can reach out.
+        authoredButNoCallback++;
+        console.warn(
+          `[yapily.abandonment] consentRequestId=${row.consent_request_id} user=${row.user_id} authorised but no callback — flagged for ops`,
+        );
+      }
+      // else: still in flight, leave as 'pending'.
+
+      const { error: updErr } = await admin
+        .from('yapily_pending_consent_requests')
+        .update(updates)
+        .eq('id', row.id);
+      if (updErr) {
+        console.error(`[yapily.abandonment] row update failed for ${row.id}: ${updErr.message}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown';
+      console.error(`[yapily.abandonment] poll failed for ${row.consent_request_id}: ${msg}`);
+    }
+  }
+
+  // ── Step 2: any pending row older than 15 min is abandoned ──
+  const { data: stale, error: staleErr } = await admin
+    .from('yapily_pending_consent_requests')
+    .select('id')
+    .eq('status', 'pending')
+    .lte('created_at', fifteenMinAgo);
+
+  if (staleErr) {
+    console.error('[yapily.abandonment] stale lookup failed:', staleErr.message);
+  } else if (stale && stale.length > 0) {
+    const ids = stale.map((r: { id: string }) => r.id);
+    const { error: bulkErr } = await admin
+      .from('yapily_pending_consent_requests')
+      .update({ status: 'abandoned', resolved_at: now.toISOString() })
+      .in('id', ids);
+    if (bulkErr) {
+      console.error('[yapily.abandonment] bulk abandon update failed:', bulkErr.message);
+    } else {
+      markedAbandoned = ids.length;
+    }
+  }
+
+  console.log(
+    `[yapily.abandonment] complete — polled=${polled} abandoned=${markedAbandoned} failed=${markedFailed} no_callback_logged=${authoredButNoCallback}`,
+  );
+
+  return NextResponse.json({
+    ok: true,
+    polled,
+    markedAbandoned,
+    markedFailed,
+    authoredButNoCallback,
+  });
+}

--- a/src/app/api/yapily/callback/route.ts
+++ b/src/app/api/yapily/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { getAccounts } from '@/lib/yapily';
+import { createClient as createAdmin } from '@supabase/supabase-js';
+import { getAccounts, getHostedConsentRequest } from '@/lib/yapily';
 import { snapshotAccounts, upsertYapilyConnection } from '@/lib/yapily/connection-store';
 
 /**
@@ -29,15 +30,19 @@ export const maxDuration = 60;
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const consentToken = searchParams.get('consent');
-  // Yapily returns consent-id as both ?consent-id and (sometimes) as
-  // a separate field — we accept either query-param form. The id is
-  // distinct from the consent token: token is the credential we use
-  // for API calls, id identifies the consent for re-authorise.
-  const yapilyConsentId =
+  // Hosted Pages returns ONLY consentRequestId on the redirect — the
+  // consentToken comes from GET /hosted/consent-requests/{id} below.
+  // Legacy /account-auth-requests returns ?consent=<token>&consent-id=<id>.
+  // We detect which mode we're in by which params are present.
+  const consentRequestId =
+    searchParams.get('consentRequestId') ||
+    searchParams.get('consent-request-id') ||
+    '';
+  let consentToken = searchParams.get('consent') || '';
+  let yapilyConsentId =
     searchParams.get('consent-id') ||
     searchParams.get('consentId') ||
-    searchParams.get('id') ||
+    (consentRequestId ? '' : searchParams.get('id') || '') ||
     '';
   const state = searchParams.get('state');
   const errorParam = searchParams.get('error');
@@ -50,7 +55,9 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  if (!consentToken || !state) {
+  // We need either a consentToken (legacy) or a consentRequestId (hosted)
+  // and always need state for CSRF.
+  if ((!consentToken && !consentRequestId) || !state) {
     return NextResponse.redirect(
       new URL('/dashboard/money-hub?error=invalid_callback', request.url),
     );
@@ -80,6 +87,65 @@ export async function GET(request: NextRequest) {
 
   const institutionId = stateData.institutionId;
   const returnTo = stateData.returnTo || '/dashboard/money-hub';
+
+  // ── Hosted Pages: resolve consentToken + consentId from consentRequestId ──
+  // On the legacy flow Yapily puts both in the redirect query. On Hosted
+  // Pages we get only consentRequestId — fetch the rest before continuing.
+  // Tutorial step 4: check status before proceeding.
+  //
+  // Schema (verified against Yapily OpenAPI 12.3.4 on 29 Apr 2026):
+  //   data.consentRequestId  — the request handle (already in our query)
+  //   data.consentId         — the underlying consent identifier; the
+  //                             same shape /account-auth-requests/{id}
+  //                             accepts. THIS is what we persist into
+  //                             bank_connections.yapily_consent_id so
+  //                             renew + delete keep working.
+  //   data.consentToken      — the credential we attach to data calls.
+  //   data.status            — AUTHORIZED once the user has completed
+  //                             the bank-side flow.
+  if (consentRequestId && !consentToken) {
+    try {
+      const hosted = await getHostedConsentRequest(consentRequestId);
+      const hostedStatus = (hosted.status || '').toUpperCase();
+      if (hostedStatus !== 'AUTHORIZED' && hostedStatus !== 'AUTHORISED') {
+        console.warn(
+          `[yapily.callback] hosted consent ${consentRequestId} status=${hostedStatus} — redirecting user back to retry`,
+        );
+        return NextResponse.redirect(
+          new URL(`/dashboard/money-hub?error=hosted_consent_${hostedStatus.toLowerCase() || 'unknown'}`, request.url),
+        );
+      }
+      if (!hosted.consentToken) {
+        console.error(`[yapily.callback] hosted consent ${consentRequestId} authorised but no consentToken returned`);
+        return NextResponse.redirect(
+          new URL('/dashboard/money-hub?error=hosted_consent_token_missing', request.url),
+        );
+      }
+      if (!hosted.consentId) {
+        // AUTHORIZED responses MUST carry consentId per OpenAPI 12.3.4.
+        // If Yapily ever returns AUTHORIZED without one, we bail rather
+        // than persist the consentRequestId in the wrong slot — the
+        // renew + disconnect flows would silently break otherwise.
+        console.error(`[yapily.callback] hosted consent ${consentRequestId} authorised but no consentId returned`);
+        return NextResponse.redirect(
+          new URL('/dashboard/money-hub?error=hosted_consent_id_missing', request.url),
+        );
+      }
+      consentToken = hosted.consentToken;
+      yapilyConsentId = hosted.consentId;
+    } catch (err) {
+      console.error(`[yapily.callback] hosted consent fetch failed for ${consentRequestId}:`, err);
+      return NextResponse.redirect(
+        new URL('/dashboard/money-hub?error=hosted_consent_fetch_failed', request.url),
+      );
+    }
+  }
+
+  if (!consentToken) {
+    return NextResponse.redirect(
+      new URL('/dashboard/money-hub?error=invalid_callback', request.url),
+    );
+  }
 
   // ── Fetch the accounts the user just authorised ──
   let accounts: Awaited<ReturnType<typeof getAccounts>>;
@@ -113,6 +179,7 @@ export async function GET(request: NextRequest) {
       bankName,
       consentToken,
       yapilyConsentId,
+      yapilyConsentRequestId: consentRequestId || null,
       consentExpiresAt,
       accounts: accountSnapshots,
     });
@@ -128,6 +195,25 @@ export async function GET(request: NextRequest) {
     `[yapily.callback] ${upsertResult.reused ? 'reused' : 'inserted'} connection ${upsertResult.connectionId}` +
     (upsertResult.previousConnectionIds.length ? ` (demoted ${upsertResult.previousConnectionIds.length} stale rows)` : ''),
   );
+
+  // ── Mark the pending Hosted Pages request resolved (if any) ──
+  // The abandonment poller treats anything still 'pending' after 15 min
+  // as abandoned. Closing the loop here keeps its working set small.
+  if (consentRequestId) {
+    try {
+      const adminBg = createAdmin(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      );
+      await adminBg
+        .from('yapily_pending_consent_requests')
+        .update({ status: 'completed', resolved_at: new Date().toISOString() })
+        .eq('consent_request_id', consentRequestId);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown';
+      console.error(`[yapily.callback] pending row update failed (non-fatal): ${msg}`);
+    }
+  }
 
   // ── Award loyalty points ──
   import('@/lib/loyalty')

--- a/src/app/api/yapily/initial-sync/route.ts
+++ b/src/app/api/yapily/initial-sync/route.ts
@@ -50,22 +50,55 @@ export async function POST(request: NextRequest) {
 
   const supabase = getAdmin();
 
-  const twelveMonthsAgo = new Date();
-  twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
-  const fromDate = twelveMonthsAgo.toISOString().split('T')[0];
+  // Yapily's 5-minute deadline (Migle, 29 Apr): if historical
+  // transactions older than 90 days aren't pulled within 5 minutes
+  // of consent grant, some banks return 403 and force a fresh
+  // consent. Our maxDuration matches that ceiling, but a multi-
+  // account bank with 12 months of paginated data can easily
+  // overflow.
+  //
+  // Two-pass strategy:
+  //   PASS 1 — last 90 days for every account first. Always within
+  //   the 5-min window, always succeeds, gives the user the bulk
+  //   of useful data immediately.
+  //
+  //   PASS 2 — 91-365 days for each account. Best-effort, gated
+  //   by elapsed time. Stops at 4m30s (270s) so we exit cleanly
+  //   before the function's 5-min ceiling AND before Yapily's
+  //   server-side deadline. Accounts that didn't get older history
+  //   are logged loudly so we can backfill via consent renewal or
+  //   a follow-up sync.
+  const HISTORICAL_BUDGET_MS = 270 * 1000; // 4m30s — safety margin under Yapily's 5min
+  const startedAt = Date.now();
 
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
   const toDate = tomorrow.toISOString().split('T')[0];
 
+  const ninetyDaysAgo = new Date();
+  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+  const ninetyDaysAgoIso = ninetyDaysAgo.toISOString().split('T')[0];
+
+  const twelveMonthsAgo = new Date();
+  twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
+  const twelveMonthsAgoIso = twelveMonthsAgo.toISOString().split('T')[0];
+
   let totalInserted = 0;
   let totalDuplicateSkipped = 0;
   let totalNoHashSkipped = 0;
   let apiCallsMade = 0;
+  let historicalSkipped = 0;
 
+  // PASS 1 — last 90 days for every account. Sequential per
+  // Migle's "wait for response before next request" rule.
   for (const account of accountSnapshots) {
     try {
-      const transactions = await getTransactions(account.yapilyAccountId, consentToken, fromDate, toDate);
+      const transactions = await getTransactions(
+        account.yapilyAccountId,
+        consentToken,
+        ninetyDaysAgoIso,
+        toDate,
+      );
       apiCallsMade++;
       if (transactions.length === 0) continue;
 
@@ -79,7 +112,43 @@ export async function POST(request: NextRequest) {
       totalDuplicateSkipped += result.skippedAsDuplicate;
       totalNoHashSkipped += result.skippedNoHash;
     } catch (err) {
-      console.error(`[yapily.initial-sync] account ${account.yapilyAccountId} failed:`, err);
+      console.error(`[yapily.initial-sync] pass1 account ${account.yapilyAccountId} failed:`, err);
+    }
+  }
+
+  // PASS 2 — older history (-91d to -365d). Time-budget gated so
+  // we never blow Yapily's 5-min historical window. The day-90
+  // boundary is exclusive on the older side (bank's day -90 is
+  // already in pass 1) and inclusive on the older side at -365.
+  for (const account of accountSnapshots) {
+    if (Date.now() - startedAt > HISTORICAL_BUDGET_MS) {
+      historicalSkipped++;
+      console.warn(
+        `[yapily.initial-sync] pass2 budget exhausted — skipping older history for account=${account.yapilyAccountId}`,
+      );
+      continue;
+    }
+    try {
+      const transactions = await getTransactions(
+        account.yapilyAccountId,
+        consentToken,
+        twelveMonthsAgoIso,
+        ninetyDaysAgoIso,
+      );
+      apiCallsMade++;
+      if (transactions.length === 0) continue;
+
+      const result = await upsertYapilyTransactions({
+        userId,
+        connectionId,
+        account,
+        transactions,
+      });
+      totalInserted += result.inserted;
+      totalDuplicateSkipped += result.skippedAsDuplicate;
+      totalNoHashSkipped += result.skippedNoHash;
+    } catch (err) {
+      console.error(`[yapily.initial-sync] pass2 account ${account.yapilyAccountId} failed:`, err);
     }
   }
 
@@ -125,7 +194,8 @@ export async function POST(request: NextRequest) {
 
   console.log(
     `[yapily.initial-sync] complete: inserted=${totalInserted}, dup_skipped=${totalDuplicateSkipped}, ` +
-    `no_hash_skipped=${totalNoHashSkipped}, accounts=${accountSnapshots.length}, api_calls=${apiCallsMade}`,
+    `no_hash_skipped=${totalNoHashSkipped}, accounts=${accountSnapshots.length}, api_calls=${apiCallsMade}, ` +
+    `historical_skipped=${historicalSkipped}, elapsed_ms=${Date.now() - startedAt}`,
   );
 
   // Push newly-synced transactions to the user's connected Google Sheet (if any).
@@ -137,5 +207,7 @@ export async function POST(request: NextRequest) {
     duplicatesSkipped: totalDuplicateSkipped,
     noHashSkipped: totalNoHashSkipped,
     apiCalls: apiCallsMade,
+    historicalSkipped,
+    elapsedMs: Date.now() - startedAt,
   });
 }

--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -225,14 +225,36 @@ export async function executeToolCall(
         priority: (toolInput.priority as string | undefined) ?? 'medium',
       });
     case 'update_dispute_status':
-      return updateDisputeStatus(supabase, userId, {
-        provider: toolInput.provider as string,
-        new_status: toolInput.new_status as string,
-        notes: toolInput.notes as string | undefined,
-        money_recovered: toolInput.money_recovered as number | undefined,
-        provider_response: toolInput.provider_response as string | undefined,
-        draft_reply: toolInput.draft_reply as string | undefined,
-      });
+      return updateDisputeStatus(
+        supabase,
+        userId,
+        {
+          provider: toolInput.provider as string,
+          new_status: toolInput.new_status as string,
+          notes: toolInput.notes as string | undefined,
+          money_recovered: toolInput.money_recovered as number | undefined,
+          use_disputed_amount: toolInput.use_disputed_amount as boolean | undefined,
+          provider_response: toolInput.provider_response as string | undefined,
+          draft_reply: toolInput.draft_reply as string | undefined,
+        },
+        channel,
+      );
+    case 'record_dispute_outcomes':
+      return recordDisputeOutcomes(
+        supabase,
+        userId,
+        (toolInput.outcomes as Array<{
+          dispute_id?: string;
+          provider?: string;
+          new_status: string;
+          notes?: string;
+          money_recovered?: number;
+          use_disputed_amount?: boolean;
+        }>) ?? [],
+        channel,
+      );
+    case 'get_total_recovered':
+      return getTotalRecovered(supabase, userId);
     case 'add_contract':
       return addContract(supabase, userId, {
         provider_name: toolInput.provider_name as string,
@@ -657,7 +679,7 @@ async function getDisputes(
 ): Promise<ToolResult> {
   let query = supabase
     .from('disputes')
-    .select('provider_name, issue_type, status, disputed_amount, money_recovered, created_at, updated_at')
+    .select('id, provider_name, issue_type, status, disputed_amount, money_recovered, recovered_amount_gbp, outcome, created_at, updated_at')
     .eq('user_id', userId)
     .order('updated_at', { ascending: false })
     .limit(20);
@@ -683,6 +705,9 @@ async function getDisputes(
     closed: '⚫',
   };
 
+  // The id + disputed_amount fields are included so the agent can pass
+  // dispute_id and "full amount" outcomes back via record_dispute_outcomes
+  // without a second lookup.
   let text = `*Disputes (${data.length})*\n\n`;
   for (const d of data) {
     const emoji = statusEmoji[d.status] ?? '⚪';
@@ -690,9 +715,14 @@ async function getDisputes(
       (Date.now() - new Date(d.updated_at).getTime()) / (1000 * 60 * 60 * 24),
     );
     text += `${emoji} *${d.provider_name}* — ${d.issue_type.replace(/_/g, ' ')}\n`;
+    text += `   id: ${d.id}\n`;
     text += `   Status: ${d.status.replace(/_/g, ' ')} · ${daysSince}d ago`;
-    if (d.money_recovered && Number(d.money_recovered) > 0) {
-      text += ` · Recovered: ${fmt(d.money_recovered)}`;
+    const recovered = Number(d.recovered_amount_gbp ?? d.money_recovered) || 0;
+    if (recovered > 0) {
+      text += ` · Recovered: ${fmt(recovered)}`;
+    }
+    if (d.disputed_amount && Number(d.disputed_amount) > 0) {
+      text += ` · Disputed: ${fmt(d.disputed_amount)}`;
     }
     text += '\n';
   }
@@ -2245,41 +2275,156 @@ async function createTask(
 // DISPUTE STATUS HANDLER
 // ============================================================
 
-async function updateDisputeStatus(
+const RESOLVED_STATUSES = new Set(['resolved_won', 'resolved_partial', 'resolved_lost', 'closed']);
+
+const STATUS_TO_OUTCOME: Record<string, 'won' | 'partial' | 'lost' | 'withdrawn' | null> = {
+  open: null,
+  awaiting_response: null,
+  escalated: null,
+  resolved_won: 'won',
+  resolved_partial: 'partial',
+  resolved_lost: 'lost',
+  closed: 'withdrawn',
+};
+
+interface DisputeOutcomeUpdate {
+  /** Direct dispute UUID (preferred when known — skips fuzzy provider match). */
+  dispute_id?: string;
+  /** Provider name (fuzzy substring match, used when dispute_id is not given). */
+  provider?: string;
+  new_status: string;
+  notes?: string;
+  money_recovered?: number;
+  /** When true, fall back to disputes.disputed_amount for money_recovered. Used when the user says "full amount", "the full thing", "all of it". */
+  use_disputed_amount?: boolean;
+  provider_response?: string;
+  draft_reply?: string;
+  outcome_set_by?: 'user' | 'agent' | 'system' | 'telegram' | 'whatsapp';
+  outcome_confidence?: 'confirmed' | 'inferred' | 'unverified';
+}
+
+interface DisputeOutcomeResult {
+  ok: boolean;
+  provider_name: string;
+  status: string;
+  outcome: string | null;
+  recovered: number;
+  /** Diagnostic when ok=false. */
+  reason?: string;
+}
+
+/**
+ * Update a single dispute outcome and log it to the audit trail.
+ *
+ * Designed to be safe to call multiple times in a single turn (from
+ * recordDisputeOutcomes) — each call does its own lookup and update,
+ * but does not throw. Callers get a structured result they can
+ * aggregate into a confirmation message.
+ *
+ * Auto-fills money_recovered from disputes.disputed_amount when the
+ * caller passes use_disputed_amount=true and no explicit amount.
+ * This is what makes "full dispute amount" / "the full thing" work
+ * without an extra round trip.
+ *
+ * On resolved_won / resolved_partial we also insert a verified_savings
+ * row so the running "total saved with Paybacker" counter stays in
+ * step with the dispute table. The row is keyed on dispute_id, so
+ * re-marking the same dispute won't double-count (we upsert).
+ */
+async function applyDisputeOutcomeUpdate(
   supabase: ReturnType<typeof getAdmin>,
   userId: string,
-  params: { provider: string; new_status: string; notes?: string; money_recovered?: number; provider_response?: string; draft_reply?: string },
-): Promise<ToolResult> {
-  const { data: dispute, error: fetchError } = await supabase
-    .from('disputes')
-    .select('id, provider_name, status, issue_type')
-    .eq('user_id', userId)
-    .ilike('provider_name', `%${params.provider}%`)
-    .not('status', 'in', '("resolved_won","resolved_partial","resolved_lost","closed")')
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .single();
-
-  if (fetchError || !dispute) {
-    return { text: `No open dispute found matching "${params.provider}". Use get_disputes to see all disputes.` };
+  params: DisputeOutcomeUpdate,
+  channel: 'telegram' | 'whatsapp' | 'chatbot' = 'telegram',
+): Promise<DisputeOutcomeResult> {
+  // 1. Find the dispute. Prefer dispute_id, fall back to provider fuzzy
+  //    match. When matching by provider we deliberately allow already-
+  //    resolved disputes through, so the agent can correct a mistaken
+  //    outcome ("I told you we won but we actually lost").
+  let dispute: { id: string; provider_name: string; status: string; issue_type: string; disputed_amount: number | null } | null = null;
+  if (params.dispute_id) {
+    const { data } = await supabase
+      .from('disputes')
+      .select('id, provider_name, status, issue_type, disputed_amount')
+      .eq('user_id', userId)
+      .eq('id', params.dispute_id)
+      .maybeSingle();
+    dispute = data;
+  } else if (params.provider) {
+    const { data } = await supabase
+      .from('disputes')
+      .select('id, provider_name, status, issue_type, disputed_amount')
+      .eq('user_id', userId)
+      .ilike('provider_name', `%${params.provider}%`)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    dispute = data;
   }
 
+  if (!dispute) {
+    return {
+      ok: false,
+      provider_name: params.provider ?? 'unknown',
+      status: params.new_status,
+      outcome: null,
+      recovered: 0,
+      reason: params.dispute_id
+        ? `No dispute found with id ${params.dispute_id}.`
+        : `No dispute found matching "${params.provider}".`,
+    };
+  }
+
+  // 2. Resolve the money figure.
+  //    - explicit money_recovered wins
+  //    - else use_disputed_amount + disputes.disputed_amount fallback
+  //    - else 0 (only meaningful for won / partial; lost stays 0)
+  let recovered = 0;
+  if (params.money_recovered !== undefined && params.money_recovered !== null) {
+    recovered = Number(params.money_recovered) || 0;
+  } else if (params.use_disputed_amount && dispute.disputed_amount) {
+    recovered = Number(dispute.disputed_amount) || 0;
+  }
+
+  const isResolved = RESOLVED_STATUSES.has(params.new_status);
+  const outcome = STATUS_TO_OUTCOME[params.new_status] ?? null;
+  const nowIso = new Date().toISOString();
+
+  // 3. Build the update. Always write the new audit fields when we're
+  //    setting an outcome — that's the whole point of this fix.
   const updates: Record<string, unknown> = {
     status: params.new_status,
-    updated_at: new Date().toISOString(),
+    updated_at: nowIso,
   };
   if (params.notes) updates.outcome_notes = params.notes;
-  if (params.money_recovered !== undefined) updates.money_recovered = params.money_recovered;
-
-  const isResolved = ['resolved_won', 'resolved_partial', 'resolved_lost', 'closed'].includes(params.new_status);
-  if (isResolved) updates.resolved_at = new Date().toISOString();
-
-  const { error } = await supabase.from('disputes').update(updates).eq('id', dispute.id);
-
-  if (error) {
-    return { text: `Failed to update dispute: ${error.message}` };
+  if (recovered > 0) {
+    updates.money_recovered = recovered;
+    updates.recovered_amount_gbp = recovered;
+  }
+  if (isResolved) {
+    updates.resolved_at = nowIso;
+  }
+  if (outcome) {
+    updates.outcome = outcome;
+    updates.outcome_set_at = nowIso;
+    updates.outcome_set_by = params.outcome_set_by ?? channel;
+    updates.outcome_confidence = params.outcome_confidence ?? 'confirmed';
   }
 
+  const { error } = await supabase.from('disputes').update(updates).eq('id', dispute.id);
+  if (error) {
+    return {
+      ok: false,
+      provider_name: dispute.provider_name,
+      status: params.new_status,
+      outcome,
+      recovered,
+      reason: error.message,
+    };
+  }
+
+  // 4. Audit trail for any provider response / draft reply text passed
+  //    alongside the outcome.
   if (params.provider_response) {
     await supabase.from('correspondence').insert({
       dispute_id: dispute.id,
@@ -2289,7 +2434,6 @@ async function updateDisputeStatus(
       content: params.provider_response,
     });
   }
-
   if (params.draft_reply) {
     await supabase.from('correspondence').insert({
       dispute_id: dispute.id,
@@ -2300,16 +2444,279 @@ async function updateDisputeStatus(
     });
   }
 
+  // 5. Log a verified_savings row on win/partial so the savings
+  //    counter stays in step. Keyed on (user_id, dispute_id) via
+  //    onConflict so re-marking the same dispute updates rather than
+  //    duplicates. We only do this when recovered > 0 — a "won with
+  //    £0 recovered" outcome (rare, e.g. a principle-only win)
+  //    shouldn't appear in savings totals.
+  if ((outcome === 'won' || outcome === 'partial') && recovered > 0) {
+    const savingTypeLabel = outcome === 'won' ? 'Dispute won' : 'Dispute partially resolved';
+    await supabase.from('verified_savings').upsert(
+      {
+        user_id: userId,
+        saving_type: 'dispute_won',
+        title: `${dispute.provider_name} — ${savingTypeLabel}`,
+        description: params.notes ?? null,
+        amount_saved: recovered,
+        dispute_id: dispute.id,
+        confirmed_by: channel,
+        confirmed_at: nowIso,
+        evidence_notes: params.notes ?? null,
+      },
+      { onConflict: 'dispute_id' },
+    );
+  }
+
+  return {
+    ok: true,
+    provider_name: dispute.provider_name,
+    status: params.new_status,
+    outcome,
+    recovered,
+  };
+}
+
+async function updateDisputeStatus(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  params: {
+    provider: string;
+    new_status: string;
+    notes?: string;
+    money_recovered?: number;
+    use_disputed_amount?: boolean;
+    provider_response?: string;
+    draft_reply?: string;
+  },
+  channel: 'telegram' | 'whatsapp' | 'chatbot' = 'telegram',
+): Promise<ToolResult> {
+  const result = await applyDisputeOutcomeUpdate(
+    supabase,
+    userId,
+    {
+      provider: params.provider,
+      new_status: params.new_status,
+      notes: params.notes,
+      money_recovered: params.money_recovered,
+      use_disputed_amount: params.use_disputed_amount,
+      provider_response: params.provider_response,
+      draft_reply: params.draft_reply,
+    },
+    channel,
+  );
+
+  if (!result.ok) {
+    return {
+      text: `${result.reason ?? 'Failed to update dispute.'} Use get_disputes to see all disputes.`,
+    };
+  }
+
   const statusEmoji: Record<string, string> = {
     open: '🔴', awaiting_response: '🟡', escalated: '🟠',
     resolved_won: '✅', resolved_partial: '🟢', resolved_lost: '❌', closed: '⚫',
   };
 
-  const emoji = statusEmoji[params.new_status] ?? '⚪';
-  let text = `${emoji} *${dispute.provider_name}* dispute updated to: *${params.new_status.replace(/_/g, ' ')}*`;
+  const emoji = statusEmoji[result.status] ?? '⚪';
+  let text = `${emoji} *${result.provider_name}* — *${result.status.replace(/_/g, ' ')}*`;
   if (params.notes) text += `\nNotes: ${params.notes}`;
-  if (params.money_recovered) text += `\nRecovered: *${fmt(params.money_recovered)}*`;
-  if (params.new_status === 'resolved_won') text += `\n\n🎉 Well done on winning this dispute!`;
+  if (result.recovered > 0) text += `\nRecovered: *${fmt(result.recovered)}*`;
+
+  if (result.outcome === 'won' || result.outcome === 'partial') {
+    // Pull the running total so the user gets the cumulative figure
+    // in the same response — saves a follow-up "how much in total?".
+    const { data: wonRows } = await supabase
+      .from('disputes')
+      .select('recovered_amount_gbp, money_recovered')
+      .eq('user_id', userId)
+      .in('outcome', ['won', 'partial']);
+    const total = (wonRows ?? []).reduce(
+      (sum: number, r: { recovered_amount_gbp: number | string | null; money_recovered: number | string | null }) =>
+        sum + (Number(r.recovered_amount_gbp ?? r.money_recovered) || 0),
+      0,
+    );
+    if (total > 0) {
+      text += `\n\nTotal recovered via Paybacker: *${fmt(total)}* 🎉`;
+    } else if (result.outcome === 'won') {
+      text += `\n\n🎉 Well done on winning this dispute!`;
+    }
+  }
+
+  return { text };
+}
+
+// ============================================================
+// BATCH DISPUTE OUTCOME HANDLER
+// ============================================================
+//
+// Called when the user resolves multiple disputes in one go — e.g.
+// after the Watchdog alert lists 2 disputes that received replies and
+// the user replies "Both won. 1. £69. 2. full amount." The agent
+// resolves the list-position → provider mapping from conversation
+// history, then hands us one call with both outcomes.
+//
+// Each item in `outcomes` is processed independently. We never abort
+// the batch on a single failure — partial success is reported back so
+// the user sees what landed and what didn't.
+
+async function recordDisputeOutcomes(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  outcomes: Array<{
+    dispute_id?: string;
+    provider?: string;
+    new_status: string;
+    notes?: string;
+    money_recovered?: number;
+    use_disputed_amount?: boolean;
+  }>,
+  channel: 'telegram' | 'whatsapp' | 'chatbot' = 'telegram',
+): Promise<ToolResult> {
+  if (!Array.isArray(outcomes) || outcomes.length === 0) {
+    return { text: 'No outcomes provided. Pass at least one dispute outcome to record.' };
+  }
+
+  const results: DisputeOutcomeResult[] = [];
+  for (const o of outcomes) {
+    results.push(
+      await applyDisputeOutcomeUpdate(
+        supabase,
+        userId,
+        {
+          dispute_id: o.dispute_id,
+          provider: o.provider,
+          new_status: o.new_status,
+          notes: o.notes,
+          money_recovered: o.money_recovered,
+          use_disputed_amount: o.use_disputed_amount,
+        },
+        channel,
+      ),
+    );
+  }
+
+  const wins = results.filter((r) => r.ok && r.outcome === 'won');
+  const partials = results.filter((r) => r.ok && r.outcome === 'partial');
+  const losses = results.filter((r) => r.ok && r.outcome === 'lost');
+  const failures = results.filter((r) => !r.ok);
+
+  let text = '';
+  if (wins.length > 0) {
+    text += wins.length === 1 ? `✅ *Dispute marked as won!*\n` : `✅ *${wins.length} disputes marked as won!*\n`;
+    for (const r of wins) {
+      text += `• ${r.provider_name}${r.recovered > 0 ? ` — *${fmt(r.recovered)}* recovered` : ''}\n`;
+    }
+  }
+  if (partials.length > 0) {
+    text += text ? '\n' : '';
+    text += partials.length === 1 ? `🟢 *Dispute partially resolved.*\n` : `🟢 *${partials.length} disputes partially resolved.*\n`;
+    for (const r of partials) {
+      text += `• ${r.provider_name}${r.recovered > 0 ? ` — *${fmt(r.recovered)}* recovered` : ''}\n`;
+    }
+  }
+  if (losses.length > 0) {
+    text += text ? '\n' : '';
+    text += losses.length === 1 ? `❌ *Dispute marked as lost.*\n` : `❌ *${losses.length} disputes marked as lost.*\n`;
+    for (const r of losses) {
+      text += `• ${r.provider_name}\n`;
+    }
+  }
+
+  const recoveredThisBatch = [...wins, ...partials].reduce((s, r) => s + r.recovered, 0);
+  if (recoveredThisBatch > 0) {
+    text += `\nTotal recovered this batch: *${fmt(recoveredThisBatch)}* 🎉\n`;
+
+    // Running cumulative total across all won/partial disputes.
+    const { data: wonRows } = await supabase
+      .from('disputes')
+      .select('recovered_amount_gbp, money_recovered')
+      .eq('user_id', userId)
+      .in('outcome', ['won', 'partial']);
+    const total = (wonRows ?? []).reduce(
+      (sum: number, r: { recovered_amount_gbp: number | string | null; money_recovered: number | string | null }) =>
+        sum + (Number(r.recovered_amount_gbp ?? r.money_recovered) || 0),
+      0,
+    );
+    if (total > recoveredThisBatch) {
+      text += `Total recovered via Paybacker: *${fmt(total)}*`;
+    }
+  }
+
+  if (failures.length > 0) {
+    text += text ? '\n\n' : '';
+    text += `⚠️ Couldn't record ${failures.length} outcome${failures.length === 1 ? '' : 's'}:\n`;
+    for (const r of failures) {
+      text += `• ${r.provider_name}: ${r.reason ?? 'unknown error'}\n`;
+    }
+  }
+
+  if (!text) {
+    text = 'No outcomes were recorded.';
+  }
+
+  return { text };
+}
+
+// ============================================================
+// TOTAL RECOVERED COUNTER
+// ============================================================
+//
+// SUM(recovered_amount_gbp) over disputes with outcome IN ('won','partial').
+// Use the new column with a fallback to the legacy money_recovered so the
+// number doesn't drop to zero for rows resolved before the migration.
+
+async function getTotalRecovered(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+): Promise<ToolResult> {
+  const { data, error } = await supabase
+    .from('disputes')
+    .select('provider_name, recovered_amount_gbp, money_recovered, outcome, status, resolved_at')
+    .eq('user_id', userId)
+    .or('outcome.eq.won,outcome.eq.partial,status.eq.resolved_won,status.eq.resolved_partial')
+    .order('resolved_at', { ascending: false, nullsFirst: false });
+
+  if (error) {
+    return { text: `Couldn't load recovered total: ${error.message}` };
+  }
+
+  const rows = data ?? [];
+  if (rows.length === 0) {
+    return {
+      text: `You haven't recovered any money via Paybacker yet.\n\nWhen a dispute is resolved in your favour, tell me "won — £X" or "they paid the full amount" and I'll log it here.`,
+    };
+  }
+
+  let won = 0;
+  let partial = 0;
+  let wonCount = 0;
+  let partialCount = 0;
+  for (const r of rows) {
+    const amount = Number(r.recovered_amount_gbp ?? r.money_recovered) || 0;
+    if (r.outcome === 'won' || r.status === 'resolved_won') {
+      won += amount;
+      wonCount += 1;
+    } else if (r.outcome === 'partial' || r.status === 'resolved_partial') {
+      partial += amount;
+      partialCount += 1;
+    }
+  }
+  const total = won + partial;
+
+  let text = `💰 *Total recovered via Paybacker: ${fmt(total)}*\n\n`;
+  if (wonCount > 0) text += `✅ Disputes won (${wonCount}): ${fmt(won)}\n`;
+  if (partialCount > 0) text += `🟢 Partial wins (${partialCount}): ${fmt(partial)}\n`;
+
+  const recent = rows.slice(0, 5);
+  if (recent.length > 0) {
+    text += `\n*Most recent:*\n`;
+    for (const r of recent) {
+      const amount = Number(r.recovered_amount_gbp ?? r.money_recovered) || 0;
+      if (amount > 0) {
+        text += `• ${r.provider_name} — *${fmt(amount)}*\n`;
+      }
+    }
+  }
 
   return { text };
 }

--- a/src/lib/telegram/tools.ts
+++ b/src/lib/telegram/tools.ts
@@ -759,22 +759,22 @@ export const telegramTools: Tool[] = [
   {
     name: 'update_dispute_status',
     description:
-      "Update the status of an existing dispute — mark it resolved, escalate it, or add a note. Use when the user provides an update from a company (e.g. an email they received). Always include the full 'provider_response' if they give one, and if you draft them a response to send back, include it in 'draft_reply' so both are logged to the dispute history audit trail.",
+      "Update a SINGLE dispute's status — mark it resolved (won / partial / lost), escalate it, or add a note. Use for one dispute at a time; for multiple disputes in one user message (e.g. \"both won, 1. £69, 2. full amount\"), use record_dispute_outcomes instead.\n\nWhen the user declares a win in natural language (\"won\", \"settled\", \"they paid\", \"got my refund\", \"resolved in our favour\") set new_status='resolved_won'. \"Lost\", \"rejected\", \"no refund\" → 'resolved_lost'. \"Partial\", \"offered half\", \"settled for £X\" → 'resolved_partial'. If the user gives an explicit £ amount, pass it as money_recovered. If they say \"full amount\", \"full dispute amount\", \"the full thing\", \"all of it\" — pass use_disputed_amount=true and the tool will read disputes.disputed_amount from the database. Do NOT ask follow-up questions when you already have enough to record the outcome — just record it and confirm.\n\nAlways include the full 'provider_response' if the user pasted one, and if you drafted a reply include it in 'draft_reply' — both go to the dispute history audit trail.",
     input_schema: {
       type: 'object' as const,
       properties: {
         provider: {
           type: 'string',
-          description: 'Provider name of the dispute to update (partial match, case-insensitive).',
+          description: 'Provider name of the dispute to update (partial match, case-insensitive). E.g. "Nuki", "E.ON", "British Gas". If the user just gave a list-position ("1." / "2."), resolve it to the provider name from your recent message before calling.',
         },
         new_status: {
           type: 'string',
           enum: ['open', 'awaiting_response', 'escalated', 'resolved_won', 'resolved_partial', 'resolved_lost', 'closed'],
-          description: 'The new status for the dispute.',
+          description: 'The new status for the dispute. Resolved_won/partial/lost auto-set outcome, outcome_set_at, outcome_set_by, outcome_confidence and resolved_at.',
         },
         notes: {
           type: 'string',
-          description: 'Optional notes about the update (e.g. "Company replied refusing refund", "Ombudsman case opened").',
+          description: 'Brief description of the outcome (e.g. "Refund agreed in full", "Offered £50 goodwill, accepted", "Final response, refused"). Saved as outcome_notes.',
         },
         provider_response: {
           type: 'string',
@@ -786,10 +786,70 @@ export const telegramTools: Tool[] = [
         },
         money_recovered: {
           type: 'number',
-          description: 'Amount of money recovered in GBP — only for resolved_won or resolved_partial.',
+          description: 'Amount of money recovered in GBP — only for resolved_won or resolved_partial. Set this OR use_disputed_amount, not both.',
+        },
+        use_disputed_amount: {
+          type: 'boolean',
+          description: 'Set to true when the user says the FULL disputed amount was recovered ("full amount", "the full thing", "all of it"). The tool will look up disputes.disputed_amount from the database and use that as money_recovered. Don\'t combine with an explicit money_recovered value.',
         },
       },
       required: ['provider', 'new_status'],
+    },
+  },
+  {
+    name: 'record_dispute_outcomes',
+    description:
+      "Record the outcome of MULTIPLE disputes in one call. Use this when the user resolves several disputes in a single message — e.g. you listed \"1. Nuki  2. ACI / E.On Next\" and they reply \"Both won. 1. £69. 2. full dispute amount.\" You MUST map their numbered/positional reply back to the providers from your previous message before calling.\n\nEach item in `outcomes` is processed independently — partial success is fine. Pass `dispute_id` when you know it (from get_disputes), otherwise pass `provider` and the tool will fuzzy-match. Use `use_disputed_amount: true` for items the user described as the \"full amount\" — the tool will read disputes.disputed_amount and use it as money_recovered. The response includes a running cumulative total of money recovered via Paybacker, so the user sees their lifetime tally.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        outcomes: {
+          type: 'array',
+          description: 'List of dispute outcomes to record. Length must be >= 1.',
+          items: {
+            type: 'object' as const,
+            properties: {
+              dispute_id: {
+                type: 'string',
+                description: 'UUID of the dispute (preferred if you have it from get_disputes — skips the fuzzy provider lookup).',
+              },
+              provider: {
+                type: 'string',
+                description: 'Provider name (used when dispute_id is not given). Case-insensitive substring match. Resolve list-positions to providers BEFORE calling.',
+              },
+              new_status: {
+                type: 'string',
+                enum: ['open', 'awaiting_response', 'escalated', 'resolved_won', 'resolved_partial', 'resolved_lost', 'closed'],
+                description: "New status for this dispute. Map natural language: 'won/settled/they paid/got refund' → resolved_won, 'partial/offered half/settled for X' → resolved_partial, 'lost/rejected/refused' → resolved_lost.",
+              },
+              notes: {
+                type: 'string',
+                description: 'Short outcome note (e.g. "Full refund", "Final response, refused", "£25 goodwill accepted").',
+              },
+              money_recovered: {
+                type: 'number',
+                description: 'Recovered amount in GBP. Set this OR use_disputed_amount, not both.',
+              },
+              use_disputed_amount: {
+                type: 'boolean',
+                description: 'True when the user said "full amount" / "the full thing" / "all of it" — looks up disputes.disputed_amount and uses that.',
+              },
+            },
+            required: ['new_status'],
+          },
+        },
+      },
+      required: ['outcomes'],
+    },
+  },
+  {
+    name: 'get_total_recovered',
+    description:
+      "Get the user's running total of money recovered via Paybacker disputes — the sum of recovered_amount_gbp (falling back to legacy money_recovered) across all disputes where outcome is 'won' or 'partial'. Returns the total, the count of won vs partial disputes, and the most recent 5 wins. Use when the user asks \"how much have I recovered?\", \"what's my total?\", or \"how much money saved?\" specifically about disputes. For broader savings (which include cancellations and price reverts), use get_savings_total instead.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
     },
   },
   {

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -154,6 +154,7 @@ READ TOOLS — Proactive Intelligence:
 - get_unused_subscriptions — Find subscriptions with no recent transactions (potential zombie payments) — use when asked "what am I not using?", "any unused subscriptions?", "zombie payments"
 - get_dispute_status — Active disputes with age and FCA deadline countdown — use when asked "how are my disputes going?", "any complaints to follow up?", "dispute deadlines"
 - get_savings_total — Total verified savings since joining Paybacker with milestone tracker — use when asked "how much have I saved?", "my total savings", "what have I saved with Paybacker"
+- get_total_recovered — Total money recovered specifically via disputes (SUM(recovered_amount_gbp) for won + partial) — use when asked "how much have I recovered from disputes?", "what's my running total?", "how much did Paybacker get back for me?"
 
 WRITE TOOLS:
 - set_budget — Create or update a monthly budget limit for a spending category
@@ -168,7 +169,8 @@ WRITE TOOLS:
 - create_savings_goal — Create a new savings goal in Money Hub
 - update_savings_goal — Update progress on a savings goal
 - create_task — Create a financial task or reminder
-- update_dispute_status — Update a dispute: mark won/lost, add notes, record money recovered
+- update_dispute_status — Update a SINGLE dispute (one provider). Marks won/partial/lost, records money_recovered. Accepts use_disputed_amount=true for "full amount" replies.
+- record_dispute_outcomes — Update MULTIPLE disputes in one call. Use whenever the user resolves more than one dispute in a single message (especially when replying to a list you just showed them).
 - update_alert_preferences — Change notification preferences (on/off, quiet hours)
 - dismiss_action_item — Dismiss an item from the Financial Action Centre by provider name (searches tasks, email findings, and alerts)
 - mark_bill_paid — Manually mark an expected bill as paid for the current month (for payments made outside connected bank accounts)
@@ -199,6 +201,23 @@ RULES:
   (b) Put what the user actually said to tell the supplier into the 'user_reply_brief' param — WORD FOR WORD from the user, lightly cleaned up. e.g. if the user typed "tell them I'm available any day except Friday", user_reply_brief = "I'm available any day except Friday, AM or PM." Do not embellish, do not invent extra points, do not add things the user didn't say. The brief is the entire content of the reply — the letter will render it as a short, polite business letter, nothing more.
   (c) Leave 'reply_tone' as 'auto' unless the user explicitly asks to be firmer / softer / more formal ("be firm", "push back hard", "keep it polite") — then set 'firm' / 'friendly' accordingly.
   (d) Never re-narrate the whole complaint history in the reply. When user_reply_brief is set, the letter is a like-for-like professional rendering of the user's words — no added deadlines, no law citations, no escalation threats unless the user asked for them. The system is a quick drafting tool, not a rewriter.
+
+DISPUTE OUTCOMES — RECORDING WINS/LOSSES (critical):
+- Map the user's natural-language outcome to the right status BEFORE asking anything:
+  · "won", "we won", "settled", "they paid", "got my refund", "resolved in our favour", "they agreed" → resolved_won
+  · "lost", "they rejected it", "no refund", "refused", "final response — no" → resolved_lost
+  · "partial", "they offered half", "settled for £X", "goodwill of £X" → resolved_partial
+- Map money amounts BEFORE asking:
+  · An explicit number ("£69", "£500") → money_recovered = that number
+  · "full amount" / "full dispute amount" / "the full thing" / "all of it" / "everything we asked for" → use_disputed_amount = true (the tool reads disputes.disputed_amount from the DB)
+- ONE dispute → call update_dispute_status. MULTIPLE disputes in one user message → call record_dispute_outcomes with an array.
+- NUMBERED LIST REPLIES — when you just listed disputes ("1. Nuki  2. ACI") and the user replies with positional references ("1. £69", "2. full amount", "Both won — 1. … 2. …"), you MUST:
+  (a) Find your previous assistant message in the conversation that contained the numbered list.
+  (b) Map each position the user mentioned back to the provider name from that list. 1 → first item's provider, 2 → second item's provider, etc.
+  (c) Call record_dispute_outcomes with one entry per dispute, populating provider (or dispute_id if get_disputes gave you one), new_status, money_recovered (or use_disputed_amount), and notes.
+  (d) Do NOT ask "which dispute did you mean?" — you already showed the list, the numbering is unambiguous.
+- DO NOT ask redundant follow-up questions. If you have provider + status + (amount OR use_disputed_amount), record it and confirm. Only ask if it's genuinely ambiguous (e.g. user said "won" with no amount and disputes.disputed_amount is null too).
+- CONFIRMATION: after the tool returns, summarise plainly — provider, outcome, amount per dispute, and the running cumulative total the tool reports back. Lead with the celebratory marker (✅) and end with the total recovered line. Do NOT propose next steps in the same message — give the user a moment with the win.
 
 FINANCIAL INTELLIGENCE — CRITICAL:
 - get_expected_bills cross-references bank transaction data to determine paid/unpaid status. Trust its ✅/❌/⏳ indicators. ❌ means a bill was due but no matching payment was found in the bank — flag this clearly to the user.

--- a/src/lib/whatsapp/user-bot.ts
+++ b/src/lib/whatsapp/user-bot.ts
@@ -81,6 +81,17 @@ KEYWORD COMMANDS — short replies to a recent alert (look at the conversation h
 
 - GIVE ME THEIR LAST UPDATE / WHAT DID THEY SAY / SHOW ME THE REPLY / WHAT'S THEIR LATEST: the user wants the actual supplier reply. Call get_dispute_detail for the recently-alerted dispute, find the most recent company_email entry, and quote the supplier's content verbatim (truncate only if >1000 chars). Add the FCA 8-week clock if relevant.
 
+DISPUTE OUTCOMES — RECORDING WINS/LOSSES (critical):
+- Map natural language BEFORE asking anything:
+  · "won" / "settled" / "they paid" / "got my refund" / "resolved in our favour" → resolved_won
+  · "lost" / "rejected" / "no refund" / "refused" → resolved_lost
+  · "partial" / "offered half" / "settled for £X" / "goodwill of £X" → resolved_partial
+- For money: an explicit number → money_recovered. "full amount" / "full dispute amount" / "the full thing" / "all of it" → use_disputed_amount = true (tool reads disputes.disputed_amount).
+- ONE dispute → update_dispute_status. MULTIPLE in one message → record_dispute_outcomes with an array.
+- NUMBERED LIST REPLIES — when you listed disputes ("1. Nuki  2. ACI") and the user replies positionally ("1. £69, 2. full amount", "Both won — 1. … 2. …"), map each number back to the provider from your previous message and call record_dispute_outcomes. Do NOT ask "which one?" — the numbering is unambiguous.
+- DO NOT ask redundant follow-ups. Provider + status + (amount OR use_disputed_amount) is enough — record and confirm. Only ask when genuinely ambiguous.
+- CONFIRMATION: report per-dispute outcome + recovered amount + the running cumulative total the tool returns. Lead with ✅; end with the total. No "next steps" in the same message.
+
 If you can't tell which dispute the keyword refers to (no recent alert in history), call get_disputes with status="open" and ask the user to confirm which one they meant. Don't guess.`;
 
 function getAdmin() {

--- a/src/lib/yapily.test.ts
+++ b/src/lib/yapily.test.ts
@@ -1,0 +1,381 @@
+// src/lib/yapily.test.ts
+//
+// Unit tests for the Yapily helpers. Run with Node's built-in test
+// runner (same pattern as src/lib/category-taxonomy.test.ts):
+//
+//   node --experimental-strip-types --test src/lib/yapily.test.ts
+//
+// We mock globalThis.fetch per-test so we can assert on the request
+// shape (URL, headers, body) and shape the response. Yapily is never
+// hit during tests.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createHostedConsentRequest,
+  getHostedConsentRequest,
+  deleteConsent,
+  isHostedPagesEnabled,
+} from './yapily.ts';
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+let originalFetch: typeof fetch;
+let originalUuid: string | undefined;
+let originalSecret: string | undefined;
+let recorded: RecordedCall[] = [];
+
+function setEnvFor(testCase: () => void): void {
+  process.env.YAPILY_APPLICATION_UUID = 'test-uuid';
+  process.env.YAPILY_APPLICATION_SECRET = 'test-secret';
+  testCase();
+}
+
+function mockFetch(
+  status: number,
+  body: unknown,
+): typeof fetch {
+  return (async (input: FetchInput, init?: FetchInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    let parsedBody: unknown;
+    if (init?.body && typeof init.body === 'string') {
+      try {
+        parsedBody = JSON.parse(init.body);
+      } catch {
+        parsedBody = init.body;
+      }
+    }
+    const headersObj: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const k of Object.keys(h)) headersObj[k] = h[k];
+    }
+    recorded.push({
+      url,
+      method: (init?.method as string) || 'GET',
+      headers: headersObj,
+      body: parsedBody,
+    });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  originalUuid = process.env.YAPILY_APPLICATION_UUID;
+  originalSecret = process.env.YAPILY_APPLICATION_SECRET;
+  recorded = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalUuid !== undefined) process.env.YAPILY_APPLICATION_UUID = originalUuid;
+  else delete process.env.YAPILY_APPLICATION_UUID;
+  if (originalSecret !== undefined) process.env.YAPILY_APPLICATION_SECRET = originalSecret;
+  else delete process.env.YAPILY_APPLICATION_SECRET;
+});
+
+describe('isHostedPagesEnabled', () => {
+  const originalFlag = process.env.YAPILY_HOSTED_PAGES_ENABLED;
+
+  it('returns false when the flag is absent', () => {
+    delete process.env.YAPILY_HOSTED_PAGES_ENABLED;
+    assert.equal(isHostedPagesEnabled(), false);
+  });
+
+  it('returns false for arbitrary non-true values', () => {
+    process.env.YAPILY_HOSTED_PAGES_ENABLED = 'yes';
+    assert.equal(isHostedPagesEnabled(), false);
+    process.env.YAPILY_HOSTED_PAGES_ENABLED = '1';
+    assert.equal(isHostedPagesEnabled(), false);
+  });
+
+  it('returns true only for the exact string "true" (case-insensitive)', () => {
+    process.env.YAPILY_HOSTED_PAGES_ENABLED = 'true';
+    assert.equal(isHostedPagesEnabled(), true);
+    process.env.YAPILY_HOSTED_PAGES_ENABLED = 'TRUE';
+    assert.equal(isHostedPagesEnabled(), true);
+  });
+
+  if (originalFlag === undefined) delete process.env.YAPILY_HOSTED_PAGES_ENABLED;
+  else process.env.YAPILY_HOSTED_PAGES_ENABLED = originalFlag;
+});
+
+describe('createHostedConsentRequest', () => {
+  it('POSTs the canonical Hosted Pages body shape', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      meta: { tracingId: 't-1' },
+      data: {
+        consentRequestId: 'consent-req-123',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'natwest', institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/abc',
+      },
+    });
+
+    const result = await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback?state=xx',
+      institutionCountryCode: 'GB',
+      institutionId: 'natwest',
+      language: 'EN',
+      location: 'GB',
+    });
+
+    assert.equal(result.consentRequestId, 'consent-req-123');
+    assert.equal(result.hostedUrl, 'https://hosted.yapily.com/abc');
+    assert.equal(recorded.length, 1);
+    const call = recorded[0]!;
+    assert.equal(call.method, 'POST');
+    assert.match(call.url, /\/hosted\/consent-requests$/);
+    assert.match(call.headers['Authorization'] ?? '', /^Basic /);
+    const body = call.body as Record<string, unknown>;
+    assert.equal(body.redirectUrl, 'https://paybacker.co.uk/api/yapily/callback?state=xx');
+    assert.equal(body.applicationUserId, 'user-abc');
+    assert.deepEqual(body.institutionIdentifiers, {
+      institutionCountryCode: 'GB',
+      institutionId: 'natwest',
+    });
+    assert.deepEqual(body.userSettings, { language: 'EN', location: 'GB' });
+  });
+
+  it('omits institutionId when not provided (lets Yapily render bank-picker)', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-456',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/def',
+      },
+    });
+
+    await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+      institutionCountryCode: 'GB',
+    });
+
+    const body = recorded[0]!.body as Record<string, unknown>;
+    assert.deepEqual(body.institutionIdentifiers, { institutionCountryCode: 'GB' });
+  });
+
+  it('defaults language=EN and location=GB when caller omits them', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-789',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'hsbc', institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/ghi',
+      },
+    });
+
+    await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+      institutionCountryCode: 'GB',
+      institutionId: 'hsbc',
+    });
+
+    const body = recorded[0]!.body as Record<string, unknown>;
+    assert.deepEqual(body.userSettings, { language: 'EN', location: 'GB' });
+  });
+
+  it('passes featureScope through accountRequest, not at the top level', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-fs',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'natwest', institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/jkl',
+      },
+    });
+
+    await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+      institutionCountryCode: 'GB',
+      institutionId: 'natwest',
+      featureScope: ['ACCOUNT_DIRECT_DEBITS', 'ACCOUNT_PERIODIC_PAYMENTS'],
+    });
+
+    const body = recorded[0]!.body as Record<string, unknown>;
+    // Top-level featureScope is NOT in the OpenAPI — it lives inside
+    // accountRequest, which is mirrored back as accountRequestDetails
+    // on the response.
+    assert.equal('featureScope' in body, false);
+    assert.deepEqual(
+      (body.accountRequest as Record<string, unknown>).featureScope,
+      ['ACCOUNT_DIRECT_DEBITS', 'ACCOUNT_PERIODIC_PAYMENTS'],
+    );
+  });
+
+  it('omits accountRequest entirely when no scopes / dates are passed', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-noar',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+        hostedUrl: 'https://hosted.yapily.com/mno',
+      },
+    });
+
+    await createHostedConsentRequest({
+      applicationUserId: 'user-abc',
+      redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+      institutionCountryCode: 'GB',
+    });
+
+    const body = recorded[0]!.body as Record<string, unknown>;
+    assert.equal('accountRequest' in body, false);
+  });
+
+  it('throws when Yapily returns a 200 with no hostedUrl', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-bad',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'natwest', institutionCountryCode: 'GB' },
+        createdAt: '2026-04-29T10:00:00Z',
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        createHostedConsentRequest({
+          applicationUserId: 'user-abc',
+          redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+          institutionCountryCode: 'GB',
+        }),
+      /hostedUrl/,
+    );
+  });
+
+  it('surfaces Yapily error messages on non-2xx', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(400, {
+      error: {
+        code: 400,
+        status: 'Bad Request',
+        message: 'institutionCountryCode is required',
+      },
+    });
+
+    await assert.rejects(
+      () =>
+        createHostedConsentRequest({
+          applicationUserId: 'user-abc',
+          redirectUrl: 'https://paybacker.co.uk/api/yapily/callback',
+          institutionCountryCode: '',
+        }),
+      /institutionCountryCode is required/,
+    );
+  });
+});
+
+describe('getHostedConsentRequest', () => {
+  it('GETs /hosted/consent-requests/{id} and returns the consent record', async () => {
+    setEnvFor(() => {});
+    // Per Yapily OpenAPI 12.3.4: AUTHORIZED responses surface
+    // consentRequestId, consentId (used by /account-auth-requests/{id}),
+    // and consentToken (used as the data-call header).
+    globalThis.fetch = mockFetch(200, {
+      data: {
+        consentRequestId: 'consent-req-123',
+        consentId: 'b22a1fe6-1e91-45b3-8ba0-6fdb1708e7bd',
+        applicationUserId: 'user-abc',
+        institutionIdentifiers: { institutionId: 'natwest', institutionCountryCode: 'GB' },
+        status: 'AUTHORIZED',
+        createdAt: '2026-04-29T10:00:00Z',
+        consentToken: 'eyJjb25zZW50dG9rZW4iLi4u',
+      },
+    });
+
+    const result = await getHostedConsentRequest('consent-req-123');
+
+    assert.equal(result.consentRequestId, 'consent-req-123');
+    assert.equal(result.consentId, 'b22a1fe6-1e91-45b3-8ba0-6fdb1708e7bd');
+    assert.equal(result.status, 'AUTHORIZED');
+    assert.equal(result.consentToken, 'eyJjb25zZW50dG9rZW4iLi4u');
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.method, 'GET');
+    assert.match(recorded[0]!.url, /\/hosted\/consent-requests\/consent-req-123$/);
+  });
+
+  it('surfaces error message on non-2xx (e.g. expired hostedUrl)', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(404, {
+      error: {
+        code: 404,
+        status: 'Not Found',
+        message: 'consent request not found',
+      },
+    });
+
+    await assert.rejects(
+      () => getHostedConsentRequest('missing-id'),
+      /consent request not found/,
+    );
+  });
+});
+
+describe('deleteConsent', () => {
+  it('DELETEs /account-auth-requests/{id}', async () => {
+    setEnvFor(() => {});
+    // Yapily returns 200 on a successful delete in the API; we test
+    // both that and the 404-already-gone path below. A test using 204
+    // wouldn't work — the global Response constructor refuses a 204
+    // with a body, which the mockFetch helper always emits.
+    globalThis.fetch = mockFetch(200, {});
+
+    await deleteConsent('consent-abc');
+
+    assert.equal(recorded.length, 1);
+    assert.equal(recorded[0]!.method, 'DELETE');
+    assert.match(recorded[0]!.url, /\/account-auth-requests\/consent-abc$/);
+    assert.match(recorded[0]!.headers['Authorization'] ?? '', /^Basic /);
+  });
+
+  it('treats 404 as success (consent already gone)', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(404, {
+      error: { code: 404, status: 'Not Found', message: 'gone' },
+    });
+
+    // No throw — Yapily-side absence IS the desired end state.
+    await deleteConsent('consent-already-gone');
+  });
+
+  it('throws on other non-2xx responses', async () => {
+    setEnvFor(() => {});
+    globalThis.fetch = mockFetch(500, {
+      error: { code: 500, status: 'Internal Server Error', message: 'boom' },
+    });
+
+    await assert.rejects(
+      () => deleteConsent('consent-broken'),
+      /boom|delete-consent error/,
+    );
+  });
+});

--- a/src/lib/yapily.test.ts
+++ b/src/lib/yapily.test.ts
@@ -341,7 +341,7 @@ describe('getHostedConsentRequest', () => {
 });
 
 describe('deleteConsent', () => {
-  it('DELETEs /account-auth-requests/{id}', async () => {
+  it('DELETEs /consents/{id}', async () => {
     setEnvFor(() => {});
     // Yapily returns 200 on a successful delete in the API; we test
     // both that and the 404-already-gone path below. A test using 204
@@ -353,7 +353,7 @@ describe('deleteConsent', () => {
 
     assert.equal(recorded.length, 1);
     assert.equal(recorded[0]!.method, 'DELETE');
-    assert.match(recorded[0]!.url, /\/account-auth-requests\/consent-abc$/);
+    assert.match(recorded[0]!.url, /\/consents\/consent-abc$/);
     assert.match(recorded[0]!.headers['Authorization'] ?? '', /^Basic /);
   });
 

--- a/src/lib/yapily.ts
+++ b/src/lib/yapily.ts
@@ -5,6 +5,8 @@ import type {
   YapilyApiResponse,
   YapilyAuthResponse,
   YapilyErrorResponse,
+  YapilyHostedConsentRequest,
+  YapilyHostedConsentResponse,
 } from '@/types/yapily';
 
 const YAPILY_BASE_URL = 'https://api.yapily.com';
@@ -50,16 +52,32 @@ async function yapilyRequest<T>(
   });
 
   if (!res.ok) {
+    // Tracing-Id capture (Vitally Support requirement). Yapily surfaces
+    // it in two places — pluck both so however ops finds the failure
+    // (Sentry, Telegram, Vercel logs) the ID is right there in the
+    // message and there's no chasing a separate header lookup.
     let errorMessage = `Yapily API error: ${res.status} ${res.statusText}`;
+    let tracingId: string | undefined;
     try {
       const errorBody = (await res.json()) as YapilyErrorResponse;
+      tracingId = errorBody.error?.tracingId;
       if (errorBody.error?.message) {
         errorMessage = `Yapily API error: ${errorBody.error.message} (${res.status})`;
       }
     } catch {
       // Body not parseable — use default message
     }
-    throw new Error(errorMessage);
+    if (!tracingId) {
+      // Some auth + 5xx paths short-circuit before the JSON body —
+      // fall back to the response header Yapily includes on every
+      // request.
+      tracingId = res.headers.get('Tracing-Id') || res.headers.get('tracing-id') || undefined;
+    }
+    if (tracingId) errorMessage += ` [tracingId=${tracingId}]`;
+    const err = new Error(errorMessage) as Error & { status?: number; tracingId?: string };
+    err.status = res.status;
+    err.tracingId = tracingId;
+    throw err;
   }
 
   return res.json() as Promise<T>;
@@ -67,10 +85,23 @@ async function yapilyRequest<T>(
 
 // ── Institutions ──
 
+// Module-level cache of the full Yapily institution list. Sized small
+// enough to live in any Vercel function instance and refreshed at most
+// once per hour. Per-instance caching is fine for this surface — the
+// data is stable, the worst case is a few extra API calls when a fresh
+// instance boots, and Yapily's recommendation is "refresh once a week"
+// (we go more aggressive for safety).
+const FEATURE_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+let _institutionsCache: { value: YapilyInstitution[]; loadedAt: number } | null = null;
+
 /**
- * Fetches all Yapily-supported institutions, filtered to UK only (country code GB).
+ * Fetches all Yapily-supported institutions, filtered to UK only
+ * (country code GB). Cached for 1 hour at the module level.
  */
 export async function getInstitutions(): Promise<YapilyInstitution[]> {
+  if (_institutionsCache && Date.now() - _institutionsCache.loadedAt < FEATURE_CACHE_TTL_MS) {
+    return _institutionsCache.value;
+  }
   const response = await yapilyRequest<YapilyApiResponse<YapilyInstitution[]>>(
     '/institutions'
   );
@@ -78,9 +109,48 @@ export async function getInstitutions(): Promise<YapilyInstitution[]> {
   const institutions = response.data || [];
 
   // Filter to UK institutions only
-  return institutions.filter((inst) =>
+  const uk = institutions.filter((inst) =>
     inst.countries?.some((c) => c.countryCode2 === 'GB')
   );
+  _institutionsCache = { value: uk, loadedAt: Date.now() };
+  return uk;
+}
+
+/**
+ * Returns the Yapily feature flags exposed by a given institution.
+ * Backed by the same cache as getInstitutions(). On a cache miss or
+ * an unknown institution returns an empty array — callers should
+ * treat absence as "feature unsupported".
+ *
+ * Source of feature names: Yapily institution metadata. Examples:
+ *   ACCOUNT_DIRECT_DEBITS, ACCOUNT_PERIODIC_PAYMENTS,
+ *   ACCOUNT_SCHEDULED_PAYMENTS, ACCOUNT_TRANSACTIONS,
+ *   INITIATE_DOMESTIC_SINGLE_PAYMENT, etc.
+ */
+export async function getInstitutionFeatures(institutionId: string): Promise<string[]> {
+  if (!institutionId) return [];
+  try {
+    const all = await getInstitutions();
+    const match = all.find((i) => i.id === institutionId);
+    return match?.features ?? [];
+  } catch (err) {
+    console.error('[yapily.getInstitutionFeatures] failed', err);
+    return [];
+  }
+}
+
+/**
+ * Returns true if `institutionId` exposes `feature`. Defaults to false
+ * on any lookup failure — Migle's spec says ~70% of UK banks support
+ * the upcoming-payments endpoints, so the safe default is to skip the
+ * call when in doubt rather than burn an API quota on a 404.
+ */
+export async function supportsFeature(
+  institutionId: string,
+  feature: string,
+): Promise<boolean> {
+  const features = await getInstitutionFeatures(institutionId);
+  return features.includes(feature);
 }
 
 // ── Account Authorisation ──
@@ -210,6 +280,201 @@ export async function getConsent(
     `/account-auth-requests/${consentId}`,
   );
   return response.data;
+}
+
+// ── Hosted Pages (Beta) ──
+//
+// Migle's onboarding plan (29 Apr 2026) requires the Hosted Pages flow
+// for build sign-off. Tutorial:
+//   https://docs.yapily.com/tools-and-services/hosted-pages/payment-tutorial-hosted-data
+//
+// Flow:
+//   1. POST /hosted/consent-requests → { hostedUrl, consentRequestId }
+//   2. Redirect user to hostedUrl (top-level, no iframe)
+//   3. User completes journey → Yapily redirects to redirectUrl with
+//      consentRequestId in query
+//   4. GET /hosted/consent-requests/{consentRequestId} → consentToken + status
+//   5. Use consentToken on /accounts and /transactions as before
+//
+// Both helpers below are guarded behind YAPILY_HOSTED_PAGES_ENABLED at
+// the call-site (src/app/api/auth/yapily/route.ts) — keeping the helpers
+// importable even when the flag is off so unit tests can exercise them.
+
+export interface CreateHostedConsentRequestInput {
+  /**
+   * The user's stable application id. We pass profile.id so Yapily can
+   * group multiple consents under the same end-user.
+   */
+  applicationUserId: string;
+  /**
+   * Where Yapily should send the user after the consent journey
+   * completes. Must include any state-bearing query params we care
+   * about — Yapily appends consentRequestId on top.
+   */
+  redirectUrl: string;
+  /**
+   * Two-letter country code for institutions allowed in this consent
+   * (Vitally checklist C1: must be set correctly per market).
+   */
+  institutionCountryCode: string;
+  /**
+   * Pre-select a specific institution so Yapily skips its own
+   * bank-picker UI. We render our own institution list, so we always
+   * pass this when the user has chosen.
+   */
+  institutionId?: string;
+  /**
+   * Two-letter language code for the hosted UI (default 'EN').
+   */
+  language?: string;
+  /**
+   * Two-letter location code for the hosted UI (default 'GB').
+   */
+  location?: string;
+  /**
+   * Yapily AccountRequest scopes — passed via the `accountRequest`
+   * field per the OpenAPI spec (mirrored back as `accountRequestDetails`
+   * on the response). Use to request ACCOUNT_SCHEDULED_PAYMENTS /
+   * ACCOUNT_PERIODIC_PAYMENTS / ACCOUNT_DIRECT_DEBITS etc. Omitted by
+   * default — Yapily applies sensible AIS defaults.
+   */
+  featureScope?: readonly string[];
+  /**
+   * Earliest transaction date to make available on this consent.
+   * Optional; useful for retrieving older history on banks that
+   * support it.
+   */
+  transactionFrom?: string;
+  /**
+   * Latest transaction date to make available on this consent.
+   * Optional.
+   */
+  transactionTo?: string;
+}
+
+/**
+ * Creates a hosted consent request. Returns the hostedUrl (short-lived,
+ * ~10min) the user must be redirected to plus the consentRequestId
+ * we'll use to look up status after the user completes the flow.
+ *
+ * NOTE on the response shape: per the Yapily OpenAPI 12.3.4, the POST
+ * response carries `consentRequestId` + `hostedUrl` but does NOT carry
+ * `consentId` or `consentToken` — those are only populated on the GET
+ * once the user has completed the bank-side journey. Don't try to
+ * persist them from this call.
+ */
+export async function createHostedConsentRequest(
+  input: CreateHostedConsentRequestInput,
+): Promise<YapilyHostedConsentRequest> {
+  const body: Record<string, unknown> = {
+    redirectUrl: input.redirectUrl,
+    institutionIdentifiers: {
+      institutionCountryCode: input.institutionCountryCode,
+      ...(input.institutionId ? { institutionId: input.institutionId } : {}),
+    },
+    applicationUserId: input.applicationUserId,
+    userSettings: {
+      language: input.language ?? 'EN',
+      location: input.location ?? 'GB',
+    },
+  };
+
+  // accountRequest (request side) ↔ accountRequestDetails (response
+  // side). Only emit it when at least one nested field is set so the
+  // serialised body stays minimal.
+  const accountRequest: Record<string, unknown> = {};
+  if (input.featureScope && input.featureScope.length) {
+    accountRequest.featureScope = Array.from(input.featureScope);
+  }
+  if (input.transactionFrom) accountRequest.transactionFrom = input.transactionFrom;
+  if (input.transactionTo) accountRequest.transactionTo = input.transactionTo;
+  if (Object.keys(accountRequest).length) body.accountRequest = accountRequest;
+
+  const response = await yapilyRequest<YapilyHostedConsentResponse>(
+    '/hosted/consent-requests',
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!response.data?.hostedUrl) {
+    throw new Error('Yapily did not return a hostedUrl for the consent request');
+  }
+  if (!response.data.consentRequestId) {
+    throw new Error('Yapily did not return a consentRequestId');
+  }
+  return response.data;
+}
+
+/**
+ * Reads the current state of a hosted consent request. After Yapily
+ * redirects back to our app we call this to confirm status before
+ * proceeding (recommended by the tutorial). Also used by the
+ * abandonment poller for users who don't return to the callback URL.
+ */
+export async function getHostedConsentRequest(
+  consentRequestId: string,
+): Promise<YapilyHostedConsentRequest> {
+  const response = await yapilyRequest<YapilyHostedConsentResponse>(
+    `/hosted/consent-requests/${consentRequestId}`,
+  );
+  return response.data;
+}
+
+/**
+ * Single source of truth for whether the Hosted Pages flow is on. Read
+ * once per request — the flag is meant to be flipped via env, not
+ * mid-process. Defaults to false so existing /account-auth-requests
+ * code stays the canonical path until we cut over.
+ */
+export function isHostedPagesEnabled(): boolean {
+  return process.env.YAPILY_HOSTED_PAGES_ENABLED?.toLowerCase() === 'true';
+}
+
+// ── Consent Deletion ──
+
+/**
+ * Revokes a consent on Yapily's side. Required by Migle for the
+ * compliance build review — the user-facing disconnect button must
+ * actually call Yapily, not just flip a local flag.
+ *
+ * Idempotent on Yapily's side: a 404 means the consent is already
+ * gone, which is what we wanted anyway. Callers should treat 404 as
+ * success and only surface other failures.
+ */
+export async function deleteConsent(consentId: string): Promise<void> {
+  const url = `${YAPILY_BASE_URL}/account-auth-requests/${consentId}`;
+
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      Authorization: getAuthHeader(),
+      'Content-Type': 'application/json',
+    },
+  });
+
+  // 404 = already revoked → success.
+  if (res.status === 404) return;
+
+  if (!res.ok) {
+    let errorMessage = `Yapily delete-consent error: ${res.status} ${res.statusText}`;
+    let tracingId: string | undefined;
+    try {
+      const errorBody = (await res.json()) as YapilyErrorResponse;
+      tracingId = errorBody.error?.tracingId;
+      if (errorBody.error?.message) {
+        errorMessage = `Yapily delete-consent error: ${errorBody.error.message} (${res.status})`;
+      }
+    } catch {
+      // body not parseable — keep default message
+    }
+    if (!tracingId) {
+      tracingId = res.headers.get('Tracing-Id') || res.headers.get('tracing-id') || undefined;
+    }
+    if (tracingId) errorMessage += ` [tracingId=${tracingId}]`;
+    throw new Error(errorMessage);
+  }
 }
 
 // ── Account-identity helpers ──

--- a/src/lib/yapily.ts
+++ b/src/lib/yapily.ts
@@ -250,22 +250,34 @@ export async function getTransactions(
 
 /**
  * Reconfirms (extends) an existing consent for the UK 90-day renewal cycle.
- * Uses PUT /account-auth-requests/{consentId}. Preserves the consent-id
- * and consent-token — no new connection row should be created on our
- * side after a successful reconfirm.
+ * Uses POST /consents/{consentId}/extend per Migle (6 May 2026) — the
+ * /account-auth-requests/{consentId} path with PUT was the legacy one and
+ * isn't part of the current API surface. Preserves the consentId and
+ * consentToken; no new connection row should be created on our side after
+ * a successful extend.
+ *
+ * Aliased as extendConsent below — same operation, more accurate name —
+ * so call sites can pick whichever reads clearer in context.
  */
 export async function reconfirmConsent(
   consentId: string
 ): Promise<YapilyAuthResponse['data']> {
   const response = await yapilyRequest<YapilyAuthResponse>(
-    `/account-auth-requests/${consentId}`,
+    `/consents/${consentId}/extend`,
     {
-      method: 'PUT',
+      method: 'POST',
     }
   );
 
   return response.data;
 }
+
+/**
+ * Alias of reconfirmConsent — POST /consents/{consentId}/extend. Use
+ * this name in 403-retry flows where "extend" reads more naturally
+ * than "reconfirm" (the API call is identical).
+ */
+export const extendConsent = reconfirmConsent;
 
 /**
  * Returns the metadata for an account-auth-request (consent), including
@@ -277,7 +289,7 @@ export async function getConsent(
   consentId: string
 ): Promise<YapilyAuthResponse['data']> {
   const response = await yapilyRequest<YapilyAuthResponse>(
-    `/account-auth-requests/${consentId}`,
+    `/consents/${consentId}`,
   );
   return response.data;
 }
@@ -444,7 +456,7 @@ export function isHostedPagesEnabled(): boolean {
  * success and only surface other failures.
  */
 export async function deleteConsent(consentId: string): Promise<void> {
-  const url = `${YAPILY_BASE_URL}/account-auth-requests/${consentId}`;
+  const url = `${YAPILY_BASE_URL}/consents/${consentId}`;
 
   const res = await fetch(url, {
     method: 'DELETE',
@@ -497,4 +509,61 @@ export function buildYapilyAccountDisplayName(account: import('@/types/yapily').
     account.type ||
     'Account'
   );
+}
+
+// ── 403 extend-first wrapper ──
+//
+// Migle (6 May 2026): when /accounts (or any consent-protected GET)
+// returns 403, the right behaviour is to call POST
+// /consents/{consentId}/extend FIRST, retry the original call once,
+// and only if THAT also 403s should the caller trigger a full
+// re-consent via POST /hosted/consent-requests. This wrapper
+// encapsulates that pattern — wrap any consent-protected call you
+// want self-healing.
+//
+// Throws ConsentExpiredError when extend → retry still 403s, so the
+// caller can flip the bank_connection to expired and surface the
+// reconfirm-consent UI.
+
+export class ConsentExpiredError extends Error {
+  consentId: string;
+  originalStatus: number;
+  constructor(consentId: string, originalStatus: number) {
+    super(`Consent ${consentId} expired beyond extend (got ${originalStatus} twice)`);
+    this.name = 'ConsentExpiredError';
+    this.consentId = consentId;
+    this.originalStatus = originalStatus;
+  }
+}
+
+function isYapily403(err: unknown): err is Error & { status?: number } {
+  return err instanceof Error && (err as Error & { status?: number }).status === 403;
+}
+
+export async function withConsentRetry<T>(
+  consentId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isYapily403(err)) throw err;
+    // First 403 → try extend.
+    try {
+      await extendConsent(consentId);
+    } catch (extendErr) {
+      // If extend itself fails, surface the original 403 — extend is
+      // best-effort.
+      throw new ConsentExpiredError(consentId, 403);
+    }
+    // Extend succeeded; retry once.
+    try {
+      return await fn();
+    } catch (retryErr) {
+      if (isYapily403(retryErr)) {
+        throw new ConsentExpiredError(consentId, 403);
+      }
+      throw retryErr;
+    }
+  }
 }

--- a/src/lib/yapily/connection-store.ts
+++ b/src/lib/yapily/connection-store.ts
@@ -56,15 +56,31 @@ export interface AccountSnapshot {
  * Project a Yapily account list into the snapshot shape the rest of
  * this module operates on. Computed once in the callback, passed to
  * the sync — keeps the hashing logic in one place.
+ *
+ * Suppresses Monzo "POT" accounts. Per Yapily docs (Vitally GA2):
+ * Monzo doesn't return transaction data for type=POT, so they show
+ * up as ghost accounts in the UI with eternally-empty histories.
+ * We hide them here so they never enter bank_connections.account_ids,
+ * never appear in the dashboard, and aren't fetched by any sync.
  */
 export function snapshotAccounts(accounts: YapilyAccount[]): AccountSnapshot[] {
-  return accounts.map((a) => ({
-    yapilyAccountId: a.id,
-    displayName: buildYapilyAccountDisplayName(a),
-    accountIdentificationsHash: buildAccountIdentificationsHash(a.accountIdentifications || []),
-    accountIdentificationsRaw: a.accountIdentifications || [],
-    currency: a.currency || 'GBP',
-  }));
+  return accounts
+    .filter((a) => {
+      const t = (a.type ?? '').toUpperCase();
+      const at = (a.accountType ?? '').toUpperCase();
+      const isPot = t === 'POT' || at === 'POT';
+      if (isPot) {
+        console.log(`[yapily.snapshotAccounts] skipping Monzo POT account id=${a.id}`);
+      }
+      return !isPot;
+    })
+    .map((a) => ({
+      yapilyAccountId: a.id,
+      displayName: buildYapilyAccountDisplayName(a),
+      accountIdentificationsHash: buildAccountIdentificationsHash(a.accountIdentifications || []),
+      accountIdentificationsRaw: a.accountIdentifications || [],
+      currency: a.currency || 'GBP',
+    }));
 }
 
 export interface ConnectionUpsertInput {
@@ -73,6 +89,14 @@ export interface ConnectionUpsertInput {
   bankName: string | null;
   consentToken: string;
   yapilyConsentId: string;
+  /**
+   * Hosted Pages flow only — the consentRequestId Yapily returned from
+   * POST /hosted/consent-requests. Distinct from yapilyConsentId; we
+   * keep both so the renew flow keeps using consentId while the
+   * abandonment poller uses consentRequestId. Optional so the legacy
+   * /account-auth-requests path stays a no-op.
+   */
+  yapilyConsentRequestId?: string | null;
   consentExpiresAt: string;
   accounts: AccountSnapshot[];
 }
@@ -153,8 +177,15 @@ export async function upsertYapilyConnection(
         bank_name: input.bankName,
         consent_token: encrypt(input.consentToken),
         yapily_consent_id: input.yapilyConsentId,
+        ...(input.yapilyConsentRequestId !== undefined
+          ? { yapily_consent_request_id: input.yapilyConsentRequestId }
+          : {}),
         consent_granted_at: now,
         consent_expires_at: input.consentExpiresAt,
+        // Reset the single-use tracking flag — a reconnect means a new
+        // consent, so the upcoming-payments endpoints become callable
+        // again. Null is the "ready to pull" sentinel the cron checks.
+        upcoming_endpoints_fetched_at: null,
         account_ids: incomingAccountIds,
         account_display_names: incomingDisplayNames,
         account_identifications_hashes: incomingHashes.length === incomingAccountIds.length
@@ -208,6 +239,9 @@ export async function upsertYapilyConnection(
       bank_name: input.bankName,
       consent_token: encrypt(input.consentToken),
       yapily_consent_id: input.yapilyConsentId,
+      ...(input.yapilyConsentRequestId !== undefined
+        ? { yapily_consent_request_id: input.yapilyConsentRequestId }
+        : {}),
       consent_granted_at: now,
       consent_expires_at: input.consentExpiresAt,
       account_ids: incomingAccountIds,

--- a/src/lib/yapily/upcoming.ts
+++ b/src/lib/yapily/upcoming.ts
@@ -23,7 +23,7 @@ function authHeader(): string {
 interface YapilyEnvelope<T> {
   meta?: unknown;
   data?: T;
-  error?: { message?: string };
+  error?: { message?: string; tracingId?: string };
 }
 
 interface RawAmount {
@@ -79,14 +79,21 @@ async function yapilyGet<T>(path: string, consentToken: string): Promise<T> {
 
   if (!res.ok) {
     let msg = `Yapily ${res.status} ${res.statusText}`;
+    let tracingId: string | undefined;
     try {
       const body = (await res.json()) as YapilyEnvelope<unknown>;
+      tracingId = body?.error?.tracingId;
       if (body?.error?.message) msg += ` — ${body.error.message}`;
     } catch {
       // ignore parse error
     }
-    const err = new Error(msg) as Error & { status?: number };
+    if (!tracingId) {
+      tracingId = res.headers.get('Tracing-Id') || res.headers.get('tracing-id') || undefined;
+    }
+    if (tracingId) msg += ` [tracingId=${tracingId}]`;
+    const err = new Error(msg) as Error & { status?: number; tracingId?: string };
     err.status = res.status;
+    err.tracingId = tracingId;
     throw err;
   }
 

--- a/src/types/yapily.ts
+++ b/src/types/yapily.ts
@@ -110,6 +110,73 @@ export interface YapilyAuthResponse {
   };
 }
 
+// ── Hosted Pages (Beta) ──
+//
+// Schema source: Yapily OpenAPI 12.3.4 — verified against
+// docs.yapily.com/api-reference/hosted-consent-pages on 29 Apr 2026.
+// Distinct from the /account-auth-requests path: Yapily renders the
+// bank-picker, the post-consent page, and any QR/decoupled-auth flows
+// itself, then redirects back to our redirectUrl with consentRequestId
+// in the query string.
+//
+// Two important nuances baked into the type:
+//
+//   1. POST /hosted/consent-requests creates the request. Its response
+//      contains consentRequestId + hostedUrl but does NOT contain
+//      consentId or consentToken — those don't exist until the user
+//      completes the flow and a Consent is created at the bank side.
+//      So consentId and consentToken are optional on this type.
+//
+//   2. GET /hosted/consent-requests/{consentRequestId} returns the
+//      same envelope but, once status is AUTHORIZED, also surfaces
+//      consentId (the underlying /account-auth-requests/{id} handle
+//      used by renew + delete) and consentToken (the credential we
+//      attach to data calls). The callback uses the GET to extract
+//      both before persisting the connection.
+//
+// hostedUrl is short-lived (~10 minutes per Migle's call notes).
+
+export interface YapilyHostedInstitutionIdentifiers {
+  institutionId?: string;
+  institutionCountryCode: string;
+}
+
+export interface YapilyHostedUserSettings {
+  language?: string;
+  location?: string;
+}
+
+export interface YapilyHostedAccountRequestDetails {
+  featureScope?: string[];
+  transactionFrom?: string;
+  transactionTo?: string;
+  expiresAt?: string;
+}
+
+export interface YapilyHostedConsentRequest {
+  consentRequestId: string;
+  userId?: string;
+  applicationUserId?: string;
+  applicationId?: string;
+  institutionIdentifiers?: YapilyHostedInstitutionIdentifiers;
+  userSettings?: YapilyHostedUserSettings;
+  redirectUrl?: string;
+  accountRequestDetails?: YapilyHostedAccountRequestDetails;
+  hostedUrl?: string;
+  createdAt?: string;
+  authorisationExpiresAt?: string;
+  // GET-only fields, present once the user completes the journey:
+  status?: string;
+  consentId?: string;
+  consentToken?: string;
+  phases?: Array<{ phaseName: string; phaseCreatedAt: string }>;
+}
+
+export interface YapilyHostedConsentResponse {
+  meta?: { tracingId?: string };
+  data: YapilyHostedConsentRequest;
+}
+
 export interface YapilyErrorResponse {
   error: {
     code: number;

--- a/supabase/migrations/20260429210000_yapily_hosted_pages_consent_request_id.sql
+++ b/supabase/migrations/20260429210000_yapily_hosted_pages_consent_request_id.sql
@@ -1,0 +1,29 @@
+-- Yapily Hosted Pages migration — Phase 1 (additive only).
+--
+-- Migle (Yapily Implementation Engineer) confirmed in our 29 Apr 2026
+-- onboarding call + follow-up email that build sign-off requires the
+-- Hosted Pages auth flow (POST /hosted/consent-requests), not the
+-- existing /account-auth-requests path. The Hosted Pages response
+-- carries a consentRequestId that's distinct from the underlying
+-- consentId we already store. We need to retain both so:
+--
+--   - the renew flow keeps using yapily_consent_id for
+--     PUT /account-auth-requests/{consentId}
+--   - the abandonment poller uses yapily_consent_request_id for
+--     GET /hosted/consent-requests/{consentRequestId}
+--   - rollback to /account-auth-requests is one env flag away — the
+--     new column being null on legacy rows is harmless.
+--
+-- Strictly additive. No DROP / no ALTER-to-remove. Honours the
+-- production-safety rules in CLAUDE.md.
+
+ALTER TABLE bank_connections
+  ADD COLUMN IF NOT EXISTS yapily_consent_request_id TEXT;
+
+-- Lookup index — the abandonment poller scans by status='pending' and
+-- then reads the request id; the index keeps that lookup cheap. Partial
+-- so we don't pay the cost on the millions of legacy / TrueLayer rows
+-- that will never have one.
+CREATE INDEX IF NOT EXISTS bank_connections_yapily_consent_request_idx
+  ON bank_connections (yapily_consent_request_id)
+  WHERE yapily_consent_request_id IS NOT NULL;

--- a/supabase/migrations/20260429210500_yapily_pending_consent_requests.sql
+++ b/supabase/migrations/20260429210500_yapily_pending_consent_requests.sql
@@ -1,0 +1,74 @@
+-- Yapily Hosted Pages — pending consent request tracking.
+--
+-- The Vitally checklist (GH2) and the Hosted Pages tutorial both call
+-- for an abandonment-handling pattern: if the user never returns to the
+-- callback URL, start polling /hosted/consent-requests/{id} after 5 min,
+-- every 5–10s, and treat as abandoned after 15 min. To do that, we need
+-- to know which consentRequestIds we've issued without yet seeing a
+-- successful callback.
+--
+-- Why a dedicated table rather than a status flag on bank_connections:
+--   - bank_connections is the live "what banks does the user have"
+--     surface. Abandoned consents shouldn't pollute it; they're an
+--     ops concern, not a user-facing one.
+--   - Keeps the flag-gated rollout clean — flipping
+--     YAPILY_HOSTED_PAGES_ENABLED=false reverts to the legacy flow
+--     without leaving orphan rows in the live table.
+--   - Lets us keep a clean audit trail of attempted connects (for
+--     funnel analysis later — drop-off at consent is meaningful).
+--
+-- Strictly additive. Honours the production-safety rules in CLAUDE.md.
+
+CREATE TABLE IF NOT EXISTS yapily_pending_consent_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  consent_request_id TEXT NOT NULL,
+  institution_id TEXT NOT NULL,
+  redirect_url TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+    'pending',     -- request created, waiting for user redirect-back
+    'completed',   -- callback fired, connection persisted
+    'abandoned',   -- 15+ min elapsed and never resolved
+    'failed'       -- Yapily reported FAILED / REVOKED / REJECTED
+  )),
+  yapily_status TEXT,
+  yapily_tracing_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at TIMESTAMPTZ,
+  last_polled_at TIMESTAMPTZ
+);
+
+-- Lookup index for the abandonment poller — "give me everything still
+-- pending after N minutes". Conditional on status='pending' so the
+-- index stays small as historical rows accumulate.
+CREATE INDEX IF NOT EXISTS yapily_pending_consent_requests_pending_idx
+  ON yapily_pending_consent_requests (created_at)
+  WHERE status = 'pending';
+
+-- Lookup by consent_request_id for the callback resolver.
+CREATE UNIQUE INDEX IF NOT EXISTS yapily_pending_consent_requests_request_idx
+  ON yapily_pending_consent_requests (consent_request_id);
+
+-- Lookup by user for any future "your in-flight bank connect" UI.
+CREATE INDEX IF NOT EXISTS yapily_pending_consent_requests_user_idx
+  ON yapily_pending_consent_requests (user_id, created_at DESC);
+
+-- RLS: users can read their own rows for diagnostic surfaces; only the
+-- service role mutates them (auth/callback/cron). No INSERT/UPDATE
+-- policy for end users.
+ALTER TABLE yapily_pending_consent_requests ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'yapily_pending_consent_requests'
+      AND policyname = 'Users read own pending consents'
+  ) THEN
+    CREATE POLICY "Users read own pending consents"
+      ON yapily_pending_consent_requests
+      FOR SELECT
+      USING (auth.uid() = user_id);
+  END IF;
+END $$;

--- a/supabase/migrations/20260429220000_yapily_upcoming_endpoints_fetched_at.sql
+++ b/supabase/migrations/20260429220000_yapily_upcoming_endpoints_fetched_at.sql
@@ -1,0 +1,29 @@
+-- Yapily upcoming-payments endpoints — single-use tracking.
+--
+-- Migle's onboarding-call clarification (29 Apr 2026): the three
+-- deterministic endpoints
+--
+--   GET /accounts/{id}/scheduled-payments
+--   GET /accounts/{id}/periodic-payments
+--   GET /accounts/{id}/direct-debits
+--
+-- are callable ONCE per consent. Re-fetching after that requires a
+-- fresh consent (full user re-auth). Today our /api/cron/sync-upcoming
+-- calls them on every cron tick, which violates the rule and can
+-- result in cached / empty responses on subsequent calls.
+--
+-- This migration adds the bookkeeping column the cron uses to gate
+-- those calls. NULL means "haven't fetched yet for this consent" → the
+-- cron can pull. NON-NULL means "already pulled for this consent" →
+-- skip the deterministic endpoints (the recurrence detector still
+-- runs against transaction history every cron tick, so predicted
+-- rows stay fresh).
+--
+-- The reset to NULL happens in src/lib/yapily/connection-store.ts
+-- upsertYapilyConnection — when a user reconnects we get a new consent,
+-- so we want the next cron tick to pull again.
+--
+-- Strictly additive — production-safety rules in CLAUDE.md.
+
+ALTER TABLE bank_connections
+  ADD COLUMN IF NOT EXISTS upcoming_endpoints_fetched_at TIMESTAMPTZ;

--- a/supabase/migrations/20260512000000_dispute_outcome_audit_fields.sql
+++ b/supabase/migrations/20260512000000_dispute_outcome_audit_fields.sql
@@ -1,0 +1,35 @@
+-- ============================================================
+-- Disputes: outcome audit fields
+-- ============================================================
+-- Adds the audit trail the Pocket Agent needs when a user declares
+-- a dispute outcome ("we won", "they paid full amount", "they
+-- rejected it") so we can record:
+--   - WHO set the outcome (user via Pocket Agent, agent, system)
+--   - WHEN it was set (separate from resolved_at so we can tell a
+--     user-marked outcome apart from an auto-detected one)
+--   - HOW CONFIDENT we are (user-confirmed vs inferred from reply)
+--   - A canonical recovered_amount_gbp mirror, kept in step with the
+--     legacy money_recovered field. The duplicate gives reporting
+--     code a single column to SUM() against the won-disputes filter
+--     without having to know about currency.
+--   - A short outcome label ('won' / 'partial' / 'lost' / 'withdrawn')
+--     to complement the longer status enum.
+--
+-- All adds are IF NOT EXISTS — additive only, never DROP/ALTER. The
+-- legacy money_recovered column stays put.
+
+ALTER TABLE disputes ADD COLUMN IF NOT EXISTS outcome TEXT
+  CHECK (outcome IS NULL OR outcome IN ('won', 'partial', 'lost', 'withdrawn'));
+ALTER TABLE disputes ADD COLUMN IF NOT EXISTS recovered_amount_gbp DECIMAL(10, 2);
+ALTER TABLE disputes ADD COLUMN IF NOT EXISTS outcome_set_at TIMESTAMPTZ;
+ALTER TABLE disputes ADD COLUMN IF NOT EXISTS outcome_set_by TEXT
+  CHECK (outcome_set_by IS NULL OR outcome_set_by IN ('user', 'agent', 'system', 'telegram', 'whatsapp'));
+ALTER TABLE disputes ADD COLUMN IF NOT EXISTS outcome_confidence TEXT
+  CHECK (outcome_confidence IS NULL OR outcome_confidence IN ('confirmed', 'inferred', 'unverified'));
+
+-- Index used by the running "money saved" counter:
+--   SELECT SUM(recovered_amount_gbp) FROM disputes
+--   WHERE user_id = $1 AND outcome = 'won';
+CREATE INDEX IF NOT EXISTS idx_disputes_user_outcome
+  ON disputes(user_id, outcome)
+  WHERE outcome IS NOT NULL;

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,7 @@
     { "path": "/api/cron/telegram-scheduler",        "schedule": "0 5,8,9,10,13,18 * * *" },
     { "path": "/api/cron/whatsapp-alerts",           "schedule": "0 */6 * * *" },
     { "path": "/api/cron/consent-renewal",           "schedule": "0 7 * * *" },
+    { "path": "/api/cron/yapily-consent-abandonment", "schedule": "*/5 * * * *" },
     { "path": "/api/cron/email-monitor",             "schedule": "0 14 * * *" },
     { "path": "/api/cron/detect-subscriptions",      "schedule": "0 4 * * *" },
     { "path": "/api/cron/sync-upcoming",             "schedule": "0 6 * * *" },


### PR DESCRIPTION
## Summary

Fixes the Pocket Agent (Telegram + WhatsApp) so it can properly handle a user declaring dispute outcomes after Watchdog alerts. Previously the bot couldn't map list-position replies (\"1. £69, 2. full amount\") back to the disputes it had just listed, didn't understand \"full dispute amount\" as a DB lookup, and kept asking redundant follow-ups instead of recording.

## Changes

**Schema** (`supabase/migrations/20260512000000_dispute_outcome_audit_fields.sql`)
- Additive `ADD COLUMN IF NOT EXISTS` for `outcome`, `recovered_amount_gbp`, `outcome_set_at`, `outcome_set_by`, `outcome_confidence`
- Partial index `idx_disputes_user_outcome` for the running money-saved counter

**Handlers** (`src/lib/telegram/tool-handlers.ts`)
- `update_dispute_status` now writes all outcome audit fields, accepts `use_disputed_amount=true` to look up `disputes.disputed_amount` for \"full amount\" replies, and inserts a `verified_savings` row on win/partial (upsert on `dispute_id` — no double counting). Confirmation message includes the running cumulative total.
- New `record_dispute_outcomes` tool — array of outcomes, processed independently; used when the user resolves multiple disputes in one message.
- New `get_total_recovered` tool — `SUM(recovered_amount_gbp)` across `outcome IN ('won','partial')` with legacy `money_recovered` fallback.
- `get_disputes` now returns dispute `id` + `disputed_amount` so the agent can pass them straight into the batch tool.

**Tool schema** (`src/lib/telegram/tools.ts`)
- `update_dispute_status` description updated with natural-language outcome mapping rules and `use_disputed_amount` parameter
- Added `record_dispute_outcomes` and `get_total_recovered` definitions

**System prompts** (`src/lib/telegram/user-bot.ts`, `src/lib/whatsapp/user-bot.ts`)
- New \"DISPUTE OUTCOMES — RECORDING WINS/LOSSES\" rules block covering:
  - Natural-language → status mapping (won/partial/lost variants)
  - Money mapping (explicit £ vs \"full amount\" → `use_disputed_amount`)
  - Numbered-list reply resolution from conversation history
  - No-redundant-follow-ups rule
  - Confirmation format with cumulative total

## Behaviour after this PR

When Paul replies \"Both have been won! 1. £69.00  2. full dispute amount.\" to a list of two disputes, the agent:
1. Maps position 1 → first provider from its earlier message, 2 → second.
2. Calls `record_dispute_outcomes` with two entries — one with `money_recovered: 69`, one with `use_disputed_amount: true`.
3. The handler looks up the disputed_amount for the second, writes outcome audit fields for both, and logs `verified_savings` rows.
4. Confirms with both wins, individual amounts, batch total, and the lifetime running total.

## Test plan

- [ ] Run the migration against staging Supabase
- [ ] Trigger a Watchdog reply alert in Telegram, reply with \"won — £42\" and verify `disputes.outcome='won'`, `disputes.outcome_set_by='telegram'`, `disputes.recovered_amount_gbp=42`, plus a new `verified_savings` row
- [ ] Same flow with two disputes alerted: reply \"Both won — 1. £69, 2. full amount\" and verify both rows update and a single confirmation message contains both providers + the cumulative total
- [ ] Ask \"how much have I recovered?\" and verify `get_total_recovered` shows the cumulative figure
- [ ] WhatsApp parity check — same flow over Twilio sandbox, confirm `outcome_set_by='whatsapp'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)