### PR TITLE
fix(pocket-agent): recategorise directly + custom subcategories — no support tickets

### DIFF
--- a/src/lib/telegram/tool-handlers.ts
+++ b/src/lib/telegram/tool-handlers.ts
@@ -25,6 +25,7 @@ import { checkClaudeRateLimit, recordClaudeCall, logClaudeCall } from '@/lib/cla
 import { generateAnnualReportData, generateOnDemandReportData } from '@/lib/report-generator';
 import { predictMonthlyIncome } from '@/lib/income-prediction';
 import { resolveAndStoreMapping } from '@/lib/subcategory-engine';
+import { isValidCategory, type Category } from '@/lib/categories';
 import { logAlertInteraction } from '@/lib/alert-interactions';
 import {
   bumpUserIntelligence,
@@ -228,7 +229,13 @@ export async function executeToolCall(
         toolInput.query as string,
       );
     case 'recategorise_transactions':
-      return recategoriseTransactions(supabase, userId, toolInput.merchant_name as string, toolInput.new_category as string);
+      return recategoriseTransactions(
+        supabase,
+        userId,
+        toolInput.merchant_name as string,
+        toolInput.new_category as string,
+        toolInput.user_subcategory as string | undefined,
+      );
     case 'set_budget':
       return setBudget(supabase, userId, toolInput.category as string, toolInput.monthly_limit as number);
     case 'recategorise_subscription':
@@ -328,6 +335,21 @@ export async function executeToolCall(
         userId,
         toolInput.transaction_id as string,
         toolInput.new_category as string,
+        toolInput.user_subcategory as string | undefined,
+      );
+    case 'upsert_user_subcategory':
+      return upsertUserSubcategory(
+        supabase,
+        userId,
+        toolInput.parent_category as string,
+        toolInput.name as string,
+        toolInput.emoji as string | undefined,
+      );
+    case 'list_user_subcategories':
+      return listUserSubcategories(
+        supabase,
+        userId,
+        toolInput.parent_category as string | undefined,
       );
     case 'get_weekly_outlook':
       return getWeeklyOutlook(supabase, userId);
@@ -1768,10 +1790,14 @@ async function recategoriseTransactions(
   userId: string,
   merchantName: string,
   newCategory: string,
+  userSubcategory?: string,
 ): Promise<ToolResult> {
-  // Resolve the user's label → canonical parent (handles custom subcategories)
-  const resolution = await resolveAndStoreMapping(supabase, userId, newCategory);
-  const { parentCategory, subcategoryLabel } = resolution;
+  // If the agent passed an explicit subcategory + a canonical parent, honour
+  // that pair directly. Otherwise auto-resolve the free-text label.
+  const hasExplicitPair = !!userSubcategory && isValidCategory(newCategory.toLowerCase().trim());
+  const { parentCategory, subcategoryLabel } = hasExplicitPair
+    ? { parentCategory: newCategory.toLowerCase().trim() as Category, subcategoryLabel: userSubcategory!.trim() }
+    : await resolveAndStoreMapping(supabase, userId, newCategory);
 
   // Build update payload: user_category always gets the canonical parent so
   // existing analytics/budget RPCs keep working. user_subcategory stores the
@@ -4219,6 +4245,77 @@ async function getDeals(
 }
 
 // ============================================================
+// CUSTOM SUBCATEGORY HANDLERS — let the agent build / re-use Tier-2
+// labels (e.g. "Energie Fitness membership" under "income") without
+// raising a support ticket.
+// ============================================================
+
+async function upsertUserSubcategory(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  parentCategory: string,
+  name: string,
+  emoji?: string,
+): Promise<ToolResult> {
+  const parent = (parentCategory || '').toLowerCase().trim();
+  const label = (name || '').trim();
+
+  if (!isValidCategory(parent)) {
+    return { text: `Invalid parent_category "${parentCategory}". Must be one of the canonical Tier-1 categories (income, transfers, groceries, …).` };
+  }
+  if (!label || label.length > 50) {
+    return { text: `Subcategory name must be 1–50 characters. Got ${label.length}.` };
+  }
+
+  const { data, error } = await supabase.rpc('upsert_user_subcategory', {
+    p_user_id: userId,
+    p_parent: parent,
+    p_name: label,
+    p_emoji: emoji?.trim() || null,
+  });
+
+  if (error) {
+    return { text: `Failed to save subcategory: ${error.message}` };
+  }
+
+  return {
+    text: `Subcategory *${label}* is now available under *${parent}*. You can recategorise transactions to it by calling recategorise_transaction / recategorise_transactions with new_category="${parent}" and user_subcategory="${label}". Subcategory id: ${data}`,
+  };
+}
+
+async function listUserSubcategories(
+  supabase: ReturnType<typeof getAdmin>,
+  userId: string,
+  parentCategory?: string,
+): Promise<ToolResult> {
+  const parent = parentCategory?.toLowerCase().trim();
+  if (parent && !isValidCategory(parent)) {
+    return { text: `Invalid parent_category "${parentCategory}".` };
+  }
+
+  const { data, error } = await supabase.rpc('get_user_subcategories', {
+    p_user_id: userId,
+    p_parent: parent ?? null,
+  });
+
+  if (error) {
+    return { text: `Failed to list subcategories: ${error.message}` };
+  }
+  if (!data || data.length === 0) {
+    return {
+      text: parent
+        ? `No custom subcategories defined yet under *${parent}*. Use upsert_user_subcategory to create one.`
+        : `No custom subcategories defined yet. Use upsert_user_subcategory to create one (e.g. "Membership income" under "income").`,
+    };
+  }
+
+  const lines = data.map((s: { parent_category: string; name: string; emoji: string | null; usage_count: number }) =>
+    `• ${s.emoji ? s.emoji + ' ' : ''}*${s.name}* — under ${s.parent_category} (${s.usage_count} transaction${s.usage_count === 1 ? '' : 's'})`,
+  );
+  return { text: `Your custom subcategories:\n${lines.join('\n')}` };
+}
+
+// ============================================================
 // PER-TRANSACTION RECATEGORISE HANDLER
 // ============================================================
 
@@ -4227,12 +4324,13 @@ async function recategoriseTransaction(
   userId: string,
   transactionId: string,
   newCategory: string,
+  userSubcategory?: string,
 ): Promise<ToolResult> {
   // Support truncated IDs (8-char prefix shown in list_transactions output)
   if (transactionId.length < 36) {
     return { text: `Error: You provided a truncated ID ("${transactionId}"). The database requires a full 36-character UUID. Please use the 'recategorise_transactions' tool to search by merchant_name instead.` };
   }
-  
+
   let txnQuery = supabase
     .from('bank_transactions')
     .select('id, merchant_name, description, amount, category, user_category')
@@ -4252,9 +4350,13 @@ async function recategoriseTransaction(
   }
   const txn = matches[0];
 
-  // Resolve the user's label → canonical parent (handles custom subcategories)
-  const resolution = await resolveAndStoreMapping(supabase, userId, newCategory);
-  const { parentCategory, subcategoryLabel } = resolution;
+  // If the agent passed an explicit subcategory + a canonical parent, honour
+  // that pair directly. Otherwise fall back to the auto-resolver, which
+  // infers a parent from the free-text label and persists the mapping.
+  const hasExplicitPair = !!userSubcategory && isValidCategory(newCategory.toLowerCase().trim());
+  const { parentCategory, subcategoryLabel } = hasExplicitPair
+    ? { parentCategory: newCategory.toLowerCase().trim() as Category, subcategoryLabel: userSubcategory!.trim() }
+    : await resolveAndStoreMapping(supabase, userId, newCategory);
 
   const { error: updateError } = await supabase
     .from('bank_transactions')

--- a/src/lib/telegram/tools.ts
+++ b/src/lib/telegram/tools.ts
@@ -615,23 +615,28 @@ export const telegramTools: Tool[] = [
   {
     name: 'recategorise_transactions',
     description:
-      'Change the category of bank transactions matching a merchant name. For example, recategorise all "Costa" transactions from "other" to "food". Returns how many transactions were updated.',
+      'Change the category of bank transactions matching a merchant name. For example, recategorise all "Costa" transactions from "other" to "eating_out", or all "Energie Fitness" credits to "income" with a "Membership income" subcategory. Returns how many transactions were updated.',
     input_schema: {
       type: 'object' as const,
       properties: {
         merchant_name: {
           type: 'string',
-          description: 'The merchant name to match (case-insensitive partial match, e.g. "Costa", "Tesco", "Netflix").',
+          description: 'The merchant name to match (case-insensitive partial match, e.g. "Costa", "Tesco", "Netflix", "Energie Fitness", "Ad").',
         },
         new_category: {
           type: 'string',
           enum: [
-            'broadband', 'council_tax', 'food', 'insurance', 'loan', 'mobile', 'mortgage',
-            'streaming', 'software', 'transport', 'utility', 'other', 'fitness', 'music',
-            'gaming', 'storage', 'healthcare', 'security', 'charity', 'education', 'pets',
-            'parking', 'travel', 'gambling', 'bills', 'fee', 'water', 'motoring', 'property_management', 'transfers',
+            'mortgage', 'housing', 'council_tax', 'energy', 'water', 'broadband', 'mobile', 'bills',
+            'groceries', 'eating_out', 'transport', 'travel', 'shopping', 'entertainment',
+            'streaming', 'software', 'health', 'personal_care', 'insurance', 'loans', 'savings',
+            'fees', 'tax', 'education', 'family', 'pets', 'charity', 'gambling',
+            'income', 'transfers', 'other',
           ],
-          description: 'The category to assign to matching transactions.',
+          description: "Canonical Tier-1 category to assign. Use 'income' for any money coming IN (salary, freelance, rent, membership income, ad revenue, refunds). Use 'transfers' ONLY for movements between the user's own accounts — never for third-party income.",
+        },
+        user_subcategory: {
+          type: 'string',
+          description: "Optional Tier-2 subcategory label (≤50 chars) for tracking a specific source under the parent — e.g. 'Energie Fitness membership' under 'income', 'Tesco shop' under 'groceries'. If the subcategory hasn't been used before, call upsert_user_subcategory(parent_category=new_category, name=this) first so it's registered for re-use.",
         },
       },
       required: ['merchant_name', 'new_category'],
@@ -1101,26 +1106,83 @@ export const telegramTools: Tool[] = [
   {
     name: 'recategorise_transaction',
     description:
-      "Change the category of a specific bank transaction by its ID. The change is immediately reflected in the Money Hub dashboard (writes to user_category). First use list_transactions to find the transaction ID, then use this tool to change its category.",
+      "Change the category of a specific bank transaction by its ID. The change is immediately reflected in the Money Hub dashboard (writes to user_category, and optionally user_subcategory). First use list_transactions to find the transaction ID, then use this tool. NEVER raise a support ticket for a categorisation request — this tool fixes it instantly.",
     input_schema: {
       type: 'object' as const,
       properties: {
         transaction_id: {
           type: 'string',
-          description: 'The unique ID of the transaction to recategorise (shown in list_transactions output).',
+          description: 'The unique ID of the transaction to recategorise (shown in list_transactions output — full 36-char UUID).',
         },
         new_category: {
           type: 'string',
           enum: [
-            'broadband', 'council_tax', 'food', 'insurance', 'loan', 'mobile', 'mortgage',
-            'streaming', 'software', 'transport', 'utility', 'other', 'fitness', 'music',
-            'gaming', 'storage', 'healthcare', 'security', 'charity', 'education', 'pets',
-            'parking', 'travel', 'gambling', 'bills', 'fee', 'water', 'motoring', 'property_management',
+            'mortgage', 'housing', 'council_tax', 'energy', 'water', 'broadband', 'mobile', 'bills',
+            'groceries', 'eating_out', 'transport', 'travel', 'shopping', 'entertainment',
+            'streaming', 'software', 'health', 'personal_care', 'insurance', 'loans', 'savings',
+            'fees', 'tax', 'education', 'family', 'pets', 'charity', 'gambling',
+            'income', 'transfers', 'other',
           ],
-          description: 'The new category for this transaction.',
+          description: "Canonical Tier-1 category. Use 'income' for any money coming IN from outside (salary, freelance, rent received, membership income, ad revenue, refunds). Use 'transfers' ONLY for movements between the user's own accounts — never for third-party payments to the user.",
+        },
+        user_subcategory: {
+          type: 'string',
+          description: "Optional Tier-2 subcategory label (≤50 chars) to record alongside the parent category — e.g. 'Energie Fitness membership' under 'income'. If this subcategory hasn't been used before for this parent, call upsert_user_subcategory first so it's registered for re-use.",
         },
       },
       required: ['transaction_id', 'new_category'],
+    },
+  },
+  {
+    name: 'upsert_user_subcategory',
+    description:
+      "Define (or re-use) a custom Tier-2 subcategory under one of the canonical parent categories — e.g. 'Membership income' under 'income', 'Energie Fitness' under 'income', 'School fees' under 'family'. Idempotent: calling with an existing (parent, name) pair returns the existing subcategory ID. Call this BEFORE recategorise_transaction / recategorise_transactions whenever the user wants to track a specific source they haven't named before. This is how the user builds up their own taxonomy without raising support tickets.",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        parent_category: {
+          type: 'string',
+          enum: [
+            'mortgage', 'housing', 'council_tax', 'energy', 'water', 'broadband', 'mobile', 'bills',
+            'groceries', 'eating_out', 'transport', 'travel', 'shopping', 'entertainment',
+            'streaming', 'software', 'health', 'personal_care', 'insurance', 'loans', 'savings',
+            'fees', 'tax', 'education', 'family', 'pets', 'charity', 'gambling',
+            'income', 'transfers', 'other',
+          ],
+          description: 'The canonical Tier-1 parent category this subcategory hangs under.',
+        },
+        name: {
+          type: 'string',
+          description: 'The subcategory label as the user described it (≤50 chars). Title-case it sensibly, e.g. "Energie Fitness membership", "Stripe / Glofox", "School fees".',
+        },
+        emoji: {
+          type: 'string',
+          description: "Optional one-character emoji for the dashboard chip, e.g. '🏋️', '💼', '🏠'.",
+        },
+      },
+      required: ['parent_category', 'name'],
+    },
+  },
+  {
+    name: 'list_user_subcategories',
+    description:
+      "List the user's existing custom subcategories, optionally filtered to one parent category. Use this before upsert_user_subcategory to check whether a similar label already exists (avoid creating 'Energie Fitness' AND 'Energie Fitness membership' for the same thing).",
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        parent_category: {
+          type: 'string',
+          enum: [
+            'mortgage', 'housing', 'council_tax', 'energy', 'water', 'broadband', 'mobile', 'bills',
+            'groceries', 'eating_out', 'transport', 'travel', 'shopping', 'entertainment',
+            'streaming', 'software', 'health', 'personal_care', 'insurance', 'loans', 'savings',
+            'fees', 'tax', 'education', 'family', 'pets', 'charity', 'gambling',
+            'income', 'transfers', 'other',
+          ],
+          description: 'Optional parent to filter by. Omit to list every custom subcategory the user has defined.',
+        },
+      },
+      required: [],
     },
   },
 

--- a/src/lib/telegram/user-bot.ts
+++ b/src/lib/telegram/user-bot.ts
@@ -194,9 +194,11 @@ READ TOOLS — Proactive Intelligence:
 WRITE TOOLS:
 - set_budget — Create or update a monthly budget limit for a spending category
 - delete_budget — Remove a budget limit
-- recategorise_transactions — Change category for all transactions from a merchant
-- recategorise_transaction — Change category of a specific transaction by ID (find ID with list_transactions first)
+- recategorise_transactions — Change category for all transactions from a merchant (also accepts an optional user_subcategory for custom labels)
+- recategorise_transaction — Change category of a specific transaction by ID (find ID with list_transactions first; also accepts an optional user_subcategory)
 - recategorise_subscription — Change a subscription's category
+- upsert_user_subcategory — Register a custom Tier-2 subcategory under a canonical parent (e.g. "Energie Fitness membership" under "income"). Idempotent.
+- list_user_subcategories — List the user's existing custom subcategories, optionally filtered by parent.
 - add_subscription — Add a new subscription or recurring payment to track
 - cancel_subscription — Mark a subscription as cancelled in the tracker
 - update_subscription — Update an existing subscription's billing cycle, amount, or next billing date (e.g. "change Netflix to yearly", "update Spotify amount to £11.99")
@@ -217,8 +219,15 @@ RULES:
 - ALWAYS call the relevant tool before answering — never make up numbers or say "I can't access that"
 - draft_dispute_letter is TERMINAL: call it exactly once when asked for a complaint letter. Do NOT call search_legal_rights first. Do NOT call anything after it.
 - generate_cancellation_email: call once when user wants to cancel a specific provider. Returns a ready-to-send letter.
-- create_support_ticket: only use when the user genuinely needs human support, not for questions you can answer yourself.
+- create_support_ticket: only use when the user genuinely needs human support, not for questions you can answer yourself. NEVER raise a ticket for a categorisation request — see RECATEGORISING below.
 - DO IT with a tool — never suggest the user "go to the dashboard" for something you can do here.
+
+RECATEGORISING — NON-NEGOTIABLE:
+- When the user says a transaction (or every transaction from a merchant) is in the wrong category, use recategorise_transaction (single, by ID) or recategorise_transactions (by merchant name) immediately. DO NOT raise a support ticket — that would be a product failure for something you can fix instantly.
+- Canonical Tier-1 parents: mortgage, housing, council_tax, energy, water, broadband, mobile, bills, groceries, eating_out, transport, travel, shopping, entertainment, streaming, software, health, personal_care, insurance, loans, savings, fees, tax, education, family, pets, charity, gambling, income, transfers, other. Anything outside this list must be expressed as a CUSTOM SUBCATEGORY under one of these parents.
+- "income" is for any money coming IN from outside the user (salary, freelance, rent received, membership / subscription income, ad revenue, refunds, dividends). "transfers" is ONLY for the user moving money between their OWN accounts — never for third-party payments to the user.
+- When the user wants to tag a transaction with a specific source they haven't named before (e.g. "Energie Fitness membership", "Stripe / Glofox payouts", "School fees"), call upsert_user_subcategory(parent_category=…, name=…) FIRST, then call recategorise_transaction (or recategorise_transactions) with new_category=<parent> AND user_subcategory=<the same name>. If they've used the label before, call list_user_subcategories first to re-use the exact spelling.
+- Confirm in one short line what was changed and how many transactions were updated.
 - Always show data the tool returns — never withhold results. If a bank connection note is included, relay it at the end only.
 - Currency: £X.XX format. Dates: DD/MM/YYYY (UK format).
 - Keep responses concise: bullet points, bold headers, no essays.

--- a/src/lib/whatsapp/user-bot.ts
+++ b/src/lib/whatsapp/user-bot.ts
@@ -67,8 +67,15 @@ GENERAL RULES (mirror the dashboard agent):
 - ALWAYS call the relevant tool before answering — never make up numbers or say "I can't access that".
 - draft_dispute_letter is TERMINAL: call once when asked for a complaint letter. Do NOT call search_legal_rights first. Do NOT call anything after it.
 - generate_cancellation_email: call once when user wants to cancel a specific provider.
-- create_support_ticket: only when the user genuinely needs human support.
+- create_support_ticket: only when the user genuinely needs human support. NEVER raise a ticket for a categorisation request — see RECATEGORISING below.
 - DO IT with a tool — never suggest "go to the dashboard" for something you can do here.
+
+RECATEGORISING — NON-NEGOTIABLE:
+- When the user says a transaction (or every transaction from a merchant) is in the wrong category, use recategorise_transaction (single, by ID) or recategorise_transactions (by merchant name) immediately. DO NOT raise a support ticket — that would be a product failure for something the agent can fix instantly.
+- The canonical Tier-1 parents are: mortgage, housing, council_tax, energy, water, broadband, mobile, bills, groceries, eating_out, transport, travel, shopping, entertainment, streaming, software, health, personal_care, insurance, loans, savings, fees, tax, education, family, pets, charity, gambling, income, transfers, other. Anything outside this list must be expressed as a CUSTOM SUBCATEGORY under one of these parents.
+- "income" is for any money coming IN from outside the user (salary, freelance, rent received, membership / subscription income, ad revenue, refunds, dividends). "transfers" is ONLY for the user moving money between their OWN accounts — never for third-party payments to the user.
+- When the user wants to tag a transaction with a specific source they haven't named before (e.g. "Energie Fitness membership", "Stripe / Glofox payouts", "School fees"), call upsert_user_subcategory(parent_category=…, name=…) FIRST to register the subcategory, then call recategorise_transaction (or recategorise_transactions) with new_category=<parent> AND user_subcategory=<the same name>. If they've used the label before, call list_user_subcategories first to re-use the exact spelling.
+- Confirm in one short line what was changed and how many transactions were updated.
 - Always show data the tool returns — never withhold results.
 - Be specific about financial impact: "that's £276/year" not "your bill went up".
 - For dispute follow-ups: always mention the FCA 8-week deadline.


### PR DESCRIPTION
A user on the WhatsApp Pocket Agent told the bot two "Ad" credits (£3,373.73 + £10,000.00 on 08/05) were actually Energie Fitness membership income. The agent raised support ticket #TKT-0019 instead of fixing it, and suggested they should land as "transfers" — which is wrong (transfers are own-account movements, not third-party income).

## Two stacked bugs

1. **Recategorise tool enums were stale.** Both `recategorise_transaction` and `recategorise_transactions` were locked to a legacy 28-item enum that didn't include `income` or most of the canonical Tier-1 parents. The agent literally couldn't recategorise anything TO income, so it had no plausible tool path and fell through to `create_support_ticket`.

2. **No tool exposed the custom-subcategory layer.** `user_category_custom` + the `upsert_user_subcategory` / `get_user_subcategories` RPCs already exist (migration `20260420100000`). The agent just had no way to call them, so it couldn't mint a label like "Energie Fitness membership" on the fly.

## Fix

- Replace both recategorise enums with the canonical 31 Tier-1 parents from the migration (`mortgage … income … transfers … other`).
- Add optional `user_subcategory` to both tools. When the agent passes (canonical parent + explicit subcategory) the handler bypasses the free-text auto-resolver and writes both `user_category` + `user_subcategory` directly.
- New tools:
  - `upsert_user_subcategory(parent_category, name, emoji?)` — idempotent wrapper round the existing RPC.
  - `list_user_subcategories(parent_category?)` — wrapper round `get_user_subcategories` so the agent can re-use an existing label rather than spawning duplicates.
- WhatsApp + Telegram system prompts gain a `RECATEGORISING — NON-NEGOTIABLE` section that:
  - forbids raising tickets for categorisation,
  - lists the canonical 31 parents inline,
  - calls out the specific `income` vs `transfers` mistake from #TKT-0019,
  - walks through the `upsert_user_subcategory` → `recategorise_transaction` flow for tagging a specific source.

## Behaviour for the Energie Fitness case after this PR

The agent should:
1. Call `list_user_subcategories(parent_category='income')` to check if "Energie Fitness membership" already exists.
2. If not, call `upsert_user_subcategory(parent_category='income', name='Energie Fitness membership')`.
3. Call `recategorise_transactions(merchant_name='Ad', new_category='income', user_subcategory='Energie Fitness membership')`.
4. Confirm "Recategorised 2 transactions (£13,373.73) from 'income / Ad revenue' to 'income / Energie Fitness membership'."

## Test plan

- [ ] Tell the WhatsApp Pocket Agent "the Ad revenue transactions are actually Energie Fitness membership income" — confirm it does NOT raise a ticket and DOES recategorise them with a custom subcategory.
- [ ] In the Money Hub dashboard, confirm the transactions show under "income → Energie Fitness membership", not under "transfers".
- [ ] Re-trigger the agent with a similar request for a different source — confirm `list_user_subcategories` is called before creating duplicates.

https://claude.ai/code/session_018hb8AfBpBnSnATphzSxwYK

---
_Generated by [Claude Code](https://claude.ai/code/session_018hb8AfBpBnSnATphzSxwYK)_