### PR TITLE
Homepage UX/UI audit fixes

### DIFF
--- a/src/app/preview/homepage/demos.tsx
+++ b/src/app/preview/homepage/demos.tsx
@@ -772,7 +772,18 @@ export function PocketAgentDemo() {
                 fontWeight: 600,
               }}
             >
-              this month · text Paybacker to find out
+              this month
+            </div>
+            <div
+              style={{
+                fontSize: 13,
+                color: '#CBD5E1',
+                marginTop: 14,
+                maxWidth: 320,
+                lineHeight: 1.45,
+              }}
+            >
+              Ask Paybacker: &ldquo;How much did I spend on food this month?&rdquo;
             </div>
           </div>
         </div>

--- a/src/app/preview/homepage/page.tsx
+++ b/src/app/preview/homepage/page.tsx
@@ -111,6 +111,12 @@ type CounterProps = {
   prefix?: string;
   suffix?: string;
   fractionDigits?: number;
+  /**
+   * Skip the count-up and render the final value immediately. Used for the
+   * "100% of your refund you keep" stat — counting 0 → 100 there flashes
+   * misleading intermediate numbers (e.g. "43%") that read as "you keep 43%".
+   */
+  instant?: boolean;
 };
 function Counter({
   to,
@@ -118,12 +124,14 @@ function Counter({
   prefix = '',
   suffix = '',
   fractionDigits = 0,
+  instant = false,
 }: CounterProps) {
   const ref = useRef<HTMLSpanElement | null>(null);
-  const [value, setValue] = useState(0);
+  const [value, setValue] = useState(instant ? to : 0);
   const started = useRef(false);
 
   useEffect(() => {
+    if (instant) return;
     const node = ref.current;
     if (!node || started.current) return;
     const prefersReduced =
@@ -156,7 +164,7 @@ function Counter({
     );
     io.observe(node);
     return () => io.disconnect();
-  }, [to, duration]);
+  }, [to, duration, instant]);
 
   const formatted = value.toLocaleString('en-GB', {
     minimumFractionDigits: fractionDigits,
@@ -827,10 +835,31 @@ export default function HomepageV3PreviewPage() {
         style={{ ['--glow-opacity' as string]: '0.22' } as CSSVarProperties}
       >
         <div className="trust-bar">
-          ICO registered <span className="dot">·</span>
-          FCA-authorised via Yapily <span className="dot">·</span>
-          GDPR compliant <span className="dot">·</span>
-          UK company · Paybacker LTD
+          <span className="trust-bar__item">
+            <svg className="trust-bar__icon" viewBox="0 0 16 16" aria-hidden="true">
+              <path d="M8 1.5 13.5 3.5 V8 C13.5 11.3 11 13.7 8 14.5 5 13.7 2.5 11.3 2.5 8 V3.5 Z" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+              <path d="M5.5 8 L7.2 9.7 L10.6 6" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            FCA-authorised via Yapily
+          </span>
+          <span className="dot">·</span>
+          <span className="trust-bar__item">
+            <svg className="trust-bar__icon" viewBox="0 0 16 16" aria-hidden="true">
+              <circle cx="8" cy="8" r="6.3" fill="none" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M5.3 8 L7 9.7 L10.7 6" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            ICO-registered
+          </span>
+          <span className="dot">·</span>
+          <span className="trust-bar__item">
+            <svg className="trust-bar__icon" viewBox="0 0 16 16" aria-hidden="true">
+              <circle cx="8" cy="8" r="6.3" fill="none" stroke="currentColor" strokeWidth="1.3" />
+              <path d="M5.3 8 L7 9.7 L10.7 6" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            GDPR-compliant
+          </span>
+          <span className="dot">·</span>
+          <span className="trust-bar__item">UK company · Paybacker LTD</span>
         </div>
 
         <div className="wrap">
@@ -843,18 +872,17 @@ export default function HomepageV3PreviewPage() {
                 <span className="l3">You keep 100% of what we recover.</span>
               </h1>
               <p className="hero-sub">
-                Paybacker reads your bank and inbox, drafts complaint letters
-                citing the exact UK statute, and runs every dispute end-to-end —
-                through provider escalation and Ombudsman if needed. Solicitors
-                charge £250/hour. Claims firms take 30%. We charge £4.99/month
-                and you keep every penny we win back.
+                Reads your bank and inbox. Drafts the legal letter. Disputes it
+                end-to-end.
+                <br />
+                You keep every penny we win back.
               </p>
               <div className="hero-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup">
                   Start free — keep 100% of your wins →
                 </Link>
                 <a className="btn btn-ghost" href="#vs-claims-firms">
-                  Why not a solicitor?
+                  See how we compare →
                 </a>
               </div>
               <div className="hero-ticker">
@@ -929,7 +957,7 @@ export default function HomepageV3PreviewPage() {
             <Reveal className="stat-card" delay={160}>
               <div className="label">Of your refund you keep</div>
               <div className="num">
-                <Counter to={100} />
+                <Counter to={100} instant />
                 <span className="unit">%</span>
               </div>
               <div className="underline" />
@@ -1063,7 +1091,6 @@ export default function HomepageV3PreviewPage() {
                 <li>Energy, broadband, parking, flight delays, council tax</li>
                 <li>Pre-send freshness gate blocks any letter citing stale law</li>
                 <li>3 free letters / month. Unlimited on Essential and Pro.</li>
-                <li>Manage on the web at paybacker.co.uk or on the move via WhatsApp Pocket Agent (Pro) and Telegram Pocket Agent (free on every plan).</li>
               </ul>
               <div className="feature-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup?redirect=%2Fdashboard%2Fcomplaints">
@@ -1083,7 +1110,7 @@ export default function HomepageV3PreviewPage() {
         <div className="wrap">
           <div className="feature-grid">
             <Reveal className="feature-copy">
-              <h2 className="feature-title">Your personal caseworker — on WhatsApp</h2>
+              <h2 className="feature-title">Your personal caseworker on WhatsApp</h2>
               <p className="feature-tagline">
                 A solicitor takes a week to reply to email. Your Paybacker
                 caseworker is on WhatsApp 24/7.
@@ -1193,7 +1220,6 @@ export default function HomepageV3PreviewPage() {
                 <li>Transactions auto-categorised across 20+ spend buckets</li>
                 <li>Budgets, savings goals, income tracking, net worth</li>
                 <li>Daily sync on Essential. Unlimited accounts on Pro.</li>
-                <li>Manage on the web at paybacker.co.uk or on the move via WhatsApp Pocket Agent (Pro) and Telegram Pocket Agent (free on every plan) — ask &ldquo;did I get paid?&rdquo;, check balances, see recent transactions.</li>
               </ul>
               <div className="feature-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup?redirect=%2Fdashboard%2Fmoney-hub">
@@ -1231,7 +1257,6 @@ export default function HomepageV3PreviewPage() {
                 <li>Auto-reply tracking — Watchdog picks up the provider&apos;s response from your inbox and progresses the dispute without you chasing</li>
                 <li>Renewal reminders 30, 14 and 7 days before charge</li>
                 <li>Contract end-date tracking for broadband, energy &amp; mobile</li>
-                <li>Manage on the web at paybacker.co.uk or on the move via WhatsApp Pocket Agent (Pro) and Telegram Pocket Agent (free on every plan).</li>
               </ul>
               <div className="feature-cta-row">
                 <Link className="btn btn-mint" href="/auth/signup?redirect=%2Fdashboard%2Fsubscriptions">

--- a/src/app/preview/homepage/styles.css
+++ b/src/app/preview/homepage/styles.css
@@ -136,6 +136,14 @@
 
 .m-v2-root .reveal.in { opacity: 1; transform: translateY(0); }
 
+/* Fallback: if JavaScript never runs (disabled, blocked, or a hydration
+ * failure), the IntersectionObserver that adds `.in` never fires and the
+ * scroll-reveal content would stay permanently invisible. Force every reveal
+ * visible when scripting is unavailable so content is never lost. */
+@media (scripting: none) {
+  .m-v2-root .reveal { opacity: 1; transform: none; transition: none; }
+}
+
 .m-v2-root section { position: relative; }
 
 .m-v2-root .section-light { background: var(--surface-base); }
@@ -248,14 +256,32 @@
 }
 
 .m-v2-root .trust-bar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
   text-align: center;
   padding: 84px 32px 0;
-  font-size: 12px;
-  color: var(--text-tertiary);
-  letter-spacing: 0.02em;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--text-secondary, #4B5563);
+  letter-spacing: 0.01em;
 }
 
-.m-v2-root .trust-bar .dot { margin: 0 10px; opacity: 0.5; }
+.m-v2-root .trust-bar__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.m-v2-root .trust-bar__icon {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  color: var(--accent-mint-deep, #059669);
+}
+
+.m-v2-root .trust-bar .dot { margin: 0 10px; opacity: 0.45; }
 
 /* =========================================================================
  * Hero
@@ -1327,6 +1353,16 @@
   color: var(--text-secondary, #4B5563);
   margin: 0;
 }
+/* Multi-line body copy reads better left-aligned. The big title + single-line
+ * tagline stay centred; the body paragraph (everything except the inline
+ * freshness-chip) forms a left-aligned 560px column that lines up with the
+ * `.feature-bullets` list below it. */
+.m-v2-root .feature-copy > p:not(.freshness-chip) {
+  text-align: left;
+  align-self: center;
+  max-width: 560px;
+  width: 100%;
+}
 .m-v2-root .feature-section--ink .feature-copy > p { color: rgba(255,255,255,.72); }
 .m-v2-root .feature-section--ink .eyebrow,
 .m-v2-root .feature-section--ink .eyebrow.on-ink {
@@ -1983,8 +2019,9 @@
   .m-v2-root .fc-btn-row .btn { width: 100%; justify-content: center; }
 
   /* Trust bar */
-  .m-v2-root .trust-bar { padding-top: 72px; font-size: 11px; }
+  .m-v2-root .trust-bar { padding-top: 72px; font-size: 12px; gap: 2px 0; }
   .m-v2-root .trust-bar .dot { margin: 0 6px; }
+  .m-v2-root .trust-bar__icon { width: 13px; height: 13px; }
   .m-v2-root .trust-row { grid-template-columns: 1fr; gap: 12px; }
 
   /* Nav — drop sign-in link to reclaim space for Start Free button */
@@ -2417,13 +2454,16 @@
   margin: 4px 0 18px;
   line-height: 1.5;
 }
+/* Rendered as a checkmark badge (not a plain dot) so the green marker on
+ * this "verified today" line matches the green checkmark bullets directly
+ * below it in the Disputes section — consistent marker style throughout. */
 .m-v2-root .freshness-chip__dot {
   display: inline-block;
-  width: 7px;
-  height: 7px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
-  background: var(--accent-mint);
   flex-shrink: 0;
+  background: #D1FAE5 url("data:image/svg+xml;utf8,<svg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><path d='M4 8.5L7 11.5L12 5.5' stroke='%23065F46' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>") center/72% no-repeat;
 }
 .m-v2-root .freshness-chip__link {
   color: var(--accent-mint-deep);


### PR DESCRIPTION
Implements UX/UI improvements identified in a homepage audit. All changes are confined to the marketing homepage (`src/app/preview/homepage/`), which `src/app/page.tsx` renders. B2C surface only — no B2B paths touched.

## Fixes
1. **Hero subtext cut to 2 lines** — removed the inline solicitor/claims-firm price comparison (it already has its own dedicated section lower on the page).
2. **Nav CTA auth-awareness** — already correct: "Open Dashboard" only renders for logged-in users; unauthenticated visitors see "Start free". Verified, no change needed.
3. **Removed repeated boilerplate bullet** — the "Manage on the web… WhatsApp/Telegram Pocket Agent" line was deleted from the AI Disputes, Money Hub and Subscriptions sections. The channel is covered by the dedicated caseworker section. (Export Hub never had it.)
4. **WhatsApp heading line break** — "Your personal caseworker — on WhatsApp" → "Your personal caseworker on WhatsApp" (removed the em-dash that broke onto its own line).
5. **Bullet style consistency (Disputes)** — the green "verified today" freshness-chip dot now renders as a checkmark, matching the checkmark bullets below it.
6. **"100% you keep" counter** — added an `instant` prop to `Counter` so this stat renders 100% immediately instead of animating 0→100 (which flashed misleading values like "43%"). The other two stat counters still animate.
7. **"Spent on food" context label** — added "Ask Paybacker: 'How much did I spend on food this month?'" to the Pocket Agent demo opener so visitors understand the spend figure.
8. **Trust signals legibility** — trust bar bumped to 13.5px, darker (`--text-secondary`), with inline shield/check SVG icons.
9. **Left-aligned body copy** — multi-line product-section paragraphs now left-align into a 560px column that lines up with the bullet list; titles and single-line taglines stay centred.
10. **CTA relabel** — "Why not a solicitor?" → "See how we compare →" (kept ghost-button style, same `#vs-claims-firms` anchor).
11. **Blank-void / reveal robustness** — there are no `<img>` tags (demos are CSS/SVG) and `.demo-stage` already reserves space via `aspect-ratio: 16/10`, so no lazy-load voids. Added a `@media (scripting: none)` fallback so scroll-reveal content can never stay permanently invisible if JS fails to run.

## Notes
- Fix 2 was already implemented correctly; verified, no change.
- For Fix 9, the Compliance Pipeline uses a centred section-header intro pattern (shared with the stats/features intros) rather than the `feature-copy` body pattern; left-aligning a lone lead under a centred title would look broken, so it was left centred.

`npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)