### PR TITLE
fix(crons): remove duplicate price-increases cron (email-spam fix)

### DIFF
--- a/shared-context/task-queue.md
+++ b/shared-context/task-queue.md
@@ -14,7 +14,7 @@
 
 ## URGENT - Email Spam Fix
 - [~PR#99] Implement global email rate limiter (max 2 emails per user per day) — rate limiter exists in email-rate-limit.ts; PR#99 fixes missing types (contract_expiry_alert, contract_end_alert, overcharge_alert) that were bypassing the cap (PR created 2026-04-20)
-- [ ] Consolidate deal alerts + targeted deals + price increases into single daily digest
+- [~PR#498] Consolidate deal alerts + targeted deals + price increases into single daily digest — daily-digest cron already does this; PR#498 removes the residual duplicate price-increases cron from vercel.json that was still emailing users at 7am (PR created 2026-05-26)
 - [ ] Add user email preference settings (daily digest / weekly / off)
 - [ ] Audit and restructure all 11 email cron triggers (see email-audit below)
 

--- a/vercel.json
+++ b/vercel.json
@@ -245,10 +245,6 @@
       "schedule": "0 6 * * *"
     },
     {
-      "path": "/api/cron/price-increases",
-      "schedule": "0 7 * * *"
-    },
-    {
       "path": "/api/cron/telegram-weekly-summary",
       "schedule": "0 8 * * 6"
     },


### PR DESCRIPTION
## What
- Remove `/api/cron/price-increases` (scheduled 0 7 * * *) from `vercel.json`
- No other code changes — the route handler at `src/app/api/cron/price-increases/route.ts` stays in place for manual debugging

## Why
The `daily-digest` cron (scheduled 0 8 * * *) explicitly states in its docstring that it **replaces three crons**: `deal-alerts`, `targeted-deals`, and `price-increases`. The first two were already removed from `vercel.json`, but `price-increases` was still scheduled at 7am UTC.

This caused **duplicate emails** for users with price increases:
- 7am: `price-increases` cron detects price increases → inserts alerts → emails Essential/Pro users
- 8am: `daily-digest` cron detects the same price increases → tries to insert (deduped by existing alerts) → emails the consolidated digest

The duplication shows up directly under the "URGENT - Email Spam Fix" section of `shared-context/task-queue.md`:

> Consolidate deal alerts + targeted deals + price increases into single daily digest

Both crons call `detectPriceIncreases()` per user (expensive), so removing the duplicate also saves compute.

## Test plan
- [ ] Confirm `daily-digest` cron still appears in Vercel cron schedule
- [ ] Confirm `price-increases` cron no longer appears in Vercel cron schedule
- [ ] Tomorrow's 8am UTC daily-digest run: verify price increases still surface in the consolidated email
- [ ] Check `business_log` / Vercel logs for the next 24h to confirm no regressions on price-increase detection
- [ ] (Optional follow-up) consider deleting `/api/cron/price-increases/route.ts` entirely once the deprecation is verified

From task queue: "Consolidate deal alerts + targeted deals + price increases into single daily digest" (URGENT - Email Spam Fix section)

🤖 Paybacker Dev Sprint Runner
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>