### PR TITLE
Wire missing PostHog product funnel events

### DIFF
--- a/src/app/api/bank/disconnect/route.ts
+++ b/src/app/api/bank/disconnect/route.ts
@@ -114,6 +114,14 @@ export async function POST(request: NextRequest) {
       .eq('user_id', user.id)
       .in('status', ['active', 'expired', 'token_expired', 'expired_legacy', 'expiring_soon']);
     if (error) return NextResponse.json({ error: 'Failed to disconnect' }, { status: 500 });
+    import('@/lib/posthog-server')
+      .then(({ captureServer }) => {
+        captureServer('bank_disconnected', user.id, {
+          mode: 'keep_history',
+          scope: 'all_connections',
+        });
+      })
+      .catch(() => { /* non-fatal */ });
     return NextResponse.json({ ok: true, mode: 'keep_history' });
   }
 
@@ -306,6 +314,22 @@ export async function POST(request: NextRequest) {
     account_id: accountId ?? null,
     account_display_name: accountDisplayName,
   });
+
+  // PostHog server-side funnel event — a user removed a bank (or trimmed
+  // one account off a multi-account consent). Captures the churn signal
+  // and which disconnect mode they chose. Fire-and-forget.
+  import('@/lib/posthog-server')
+    .then(({ captureServer }) => {
+      captureServer('bank_disconnected', user.id, {
+        mode,
+        provider: conn.provider || 'yapily',
+        bank_name: conn.bank_name || null,
+        connection_revoked: willRevokeConnection,
+        account_scoped: isAccountScoped,
+        transactions_affected: transactionsAffected,
+      });
+    })
+    .catch(() => { /* non-fatal */ });
 
   return NextResponse.json({
     ok: true,

--- a/src/app/api/complaints/generate/route.ts
+++ b/src/app/api/complaints/generate/route.ts
@@ -852,6 +852,20 @@ export async function POST(request: NextRequest) {
       provider: body.companyName,
     }).catch(() => {});
 
+    // PostHog server-side funnel event — every generated AI letter, whether
+    // standalone or part of a dispute thread. Reliable (not consent-gated /
+    // ad-blockable like the client capture()).
+    import('@/lib/posthog-server')
+      .then(({ captureServer }) => {
+        captureServer('letter_generated', user.id, {
+          provider: body.companyName,
+          letter_type: body.letterType || 'complaint',
+          dispute_id: body.disputeId || null,
+          tier: usageCheck.tier,
+        });
+      })
+      .catch(() => { /* non-fatal */ });
+
     // Buzz Pocket Agent on WhatsApp if the user has it on.
     // Template: paybacker_complaint_letter_ready vars [merchant, letter_url].
     // Best-effort, fire-and-forget — never block the API response.

--- a/src/app/api/disputes/[id]/letter-sent/route.ts
+++ b/src/app/api/disputes/[id]/letter-sent/route.ts
@@ -155,6 +155,20 @@ export async function POST(
     }
   }
 
+  // PostHog server-side funnel event — the user has actually sent the
+  // dispute letter (the conversion that matters downstream of
+  // dispute_created + letter_generated). Fire-and-forget.
+  import('@/lib/posthog-server')
+    .then(({ captureServer }) => {
+      captureServer('dispute_submitted', user.id, {
+        dispute_id: disputeId,
+        provider: dispute.provider_name || null,
+        edited: edited,
+        watchdog_linked: watchdogLinked,
+      });
+    })
+    .catch(() => { /* non-fatal */ });
+
   return NextResponse.json({
     ok: true,
     dispute_id: disputeId,

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -380,6 +380,24 @@ export async function POST(request: NextRequest) {
           } catch (e) {
             console.error('Webhook: openDowngradeEvent failed:', e);
           }
+
+          // PostHog server-side funnel — distinguish an upgrade from a
+          // downgrade by comparing tier rank (free < essential < pro).
+          // Only emit when the tier actually changed.
+          const tierRank: Record<string, number> = { free: 0, essential: 1, pro: 2 };
+          const oldRank = tierRank[existing.subscription_tier] ?? 0;
+          const newRank = tierRank[newTier] ?? 0;
+          if (newRank > oldRank) {
+            captureServer('plan_upgraded', existing.id, {
+              from_plan: existing.subscription_tier,
+              to_plan: newTier,
+            });
+          } else if (newRank < oldRank) {
+            captureServer('plan_downgraded', existing.id, {
+              from_plan: existing.subscription_tier,
+              to_plan: newTier,
+            });
+          }
         }
         break;
       }
@@ -427,6 +445,16 @@ export async function POST(request: NextRequest) {
             await openDowngradeEvent(supabase as any, existing.id, existing.subscription_tier as any, 'free' as any);
           } catch (e) {
             console.error('Webhook: openDowngradeEvent failed:', e);
+          }
+
+          // PostHog server-side funnel — a full cancellation is a downgrade
+          // to free. Only emit when the user was actually on a paid tier.
+          if (existing.subscription_tier !== 'free') {
+            captureServer('plan_downgraded', existing.id, {
+              from_plan: existing.subscription_tier,
+              to_plan: 'free',
+              reason: 'subscription_deleted',
+            });
           }
 
           // Phase 3 — churn capture. Emit a churn_prompted event so we


### PR DESCRIPTION
## Summary

The morning audit reported PostHog only captures `$pageview`, `$identify`, and `dispute_resolved`. On investigation that audit was **stale**: the four "missing" core events were already wired server-side via `captureServer` in commit `acdaef79`:

- `user_signed_up` — `src/app/api/auth/welcome/route.ts` (idempotent, once per new user)
- `bank_connected` — `src/app/api/yapily/callback/route.ts` (skips re-auths via `reused` guard)
- `dispute_created` — `src/app/api/disputes/route.ts` + `from-email/route.ts`
- `subscription_created` — `src/app/api/webhooks/stripe/route.ts` (`checkout.session.completed`)

This PR adds the genuinely-missing **secondary funnel events** so the product funnel is complete end-to-end. All are **server-side** (`captureServer`) — reliable, not gated by the cookie-consent / ad-blockable client `capture()` path:

| Event | Call site | Trigger |
|---|---|---|
| `letter_generated` | `api/complaints/generate` | AI letter drafted (alongside Meta `trackLetterGenerated`) |
| `dispute_submitted` | `api/disputes/[id]/letter-sent` | User clicked "I've sent it" |
| `bank_disconnected` | `api/bank/disconnect` | Bank/account removed (both legacy + scoped return paths) |
| `plan_upgraded` | Stripe webhook `customer.subscription.updated` | Tier rank increased (free<essential<pro) |
| `plan_downgraded` | Stripe webhook `subscription.{updated,deleted}` | Tier rank decreased / cancellation to free |

## Architecture notes

- Uses the existing `src/lib/posthog-server.ts` client — no new infra needed; it already exists and is used by 10+ call sites.
- Every capture is **fire-and-forget and non-fatal** — analytics never breaks a user request.
- **No double-counting**: each event fires once per terminal action. `plan_upgraded`/`plan_downgraded` only emit when the tier rank actually changes; the cancellation path only emits when the user was on a paid tier.
- `plan_upgraded`/`plan_downgraded` distinguish direction via a `{ free:0, essential:1, pro:2 }` rank comparison rather than assuming every `subscription.updated` is a change.

## Verification

- `npx tsc --noEmit` → 0 errors.
- Scoped to B2C consumer surface only — no B2B paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)